### PR TITLE
feat: add initial persistent scheduler system

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -116,6 +116,15 @@
         "vitest": "catalog:testing",
       },
     },
+    "packages/scheduler": {
+      "name": "@stitch/scheduler",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+        "vitest": "catalog:testing",
+      },
+    },
     "packages/server": {
       "name": "@stitch/server",
       "version": "0.0.0",
@@ -133,6 +142,7 @@
         "@stitch-connectors/google": "workspace:*",
         "@stitch-connectors/sdk": "workspace:*",
         "@stitch/recordings": "workspace:*",
+        "@stitch/scheduler": "workspace:*",
         "@stitch/shared": "workspace:*",
         "ai": "catalog:ai",
         "drizzle-orm": "^0.45.1",
@@ -817,6 +827,8 @@
     "@stitch/desktop": ["@stitch/desktop@workspace:apps/desktop"],
 
     "@stitch/recordings": ["@stitch/recordings@workspace:packages/recordings"],
+
+    "@stitch/scheduler": ["@stitch/scheduler@workspace:packages/scheduler"],
 
     "@stitch/server": ["@stitch/server@workspace:packages/server"],
 

--- a/packages/scheduler/__test__/scheduler.test.ts
+++ b/packages/scheduler/__test__/scheduler.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { createScheduler } from '../src/scheduler.js';
+import type { JobSchedule, PersistedJob, PersistedJobRun, SchedulerLogger, SchedulerStore } from '../src/types.js';
+
+function makeLogger(): SchedulerLogger {
+  const noop = () => {};
+  return { debug: noop, info: noop, warn: noop, error: noop };
+}
+
+class MemoryStore implements SchedulerStore {
+  private jobs = new Map<string, PersistedJob>();
+  private runs = new Map<string, PersistedJobRun>();
+  private nextJobId = 1;
+  private nextRunId = 1;
+
+  async upsertJob(input: {
+    key: string;
+    schedule: JobSchedule;
+    enabled: boolean;
+    maxConcurrency: number;
+    queueEnabled: boolean;
+    catchup: 'none' | 'one' | 'all';
+    catchupMaxRuns: number;
+    initialNextRunAt: number;
+    now: number;
+  }): Promise<PersistedJob> {
+    const existing = this.jobs.get(input.key);
+
+    if (existing) {
+      const next: PersistedJob = {
+        ...existing,
+        schedule: input.schedule,
+        enabled: input.enabled,
+        maxConcurrency: input.maxConcurrency,
+        queueEnabled: input.queueEnabled,
+        catchup: input.catchup,
+        catchupMaxRuns: input.catchupMaxRuns,
+        updatedAt: input.now,
+      };
+      this.jobs.set(input.key, next);
+      return next;
+    }
+
+    const row: PersistedJob = {
+      id: `job_${this.nextJobId++}`,
+      key: input.key,
+      schedule: input.schedule,
+      enabled: input.enabled,
+      maxConcurrency: input.maxConcurrency,
+      queueEnabled: input.queueEnabled,
+      catchup: input.catchup,
+      catchupMaxRuns: input.catchupMaxRuns,
+      nextRunAt: input.initialNextRunAt,
+      runningCount: 0,
+      queuedCount: 0,
+      totalRuns: 0,
+      totalFailures: 0,
+      lastRunAt: null,
+      lastSuccessAt: null,
+      lastErrorAt: null,
+      lastErrorMessage: null,
+      updatedAt: input.now,
+    };
+
+    this.jobs.set(input.key, row);
+    return row;
+  }
+
+  async getJob(key: string): Promise<PersistedJob | null> {
+    return this.jobs.get(key) ?? null;
+  }
+
+  async listJobs(keys: string[]): Promise<PersistedJob[]> {
+    return keys
+      .map((key) => this.jobs.get(key))
+      .filter((value): value is PersistedJob => Boolean(value));
+  }
+
+  async enqueueDueRuns(input: {
+    key: string;
+    incrementBy: number;
+    nextRunAt: number;
+    now: number;
+  }): Promise<PersistedJob | null> {
+    const row = this.jobs.get(input.key);
+    if (!row) return null;
+    const next = {
+      ...row,
+      nextRunAt: input.nextRunAt,
+      queuedCount: row.queuedCount + input.incrementBy,
+      updatedAt: input.now,
+    };
+    this.jobs.set(input.key, next);
+    return next;
+  }
+
+  async startQueuedRun(input: { key: string; now: number }): Promise<PersistedJobRun | null> {
+    const row = this.jobs.get(input.key);
+    if (!row) return null;
+    if (!row.enabled) return null;
+    if (row.queuedCount <= 0) return null;
+    if (row.runningCount >= row.maxConcurrency) return null;
+
+    const run: PersistedJobRun = {
+      id: `run_${this.nextRunId++}`,
+      jobId: row.id,
+      key: row.key,
+      scheduledFor: input.now,
+      startedAt: input.now,
+    };
+
+    this.runs.set(run.id, run);
+    this.jobs.set(input.key, {
+      ...row,
+      queuedCount: row.queuedCount - 1,
+      runningCount: row.runningCount + 1,
+      lastRunAt: input.now,
+      totalRuns: row.totalRuns + 1,
+      updatedAt: input.now,
+    });
+
+    return run;
+  }
+
+  async completeRun(input: {
+    runId: string;
+    key: string;
+    finishedAt: number;
+    succeeded: boolean;
+    errorMessage?: string;
+  }): Promise<void> {
+    this.runs.delete(input.runId);
+    const row = this.jobs.get(input.key);
+    if (!row) return;
+
+    this.jobs.set(input.key, {
+      ...row,
+      runningCount: Math.max(0, row.runningCount - 1),
+      totalFailures: input.succeeded ? row.totalFailures : row.totalFailures + 1,
+      lastSuccessAt: input.succeeded ? input.finishedAt : row.lastSuccessAt,
+      lastErrorAt: input.succeeded ? row.lastErrorAt : input.finishedAt,
+      lastErrorMessage: input.succeeded ? null : (input.errorMessage ?? 'unknown error'),
+      updatedAt: input.finishedAt,
+    });
+  }
+
+  async unregisterJob(key: string): Promise<boolean> {
+    return this.jobs.delete(key);
+  }
+}
+
+describe('scheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('runs queued interval jobs and updates status', async () => {
+    const store = new MemoryStore();
+    const callback = vi.fn();
+    const scheduler = createScheduler({ store, logger: makeLogger(), pollIntervalMs: 25 });
+
+    await scheduler.registerJob({
+      key: 'interval-job',
+      schedule: { type: 'interval', everyMs: 100 },
+      callback,
+      immediate: true,
+      maxConcurrency: 1,
+      queueEnabled: true,
+    });
+
+    await scheduler.start();
+    await vi.advanceTimersByTimeAsync(240);
+    await scheduler.stop();
+
+    expect(callback).toHaveBeenCalledTimes(3);
+
+    const status = await scheduler.getJobStatus('interval-job');
+    expect(status).not.toBeNull();
+    expect(status?.runningCount).toBe(0);
+    expect(status?.queuedCount).toBe(0);
+    expect(status?.totalRuns).toBe(3);
+  });
+
+  test('respects maxConcurrency and drains queued runs', async () => {
+    const store = new MemoryStore();
+    const callback = vi.fn(async () => {
+      await vi.advanceTimersByTimeAsync(120);
+    });
+
+    const scheduler = createScheduler({ store, logger: makeLogger(), pollIntervalMs: 20 });
+
+    await scheduler.registerJob({
+      key: 'concurrency-job',
+      schedule: { type: 'interval', everyMs: 30 },
+      callback,
+      immediate: true,
+      maxConcurrency: 1,
+      queueEnabled: true,
+      catchup: 'all',
+      catchupMaxRuns: 20,
+    });
+
+    await scheduler.start();
+    await vi.advanceTimersByTimeAsync(260);
+    await scheduler.stop();
+
+    const status = await scheduler.getJobStatus('concurrency-job');
+    expect(status).not.toBeNull();
+    expect(status!.totalRuns).toBeGreaterThanOrEqual(2);
+    expect(status!.queuedCount).toBeGreaterThanOrEqual(1);
+    expect(status!.runningCount).toBe(0);
+  });
+
+  test('catchup none skips replay backlog', async () => {
+    const store = new MemoryStore();
+    const callback = vi.fn();
+    const scheduler = createScheduler({ store, logger: makeLogger(), pollIntervalMs: 1_000 });
+
+    await scheduler.registerJob({
+      key: 'catchup-none',
+      schedule: { type: 'interval', everyMs: 1_000 },
+      callback,
+      maxConcurrency: 1,
+      queueEnabled: true,
+      catchup: 'none',
+    });
+
+    await scheduler.start();
+    await vi.advanceTimersByTimeAsync(1_100);
+
+    await scheduler.stop();
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await scheduler.start();
+    await vi.advanceTimersByTimeAsync(1_100);
+    await scheduler.stop();
+
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  test('catchup all replays backlog up to limit', async () => {
+    const store = new MemoryStore();
+    const callback = vi.fn();
+    const scheduler = createScheduler({ store, logger: makeLogger(), pollIntervalMs: 500 });
+
+    await scheduler.registerJob({
+      key: 'catchup-all',
+      schedule: { type: 'interval', everyMs: 500 },
+      callback,
+      maxConcurrency: 5,
+      queueEnabled: true,
+      catchup: 'all',
+      catchupMaxRuns: 4,
+    });
+
+    await scheduler.start();
+    await vi.advanceTimersByTimeAsync(600);
+    await scheduler.stop();
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await scheduler.start();
+    await vi.advanceTimersByTimeAsync(600);
+    await scheduler.stop();
+
+    expect(callback).toHaveBeenCalledTimes(6);
+  });
+
+  test('supports cron schedule', async () => {
+    const store = new MemoryStore();
+    const callback = vi.fn();
+    const scheduler = createScheduler({ store, logger: makeLogger(), pollIntervalMs: 5_000 });
+
+    await scheduler.registerJob({
+      key: 'cron-job',
+      schedule: { type: 'cron', expression: '*/1 * * * *', timezone: 'UTC' },
+      callback,
+      maxConcurrency: 1,
+      queueEnabled: true,
+      catchup: 'one',
+    });
+
+    await scheduler.start();
+    await vi.advanceTimersByTimeAsync(130_000);
+    await scheduler.stop();
+
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  test('unregister removes job from status', async () => {
+    const store = new MemoryStore();
+    const scheduler = createScheduler({ store, logger: makeLogger(), pollIntervalMs: 100 });
+
+    await scheduler.registerJob({
+      key: 'remove-me',
+      schedule: { type: 'interval', everyMs: 100 },
+      callback: () => {},
+    });
+
+    const removed = await scheduler.unregisterJob('remove-me');
+    const status = await scheduler.getJobStatus('remove-me');
+
+    expect(removed).toBe(true);
+    expect(status).toBeNull();
+  });
+});

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@stitch/scheduler",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/bun": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:testing"
+  }
+}

