### PR TITLE
fix(mac): prevent traffic light buttons from overlapping activity bar UI

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -90,6 +90,14 @@ async function createWindow() {
     });
   });
 
+  mainWindow.on('enter-full-screen', () => {
+    mainWindow?.webContents.send('window:fullscreen-changed', true);
+  });
+
+  mainWindow.on('leave-full-screen', () => {
+    mainWindow?.webContents.send('window:fullscreen-changed', false);
+  });
+
   if (!app.isPackaged && process.env['ELECTRON_RENDERER_URL']) {
     await waitForDevServer(process.env['ELECTRON_RENDERER_URL']);
     void mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL']);
@@ -124,6 +132,10 @@ ipcMain.handle('window:close', () => {
 
 ipcMain.handle('window:isMaximized', () => {
   return mainWindow?.isMaximized() ?? false;
+});
+
+ipcMain.handle('window:isFullScreen', () => {
+  return mainWindow?.isFullScreen() ?? false;
 });
 
 ipcMain.handle('get-server-config', () => ({ url: serverUrl }));

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -33,6 +33,7 @@ contextBridge.exposeInMainWorld('api', {
     maximize: () => ipcRenderer.invoke('window:maximize'),
     close: () => ipcRenderer.invoke('window:close'),
     isMaximized: () => ipcRenderer.invoke('window:isMaximized') as Promise<boolean>,
+    isFullScreen: () => ipcRenderer.invoke('window:isFullScreen') as Promise<boolean>,
   },
   devtools: {
     toggle: () => ipcRenderer.invoke('devtools:toggle'),

--- a/apps/web/src/components/layout/mac-title-bar.tsx
+++ b/apps/web/src/components/layout/mac-title-bar.tsx
@@ -2,11 +2,12 @@ import { PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 
 import { ServerStatus } from '@/components/layout/server-status';
 import { useSidebar } from '@/components/ui/sidebar';
-
-const MAC_TRAFFIC_LIGHTS_SPACE_PX = 76;
+import { useFullScreen } from '@/hooks/ui/use-fullscreen';
+import { cn } from '@/lib/utils';
 
 export function MacTitleBar() {
   const { open, toggleSidebar } = useSidebar();
+  const isFullScreen = useFullScreen();
 
   return (
     <div
@@ -14,10 +15,9 @@ export function MacTitleBar() {
       style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
     >
       <div
-        className="flex h-full items-center"
+        className={cn('flex h-full items-center', !isFullScreen && 'pl-6')}
         style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       >
-        <div style={{ width: MAC_TRAFFIC_LIGHTS_SPACE_PX }} />
         <button
           onClick={toggleSidebar}
           className="flex h-full w-9 items-center justify-center transition-colors hover:bg-muted"

--- a/apps/web/src/components/navigation/activity-bar.tsx
+++ b/apps/web/src/components/navigation/activity-bar.tsx
@@ -4,6 +4,7 @@ import { Link, useRouterState } from '@tanstack/react-router';
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useDialogContext } from '@/context/dialog-context';
+import { useFullScreen } from '@/hooks/ui/use-fullscreen';
 import { cn } from '@/lib/utils';
 
 type ActivityItem = {
@@ -60,9 +61,20 @@ export function ActivityBar() {
   const routerState = useRouterState();
   const currentPath = routerState.location.pathname;
   const { setSettingsTab } = useDialogContext();
+  const isMac = window.electron?.platform === 'darwin';
+  const isFullScreen = useFullScreen();
+  const showTrafficLightPadding = isMac && !isFullScreen;
 
   return (
-    <div className="flex w-14 flex-col items-center border-r border-border/50 bg-sidebar px-1.5 pt-3 pb-3">
+    <div
+      className={cn(
+        'relative flex w-14 flex-col items-center bg-sidebar px-1.5 pb-3',
+        showTrafficLightPadding ? 'pt-10' : 'border-r border-border/50 pt-3',
+      )}
+    >
+      {showTrafficLightPadding && (
+        <div className="pointer-events-none absolute top-9 right-0 bottom-0 border-r border-border/50" />
+      )}
       <div className="flex w-full flex-col items-center gap-2">
         {ACTIVITY_ITEMS.map((item) => {
           const active = isActive(item.matchPrefix, currentPath);

--- a/apps/web/src/hooks/ui/use-fullscreen.ts
+++ b/apps/web/src/hooks/ui/use-fullscreen.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+export function useFullScreen() {
+  const [isFullScreen, setIsFullScreen] = useState(false);
+
+  useEffect(() => {
+    const checkFullScreen = async () => {
+      if (window.api?.window?.isFullScreen) {
+        const fullScreen = await window.api.window.isFullScreen();
+        setIsFullScreen(fullScreen);
+      }
+    };
+    void checkFullScreen();
+
+    const unsubscribe = window.electron?.on('window:fullscreen-changed', (value) => {
+      setIsFullScreen(value as boolean);
+    });
+
+    return () => unsubscribe?.();
+  }, []);
+
+  return isFullScreen;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -27,6 +27,7 @@ declare global {
         maximize: () => Promise<void>;
         close: () => Promise<void>;
         isMaximized: () => Promise<boolean>;
+        isFullScreen: () => Promise<boolean>;
       };
       devtools?: {
         toggle: () => Promise<void>;


### PR DESCRIPTION
## Summary

- Fix macOS traffic light buttons (close/minimize/maximize) overlapping with the activity bar icons and sidebar toggle button
- Add fullscreen detection so layout adjusts dynamically when traffic lights are hidden in macOS fullscreen mode
- Ensure all changes are macOS-specific with no impact on Windows/Linux

## Changes

### Activity bar (`activity-bar.tsx`)
- Add `pt-10` top padding on macOS (non-fullscreen) to push icons below the traffic lights, falling back to `pt-3` on other platforms
- Use a positioned border element starting at `top-9` so the vertical separator aligns with the content section without cutting through the traffic light area

### Title bar (`mac-title-bar.tsx`)
- Replace the fixed 76px traffic light spacer with dynamic `pl-6` left padding
- Remove padding in fullscreen mode since macOS hides the traffic lights

### Fullscreen detection (new)
- `window:isFullScreen` IPC handler and `enter/leave-full-screen` event forwarding in Electron main process
- `isFullScreen` exposed in preload bridge and window API types
- `useFullScreen` hook tracks fullscreen state reactively via IPC events