### PR TITLE
chore: promote CI workflow updates to production

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @maharshi365 @aditpatel14
+
+# Workflow and release governance
+.github/workflows/ @maharshi365 @aditpatel14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,13 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Allow only release maintainers
         if: ${{ github.actor != 'maharshi365' && github.actor != 'aditpatel14' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: ci
+run-name: 'ci by @${{ github.actor }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or commit to validate'
+        required: false
+        type: string
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Allow only release maintainers
+        if: ${{ github.actor != 'maharshi365' && github.actor != 'aditpatel14' }}
+        run: |
+          echo "Only maharshi365 or aditpatel14 can run this workflow."
+          exit 1
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Run full checks
+        run: bun run check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,21 @@ permissions:
   contents: write
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require production branch
+        run: |
+          if [ "${{ github.ref_name }}" != "production" ]; then
+            echo "Release workflow must run from the production branch."
+            exit 1
+          fi
+
   # ---------------------------------------------------------------------------
   # Version: compute the next semver tag
   # ---------------------------------------------------------------------------
   version:
+    needs: guard
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.bump.outputs.version }}
@@ -78,6 +89,7 @@ jobs:
   # Quality gates: test + typecheck (per OS, in parallel)
   # ---------------------------------------------------------------------------
   quality-windows:
+    needs: guard
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -93,6 +105,7 @@ jobs:
           wait $PID_TC || exit 1
 
   quality-macos:
+    needs: guard
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -198,6 +211,8 @@ jobs:
   release:
     needs: [version, build-windows, build-macos]
     runs-on: ubuntu-latest
+    environment:
+      name: production
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,8 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
+      - name: Run typecheck
+        run: bun run typecheck
+
       - name: Run unit tests
         run: bun run --filter '*' test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    name: unit (${{ matrix.settings.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - name: windows
+            os: windows-latest
+          - name: macos
+            os: macos-latest
+    runs-on: ${{ matrix.settings.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Run unit tests
+        run: bun run --filter '*' test

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -18,11 +18,7 @@ permissions:
 
 jobs:
   typecheck:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/setup-bun
-
-      - name: Run typecheck
-        run: bun run typecheck
+      - name: Typecheck is run in test workflow
+        run: echo "Typecheck runs in the OS-specific test jobs."

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,28 @@
+name: typecheck
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: typecheck-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Run typecheck
+        run: bun run typecheck

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Stitch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- promote recent CI infrastructure updates from `master` to `production`
- include the new cross-platform test/typecheck workflow setup and related workflow guardrails
- carry forward repository metadata additions included in this release window (e.g., CODEOWNERS and LICENSE)