--- a/packages/scheduler/src/cron.ts
+++ b/packages/scheduler/src/cron.ts
@@ -1,0 +1,103 @@
+import type { CronSchedule } from './types.js';
+
+type CronParts = {
+  minute: Set<number>;
+  hour: Set<number>;
+  dayOfMonth: Set<number>;
+  month: Set<number>;
+  dayOfWeek: Set<number>;
+};
+
+const MAX_SCAN_MINUTES = 60 * 24 * 366;
+
+function parseField(raw: string, min: number, max: number): Set<number> {
+  const values = new Set<number>();
+
+  for (const part of raw.split(',')) {
+    if (part === '*') {
+      for (let i = min; i <= max; i++) values.add(i);
+      continue;
+    }
+
+    if (part.startsWith('*/')) {
+      const step = Number(part.slice(2));
+      if (!Number.isInteger(step) || step <= 0) {
+        throw new Error(`Invalid cron step: ${part}`);
+      }
+      for (let i = min; i <= max; i += step) values.add(i);
+      continue;
+    }
+
+    if (part.includes('-')) {
+      const [startRaw, endRaw] = part.split('-');
+      const start = Number(startRaw);
+      const end = Number(endRaw);
+      if (!Number.isInteger(start) || !Number.isInteger(end) || start > end) {
+        throw new Error(`Invalid cron range: ${part}`);
+      }
+      if (start < min || end > max) throw new Error(`Cron range out of bounds: ${part}`);
+      for (let i = start; i <= end; i++) values.add(i);
+      continue;
+    }
+
+    const value = Number(part);
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new Error(`Invalid cron value: ${part}`);
+    }
+    values.add(value);
+  }
+
+  return values;
+}
+
+function parseCron(expression: string): CronParts {
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    throw new Error(`Invalid cron expression "${expression}": expected 5 fields`);
+  }
+
+  return {
+    minute: parseField(fields[0], 0, 59),
+    hour: parseField(fields[1], 0, 23),
+    dayOfMonth: parseField(fields[2], 1, 31),
+    month: parseField(fields[3], 1, 12),
+    dayOfWeek: parseField(fields[4], 0, 6),
+  };
+}
+
+function matchesCron(parts: CronParts, at: Date, timezone: CronSchedule['timezone']): boolean {
+  const minute = timezone === 'local' ? at.getMinutes() : at.getUTCMinutes();
+  const hour = timezone === 'local' ? at.getHours() : at.getUTCHours();
+  const day = timezone === 'local' ? at.getDate() : at.getUTCDate();
+  const month = (timezone === 'local' ? at.getMonth() : at.getUTCMonth()) + 1;
+  const dayOfWeek = timezone === 'local' ? at.getDay() : at.getUTCDay();
+
+  return (
+    parts.minute.has(minute) &&
+    parts.hour.has(hour) &&
+    parts.dayOfMonth.has(day) &&
+    parts.month.has(month) &&
+    parts.dayOfWeek.has(dayOfWeek)
+  );
+}
+
+export function getNextCronRunMs(expression: string, afterMs: number, timezone: 'UTC' | 'local'): number {
+  const parts = parseCron(expression);
+  const cursor = new Date(afterMs);
+
+  if (timezone === 'local') {
+    cursor.setSeconds(0, 0);
+    cursor.setMinutes(cursor.getMinutes() + 1);
+  } else {
+    cursor.setUTCSeconds(0, 0);
+    cursor.setUTCMinutes(cursor.getUTCMinutes() + 1);
+  }
+
+  for (let i = 0; i < MAX_SCAN_MINUTES; i++) {
+    if (matchesCron(parts, cursor, timezone)) return cursor.getTime();
+    if (timezone === 'local') cursor.setMinutes(cursor.getMinutes() + 1);
+    else cursor.setUTCMinutes(cursor.getUTCMinutes() + 1);
+  }
+
+  throw new Error(`Unable to find next cron run within ${MAX_SCAN_MINUTES} minutes for "${expression}"`);
+}

