### PR TITLE
Improve Google connector quota handling with queued rate limiting

### DIFF
--- a/connectors/google/src/__test__/client.test.ts
+++ b/connectors/google/src/__test__/client.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { GoogleClient } from '../client.js';
+import { resetGoogleRateLimitCoordinatorForTests } from '../rate-limit.js';
+
+describe('GoogleClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    resetGoogleRateLimitCoordinatorForTests();
+  });
+
+  it('retries with Retry-After when Google returns rate-limit errors', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              message: 'Rate Limit Exceeded',
+              status: 'RESOURCE_EXHAUSTED',
+              errors: [{ reason: 'rateLimitExceeded' }],
+            },
+          }),
+          {
+            status: 429,
+            statusText: 'Too Many Requests',
+            headers: { 'Content-Type': 'application/json', 'Retry-After': '1' },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new GoogleClient({
+      getAccessToken: async () => 'token',
+      quotaAccountKey: 'retry-test-account',
+    });
+
+    const pending = client.request<{ ok: boolean }>('https://www.googleapis.com/drive/v3/files');
+
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await pending;
+
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/connectors/google/src/__test__/rate-limit.test.ts
+++ b/connectors/google/src/__test__/rate-limit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_GOOGLE_RATE_LIMIT_CONFIG,
+  GoogleRateLimitCoordinator,
+  resetGoogleRateLimitCoordinatorForTests,
+  resolveGoogleQuotaOperation,
+} from '../rate-limit.js';
+
+describe('resolveGoogleQuotaOperation', () => {
+  it('maps Gmail endpoints to method-specific quota units', () => {
+    expect(
+      resolveGoogleQuotaOperation('https://gmail.googleapis.com/gmail/v1/users/me/messages', 'GET'),
+    ).toEqual({ service: 'gmail', quotaCost: 5 });
+
+    expect(
+      resolveGoogleQuotaOperation(
+        'https://gmail.googleapis.com/gmail/v1/users/me/messages/abc?format=FULL',
+        'GET',
+      ),
+    ).toEqual({ service: 'gmail', quotaCost: 5 });
+
+    expect(
+      resolveGoogleQuotaOperation('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', 'POST'),
+    ).toEqual({ service: 'gmail', quotaCost: 100 });
+
+    expect(
+      resolveGoogleQuotaOperation(
+        'https://gmail.googleapis.com/gmail/v1/users/me/threads/thread-1/modify',
+        'POST',
+      ),
+    ).toEqual({ service: 'gmail', quotaCost: 10 });
+  });
+
+  it('maps non-Gmail services to request-count quota units', () => {
+    expect(
+      resolveGoogleQuotaOperation('https://www.googleapis.com/drive/v3/files?q=test', 'GET'),
+    ).toEqual({ service: 'drive', quotaCost: 1 });
+
+    expect(resolveGoogleQuotaOperation('https://docs.googleapis.com/v1/documents/abc', 'GET')).toEqual(
+      { service: 'docsRead', quotaCost: 1 },
+    );
+
+    expect(
+      resolveGoogleQuotaOperation('https://docs.googleapis.com/v1/documents/abc:batchUpdate', 'POST'),
+    ).toEqual({ service: 'docsWrite', quotaCost: 1 });
+
+    expect(
+      resolveGoogleQuotaOperation('https://www.googleapis.com/calendar/v3/calendars/primary/events', 'GET'),
+    ).toEqual({ service: 'calendar', quotaCost: 1 });
+  });
+});
+
+describe('GoogleRateLimitCoordinator', () => {
+  it('queues requests when account quota is saturated', async () => {
+    vi.useFakeTimers();
+    resetGoogleRateLimitCoordinatorForTests();
+
+    const coordinator = new GoogleRateLimitCoordinator(
+      {
+        ...DEFAULT_GOOGLE_RATE_LIMIT_CONFIG,
+        maxQueueWaitMs: 2000,
+        services: {
+          ...DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services,
+          drive: {
+            project: { capacity: 100, windowMs: 1000 },
+            account: { capacity: 1, windowMs: 1000 },
+          },
+        },
+      },
+      'account-a',
+    );
+
+    await coordinator.acquire('https://www.googleapis.com/drive/v3/files', 'GET');
+
+    let settled = false;
+    const queued = coordinator
+      .acquire('https://www.googleapis.com/drive/v3/files', 'GET')
+      .then(() => {
+        settled = true;
+      });
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await queued;
+    expect(settled).toBe(true);
+
+    vi.useRealTimers();
+  });
+});

