### PR TITLE
chore(release): adopt script-driven release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,62 +32,6 @@ jobs:
             exit 1
           fi
 
-  # ---------------------------------------------------------------------------
-  # Version: compute the next semver tag
-  # ---------------------------------------------------------------------------
-  version:
-    needs: guard
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.bump.outputs.version }}
-      tag: ${{ steps.bump.outputs.tag }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Compute next version
-        id: bump
-        shell: bash
-        run: |
-          # Get latest version tag, default to 0.0.0 if none exist
-          LATEST=$(git tag --list 'v*' --sort=-v:refname | head -n1)
-          if [ -z "$LATEST" ]; then
-            LATEST="v0.0.0"
-          fi
-          LATEST="${LATEST#v}"
-
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST"
-          MAJOR="${MAJOR:-0}"
-          MINOR="${MINOR:-0}"
-          PATCH="${PATCH:-0}"
-
-          BUMP="${{ inputs.bump }}"
-          case "$BUMP" in
-            major)
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
-              ;;
-            minor)
-              MINOR=$((MINOR + 1))
-              PATCH=0
-              ;;
-            patch)
-              PATCH=$((PATCH + 1))
-              ;;
-          esac
-
-          VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          TAG="v${VERSION}"
-
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Bumping ${LATEST} -> ${VERSION} (${BUMP})"
-
-  # ---------------------------------------------------------------------------
-  # Quality gates: test + typecheck (per OS, in parallel)
-  # ---------------------------------------------------------------------------
   quality-windows:
     needs: guard
     runs-on: windows-latest
@@ -120,24 +64,43 @@ jobs:
           wait $PID_TEST || exit 1
           wait $PID_TC || exit 1
 
