### PR TITLE
fix(desktop): resolve native-audio-node crash in packaged app

### DIFF
--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -20,6 +20,11 @@ const config: Configuration = {
       filter: ['stitch-server*'],
     },
     {
+      from: '../../packages/server/dist/node_modules',
+      to: 'node_modules',
+      filter: ['**/*'],
+    },
+    {
       from: '../../packages/server/drizzle',
       to: 'drizzle',
       filter: ['**/*'],

--- a/oxlint.json
+++ b/oxlint.json
@@ -27,6 +27,14 @@
     "react/hooks-extra/no-direct-set-state-in-use-effect": "error"
   },
   "ignorePatterns": ["node_modules", "dist", "out", "dist-electron", ".turbo"],
+  "overrides": [
+    {
+      "files": ["packages/recordings/src/native-audio.ts"],
+      "rules": {
+        "import/no-dynamic-require": "off"
+      }
+    }
+  ],
   "env": {
     "browser": true,
     "node": true,

--- a/packages/recordings/__test__/mac-meeting.test.ts
+++ b/packages/recordings/__test__/mac-meeting.test.ts
@@ -32,7 +32,7 @@ interface MockMonitorInstance {
 const monitorRef: { current: MockMonitorInstance | null } = { current: null };
 const processRef: { current: MockProcessInfo[] } = { current: [] };
 
-vi.mock('native-audio-node', () => {
+vi.mock('../src/native-audio.js', () => {
   const { EventEmitter } = require('node:events');
 
   class MockMicrophoneActivityMonitor extends EventEmitter {

--- a/packages/recordings/__test__/recording-writer.test.ts
+++ b/packages/recordings/__test__/recording-writer.test.ts
@@ -37,7 +37,7 @@ interface MockRecorderInstance {
   emit(event: string, ...args: unknown[]): boolean;
 }
 
-vi.mock('native-audio-node', () => {
+vi.mock('../src/native-audio.js', () => {
   const { EventEmitter } = require('node:events');
 
   class MockRecorder extends EventEmitter {

--- a/packages/recordings/src/meetings/mac-meeting.ts
+++ b/packages/recordings/src/meetings/mac-meeting.ts
@@ -1,4 +1,4 @@
-import { MicrophoneActivityMonitor } from 'native-audio-node';
+import { MicrophoneActivityMonitor } from '../native-audio.js';
 
 import { createRecordingId } from '@stitch/shared/id';
 

--- a/packages/recordings/src/native-audio.ts
+++ b/packages/recordings/src/native-audio.ts
@@ -1,0 +1,49 @@
+/**
+ * Native audio binding loader.
+ *
+ * Bun's --compile cannot bundle native .node addons loaded via dynamic
+ * createRequire() patterns when using require(). However, dynamic import()
+ * with an absolute path DOES work from compiled binaries. When running as a
+ * compiled binary, we use import() to load native-audio-node from a
+ * node_modules directory shipped next to the binary.
+ */
+
+import { dirname, join } from 'node:path';
+
+import type * as NativeAudioTypes from 'native-audio-node';
+
+type NativeAudioModule = typeof NativeAudioTypes;
+
+function isCompiledBinary(): boolean {
+  // In a Bun compiled binary, process.versions.bun exists but process.execPath
+  // points to the compiled binary itself (not the bun runtime).
+  // In dev (bun run), process.execPath contains 'bun'.
+  // In test (vitest/node), process.versions.bun is undefined.
+  return 'bun' in process.versions && !process.execPath.includes('bun');
+}
+
+async function loadModule(): Promise<NativeAudioModule> {
+  if (isCompiledBinary()) {
+    const modulePath = join(
+      dirname(process.execPath),
+      'node_modules',
+      'native-audio-node',
+      'dist',
+      'index.js',
+    );
+    return import(modulePath);
+  }
+
+  return require('native-audio-node');
+}
+
+const mod = await loadModule();
+
+export const MicrophoneActivityMonitor = mod.MicrophoneActivityMonitor;
+export type MicrophoneActivityMonitor = NativeAudioTypes.MicrophoneActivityMonitor;
+
+export const MicrophoneRecorder = mod.MicrophoneRecorder;
+export type MicrophoneRecorder = NativeAudioTypes.MicrophoneRecorder;
+
+export const SystemAudioRecorder = mod.SystemAudioRecorder;
+export type SystemAudioRecorder = NativeAudioTypes.SystemAudioRecorder;

--- a/packages/recordings/src/writers/platform-recording-writer.ts
+++ b/packages/recordings/src/writers/platform-recording-writer.ts
@@ -1,4 +1,4 @@
-import { MicrophoneRecorder, SystemAudioRecorder } from 'native-audio-node';
+import { MicrophoneRecorder, SystemAudioRecorder } from '../native-audio.js';
 import { createWriteStream, existsSync, mkdirSync, statSync } from 'node:fs';
 import { open, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "vitest run",
     "dev": "NODE_ENV=development bun --watch src/index.ts",
-    "build": "bun build src/index.ts --compile --outfile dist/stitch-server",
+    "build": "bun build src/index.ts --compile --outfile dist/stitch-server && bun run scripts/copy-native-modules.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/server/scripts/copy-native-modules.ts
+++ b/packages/server/scripts/copy-native-modules.ts
@@ -1,0 +1,114 @@
+/**
+ * Copies native-audio-node and its platform-specific native addon into
+ * dist/node_modules so the compiled sidecar binary can resolve them at runtime.
+ *
+ * Bun's --compile cannot embed native .node addons that are loaded via dynamic
+ * require() patterns (like createRequire + platform detection). By externalizing
+ * native-audio-node in the build and shipping its files alongside the binary,
+ * the compiled executable resolves the module from disk via NODE_PATH.
+ */
+
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '../../..');
+const DIST_NODE_MODULES = resolve(import.meta.dirname, '../dist/node_modules');
+
+const platform = process.platform;
+const arch = process.arch;
+
+const platformPackageMap: Record<string, Record<string, string>> = {
+  darwin: {
+    arm64: '@native-audio-node/darwin-arm64',
+    x64: '@native-audio-node/darwin-x64',
+  },
+  win32: {
+    x64: '@native-audio-node/win32-x64',
+    arm64: '@native-audio-node/win32-arm64',
+  },
+};
+
+const platformPackage = platformPackageMap[platform]?.[arch];
+if (!platformPackage) {
+  console.warn(`[copy-native-modules] No native-audio-node package for ${platform}-${arch}, skipping`);
+  process.exit(0);
+}
+
+function findPackage(packageName: string): string | null {
+  // Check recordings workspace node_modules (where it's actually installed)
+  const recordingsNm = join(ROOT, 'packages/recordings/node_modules', packageName);
+  if (existsSync(join(recordingsNm, 'package.json'))) {
+    return recordingsNm;
+  }
+
+  // Check root node_modules
+  const rootNm = join(ROOT, 'node_modules', packageName);
+  if (existsSync(join(rootNm, 'package.json'))) {
+    return rootNm;
+  }
+
+  // Check bun's internal module cache
+  const bunModules = join(ROOT, 'node_modules/.bun');
+  if (existsSync(bunModules)) {
+    const slug = packageName.replace('@', '').replace('/', '+');
+    const entries = readdirSync(bunModules);
+    for (const entry of entries) {
+      if (entry.startsWith(slug + '@') || entry.startsWith(packageName.replace('/', '+') + '@')) {
+        const candidate = join(bunModules, entry, 'node_modules', packageName);
+        if (existsSync(join(candidate, 'package.json'))) {
+          return candidate;
+        }
+      }
+    }
+
+    // Also check the symlinked location
+    const bunLinked = join(bunModules, 'node_modules', packageName);
+    if (existsSync(join(bunLinked, 'package.json'))) {
+      return bunLinked;
+    }
+  }
+
+  return null;
+}
+
+const nativeAudioDir = findPackage('native-audio-node');
+if (!nativeAudioDir) {
+  console.error('[copy-native-modules] Could not find native-audio-node package');
+  process.exit(1);
+}
+
+const platformDir = findPackage(platformPackage);
+if (!platformDir) {
+  console.error(`[copy-native-modules] Could not find ${platformPackage} package`);
+  process.exit(1);
+}
+
+// Clean previous copy
+if (existsSync(DIST_NODE_MODULES)) {
+  rmSync(DIST_NODE_MODULES, { recursive: true });
+}
+
+// Copy native-audio-node JS package (dereference symlinks)
+const destNativeAudio = join(DIST_NODE_MODULES, 'native-audio-node');
+mkdirSync(destNativeAudio, { recursive: true });
+cpSync(nativeAudioDir, destNativeAudio, { recursive: true, dereference: true });
+
+// Copy platform-specific native addon package (dereference symlinks)
+const destPlatform = join(DIST_NODE_MODULES, platformPackage);
+mkdirSync(dirname(destPlatform), { recursive: true });
+cpSync(platformDir, destPlatform, { recursive: true, dereference: true });
+
+console.log(`[copy-native-modules] Copied native-audio-node -> ${destNativeAudio}`);
+console.log(`[copy-native-modules] Copied ${platformPackage} -> ${destPlatform}`);
+
+// Patch native-audio-node/dist/index.js: Bun's createRequire does not resolve
+// the "main" field from package.json for .node files. We append the explicit
+// filename so the require call resolves directly to the native addon.
+const indexJsPath = join(destNativeAudio, 'dist', 'index.js');
+let indexJs = readFileSync(indexJsPath, 'utf8');
+indexJs = indexJs.replace(
+  'cachedBinding = require2(packageName)',
+  'cachedBinding = require2(packageName + "/native_audio.node")',
+);
+writeFileSync(indexJsPath, indexJs);
+console.log(`[copy-native-modules] Patched ${indexJsPath} for Bun .node resolution`);


### PR DESCRIPTION
## Summary

- Fix packaged desktop app crashing on launch with "Server exited before becoming healthy (code=1)" due to the compiled stitch-server binary failing to load native-audio-node's N-API addon
- Ship native-audio-node and its platform-specific .node binary alongside the server in the Electron app bundle
- Add a runtime loader abstraction that uses `import()` for compiled binaries and `require()` for development, working around three Bun `--compile` limitations with native addon resolution

## Details

**Root cause:** `native-audio-node` uses `createRequire(import.meta.url)` to dynamically load `@native-audio-node/darwin-arm64`. Inside a Bun compiled binary, `import.meta.url` resolves to the virtual `/$bunfs/` filesystem, breaking module resolution and crashing the server on startup.

**Bun limitations worked around:**

1. `require()` from bundled code resolves from `/$bunfs/`, not the real filesystem — solved by using `import()` with an absolute path from `process.execPath`
2. Bun's `createRequire` doesn't resolve `package.json` `main` fields pointing to `.node` files — solved by patching the shipped copy to use an explicit `/native_audio.node` suffix
3. Native `.node` addons must exist on the real filesystem next to the binary — solved by copying them to `dist/node_modules/` post-build and shipping via `extraResources`

## Changes

- `packages/recordings/src/native-audio.ts` — new loader that detects compiled binary vs dev/test and loads native-audio-node accordingly
- `packages/server/scripts/copy-native-modules.ts` — post-build script that copies native modules to dist and patches .node resolution
- `apps/desktop/electron-builder.config.ts` — ship `node_modules/` in extraResources
- `packages/server/package.json` — chain copy-native-modules into build script
- Updated imports in `mac-meeting.ts` and `platform-recording-writer.ts` to use the new loader
- Updated test mocks to target the new module path
- `oxlint.json` — file-level override for dynamic require in native-audio.ts