--- a/connectors/google/src/client.ts
+++ b/connectors/google/src/client.ts
@@ -5,23 +5,40 @@
  */
 
 import { noopLogger, type GoogleLogger } from './logger.js';
+import {
+  DEFAULT_GOOGLE_RATE_LIMIT_CONFIG,
+  GoogleRateLimitCoordinator,
+  type GoogleRateLimitConfig,
+} from './rate-limit.js';
 
 export type GoogleClientConfig = {
   /** Callback that returns a fresh access token (post-refresh if needed). */
   getAccessToken: () => Promise<string>;
   /** Optional logger instance — defaults to no-op if not provided. */
   logger?: GoogleLogger;
+  /** Stable per-account key for account-level quota limiting. */
+  quotaAccountKey?: string | null;
+  /** Optional overrides for the built-in Google API limiter config. */
+  rateLimits?: Partial<GoogleRateLimitConfig>;
 };
 
 export class GoogleApiError extends Error {
   readonly status: number;
   readonly code: string | undefined;
+  readonly reason: string | undefined;
+  readonly retryAfterMs: number | undefined;
 
-  constructor(status: number, message: string, code?: string) {
+  constructor(
+    status: number,
+    message: string,
+    options?: { code?: string; reason?: string; retryAfterMs?: number },
+  ) {
     super(message);
     this.name = 'GoogleApiError';
     this.status = status;
-    this.code = code;
+    this.code = options?.code;
+    this.reason = options?.reason;
+    this.retryAfterMs = options?.retryAfterMs;
   }
 }
 
@@ -30,6 +47,7 @@ type GoogleErrorResponse = {
     message?: string;
     code?: number;
     status?: string;
+    errors?: Array<{ reason?: string; message?: string }>;
   };
 };
 