--- a/packages/scheduler/src/index.ts
+++ b/packages/scheduler/src/index.ts
@@ -1,0 +1,13 @@
+export { createScheduler } from './scheduler.js';
+export type {
+  CatchupPolicy,
+  CronSchedule,
+  IntervalSchedule,
+  JobSchedule,
+  JobStatus,
+  PersistedJob,
+  PersistedJobRun,
+  RegisteredJob,
+  SchedulerLogger,
+  SchedulerStore,
+} from './types.js';

--- a/packages/scheduler/src/scheduler.ts
+++ b/packages/scheduler/src/scheduler.ts
@@ -1,0 +1,283 @@
+import { getNextCronRunMs } from './cron.js';
+
+import type {
+  CatchupPolicy,
+  JobSchedule,
+  JobStatus,
+  RegisteredJob,
+  SchedulerLogger,
+  SchedulerStore,
+} from './types.js';
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+const DEFAULT_MAX_CONCURRENCY = 1;
+const DEFAULT_CATCHUP_MAX_RUNS = 100;
+
+type SchedulerOptions = {
+  logger: SchedulerLogger;
+  store: SchedulerStore;
+  pollIntervalMs?: number;
+};
+
+type RegisteredJobInternal = Omit<Required<RegisteredJob>, 'callback' | 'schedule'> & {
+  callback: RegisteredJob['callback'];
+  schedule: JobSchedule;
+};
+
+function calculateNextRunMs(schedule: JobSchedule, afterMs: number): number {
+  if (schedule.type === 'interval') return afterMs + schedule.everyMs;
+  return getNextCronRunMs(schedule.expression, afterMs, schedule.timezone ?? 'UTC');
+}
+
+function calculateDueCount(schedule: JobSchedule, nextRunAt: number, now: number, hardLimit: number): number {
+  if (now < nextRunAt) return 0;
+
+  if (schedule.type === 'interval') {
+    return Math.max(1, Math.floor((now - nextRunAt) / schedule.everyMs) + 1);
+  }
+
+  let due = 0;
+  let cursor = nextRunAt;
+
+  while (cursor <= now && due < hardLimit) {
+    due++;
+    cursor = calculateNextRunMs(schedule, cursor);
+  }
+
+  return due;
+}
+
+function runsToQueue(dueCount: number, catchup: CatchupPolicy, maxRuns: number): number {
+  if (dueCount <= 0) return 0;
+  if (catchup === 'all') return Math.min(dueCount, Math.max(1, maxRuns));
+  if (catchup === 'one') return 1;
+  return dueCount > 1 ? 0 : 1;
+}
+
+export function createScheduler(options: SchedulerOptions) {
+  const logger = options.logger;
+  const store = options.store;
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  const jobs = new Map<string, RegisteredJobInternal>();
+  const jobLocks = new Set<string>();
+  const inFlightRuns = new Set<Promise<void>>();
+
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let stopped = false;
+
+  async function runCallback(jobKey: string): Promise<void> {
+    const job = jobs.get(jobKey);
+    if (!job) return;
+
+    const startedRun = await store.startQueuedRun({ key: jobKey, now: Date.now() });
+    if (!startedRun) return;
+
+    try {
+      await job.callback();
+      await store.completeRun({
+        runId: startedRun.id,
+        key: jobKey,
+        finishedAt: Date.now(),
+        succeeded: true,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      await store.completeRun({
+        runId: startedRun.id,
+        key: jobKey,
+        finishedAt: Date.now(),
+        succeeded: false,
+        errorMessage,
+      });
+
+      logger.error(
+        {
+          event: 'scheduler.job.failed',
+          key: jobKey,
+          runId: startedRun.id,
+          error: errorMessage,
+        },
+        'scheduled job failed',
+      );
+    }
+  }
+
+  async function refillWorkers(jobKey: string, safetyLimit = 1_000): Promise<void> {
+    const job = jobs.get(jobKey);
+    if (!job) return;
+
+    const status = await store.getJob(jobKey);
+    if (!status || !status.enabled || status.maxConcurrency <= status.runningCount) return;
+
+    const availableSlots = Math.max(0, status.maxConcurrency - status.runningCount);
+    const toStart = Math.min(availableSlots, status.queuedCount, safetyLimit);
+
+    for (let i = 0; i < toStart; i++) {
+      const runPromise = runCallback(jobKey).finally(() => {
+        inFlightRuns.delete(runPromise);
+      });
+      inFlightRuns.add(runPromise);
+    }
+  }
+
+  async function evaluateDue(jobKey: string): Promise<void> {
+    if (jobLocks.has(jobKey)) return;
+    const job = jobs.get(jobKey);
+    if (!job) return;
+
+    jobLocks.add(jobKey);
+
+    try {
+      const state = await store.getJob(jobKey);
+      if (!state || !state.enabled) return;
+
+      const now = Date.now();
+      const dueCount = calculateDueCount(job.schedule, state.nextRunAt, now, Math.max(1, job.catchupMaxRuns));
+
+      if (dueCount > 0) {
+        let nextRunAt = state.nextRunAt;
+        const stepped = Math.max(dueCount, 1);
+        for (let i = 0; i < stepped; i++) {
+          nextRunAt = calculateNextRunMs(job.schedule, nextRunAt);
+        }
+
+        const incrementBy = job.queueEnabled ? runsToQueue(dueCount, job.catchup, job.catchupMaxRuns) : 0;
+
+        await store.enqueueDueRuns({
+          key: jobKey,
+          incrementBy,
+          nextRunAt,
+          now,
+        });
+      }
+
+      if (job.queueEnabled) await refillWorkers(jobKey);
+    } finally {
+      jobLocks.delete(jobKey);
+    }
+  }
+
+  async function tick(): Promise<void> {
+    await Promise.all(Array.from(jobs.keys()).map((jobKey) => evaluateDue(jobKey)));
+  }
+
+  async function registerJob(job: RegisteredJob): Promise<void> {
+    if (!job.key.trim()) throw new Error('job key must be non-empty');
+    if (job.schedule.type === 'interval' && job.schedule.everyMs <= 0) {
+      throw new Error('interval schedule everyMs must be greater than zero');
+    }
+
+    const normalized: RegisteredJobInternal = {
+      ...job,
+      enabled: job.enabled ?? true,
+      immediate: job.immediate ?? false,
+      maxConcurrency: Math.max(1, job.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY),
+      queueEnabled: job.queueEnabled ?? true,
+      catchup: job.catchup ?? 'one',
+      catchupMaxRuns: Math.max(1, job.catchupMaxRuns ?? DEFAULT_CATCHUP_MAX_RUNS),
+    };
+
+    jobs.set(job.key, normalized);
+
+    const now = Date.now();
+
+    await store.upsertJob({
+      key: normalized.key,
+      schedule: normalized.schedule,
+      enabled: normalized.enabled,
+      maxConcurrency: normalized.maxConcurrency,
+      queueEnabled: normalized.queueEnabled,
+      catchup: normalized.catchup,
+      catchupMaxRuns: normalized.catchupMaxRuns,
+      initialNextRunAt: normalized.immediate ? now : calculateNextRunMs(normalized.schedule, now),
+      now,
+    });
+
+    logger.info({ event: 'scheduler.job.registered', key: normalized.key }, 'scheduled job registered');
+
+    if (timer) await evaluateDue(normalized.key);
+  }
+
+  async function unregisterJob(key: string): Promise<boolean> {
+    jobs.delete(key);
+    const removed = await store.unregisterJob(key);
+
+    logger.info({ event: 'scheduler.job.unregistered', key, removed }, 'scheduled job unregistered');
+
+    return removed;
+  }
+
+  async function listJobStatus(): Promise<JobStatus[]> {
+    const keys = Array.from(jobs.keys());
+    const rows = await store.listJobs(keys);
+    return rows.map((row) => ({
+      key: row.key,
+      enabled: row.enabled,
+      runningCount: row.runningCount,
+      queuedCount: row.queuedCount,
+      maxConcurrency: row.maxConcurrency,
+      nextRunAt: row.nextRunAt,
+      lastRunAt: row.lastRunAt,
+      lastSuccessAt: row.lastSuccessAt,
+      lastErrorAt: row.lastErrorAt,
+      lastErrorMessage: row.lastErrorMessage,
+      totalRuns: row.totalRuns,
+      totalFailures: row.totalFailures,
+    }));
+  }
+
+  async function getJobStatus(key: string): Promise<JobStatus | null> {
+    const row = await store.getJob(key);
+    if (!row) return null;
+    return {
+      key: row.key,
+      enabled: row.enabled,
+      runningCount: row.runningCount,
+      queuedCount: row.queuedCount,
+      maxConcurrency: row.maxConcurrency,
+      nextRunAt: row.nextRunAt,
+      lastRunAt: row.lastRunAt,
+      lastSuccessAt: row.lastSuccessAt,
+      lastErrorAt: row.lastErrorAt,
+      lastErrorMessage: row.lastErrorMessage,
+      totalRuns: row.totalRuns,
+      totalFailures: row.totalFailures,
+    };
+  }
+
+  async function start(): Promise<void> {
+    if (timer) return;
+    stopped = false;
+
+    timer = setInterval(() => {
+      if (!stopped) void tick();
+    }, pollIntervalMs);
+
+    await tick();
+
+    logger.info({ event: 'scheduler.started', pollIntervalMs }, 'scheduler started');
+  }
+
+  async function stop(): Promise<void> {
+    stopped = true;
+
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+
+    await Promise.allSettled(Array.from(inFlightRuns));
+
+    logger.info({ event: 'scheduler.stopped' }, 'scheduler stopped');
+  }
+
+  return {
+    start,
+    stop,
+    registerJob,
+    unregisterJob,
+    listJobStatus,
+    getJobStatus,
+  };
+}

--- a/packages/scheduler/src/types.ts
+++ b/packages/scheduler/src/types.ts
@@ -1,0 +1,108 @@
+export type SchedulerLogger = {
+  debug(extra: Record<string, unknown>, message: string): void;
+  info(extra: Record<string, unknown>, message: string): void;
+  warn(extra: Record<string, unknown>, message: string): void;
+  error(extra: Record<string, unknown>, message: string): void;
+};
+
+export type IntervalSchedule = {
+  type: 'interval';
+  everyMs: number;
+};
+
+export type CronSchedule = {
+  type: 'cron';
+  expression: string;
+  timezone?: 'UTC' | 'local';
+};
+
+export type JobSchedule = IntervalSchedule | CronSchedule;
+
+export type CatchupPolicy = 'none' | 'one' | 'all';
+
+export type RegisteredJob = {
+  key: string;
+  schedule: JobSchedule;
+  callback: () => void | Promise<void>;
+  enabled?: boolean;
+  immediate?: boolean;
+  maxConcurrency?: number;
+  queueEnabled?: boolean;
+  catchup?: CatchupPolicy;
+  catchupMaxRuns?: number;
+};
+
+export type PersistedJob = {
+  id: string;
+  key: string;
+  schedule: JobSchedule;
+  enabled: boolean;
+  maxConcurrency: number;
+  queueEnabled: boolean;
+  catchup: CatchupPolicy;
+  catchupMaxRuns: number;
+  nextRunAt: number;
+  runningCount: number;
+  queuedCount: number;
+  totalRuns: number;
+  totalFailures: number;
+  lastRunAt: number | null;
+  lastSuccessAt: number | null;
+  lastErrorAt: number | null;
+  lastErrorMessage: string | null;
+  updatedAt: number;
+};
+
+export type PersistedJobRun = {
+  id: string;
+  jobId: string;
+  key: string;
+  scheduledFor: number;
+  startedAt: number;
+};
+
+export type JobStatus = {
+  key: string;
+  enabled: boolean;
+  runningCount: number;
+  queuedCount: number;
+  maxConcurrency: number;
+  nextRunAt: number;
+  lastRunAt: number | null;
+  lastSuccessAt: number | null;
+  lastErrorAt: number | null;
+  lastErrorMessage: string | null;
+  totalRuns: number;
+  totalFailures: number;
+};
+
+export type SchedulerStore = {
+  upsertJob(input: {
+    key: string;
+    schedule: JobSchedule;
+    enabled: boolean;
+    maxConcurrency: number;
+    queueEnabled: boolean;
+    catchup: CatchupPolicy;
+    catchupMaxRuns: number;
+    initialNextRunAt: number;
+    now: number;
+  }): Promise<PersistedJob>;
+  getJob(key: string): Promise<PersistedJob | null>;
+  listJobs(keys: string[]): Promise<PersistedJob[]>;
+  enqueueDueRuns(input: {
+    key: string;
+    incrementBy: number;
+    nextRunAt: number;
+    now: number;
+  }): Promise<PersistedJob | null>;
+  startQueuedRun(input: { key: string; now: number }): Promise<PersistedJobRun | null>;
+  completeRun(input: {
+    runId: string;
+    key: string;
+    finishedAt: number;
+    succeeded: boolean;
+    errorMessage?: string;
+  }): Promise<void>;
+  unregisterJob(key: string): Promise<boolean>;
+};

--- a/packages/scheduler/tsconfig.json
+++ b/packages/scheduler/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["bun"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*", "__test__/**/*"]
+}

--- a/packages/server/drizzle/0006_cold_the_santerians.sql
+++ b/packages/server/drizzle/0006_cold_the_santerians.sql
@@ -1,0 +1,41 @@
+CREATE TABLE `scheduled_job_runs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`job_id` text NOT NULL,
+	`key` text NOT NULL,
+	`status` text DEFAULT 'running' NOT NULL,
+	`scheduled_for` integer NOT NULL,
+	`started_at` integer NOT NULL,
+	`finished_at` integer,
+	`error_message` text,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`job_id`) REFERENCES `scheduled_jobs`(`id`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "scheduled_job_runs_status_check" CHECK("scheduled_job_runs"."status" in ('running', 'succeeded', 'failed'))
+);
+--> statement-breakpoint
+CREATE INDEX `scheduled_job_runs_job_id_idx` ON `scheduled_job_runs` (`job_id`);--> statement-breakpoint
+CREATE INDEX `scheduled_job_runs_key_idx` ON `scheduled_job_runs` (`key`);--> statement-breakpoint
+CREATE TABLE `scheduled_jobs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`key` text NOT NULL,
+	`schedule` blob NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`max_concurrency` integer DEFAULT 1 NOT NULL,
+	`queue_enabled` integer DEFAULT true NOT NULL,
+	`catchup` text DEFAULT 'one' NOT NULL,
+	`catchup_max_runs` integer DEFAULT 100 NOT NULL,
+	`next_run_at` integer NOT NULL,
+	`running_count` integer DEFAULT 0 NOT NULL,
+	`queued_count` integer DEFAULT 0 NOT NULL,
+	`total_runs` integer DEFAULT 0 NOT NULL,
+	`total_failures` integer DEFAULT 0 NOT NULL,
+	`last_run_at` integer,
+	`last_success_at` integer,
+	`last_error_at` integer,
+	`last_error_message` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	CONSTRAINT "scheduled_jobs_catchup_check" CHECK("scheduled_jobs"."catchup" in ('none', 'one', 'all'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `scheduled_jobs_key_uidx` ON `scheduled_jobs` (`key`);--> statement-breakpoint
+CREATE INDEX `scheduled_jobs_next_run_at_idx` ON `scheduled_jobs` (`next_run_at`);

--- a/packages/server/drizzle/meta/0006_snapshot.json
+++ b/packages/server/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1690 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b03354d8-2e40-4bbd-9eea-489353382b39",
+  "prevId": "cbced8db-9485-46e5-8aa2-84d7d93a2cf6",
+  "tables": {
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "is_attributable": {
+          "name": "is_attributable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_id": {
+          "name": "transcription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_index": {
+          "name": "attempt_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_run_id_idx": {
+          "name": "llm_usage_events_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meetings": {
+      "name": "meetings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_path": {
+          "name": "app_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'detected'"
+        },
+        "recording_file_path": {
+          "name": "recording_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_secs": {
+          "name": "duration_secs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meetings_status_check": {
+          "name": "meetings_status_check",
+          "value": "\"meetings\".\"status\" in ('detected', 'recording', 'completed')"
+        }
+      }
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permission_responses": {
+      "name": "permission_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_reminder": {
+          "name": "system_reminder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_responses_session_id_sessions_id_fk": {
+          "name": "permission_responses_session_id_sessions_id_fk",
+          "tableFrom": "permission_responses",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_messages": {
+      "name": "queued_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "queued_messages_session_id_sessions_id_fk": {
+          "name": "queued_messages_session_id_sessions_id_fk",
+          "tableFrom": "queued_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_transcriptions": {
+      "name": "recording_transcriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recording_transcriptions_meeting_id_meetings_id_fk": {
+          "name": "recording_transcriptions_meeting_id_meetings_id_fk",
+          "tableFrom": "recording_transcriptions",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "transcription_status_check": {
+          "name": "transcription_status_check",
+          "value": "\"recording_transcriptions\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": [
+            "job_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "queue_enabled": {
+          "name": "queue_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": [
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": [
+            "tool_name",
+            "pattern"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1775256383180,
       "tag": "0005_calm_shape",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1775258328166,
+      "tag": "0006_cold_the_santerians",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,6 +24,7 @@
     "@stitch-connectors/google": "workspace:*",
     "@stitch-connectors/sdk": "workspace:*",
     "@stitch/recordings": "workspace:*",
+    "@stitch/scheduler": "workspace:*",
     "@stitch/shared": "workspace:*",
     "ai": "catalog:ai",
     "drizzle-orm": "^0.45.1",

--- a/packages/server/src/connectors/auth/token-refresh.ts
+++ b/packages/server/src/connectors/auth/token-refresh.ts
@@ -11,30 +11,9 @@ import * as Log from '@/lib/log.js';
 
 const log = Log.create({ service: 'token-refresh' });
 
-const REFRESH_INTERVAL_MS = 60_000; // Check every minute
 const REFRESH_BUFFER_MS = 5 * 60_000; // Refresh 5 minutes before expiry
 
-let intervalId: ReturnType<typeof setInterval> | null = null;
-
-export function startTokenRefreshService(): void {
-  if (intervalId) return;
-
-  intervalId = setInterval(() => {
-    void refreshExpiringTokens();
-  }, REFRESH_INTERVAL_MS);
-
-  log.info({ event: 'token-refresh.started' }, 'Token refresh service started');
-}
-
-export function stopTokenRefreshService(): void {
-  if (intervalId) {
-    clearInterval(intervalId);
-    intervalId = null;
-    log.info({ event: 'token-refresh.stopped' }, 'Token refresh service stopped');
-  }
-}
-
-async function refreshExpiringTokens(): Promise<void> {
+export async function refreshExpiringTokens(): Promise<void> {
   const db = getDb();
   const now = Date.now();
   const threshold = now + REFRESH_BUFFER_MS;

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -16,6 +16,7 @@ import type { ConnectorStatus } from '@stitch/shared/connectors/types';
 import type { PrefixedString } from '@stitch/shared/id';
 import type { McpAuthConfig, McpTool, McpTransport } from '@stitch/shared/mcp/types';
 import type { MeetingStatus, TranscriptionStatus } from '@stitch/shared/meetings/types';
+import type { JobSchedule, CatchupPolicy } from '@stitch/scheduler';
 import type {
   ToolPermissionValue,
   PermissionResponseStatus,
@@ -248,6 +249,68 @@ export const queuedMessages = sqliteTable('queued_messages', {
     .notNull()
     .$defaultFn(() => Date.now()),
 });
+
+export const scheduledJobs = sqliteTable(
+  'scheduled_jobs',
+  {
+    id: text('id').$type<PrefixedString<'schjob'>>().primaryKey(),
+    key: text('key').notNull(),
+    schedule: blob('schedule', { mode: 'json' }).$type<JobSchedule>().notNull(),
+    enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+    maxConcurrency: integer('max_concurrency').notNull().default(1),
+    queueEnabled: integer('queue_enabled', { mode: 'boolean' }).notNull().default(true),
+    catchup: text('catchup').$type<CatchupPolicy>().notNull().default('one'),
+    catchupMaxRuns: integer('catchup_max_runs').notNull().default(100),
+    nextRunAt: integer('next_run_at', { mode: 'number' }).notNull(),
+    runningCount: integer('running_count').notNull().default(0),
+    queuedCount: integer('queued_count').notNull().default(0),
+    totalRuns: integer('total_runs').notNull().default(0),
+    totalFailures: integer('total_failures').notNull().default(0),
+    lastRunAt: integer('last_run_at', { mode: 'number' }),
+    lastSuccessAt: integer('last_success_at', { mode: 'number' }),
+    lastErrorAt: integer('last_error_at', { mode: 'number' }),
+    lastErrorMessage: text('last_error_message'),
+    createdAt: integer('created_at', { mode: 'number' })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+    updatedAt: integer('updated_at', { mode: 'number' })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (table) => [
+    uniqueIndex('scheduled_jobs_key_uidx').on(table.key),
+    index('scheduled_jobs_next_run_at_idx').on(table.nextRunAt),
+    check('scheduled_jobs_catchup_check', sql`${table.catchup} in ('none', 'one', 'all')`),
+  ],
+);
+
+export const scheduledJobRuns = sqliteTable(
+  'scheduled_job_runs',
+  {
+    id: text('id').$type<PrefixedString<'schrun'>>().primaryKey(),
+    jobId: text('job_id')
+      .$type<PrefixedString<'schjob'>>()
+      .notNull()
+      .references(() => scheduledJobs.id, { onDelete: 'cascade' }),
+    key: text('key').notNull(),
+    status: text('status').$type<'running' | 'succeeded' | 'failed'>().notNull().default('running'),
+    scheduledFor: integer('scheduled_for', { mode: 'number' }).notNull(),
+    startedAt: integer('started_at', { mode: 'number' }).notNull(),
+    finishedAt: integer('finished_at', { mode: 'number' }),
+    errorMessage: text('error_message'),
+    createdAt: integer('created_at', { mode: 'number' })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (table) => [
+    index('scheduled_job_runs_job_id_idx').on(table.jobId),
+    index('scheduled_job_runs_key_idx').on(table.key),
+    check(
+      'scheduled_job_runs_status_check',
+      sql`${table.status} in ('running', 'succeeded', 'failed')`,
+    ),
+  ],
+);
 
 export const meetings = sqliteTable(
   'meetings',

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -1,24 +1,14 @@
-import { startTokenRefreshService } from '@/connectors/auth/token-refresh.js';
 import { registerAllConnectors } from '@/connectors/definitions/index.js';
 import { initConnectorRuntime } from '@/connectors/runtime.js';
 import { initDb } from '@/db/client.js';
 import * as Log from '@/lib/log.js';
-import * as Scheduler from '@/lib/scheduler.js';
 import { refreshMcpToolsets } from '@/mcp/tool-executor.js';
 import { initMeetingService } from '@/meeting/service.js';
 import { recoverStaleTranscriptions } from '@/meeting/transcription-service.js';
-import * as ModelsDev from '@/provider/models.js';
+import { startScheduler } from '@/scheduler/runtime.js';
 import { registerProviderToolsets } from '@/tools/providers/index.js';
-import * as ToolTruncation from '@/tools/runtime/truncation.js';
 
 const log = Log.create({ service: 'init' });
-
-const HOUR_MS = 60 * 60 * 1000;
-
-const LOG_CLEANUP_INTERVAL_MS = 24 * HOUR_MS;
-const MODELS_REFRESH_INTERVAL_MS = 1 * HOUR_MS;
-const TOOL_OUTPUT_CLEANUP_INTERVAL_MS = 1 * HOUR_MS;
-const MCP_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
 
 export async function init() {
   await Log.init({ print: false });
@@ -34,26 +24,10 @@ export async function init() {
 
   // Register connector definitions and start token refresh
   registerAllConnectors();
-  startTokenRefreshService();
 
   await initConnectorRuntime();
 
-  Scheduler.scheduleRecurring('log-cleanup', LOG_CLEANUP_INTERVAL_MS, () => Log.cleanup());
-
-  Scheduler.scheduleRecurring(
-    'models-refresh',
-    MODELS_REFRESH_INTERVAL_MS,
-    () => ModelsDev.refresh(),
-    { immediate: true },
-  );
-
-  Scheduler.scheduleRecurring('tool-output-cleanup', TOOL_OUTPUT_CLEANUP_INTERVAL_MS, () =>
-    ToolTruncation.cleanup(),
-  );
-
-  Scheduler.scheduleRecurring('mcp-refresh', MCP_REFRESH_INTERVAL_MS, () =>
-    refreshMcpToolsets({ refreshTools: true }),
-  );
+  await startScheduler();
 
   log.info('server initialized');
 }

--- a/packages/server/src/scheduler/runtime.ts
+++ b/packages/server/src/scheduler/runtime.ts
@@ -1,0 +1,88 @@
+import { createScheduler } from '@stitch/scheduler';
+
+import { refreshExpiringTokens } from '@/connectors/auth/token-refresh.js';
+import * as Log from '@/lib/log.js';
+import { refreshMcpToolsets } from '@/mcp/tool-executor.js';
+import * as ModelsDev from '@/provider/models.js';
+import { createSchedulerStore } from '@/scheduler/store.js';
+import * as ToolTruncation from '@/tools/runtime/truncation.js';
+
+const log = Log.create({ service: 'scheduler' });
+
+const HOUR_MS = 60 * 60 * 1000;
+const LOG_CLEANUP_INTERVAL_MS = 24 * HOUR_MS;
+const MODELS_REFRESH_INTERVAL_MS = 1 * HOUR_MS;
+const TOOL_OUTPUT_CLEANUP_INTERVAL_MS = 1 * HOUR_MS;
+const MCP_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
+const TOKEN_REFRESH_INTERVAL_MS = 60 * 1000;
+
+let scheduler: ReturnType<typeof createScheduler> | null = null;
+
+export async function startScheduler(): Promise<void> {
+  if (scheduler) return;
+
+  scheduler = createScheduler({
+    logger: {
+      debug: (extra, message) => log.debug(extra, message),
+      info: (extra, message) => log.info(extra, message),
+      warn: (extra, message) => log.warn(extra, message),
+      error: (extra, message) => log.error(extra, message),
+    },
+    store: createSchedulerStore(),
+    pollIntervalMs: 1_000,
+  });
+
+  await scheduler.registerJob({
+    key: 'log-cleanup',
+    schedule: { type: 'interval', everyMs: LOG_CLEANUP_INTERVAL_MS },
+    callback: () => Log.cleanup(),
+    maxConcurrency: 1,
+    queueEnabled: true,
+    catchup: 'none',
+  });
+
+  await scheduler.registerJob({
+    key: 'models-refresh',
+    schedule: { type: 'interval', everyMs: MODELS_REFRESH_INTERVAL_MS },
+    callback: () => ModelsDev.refresh(),
+    immediate: true,
+    maxConcurrency: 1,
+    queueEnabled: true,
+    catchup: 'one',
+  });
+
+  await scheduler.registerJob({
+    key: 'tool-output-cleanup',
+    schedule: { type: 'interval', everyMs: TOOL_OUTPUT_CLEANUP_INTERVAL_MS },
+    callback: () => ToolTruncation.cleanup(),
+    maxConcurrency: 1,
+    queueEnabled: true,
+    catchup: 'none',
+  });
+
+  await scheduler.registerJob({
+    key: 'mcp-refresh',
+    schedule: { type: 'interval', everyMs: MCP_REFRESH_INTERVAL_MS },
+    callback: () => refreshMcpToolsets({ refreshTools: true }),
+    maxConcurrency: 1,
+    queueEnabled: true,
+    catchup: 'one',
+  });
+
+  await scheduler.registerJob({
+    key: 'token-refresh',
+    schedule: { type: 'interval', everyMs: TOKEN_REFRESH_INTERVAL_MS },
+    callback: () => refreshExpiringTokens(),
+    maxConcurrency: 1,
+    queueEnabled: true,
+    catchup: 'one',
+  });
+
+  await scheduler.start();
+}
+
+export async function stopScheduler(): Promise<void> {
+  if (!scheduler) return;
+  await scheduler.stop();
+  scheduler = null;
+}

--- a/packages/server/src/scheduler/store.ts
+++ b/packages/server/src/scheduler/store.ts
@@ -1,0 +1,184 @@
+import { and, eq, inArray, sql } from 'drizzle-orm';
+
+import { createScheduledJobId, createScheduledJobRunId } from '@stitch/shared/id';
+
+import { getDb } from '@/db/client.js';
+import { scheduledJobs, scheduledJobRuns } from '@/db/schema.js';
+
+import type { SchedulerStore } from '@stitch/scheduler';
+
+type ScheduledJobRunId = (typeof scheduledJobRuns.$inferSelect)['id'];
+
+export function createSchedulerStore(): SchedulerStore {
+  return {
+    async upsertJob(input) {
+      const db = getDb();
+      const existing = db.select().from(scheduledJobs).where(eq(scheduledJobs.key, input.key)).get();
+
+      if (existing) {
+        const updated = db
+          .update(scheduledJobs)
+          .set({
+            schedule: input.schedule,
+            enabled: input.enabled,
+            maxConcurrency: input.maxConcurrency,
+            queueEnabled: input.queueEnabled,
+            catchup: input.catchup,
+            catchupMaxRuns: input.catchupMaxRuns,
+            updatedAt: input.now,
+          })
+          .where(eq(scheduledJobs.key, input.key))
+          .returning()
+          .get();
+
+        if (!updated) throw new Error(`failed to update scheduled job ${input.key}`);
+        return updated;
+      }
+
+      const inserted = db
+        .insert(scheduledJobs)
+        .values({
+          id: createScheduledJobId(),
+          key: input.key,
+          schedule: input.schedule,
+          enabled: input.enabled,
+          maxConcurrency: input.maxConcurrency,
+          queueEnabled: input.queueEnabled,
+          catchup: input.catchup,
+          catchupMaxRuns: input.catchupMaxRuns,
+          nextRunAt: input.initialNextRunAt,
+          runningCount: 0,
+          queuedCount: 0,
+          totalRuns: 0,
+          totalFailures: 0,
+          createdAt: input.now,
+          updatedAt: input.now,
+        })
+        .returning()
+        .get();
+
+      if (!inserted) throw new Error(`failed to insert scheduled job ${input.key}`);
+      return inserted;
+    },
+
+    async getJob(key) {
+      const db = getDb();
+      return db.select().from(scheduledJobs).where(eq(scheduledJobs.key, key)).get() ?? null;
+    },
+
+    async listJobs(keys) {
+      if (keys.length === 0) return [];
+      const db = getDb();
+      return db.select().from(scheduledJobs).where(inArray(scheduledJobs.key, keys)).all();
+    },
+
+    async enqueueDueRuns(input) {
+      const db = getDb();
+      return (
+        db
+          .update(scheduledJobs)
+          .set({
+            queuedCount: sql`max(0, ${scheduledJobs.queuedCount} + ${input.incrementBy})`,
+            nextRunAt: input.nextRunAt,
+            updatedAt: input.now,
+          })
+          .where(eq(scheduledJobs.key, input.key))
+          .returning()
+          .get() ?? null
+      );
+    },
+
+    async startQueuedRun(input) {
+      const db = getDb();
+
+      return db.transaction((tx) => {
+        const job = tx.select().from(scheduledJobs).where(eq(scheduledJobs.key, input.key)).get();
+        if (!job || !job.enabled || job.queuedCount <= 0 || job.runningCount >= job.maxConcurrency) {
+          return null;
+        }
+
+        const runId = createScheduledJobRunId();
+
+        tx.update(scheduledJobs)
+          .set({
+            queuedCount: job.queuedCount - 1,
+            runningCount: job.runningCount + 1,
+            totalRuns: job.totalRuns + 1,
+            lastRunAt: input.now,
+            updatedAt: input.now,
+          })
+          .where(eq(scheduledJobs.id, job.id))
+          .run();
+
+        const inserted = tx
+          .insert(scheduledJobRuns)
+          .values({
+            id: runId,
+            jobId: job.id,
+            key: job.key,
+            status: 'running',
+            scheduledFor: input.now,
+            startedAt: input.now,
+            createdAt: input.now,
+          })
+          .returning()
+          .get();
+
+        if (!inserted) return null;
+
+        return {
+          id: inserted.id,
+          jobId: inserted.jobId,
+          key: inserted.key,
+          scheduledFor: inserted.scheduledFor,
+          startedAt: inserted.startedAt,
+        };
+      });
+    },
+
+    async completeRun(input) {
+      const db = getDb();
+      const runId = input.runId as ScheduledJobRunId;
+
+      db.transaction((tx) => {
+        const run = tx.select().from(scheduledJobRuns).where(eq(scheduledJobRuns.id, runId)).get();
+        if (!run) return;
+
+        tx.update(scheduledJobRuns)
+          .set({
+            status: input.succeeded ? 'succeeded' : 'failed',
+            finishedAt: input.finishedAt,
+            errorMessage: input.succeeded ? null : (input.errorMessage ?? 'unknown error'),
+          })
+          .where(eq(scheduledJobRuns.id, runId))
+          .run();
+
+        const job = tx
+          .select()
+          .from(scheduledJobs)
+          .where(and(eq(scheduledJobs.id, run.jobId), eq(scheduledJobs.key, input.key)))
+          .get();
+
+        if (!job) return;
+
+        tx.update(scheduledJobs)
+          .set({
+            runningCount: Math.max(0, job.runningCount - 1),
+            totalFailures: input.succeeded ? job.totalFailures : job.totalFailures + 1,
+            lastSuccessAt: input.succeeded ? input.finishedAt : job.lastSuccessAt,
+            lastErrorAt: input.succeeded ? job.lastErrorAt : input.finishedAt,
+            lastErrorMessage: input.succeeded ? null : (input.errorMessage ?? 'unknown error'),
+            updatedAt: input.finishedAt,
+          })
+          .where(eq(scheduledJobs.id, job.id))
+          .run();
+      });
+    },
+
+    async unregisterJob(key) {
+      const db = getDb();
+      const deleted = db.delete(scheduledJobs).where(eq(scheduledJobs.key, key)).returning().get();
+      return Boolean(deleted);
+    },
+  };
+}

--- a/packages/server/src/shutdown.ts
+++ b/packages/server/src/shutdown.ts
@@ -1,15 +1,13 @@
-import { stopTokenRefreshService } from '@/connectors/auth/token-refresh.js';
 import { shutdownConnectorRuntime } from '@/connectors/runtime.js';
 import * as Log from '@/lib/log.js';
-import * as Scheduler from '@/lib/scheduler.js';
+import { stopScheduler } from '@/scheduler/runtime.js';
 
 const log = Log.create({ service: 'shutdown' });
 
 async function shutdown(signal: string) {
   log.info({ signal }, 'shutting down');
-  stopTokenRefreshService();
+  await stopScheduler();
   await shutdownConnectorRuntime();
-  Scheduler.cancelAll();
   process.exit(0);
 }
 

--- a/packages/shared/src/id/index.ts
+++ b/packages/shared/src/id/index.ts
@@ -13,6 +13,8 @@ export const ID_PREFIXES = {
   recording: 'rec',
   transcription: 'transcr',
   connectorInstance: 'conn',
+  scheduledJob: 'schjob',
+  scheduledJobRun: 'schrun',
 } as const;
 
 export type IdPrefix = (typeof ID_PREFIXES)[keyof typeof ID_PREFIXES];
@@ -70,6 +72,8 @@ export const createQueuedMessageId = createIdFactory(ID_PREFIXES.queuedMessage);
 export const createRecordingId = createIdFactory(ID_PREFIXES.recording);
 export const createTranscriptionId = createIdFactory(ID_PREFIXES.transcription);
 export const createConnectorInstanceId = createIdFactory(ID_PREFIXES.connectorInstance);
+export const createScheduledJobId = createIdFactory(ID_PREFIXES.scheduledJob);
+export const createScheduledJobRunId = createIdFactory(ID_PREFIXES.scheduledJobRun);
 
 export function extractTimestamp(id: string): number {
   const prefix = id.split('_')[0];


### PR DESCRIPTION
## Summary
- add a new @stitch/scheduler package with interval and cron scheduling, queued runs, max-concurrency limits, and catchup policies
- persist scheduler state in the server database with new scheduled_jobs and scheduled_job_runs tables plus a generated drizzle migration
- wire scheduler lifecycle into server init/shutdown and move token-refresh/background recurring tasks into the new scheduler runtime