-  # ---------------------------------------------------------------------------
-  # Build: Windows x64
-  # ---------------------------------------------------------------------------
+  prepare-release:
+    needs: [guard, quality-windows, quality-macos]
+    runs-on: ubuntu-latest
+    outputs:
+      previous_tag: ${{ steps.publish.outputs.previous_tag }}
+      version: ${{ steps.publish.outputs.version }}
+      tag: ${{ steps.publish.outputs.tag }}
+      release_sha: ${{ steps.publish.outputs.release_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch tags
+        run: git fetch --force --tags
+
+      - name: Commit release version and tag
+        id: publish
+        env:
+          RELEASE_BUMP: ${{ inputs.bump }}
+        run: bun run release:publish
+
   build-windows:
-    needs: [version, quality-windows]
+    needs: prepare-release
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
       - uses: ./.github/actions/setup-bun
-
-      - name: Set version in package manifests
-        shell: bash
-        run: |
-          for PKG in apps/desktop apps/web; do
-            TMPFILE=$(mktemp)
-            jq --arg v "${{ needs.version.outputs.version }}" '.version = $v' "$PKG/package.json" > "$TMPFILE"
-            mv "$TMPFILE" "$PKG/package.json"
-          done
 
       - name: Build all packages
         shell: bash
@@ -162,24 +125,14 @@ jobs:
             apps/desktop/dist/*.exe
           if-no-files-found: error
 
-  # ---------------------------------------------------------------------------
-  # Build: macOS ARM64
-  # ---------------------------------------------------------------------------
   build-macos:
-    needs: [version, quality-macos]
+    needs: prepare-release
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
       - uses: ./.github/actions/setup-bun
-
-      - name: Set version in package manifests
-        shell: bash
-        run: |
-          for PKG in apps/desktop apps/web; do
-            TMPFILE=$(mktemp)
-            jq --arg v "${{ needs.version.outputs.version }}" '.version = $v' "$PKG/package.json" > "$TMPFILE"
-            mv "$TMPFILE" "$PKG/package.json"
-          done
 
       - name: Build all packages
         shell: bash
@@ -205,16 +158,15 @@ jobs:
             apps/desktop/dist/*.zip
           if-no-files-found: error
 
-  # ---------------------------------------------------------------------------
-  # Release: create GitHub Release and upload all installers
-  # ---------------------------------------------------------------------------
   release:
-    needs: [version, build-windows, build-macos]
+    needs: [prepare-release, build-windows, build-macos]
     runs-on: ubuntu-latest
     environment:
       name: production
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_sha }}
 
       - name: Download Windows artifacts
         uses: actions/download-artifact@v4
@@ -228,17 +180,19 @@ jobs:
           name: stitch-macos-arm64
           path: artifacts/macos
 
-      - name: Create Git tag
-        run: |
-          git tag "${{ needs.version.outputs.tag }}"
-          git push origin "${{ needs.version.outputs.tag }}"
+      - name: Generate release notes body
+        env:
+          RELEASE_PREVIOUS_TAG: ${{ needs.prepare-release.outputs.previous_tag }}
+          RELEASE_NOTES_PATH: ${{ runner.temp }}/release-notes.md
+        run: bun run release:notes
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ needs.version.outputs.tag }}
-          name: Stitch ${{ needs.version.outputs.tag }}
-          generate_release_notes: true
+          tag_name: ${{ needs.prepare-release.outputs.tag }}
+          target_commitish: ${{ needs.prepare-release.outputs.release_sha }}
+          name: Stitch ${{ needs.prepare-release.outputs.tag }}
+          body_path: ${{ runner.temp }}/release-notes.md
           files: |
             artifacts/windows/*
             artifacts/macos/*

--- a/.github/workflows/sync-production-to-master.yml
+++ b/.github/workflows/sync-production-to-master.yml
@@ -1,0 +1,54 @@
+name: sync-production-to-master
+
+on:
+  workflow_run:
+    workflows: ['release']
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-sync-pr:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'production'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure production is ahead of master
+        id: diff
+        run: |
+          git fetch origin master production
+          AHEAD_COUNT=$(git rev-list --count origin/master..origin/production)
+          echo "ahead_count=${AHEAD_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Check for existing sync PR
+        id: existing
+        if: ${{ steps.diff.outputs.ahead_count != '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COUNT=$(gh pr list --base master --head production --state open --json number --jq 'length')
+          echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Open sync PR
+        if: ${{ steps.diff.outputs.ahead_count != '0' && steps.existing.outputs.count == '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BODY=$(cat <<'EOF'
+          ## Summary
+          - sync release commits from production back into master
+          - keep long-lived branches aligned after automated release tagging/versioning
+          EOF
+          )
+          gh pr create \
+            --base master \
+            --head production \
+            --title "chore(release): sync production back to master" \
+            --body "$BODY"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "typecheck": "turbo typecheck",
     "test": "turbo test",
     "knip": "knip",
-    "check": "bun run scripts/check.ts"
+    "check": "bun run scripts/check.ts",
+    "release:version": "bun run scripts/release/version.ts",
+    "release:bump": "bun run scripts/release/bump.ts",
+    "release:notes": "bun run scripts/release/notes.ts",
+    "release:publish": "bun run scripts/release/publish.ts"
   },
   "devDependencies": {
     "knip": "latest",

--- a/scripts/release/bump.ts
+++ b/scripts/release/bump.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env bun
+
+import { updateWorkspaceVersions } from './lib.js';
+
+async function main(): Promise<void> {
+  const version = process.env.RELEASE_VERSION;
+  if (!version) {
+    throw new Error('RELEASE_VERSION is required');
+  }
+
+  const root = process.cwd();
+  const updated = await updateWorkspaceVersions(root, version);
+
+  if (updated.length === 0) {
+    throw new Error(`No package manifests updated for version ${version}`);
+  }
+
+  console.log(`Updated ${updated.length} manifests to ${version}`);
+}
+
+await main();

--- a/scripts/release/lib.ts
+++ b/scripts/release/lib.ts
@@ -1,0 +1,138 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { $ } from 'bun';
+
+const SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)$/;
+
+export type BumpKind = 'major' | 'minor' | 'patch';
+
+export interface ReleaseVersionInfo {
+  previousTag: string;
+  previousVersion: string;
+  version: string;
+  tag: string;
+}
+
+interface Semver {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+function parseSemver(value: string): Semver {
+  const match = value.match(SEMVER_RE);
+  if (!match) {
+    throw new Error(`Invalid semver value: ${value}`);
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function formatSemver(value: Semver): string {
+  return `${value.major}.${value.minor}.${value.patch}`;
+}
+
+function bumpSemver(version: string, bump: BumpKind): string {
+  const parsed = parseSemver(version);
+
+  if (bump === 'major') {
+    return formatSemver({ major: parsed.major + 1, minor: 0, patch: 0 });
+  }
+
+  if (bump === 'minor') {
+    return formatSemver({ major: parsed.major, minor: parsed.minor + 1, patch: 0 });
+  }
+
+  return formatSemver({ major: parsed.major, minor: parsed.minor, patch: parsed.patch + 1 });
+}
+
+export async function getLatestTag(): Promise<string | null> {
+  const output = (await $`git tag --list "v*" --sort=-v:refname`.text()).trim();
+  if (!output) {
+    return null;
+  }
+
+  const tags = output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  for (const tag of tags) {
+    if (SEMVER_RE.test(tag.replace(/^v/, ''))) {
+      return tag;
+    }
+  }
+
+  return null;
+}
+
+export async function computeNextVersion(bump: BumpKind): Promise<ReleaseVersionInfo> {
+  const previousTag = (await getLatestTag()) ?? 'v0.0.0';
+  const previousVersion = previousTag.replace(/^v/, '');
+  const version = bumpSemver(previousVersion, bump);
+
+  return {
+    previousTag,
+    previousVersion,
+    version,
+    tag: `v${version}`,
+  };
+}
+
+async function listManifestFiles(root: string): Promise<string[]> {
+  const dirs = [join(root, 'apps'), join(root, 'packages')];
+  const manifests: string[] = [];
+
+  for (const dir of dirs) {
+    let entries: Array<{ name: string; isDirectory: () => boolean }> = [];
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+
+      manifests.push(join(dir, entry.name, 'package.json'));
+    }
+  }
+
+  return manifests;
+}
+
+export async function updateWorkspaceVersions(root: string, version: string): Promise<string[]> {
+  const manifests = await listManifestFiles(root);
+  const updated: string[] = [];
+
+  for (const file of manifests) {
+    let raw = '';
+    try {
+      raw = await readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+
+    const parsed = JSON.parse(raw) as { version?: string };
+    if (!parsed.version || parsed.version === version) {
+      continue;
+    }
+
+    parsed.version = version;
+    await writeFile(file, `${JSON.stringify(parsed, null, 2)}\n`);
+    updated.push(file);
+  }
+
+  return updated;
+}
+
+export function isValidBump(value: string): value is BumpKind {
+  return value === 'major' || value === 'minor' || value === 'patch';
+}

--- a/scripts/release/notes.ts
+++ b/scripts/release/notes.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env bun
+
+import { $ } from 'bun';
+
+async function main(): Promise<void> {
+  const previousTag = process.env.RELEASE_PREVIOUS_TAG;
+  if (!previousTag) {
+    throw new Error('RELEASE_PREVIOUS_TAG is required');
+  }
+
+  const tagExists = (await $`git tag --list ${previousTag}`.text()).trim().length > 0;
+  const range = tagExists ? `${previousTag}..HEAD` : 'HEAD';
+  const raw = (await $`git log --pretty=format:- %s (%h) ${range}`.text()).trim();
+
+  const body = raw.length > 0 ? raw : '- Initial release';
+  const outputPath = process.env.RELEASE_NOTES_PATH;
+
+  if (outputPath) {
+    await Bun.write(outputPath, `${body}\n`);
+  }
+
+  if (process.env.GITHUB_OUTPUT) {
+    await Bun.write(process.env.GITHUB_OUTPUT, `notes_path=${outputPath ?? ''}\n`);
+  }
+
+  console.log(body);
+}
+
+await main();

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env bun
+
+import { $ } from 'bun';
+
+import { computeNextVersion, isValidBump, updateWorkspaceVersions } from './lib.js';
+
+async function ensureTagDoesNotExist(tag: string): Promise<void> {
+  const existing = (await $`git tag --list ${tag}`.text()).trim();
+  if (existing.length > 0) {
+    throw new Error(`Tag already exists: ${tag}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const bumpInput = process.env.RELEASE_BUMP ?? 'patch';
+  if (!isValidBump(bumpInput)) {
+    throw new Error(`Invalid RELEASE_BUMP value: ${bumpInput}`);
+  }
+
+  const info = await computeNextVersion(bumpInput);
+  await ensureTagDoesNotExist(info.tag);
+
+  const updated = await updateWorkspaceVersions(process.cwd(), info.version);
+  if (updated.length === 0) {
+    throw new Error(`No package manifests updated for version ${info.version}`);
+  }
+
+  await $`git add ${updated}`;
+  await $`git commit -m ${`release: v${info.version}`}`;
+  await $`git tag ${info.tag}`;
+  await $`git push origin HEAD --follow-tags`;
+
+  const releaseSha = (await $`git rev-parse HEAD`.text()).trim();
+
+  const lines = [
+    `previous_tag=${info.previousTag}`,
+    `version=${info.version}`,
+    `tag=${info.tag}`,
+    `release_sha=${releaseSha}`,
+  ];
+
+  if (process.env.GITHUB_OUTPUT) {
+    await Bun.write(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
+  }
+
+  console.log(`Created ${info.tag} at ${releaseSha}`);
+}
+
+await main();

--- a/scripts/release/version.ts
+++ b/scripts/release/version.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env bun
+
+import { computeNextVersion, isValidBump } from './lib.js';
+
+async function main(): Promise<void> {
+  const bumpInput = process.env.RELEASE_BUMP ?? 'patch';
+  if (!isValidBump(bumpInput)) {
+    throw new Error(`Invalid RELEASE_BUMP value: ${bumpInput}`);
+  }
+
+  const info = await computeNextVersion(bumpInput);
+
+  const lines = [
+    `previous_tag=${info.previousTag}`,
+    `previous_version=${info.previousVersion}`,
+    `version=${info.version}`,
+    `tag=${info.tag}`,
+  ];
+
+  if (process.env.GITHUB_OUTPUT) {
+    await Bun.write(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
+  }
+
+  console.log(`Next release: ${info.previousTag} -> ${info.tag}`);
+}
+
+await main();


### PR DESCRIPTION
## Summary
- replace inline release workflow versioning logic with script-driven release automation under `scripts/release`
- make release preparation commit and tag versions on `production`, then build from that exact release SHA
- add a post-release workflow that opens a `production -> master` sync PR when production is ahead

## Notes
- production ruleset updated to include bypass actor `RepositoryRole:5` (always) so admins can bypass when needed for release operations