@@ -41,72 +59,293 @@ type RequestOptions = {
 };
 
 export class GoogleClient {
+  private static readonly MAX_RETRIES = 5;
+  private static readonly MAX_BACKOFF_MS = 64_000;
+
   private readonly getAccessToken: () => Promise<string>;
+  private readonly rateLimitCoordinator: GoogleRateLimitCoordinator;
   readonly log: GoogleLogger;
 
   constructor(config: GoogleClientConfig) {
     this.getAccessToken = config.getAccessToken;
     this.log = config.logger ?? noopLogger;
+    this.rateLimitCoordinator = new GoogleRateLimitCoordinator(
+      mergeRateLimitConfig(config.rateLimits),
+      config.quotaAccountKey,
+    );
   }
 
   async request<T>(url: string, options?: RequestOptions): Promise<T> {
-    const token = await this.getAccessToken();
-
-    this.log.debug({ url, method: options?.method ?? 'GET' }, 'Google API request');
-
-    const response = await fetch(url, {
-      method: options?.method,
-      body: options?.body,
-      signal: options?.signal,
+    const response = await this.executeWithRetries(url, {
+      ...options,
       headers: {
-        Authorization: `Bearer ${token}`,
         'Content-Type': 'application/json',
         ...options?.headers,
       },
     });
-
-    if (!response.ok) {
-      let errorMessage = `Google API error: ${response.status} ${response.statusText}`;
-      let errorCode: string | undefined;
-
-      try {
-        const body = (await response.json()) as GoogleErrorResponse;
-        if (body.error?.message) {
-          errorMessage = body.error.message;
-          errorCode = body.error.status;
-        }
-      } catch {
-        // Use default error message
-      }
-
-      this.log.error({ url, status: response.status, errorCode }, errorMessage);
-      throw new GoogleApiError(response.status, errorMessage, errorCode);
-    }
-
     return (await response.json()) as T;
   }
 
   async requestText(url: string, options?: RequestOptions): Promise<string> {
-    const token = await this.getAccessToken();
+    const response = await this.executeWithRetries(url, options);
+    return await response.text();
+  }
 
-    this.log.debug({ url, method: options?.method ?? 'GET' }, 'Google API text request');
+  private async executeWithRetries(url: string, options?: RequestOptions): Promise<Response> {
+    const method = options?.method ?? 'GET';
 
-    const response = await fetch(url, {
-      method: options?.method,
-      body: options?.body,
-      signal: options?.signal,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        ...options?.headers,
-      },
-    });
+    for (let attempt = 1; attempt <= GoogleClient.MAX_RETRIES + 1; attempt += 1) {
+      try {
+        const queuedMs = await this.rateLimitCoordinator.acquire(url, method, options?.signal);
+        if (queuedMs > 0) {
+          this.log.debug(
+            { url, method, queuedMs },
+            'Delayed Google API request due to local quota queue',
+          );
+        }
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Local Google quota queue wait exceeded';
+        throw new GoogleApiError(429, message, { reason: 'localRateLimitExceeded' });
+      }
 
-    if (!response.ok) {
-      const errorMessage = `Google API error: ${response.status} ${response.statusText}`;
-      this.log.error({ url, status: response.status }, errorMessage);
-      throw new GoogleApiError(response.status, errorMessage);
+      const token = await this.getAccessToken();
+
+      this.log.debug({ url, method, attempt }, 'Google API request');
+
+      const response = await fetch(url, {
+        method,
+        body: options?.body,
+        signal: options?.signal,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...options?.headers,
+        },
+      });
+
+      if (response.ok) {
+        return response;
+      }
+
+      const parsedError = await parseGoogleApiError(response);
+      const apiError = new GoogleApiError(response.status, parsedError.message, {
+        code: parsedError.code,
+        reason: parsedError.reason,
+        retryAfterMs: parsedError.retryAfterMs,
+      });
+
+      const retryable =
+        attempt <= GoogleClient.MAX_RETRIES &&
+        isRetryableRateLimit(response.status, parsedError.reason, parsedError.message);
+
+      if (!retryable) {
+        this.log.error(
+          {
+            url,
+            method,
+            status: response.status,
+            code: parsedError.code,
+            reason: parsedError.reason,
+          },
+          parsedError.message,
+        );
+        throw apiError;
+      }
+
+      const backoffMs =
+        parsedError.retryAfterMs ??
+        computeExponentialBackoffMs(attempt, GoogleClient.MAX_BACKOFF_MS);
+
+      this.log.warn(
+        {
+          url,
+          method,
+          status: response.status,
+          code: parsedError.code,
+          reason: parsedError.reason,
+          attempt,
+          backoffMs,
+        },
+        'Google API rate limited, retrying request',
+      );
+
+      await sleep(backoffMs, options?.signal);
     }
 
-    return response.text();
+    throw new GoogleApiError(503, 'Google API request failed after retries', {
+      reason: 'maxRetriesExceeded',
+    });
   }
+}
+
+type ParsedApiError = {
+  message: string;
+  code: string | undefined;
+  reason: string | undefined;
+  retryAfterMs: number | undefined;
+};
+
+function mergeRateLimitConfig(overrides: Partial<GoogleRateLimitConfig> | undefined): GoogleRateLimitConfig {
+  if (!overrides) {
+    return DEFAULT_GOOGLE_RATE_LIMIT_CONFIG;
+  }
+
+  return {
+    maxQueueWaitMs: overrides.maxQueueWaitMs ?? DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.maxQueueWaitMs,
+    services: {
+      gmail: {
+        project:
+          overrides.services?.gmail?.project ?? DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.gmail.project,
+        account:
+          overrides.services?.gmail?.account ?? DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.gmail.account,
+      },
+      drive: {
+        project:
+          overrides.services?.drive?.project ?? DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.drive.project,
+        account:
+          overrides.services?.drive?.account ?? DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.drive.account,
+      },
+      docsRead: {
+        project:
+          overrides.services?.docsRead?.project ??
+          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.docsRead.project,
+        account:
+          overrides.services?.docsRead?.account ??
+          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.docsRead.account,
+      },
+      docsWrite: {
+        project:
+          overrides.services?.docsWrite?.project ??
+          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.docsWrite.project,
+        account:
+          overrides.services?.docsWrite?.account ??
+          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.docsWrite.account,
+      },
+      calendar: {
+        project:
+          overrides.services?.calendar?.project ??
+          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.calendar.project,
+        account:
+          overrides.services?.calendar?.account ??
+          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.calendar.account,
+      },
+    },
+  };
+}
+
+async function parseGoogleApiError(response: Response): Promise<ParsedApiError> {
+  const fallbackMessage = `Google API error: ${response.status} ${response.statusText}`;
+  const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
+
+  let bodyText = '';
+  try {
+    bodyText = await response.text();
+  } catch {
+    return {
+      message: fallbackMessage,
+      code: undefined,
+      reason: undefined,
+      retryAfterMs,
+    };
+  }
+
+  if (!bodyText) {
+    return {
+      message: fallbackMessage,
+      code: undefined,
+      reason: undefined,
+      retryAfterMs,
+    };
+  }
+
+  try {
+    const parsed = JSON.parse(bodyText) as GoogleErrorResponse;
+    const message = parsed.error?.message ?? fallbackMessage;
+    const code = parsed.error?.status;
+    const reason = parsed.error?.errors?.[0]?.reason;
+    return {
+      message,
+      code,
+      reason,
+      retryAfterMs,
+    };
+  } catch {
+    return {
+      message: fallbackMessage,
+      code: undefined,
+      reason: undefined,
+      retryAfterMs,
+    };
+  }
+}
+
+function parseRetryAfterMs(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const asSeconds = Number.parseFloat(value);
+  if (!Number.isNaN(asSeconds)) {
+    return Math.max(0, Math.ceil(asSeconds * 1000));
+  }
+
+  const asDateDelta = Date.parse(value) - Date.now();
+  if (!Number.isNaN(asDateDelta) && asDateDelta > 0) {
+    return Math.ceil(asDateDelta);
+  }
+
+  return undefined;
+}
+
+function computeExponentialBackoffMs(attempt: number, maxDelayMs: number): number {
+  const baseMs = Math.min(Math.pow(2, attempt - 1) * 1000, maxDelayMs);
+  return Math.min(maxDelayMs, baseMs + Math.floor(Math.random() * 1000));
+}
+
+function isRetryableRateLimit(status: number, reason: string | undefined, message: string): boolean {
+  if (status === 429 || status === 503) {
+    return true;
+  }
+
+  if (status !== 403) {
+    return false;
+  }
+
+  if (reason) {
+    const normalized = reason.toLowerCase();
+    if (
+      normalized === 'ratelimitexceeded' ||
+      normalized === 'userratelimitexceeded' ||
+      normalized === 'quotaexceeded'
+    ) {
+      return true;
+    }
+  }
+
+  return /rate.?limit|too many requests|quota/i.test(message);
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ms <= 0) {
+      resolve();
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+
+    const timeout = setTimeout(() => {
+      if (signal) {
+        signal.removeEventListener('abort', onAbort);
+      }
+      resolve();
+    }, ms);
+
+    if (signal) {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
 }

--- a/connectors/google/src/rate-limit.ts
+++ b/connectors/google/src/rate-limit.ts
@@ -1,0 +1,307 @@
+type RateLimitBucket = {
+  capacity: number;
+  windowMs: number;
+};
+
+type RateLimitServiceConfig = {
+  project: RateLimitBucket;
+  account: RateLimitBucket;
+};
+
+export type GoogleRateLimitConfig = {
+  services: {
+    gmail: RateLimitServiceConfig;
+    drive: RateLimitServiceConfig;
+    docsRead: RateLimitServiceConfig;
+    docsWrite: RateLimitServiceConfig;
+    calendar: RateLimitServiceConfig;
+  };
+  maxQueueWaitMs: number;
+};
+
+export const DEFAULT_GOOGLE_RATE_LIMIT_CONFIG: GoogleRateLimitConfig = {
+  services: {
+    gmail: {
+      project: { capacity: 1_200_000, windowMs: 60_000 },
+      account: { capacity: 15_000, windowMs: 60_000 },
+    },
+    drive: {
+      project: { capacity: 12_000, windowMs: 60_000 },
+      account: { capacity: 12_000, windowMs: 60_000 },
+    },
+    docsRead: {
+      project: { capacity: 3000, windowMs: 60_000 },
+      account: { capacity: 300, windowMs: 60_000 },
+    },
+    docsWrite: {
+      project: { capacity: 600, windowMs: 60_000 },
+      account: { capacity: 60, windowMs: 60_000 },
+    },
+    calendar: {
+      project: { capacity: 6000, windowMs: 60_000 },
+      account: { capacity: 600, windowMs: 60_000 },
+    },
+  },
+  maxQueueWaitMs: 60_000,
+};
+
+type GoogleQuotaOperation = {
+  service: keyof GoogleRateLimitConfig['services'];
+  quotaCost: number;
+};
+
+const GMAIL_METHOD_COSTS = {
+  MESSAGES_LIST: 5,
+  MESSAGES_GET: 5,
+  MESSAGES_MODIFY: 5,
+  MESSAGES_SEND: 100,
+  LABELS_LIST: 1,
+  LABELS_GET: 1,
+  LABELS_MUTATE: 5,
+  THREADS_MODIFY: 10,
+  DEFAULT: 5,
+} as const;
+
+function normalizeMethod(method: string | undefined): string {
+  return (method ?? 'GET').toUpperCase();
+}
+
+function isWriteMethod(method: string): boolean {
+  return method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS';
+}
+
+function parseUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+function resolveGmailQuotaCost(pathname: string, method: string): number {
+  const withoutQuery = pathname;
+
+  if (withoutQuery.endsWith('/messages/send') && method === 'POST') {
+    return GMAIL_METHOD_COSTS.MESSAGES_SEND;
+  }
+
+  if (/\/messages\/[^/]+\/modify$/.test(withoutQuery) && method === 'POST') {
+    return GMAIL_METHOD_COSTS.MESSAGES_MODIFY;
+  }
+
+  if (/\/threads\/[^/]+\/modify$/.test(withoutQuery) && method === 'POST') {
+    return GMAIL_METHOD_COSTS.THREADS_MODIFY;
+  }
+
+  if (withoutQuery.endsWith('/messages') && method === 'GET') {
+    return GMAIL_METHOD_COSTS.MESSAGES_LIST;
+  }
+
+  if (/\/messages\/[^/]+$/.test(withoutQuery) && method === 'GET') {
+    return GMAIL_METHOD_COSTS.MESSAGES_GET;
+  }
+
+  if (withoutQuery.endsWith('/labels')) {
+    return method === 'GET' ? GMAIL_METHOD_COSTS.LABELS_LIST : GMAIL_METHOD_COSTS.LABELS_MUTATE;
+  }
+
+  if (/\/labels\/[^/]+$/.test(withoutQuery)) {
+    return method === 'GET' ? GMAIL_METHOD_COSTS.LABELS_GET : GMAIL_METHOD_COSTS.LABELS_MUTATE;
+  }
+
+  return GMAIL_METHOD_COSTS.DEFAULT;
+}
+
+export function resolveGoogleQuotaOperation(
+  url: string,
+  method: string | undefined,
+): GoogleQuotaOperation | null {
+  const parsed = parseUrl(url);
+  if (!parsed) {
+    return null;
+  }
+
+  const normalizedMethod = normalizeMethod(method);
+
+  if (parsed.hostname === 'gmail.googleapis.com') {
+    return {
+      service: 'gmail',
+      quotaCost: resolveGmailQuotaCost(parsed.pathname, normalizedMethod),
+    };
+  }
+
+  if (parsed.hostname === 'docs.googleapis.com') {
+    return {
+      service: isWriteMethod(normalizedMethod) ? 'docsWrite' : 'docsRead',
+      quotaCost: 1,
+    };
+  }
+
+  if (parsed.hostname === 'www.googleapis.com') {
+    if (parsed.pathname.startsWith('/drive/')) {
+      return { service: 'drive', quotaCost: 1 };
+    }
+    if (parsed.pathname.startsWith('/calendar/')) {
+      return { service: 'calendar', quotaCost: 1 };
+    }
+  }
+
+  return null;
+}
+
+type AcquireOptions = {
+  signal?: AbortSignal;
+  maxWaitMs: number;
+};
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ms <= 0) {
+      resolve();
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+
+    const timeout = setTimeout(() => {
+      if (signal) {
+        signal.removeEventListener('abort', onAbort);
+      }
+      resolve();
+    }, ms);
+
+    if (signal) {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+
+class SlidingWindowLimiter {
+  private readonly capacity: number;
+  private readonly windowMs: number;
+  private readonly events: { timestamp: number; weight: number }[] = [];
+  private pending: Promise<void> = Promise.resolve();
+
+  constructor(config: RateLimitBucket) {
+    this.capacity = config.capacity;
+    this.windowMs = config.windowMs;
+  }
+
+  async acquire(weight: number, options: AcquireOptions): Promise<number> {
+    if (weight > this.capacity) {
+      throw new Error(
+        `Requested quota cost (${weight}) exceeds limiter capacity (${this.capacity}) for ${this.windowMs}ms window`,
+      );
+    }
+
+    const run = this.pending.then(async () => this.acquireInternal(weight, options));
+    this.pending = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  private pruneExpired(now: number): void {
+    while (this.events.length > 0 && now - this.events[0].timestamp >= this.windowMs) {
+      this.events.shift();
+    }
+  }
+
+  private used(): number {
+    return this.events.reduce((total, event) => total + event.weight, 0);
+  }
+
+  private async acquireInternal(weight: number, options: AcquireOptions): Promise<number> {
+    let waitedMs = 0;
+
+    while (true) {
+      const now = Date.now();
+      this.pruneExpired(now);
+
+      if (this.used() + weight <= this.capacity) {
+        this.events.push({ timestamp: now, weight });
+        return waitedMs;
+      }
+
+      const oldest = this.events[0];
+      if (!oldest) {
+        this.events.push({ timestamp: now, weight });
+        return waitedMs;
+      }
+
+      const waitForMs = Math.max(1, oldest.timestamp + this.windowMs - now);
+      if (waitedMs + waitForMs > options.maxWaitMs) {
+        throw new Error(`Rate limiter queue wait exceeded ${options.maxWaitMs}ms`);
+      }
+
+      await sleep(waitForMs, options.signal);
+      waitedMs += waitForMs;
+    }
+  }
+}
+
+const projectLimiters = new Map<string, SlidingWindowLimiter>();
+const accountLimiters = new Map<string, SlidingWindowLimiter>();
+
+function getLimiter(
+  cache: Map<string, SlidingWindowLimiter>,
+  key: string,
+  config: RateLimitBucket,
+): SlidingWindowLimiter {
+  const existing = cache.get(key);
+  if (existing) {
+    return existing;
+  }
+  const created = new SlidingWindowLimiter(config);
+  cache.set(key, created);
+  return created;
+}
+
+export class GoogleRateLimitCoordinator {
+  private readonly config: GoogleRateLimitConfig;
+  private readonly accountKey: string;
+
+  constructor(config: GoogleRateLimitConfig, accountKey?: string | null) {
+    this.config = config;
+    this.accountKey = accountKey?.trim() || 'default';
+  }
+
+  async acquire(url: string, method: string | undefined, signal?: AbortSignal): Promise<number> {
+    const operation = resolveGoogleQuotaOperation(url, method);
+    if (!operation) {
+      return 0;
+    }
+
+    const serviceConfig = this.config.services[operation.service];
+    const projectLimiter = getLimiter(
+      projectLimiters,
+      `${operation.service}:project`,
+      serviceConfig.project,
+    );
+    const accountLimiter = getLimiter(
+      accountLimiters,
+      `${operation.service}:account:${this.accountKey}`,
+      serviceConfig.account,
+    );
+
+    const projectWait = await projectLimiter.acquire(operation.quotaCost, {
+      maxWaitMs: this.config.maxQueueWaitMs,
+      signal,
+    });
+    const accountWait = await accountLimiter.acquire(operation.quotaCost, {
+      maxWaitMs: this.config.maxQueueWaitMs,
+      signal,
+    });
+
+    return projectWait + accountWait;
+  }
+}
+
+export function resetGoogleRateLimitCoordinatorForTests(): void {
+  projectLimiters.clear();
+  accountLimiters.clear();
+}

--- a/packages/server/src/connectors/google-toolsets.ts
+++ b/packages/server/src/connectors/google-toolsets.ts
@@ -194,6 +194,7 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
             return latest.accessToken;
           },
           logger: log,
+          quotaAccountKey: chosen.id,
         });
 
         return {


### PR DESCRIPTION
## Summary
- add a quota-aware rate limiting coordinator for Google APIs with project-level and per-account buckets, including Gmail method-weighted quota costs
- update `GoogleClient` to queue/wait locally before sending requests and to retry Google rate-limit responses (403/429/503) using `Retry-After` and exponential backoff with jitter
- pass a stable account key from server toolset activation so per-account throttling is isolated by connected Google account
- add tests for quota operation mapping, queue behavior, and retry handling

## Validation
- bun run test (connectors/google)
- bun run check