### PR TITLE
feat: add automations workspace with schedule and session generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,27 @@ function ProductList({ filters, minRating }: Props) {
 - Never include the coding agent (Claude or any other agent) as an author in pull request descriptions.
 - Use `gh` command for all GitHub-related tasks.
 - Never add test plans directly to the PR body for merges into `dev`.
+- Example structure:
+
+      ```markdown
+      ## 🚀 Change Summary
+
+      <One paragraph overview of what this PR enables>
+
+      ### ✨ New Features
+      - **Major Feature Name**: Brief description of what it enables and key capabilities
+      - **Another Feature**: What problem it solves or functionality it adds
+
+      ### 🛠 Improvements & Refactors
+      - Only significant improvements that affect functionality or performance
+      - Consolidate minor refactors into one line if needed
+
+      ### 🐛 Bug Fixes
+      - Only user-facing bugs or critical issues fixed
+
+      ### 📚 Documentation
+      - Major documentation additions (if applicable)
+      ```
 
 ##### Creating PRs
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,8 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "cron-parser": "^5.5.0",
+    "date-fns": "^4.1.0",
     "katex": "^0.16.38",
     "lucide-react": "^0.577.0",
     "react": "19.2.4",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-hotkeys": "0.4.1",
     "@tanstack/react-query": "5.90.21",
     "@tanstack/react-router": "1.166.7",
+    "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.22",
     "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/components/automations/automation-dialog.tsx
+++ b/apps/web/src/components/automations/automation-dialog.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 
-import type { Automation } from '@stitch/shared/automations/types';
+import type { Automation, AutomationSchedule } from '@stitch/shared/automations/types';
 
+import { CronExpressionBuilder } from '@/components/cron-expression-builder';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
@@ -14,6 +15,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { getAutomationScheduleLabel } from '@/lib/automations/schedule-label';
 import type { ProviderModels } from '@/lib/queries/providers';
 
 type AutomationDialogProps = {
@@ -27,8 +29,10 @@ type AutomationDialogProps = {
     modelId: string;
     title: string;
     initialMessage: string;
+    schedule: AutomationSchedule | null;
   }) => Promise<void>;
   isPending: boolean;
+  timezone: string;
 };
 
 function getInitialSelection(providerModels: ProviderModels[]): { providerId: string; modelId: string } | null {
@@ -46,11 +50,17 @@ export function AutomationDialog({
   providerModels,
   onSubmit,
   isPending,
+  timezone,
 }: AutomationDialogProps) {
   const [title, setTitle] = React.useState('');
   const [initialMessage, setInitialMessage] = React.useState('');
   const [providerId, setProviderId] = React.useState('');
   const [modelId, setModelId] = React.useState('');
+  const [isScheduled, setIsScheduled] = React.useState(false);
+  const [scheduleType, setScheduleType] = React.useState<'interval' | 'cron'>('interval');
+  const [editorView, setEditorView] = React.useState<'prompt' | 'schedule'>('prompt');
+  const [intervalMinutes, setIntervalMinutes] = React.useState('60');
+  const [cronExpression, setCronExpression] = React.useState('0 9 * * *');
 
   React.useEffect(() => {
     if (!open) return;
@@ -60,6 +70,24 @@ export function AutomationDialog({
       setInitialMessage(automation.initialMessage);
       setProviderId(automation.providerId);
       setModelId(automation.modelId);
+      const schedule = automation.schedule;
+      if (!schedule) {
+        setIsScheduled(false);
+        setScheduleType('interval');
+        setEditorView('prompt');
+        setIntervalMinutes('60');
+        setCronExpression('0 9 * * *');
+      } else if (schedule.type === 'interval') {
+        setIsScheduled(true);
+        setScheduleType('interval');
+        setEditorView('schedule');
+        setIntervalMinutes(String(schedule.everyMinutes));
+      } else {
+        setIsScheduled(true);
+        setScheduleType('cron');
+        setEditorView('schedule');
+        setCronExpression(schedule.expression);
+      }
       return;
     }
 
@@ -68,6 +96,11 @@ export function AutomationDialog({
     setInitialMessage('');
     setProviderId(initialSelection?.providerId ?? '');
     setModelId(initialSelection?.modelId ?? '');
+    setIsScheduled(false);
+    setScheduleType('interval');
+    setEditorView('prompt');
+    setIntervalMinutes('60');
+    setCronExpression('0 9 * * *');
   }, [open, mode, automation, providerModels]);
 
   const selectedProvider = providerModels.find((provider) => provider.providerId === providerId) ?? null;
@@ -86,20 +119,43 @@ export function AutomationDialog({
     }
   }, [selectedProvider, availableModels, modelId]);
 
+  const parsedIntervalMinutes = Number.parseInt(intervalMinutes, 10);
+  const isIntervalValid = Number.isInteger(parsedIntervalMinutes) && parsedIntervalMinutes >= 1;
+  const isCronValid = cronExpression.trim().length > 0;
+  const intervalSummaryMinutes = Number.isInteger(parsedIntervalMinutes) && parsedIntervalMinutes >= 1 ? parsedIntervalMinutes : 1;
+  const triggerLabel = isScheduled ? 'Scheduled' : 'Manual';
+  const scheduleTypeLabel = scheduleType === 'interval' ? 'Interval' : 'Cron';
+  const scheduleSummary = getAutomationScheduleLabel(
+    !isScheduled
+      ? null
+      : scheduleType === 'interval'
+        ? { type: 'interval', everyMinutes: intervalSummaryMinutes }
+        : { type: 'cron', expression: cronExpression.trim() },
+  );
+
   const canSubmit =
     title.trim().length > 0 &&
     initialMessage.trim().length > 0 &&
     providerId.length > 0 &&
     modelId.length > 0 &&
+    (!isScheduled || (scheduleType === 'interval' ? isIntervalValid : isCronValid)) &&
     !isPending;
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
+
+    const schedule: AutomationSchedule | null = !isScheduled
+      ? null
+      : scheduleType === 'interval'
+        ? { type: 'interval', everyMinutes: parsedIntervalMinutes }
+        : { type: 'cron', expression: cronExpression.trim() };
+
     await onSubmit({
       title: title.trim(),
       initialMessage: initialMessage.trim(),
       providerId,
       modelId,
+      schedule,
     });
   };
 
@@ -108,7 +164,7 @@ export function AutomationDialog({
       <DialogHeader className="sr-only">
         <DialogTitle>{mode === 'create' ? 'Create automation' : 'Edit automation'}</DialogTitle>
       </DialogHeader>
-      <DialogContent className="w-[min(1080px,calc(100vw-2rem))] max-w-none overflow-hidden p-0 sm:max-w-none">
+      <DialogContent className="flex max-h-[calc(100vh-2rem)] w-[min(1080px,calc(100vw-2rem))] max-w-none flex-col overflow-hidden p-0 sm:max-w-none">
         <div className="border-b border-border/60 px-6 py-5">
           <h2 className="text-xl font-semibold tracking-tight">
             {mode === 'create' ? 'Create automation' : 'Edit automation'}
@@ -118,8 +174,8 @@ export function AutomationDialog({
           </p>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-[minmax(280px,1fr)_minmax(0,2fr)]">
-          <div className="space-y-5 border-b border-border/50 bg-muted/10 px-6 py-5 lg:border-r lg:border-b-0">
+        <div className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[minmax(280px,1fr)_minmax(0,2fr)]">
+          <div className="space-y-5 overflow-y-auto border-b border-border/50 bg-muted/10 px-6 py-5 lg:border-r lg:border-b-0">
             <div className="space-y-1.5">
               <Label htmlFor="automation-title">Title</Label>
               <Input
@@ -162,25 +218,127 @@ export function AutomationDialog({
                 </SelectContent>
               </Select>
             </div>
+
+            <div className="space-y-1.5">
+              <Label>Trigger</Label>
+              <Select
+                value={isScheduled ? 'scheduled' : 'manual'}
+                onValueChange={(value) => {
+                  const scheduled = value === 'scheduled';
+                  setIsScheduled(scheduled);
+                  if (scheduled) {
+                    setEditorView('schedule');
+                  } else {
+                    setEditorView('prompt');
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue>{triggerLabel}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="manual">Manual</SelectItem>
+                  <SelectItem value="scheduled">Scheduled</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {isScheduled ? (
+              <div className="space-y-1.5">
+                <Label>Schedule type</Label>
+                <Select
+                  value={scheduleType}
+                  onValueChange={(value) => setScheduleType(value === 'cron' ? 'cron' : 'interval')}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue>{scheduleTypeLabel}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="interval">Interval</SelectItem>
+                    <SelectItem value="cron">Cron</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            ) : null}
+
+            <div className="rounded-lg border border-border/60 bg-card/70 px-3 py-2.5">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Current schedule</p>
+              <p className="mt-1 text-sm text-foreground">{scheduleSummary}</p>
+            </div>
           </div>
 
-          <div className="space-y-2 px-6 py-5">
-            <div className="flex items-center justify-between">
-              <Label htmlFor="automation-message">Initial prompt</Label>
-              <span className="text-xs text-muted-foreground">{initialMessage.length} chars</span>
+          <div className="flex min-h-0 flex-col px-6 py-5">
+            <div className="mb-3 inline-flex w-fit gap-1 rounded-lg border border-border/60 bg-muted/20 p-1">
+              <Button
+                type="button"
+                size="sm"
+                variant={editorView === 'prompt' ? 'secondary' : 'ghost'}
+                onClick={() => setEditorView('prompt')}
+              >
+                Prompt
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant={editorView === 'schedule' ? 'secondary' : 'ghost'}
+                onClick={() => {
+                  if (!isScheduled) return;
+                  setEditorView('schedule');
+                }}
+                disabled={!isScheduled}
+              >
+                Schedule
+              </Button>
             </div>
-            <p className="text-xs text-muted-foreground">
-              This message is used to kick off the session when the automation runs.
-            </p>
-            <div className="rounded-xl border border-border/60 bg-muted/15 p-3">
-              <Textarea
-                id="automation-message"
-                value={initialMessage}
-                onChange={(event) => setInitialMessage(event.target.value)}
-                placeholder="Write the prompt that should be sent when this automation starts..."
-                className="h-105 resize-none overflow-y-auto border-0 bg-transparent px-1.5 py-1 text-sm leading-6 shadow-none focus-visible:ring-0"
-              />
-            </div>
+
+            {editorView === 'prompt' || !isScheduled ? (
+              <div className="flex min-h-0 flex-1 flex-col space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="automation-message">Initial prompt</Label>
+                  <span className="text-xs text-muted-foreground">{initialMessage.length} chars</span>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  This message is used to kick off the session when the automation runs.
+                </p>
+                <div className="flex min-h-0 flex-1 rounded-xl border border-border/60 bg-muted/15 p-3">
+                  <Textarea
+                    id="automation-message"
+                    value={initialMessage}
+                    onChange={(event) => setInitialMessage(event.target.value)}
+                    placeholder="Write the prompt that should be sent when this automation starts..."
+                    className="min-h-[220px] flex-1 resize-none overflow-y-auto border-0 bg-transparent px-1.5 py-1 text-sm leading-6 shadow-none focus-visible:ring-0"
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className="flex min-h-0 flex-1 flex-col space-y-3">
+                {scheduleType === 'interval' ? (
+                  <div className="space-y-1.5 rounded-xl border border-border/60 bg-muted/15 p-3">
+                    <Label htmlFor="automation-interval">Every (minutes)</Label>
+                    <Input
+                      id="automation-interval"
+                      type="number"
+                      min={1}
+                      step={1}
+                      value={intervalMinutes}
+                      onChange={(event) => setIntervalMinutes(event.target.value)}
+                    />
+                    {!isIntervalValid ? (
+                      <p className="text-xs text-destructive">Interval must be at least 1 minute.</p>
+                    ) : (
+                      <p className="text-xs text-muted-foreground">Automation will run repeatedly based on this minute interval.</p>
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex min-h-0 flex-1 flex-col space-y-2">
+                    <Label>Cron schedule</Label>
+                    <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-border/60 bg-muted/15 p-3">
+                      <CronExpressionBuilder value={cronExpression} onChange={setCronExpression} timezone={timezone} />
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
 

--- a/apps/web/src/components/automations/automation-dialog.tsx
+++ b/apps/web/src/components/automations/automation-dialog.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 
-import type { Automation, AutomationSchedule } from '@stitch/shared/automations/types';
+import type {
+  Automation,
+  AutomationSchedule,
+  GeneratedAutomationDraft,
+} from '@stitch/shared/automations/types';
 
+import ChatMarkdown from '@/components/chat/chat-markdown';
 import { CronExpressionBuilder } from '@/components/cron-expression-builder';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -24,13 +29,17 @@ type AutomationDialogProps = {
   mode: 'create' | 'edit';
   automation?: Automation;
   providerModels: ProviderModels[];
-  onSubmit: (input: {
-    providerId: string;
-    modelId: string;
-    title: string;
-    initialMessage: string;
-    schedule: AutomationSchedule | null;
-  }) => Promise<void>;
+  prefill?: GeneratedAutomationDraft | null;
+  onSubmit: (
+    input: {
+      providerId: string;
+      modelId: string;
+      title: string;
+      initialMessage: string;
+      schedule: AutomationSchedule | null;
+    },
+    action: 'create' | 'create-view' | 'save',
+  ) => Promise<void>;
   isPending: boolean;
   timezone: string;
 };
@@ -48,6 +57,7 @@ export function AutomationDialog({
   mode,
   automation,
   providerModels,
+  prefill,
   onSubmit,
   isPending,
   timezone,
@@ -58,7 +68,7 @@ export function AutomationDialog({
   const [modelId, setModelId] = React.useState('');
   const [isScheduled, setIsScheduled] = React.useState(false);
   const [scheduleType, setScheduleType] = React.useState<'interval' | 'cron'>('interval');
-  const [editorView, setEditorView] = React.useState<'prompt' | 'schedule'>('prompt');
+  const [editorView, setEditorView] = React.useState<'prompt' | 'preview' | 'schedule'>('prompt');
   const [intervalMinutes, setIntervalMinutes] = React.useState('60');
   const [cronExpression, setCronExpression] = React.useState('0 9 * * *');
 
@@ -92,16 +102,16 @@ export function AutomationDialog({
     }
 
     const initialSelection = getInitialSelection(providerModels);
-    setTitle('');
-    setInitialMessage('');
-    setProviderId(initialSelection?.providerId ?? '');
-    setModelId(initialSelection?.modelId ?? '');
+    setTitle(prefill?.title ?? '');
+    setInitialMessage(prefill?.prompt ?? '');
+    setProviderId(prefill?.providerId ?? initialSelection?.providerId ?? '');
+    setModelId(prefill?.modelId ?? initialSelection?.modelId ?? '');
     setIsScheduled(false);
     setScheduleType('interval');
     setEditorView('prompt');
     setIntervalMinutes('60');
     setCronExpression('0 9 * * *');
-  }, [open, mode, automation, providerModels]);
+  }, [open, mode, automation, providerModels, prefill]);
 
   const selectedProvider = providerModels.find((provider) => provider.providerId === providerId) ?? null;
   const availableModels = React.useMemo(() => selectedProvider?.models ?? [], [selectedProvider]);
@@ -141,7 +151,7 @@ export function AutomationDialog({
     (!isScheduled || (scheduleType === 'interval' ? isIntervalValid : isCronValid)) &&
     !isPending;
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (action: 'create' | 'create-view' | 'save') => {
     if (!canSubmit) return;
 
     const schedule: AutomationSchedule | null = !isScheduled
@@ -150,13 +160,16 @@ export function AutomationDialog({
         ? { type: 'interval', everyMinutes: parsedIntervalMinutes }
         : { type: 'cron', expression: cronExpression.trim() };
 
-    await onSubmit({
+    await onSubmit(
+      {
       title: title.trim(),
       initialMessage: initialMessage.trim(),
       providerId,
       modelId,
       schedule,
-    });
+      },
+      action,
+    );
   };
 
   return (
@@ -280,6 +293,14 @@ export function AutomationDialog({
               <Button
                 type="button"
                 size="sm"
+                variant={editorView === 'preview' ? 'secondary' : 'ghost'}
+                onClick={() => setEditorView('preview')}
+              >
+                Preview
+              </Button>
+              <Button
+                type="button"
+                size="sm"
                 variant={editorView === 'schedule' ? 'secondary' : 'ghost'}
                 onClick={() => {
                   if (!isScheduled) return;
@@ -291,7 +312,21 @@ export function AutomationDialog({
               </Button>
             </div>
 
-            {editorView === 'prompt' || !isScheduled ? (
+            {editorView === 'preview' ? (
+              <div className="flex min-h-0 flex-1 flex-col space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label>Prompt preview</Label>
+                  <span className="text-xs text-muted-foreground">Markdown</span>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-border/60 bg-muted/10 p-3">
+                  {initialMessage.trim() ? (
+                    <ChatMarkdown text={initialMessage} />
+                  ) : (
+                    <p className="text-sm text-muted-foreground">Prompt preview appears here.</p>
+                  )}
+                </div>
+              </div>
+            ) : editorView === 'prompt' || !isScheduled ? (
               <div className="flex min-h-0 flex-1 flex-col space-y-2">
                 <div className="flex items-center justify-between">
                   <Label htmlFor="automation-message">Initial prompt</Label>
@@ -306,7 +341,7 @@ export function AutomationDialog({
                     value={initialMessage}
                     onChange={(event) => setInitialMessage(event.target.value)}
                     placeholder="Write the prompt that should be sent when this automation starts..."
-                    className="min-h-[220px] flex-1 resize-none overflow-y-auto border-0 bg-transparent px-1.5 py-1 text-sm leading-6 shadow-none focus-visible:ring-0"
+                    className="min-h-55 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-1.5 py-1 text-sm leading-6 shadow-none focus-visible:ring-0"
                   />
                 </div>
               </div>
@@ -346,9 +381,20 @@ export function AutomationDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
             Cancel
           </Button>
-          <Button onClick={() => void handleSubmit()} disabled={!canSubmit}>
-            {isPending ? (mode === 'create' ? 'Creating...' : 'Saving...') : mode === 'create' ? 'Create' : 'Save'}
-          </Button>
+          {mode === 'create' ? (
+            <>
+              <Button variant="outline" onClick={() => void handleSubmit('create')} disabled={!canSubmit}>
+                {isPending ? 'Creating...' : 'Create'}
+              </Button>
+              <Button onClick={() => void handleSubmit('create-view')} disabled={!canSubmit}>
+                {isPending ? 'Creating...' : 'Create and View'}
+              </Button>
+            </>
+          ) : (
+            <Button onClick={() => void handleSubmit('save')} disabled={!canSubmit}>
+              {isPending ? 'Saving...' : 'Save'}
+            </Button>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/automations/automation-dialog.tsx
+++ b/apps/web/src/components/automations/automation-dialog.tsx
@@ -1,0 +1,198 @@
+import * as React from 'react';
+
+import type { Automation } from '@stitch/shared/automations/types';
+
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import type { ProviderModels } from '@/lib/queries/providers';
+
+type AutomationDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: 'create' | 'edit';
+  automation?: Automation;
+  providerModels: ProviderModels[];
+  onSubmit: (input: {
+    providerId: string;
+    modelId: string;
+    title: string;
+    initialMessage: string;
+  }) => Promise<void>;
+  isPending: boolean;
+};
+
+function getInitialSelection(providerModels: ProviderModels[]): { providerId: string; modelId: string } | null {
+  const provider = providerModels[0];
+  const model = provider?.models[0];
+  if (!provider || !model) return null;
+  return { providerId: provider.providerId, modelId: model.id };
+}
+
+export function AutomationDialog({
+  open,
+  onOpenChange,
+  mode,
+  automation,
+  providerModels,
+  onSubmit,
+  isPending,
+}: AutomationDialogProps) {
+  const [title, setTitle] = React.useState('');
+  const [initialMessage, setInitialMessage] = React.useState('');
+  const [providerId, setProviderId] = React.useState('');
+  const [modelId, setModelId] = React.useState('');
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    if (mode === 'edit' && automation) {
+      setTitle(automation.title);
+      setInitialMessage(automation.initialMessage);
+      setProviderId(automation.providerId);
+      setModelId(automation.modelId);
+      return;
+    }
+
+    const initialSelection = getInitialSelection(providerModels);
+    setTitle('');
+    setInitialMessage('');
+    setProviderId(initialSelection?.providerId ?? '');
+    setModelId(initialSelection?.modelId ?? '');
+  }, [open, mode, automation, providerModels]);
+
+  const selectedProvider = providerModels.find((provider) => provider.providerId === providerId) ?? null;
+  const availableModels = React.useMemo(() => selectedProvider?.models ?? [], [selectedProvider]);
+  const selectedProviderLabel = selectedProvider?.providerName ?? null;
+  const selectedModelLabel =
+    availableModels.find((model) => model.id === modelId)?.name ??
+    providerModels.flatMap((provider) => provider.models).find((model) => model.id === modelId)?.name ??
+    null;
+
+  React.useEffect(() => {
+    if (!selectedProvider) return;
+    const hasCurrentModel = availableModels.some((model) => model.id === modelId);
+    if (!hasCurrentModel) {
+      setModelId(availableModels[0]?.id ?? '');
+    }
+  }, [selectedProvider, availableModels, modelId]);
+
+  const canSubmit =
+    title.trim().length > 0 &&
+    initialMessage.trim().length > 0 &&
+    providerId.length > 0 &&
+    modelId.length > 0 &&
+    !isPending;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    await onSubmit({
+      title: title.trim(),
+      initialMessage: initialMessage.trim(),
+      providerId,
+      modelId,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{mode === 'create' ? 'Create automation' : 'Edit automation'}</DialogTitle>
+      </DialogHeader>
+      <DialogContent className="w-[min(1080px,calc(100vw-2rem))] max-w-none overflow-hidden p-0 sm:max-w-none">
+        <div className="border-b border-border/60 px-6 py-5">
+          <h2 className="text-xl font-semibold tracking-tight">
+            {mode === 'create' ? 'Create automation' : 'Edit automation'}
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Save a reusable model + prompt pair for recurring tasks.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-[minmax(280px,1fr)_minmax(0,2fr)]">
+          <div className="space-y-5 border-b border-border/50 bg-muted/10 px-6 py-5 lg:border-r lg:border-b-0">
+            <div className="space-y-1.5">
+              <Label htmlFor="automation-title">Title</Label>
+              <Input
+                id="automation-title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="e.g. Daily standup prep"
+                autoFocus
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Provider</Label>
+              <Select value={providerId} onValueChange={(value) => setProviderId(value ?? '')}>
+                <SelectTrigger className="w-full">
+                  <SelectValue>{selectedProviderLabel ?? 'Select provider'}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {providerModels.map((provider) => (
+                    <SelectItem key={provider.providerId} value={provider.providerId}>
+                      {provider.providerName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Model</Label>
+              <Select value={modelId} onValueChange={(value) => setModelId(value ?? '')}>
+                <SelectTrigger className="w-full">
+                  <SelectValue>{selectedModelLabel ?? 'Select model'}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {availableModels.map((model) => (
+                    <SelectItem key={model.id} value={model.id}>
+                      {model.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="space-y-2 px-6 py-5">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="automation-message">Initial prompt</Label>
+              <span className="text-xs text-muted-foreground">{initialMessage.length} chars</span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              This message is used to kick off the session when the automation runs.
+            </p>
+            <div className="rounded-xl border border-border/60 bg-muted/15 p-3">
+              <Textarea
+                id="automation-message"
+                value={initialMessage}
+                onChange={(event) => setInitialMessage(event.target.value)}
+                placeholder="Write the prompt that should be sent when this automation starts..."
+                className="h-105 resize-none overflow-y-auto border-0 bg-transparent px-1.5 py-1 text-sm leading-6 shadow-none focus-visible:ring-0"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-border/60 px-6 py-4">
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSubmit()} disabled={!canSubmit}>
+            {isPending ? (mode === 'create' ? 'Creating...' : 'Saving...') : mode === 'create' ? 'Create' : 'Save'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/automations/automation-runs-table.tsx
+++ b/apps/web/src/components/automations/automation-runs-table.tsx
@@ -1,0 +1,100 @@
+import { ArrowUpRightIcon } from 'lucide-react';
+import * as React from 'react';
+
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable,
+} from '@tanstack/react-table';
+
+import type { Session } from '@stitch/shared/chat/messages';
+
+import { Button } from '@/components/ui/button';
+
+type AutomationRunsTableProps = {
+  sessions: Session[];
+  onOpen: (sessionId: string) => void;
+};
+
+const columnHelper = createColumnHelper<Session>();
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+export function AutomationRunsTable({ sessions, onOpen }: AutomationRunsTableProps) {
+  const [sorting, setSorting] = React.useState<SortingState>([{ id: 'updatedAt', desc: true }]);
+
+  const columns = React.useMemo(
+    () => [
+      columnHelper.accessor('title', {
+        header: 'Run',
+        cell: ({ row }) => <span className="truncate font-medium">{row.original.title ?? 'Untitled run'}</span>,
+      }),
+      columnHelper.accessor('createdAt', {
+        header: 'Started',
+        cell: ({ getValue }) => <span className="text-sm text-muted-foreground">{formatDate(getValue())}</span>,
+      }),
+      columnHelper.accessor('updatedAt', {
+        header: 'Updated',
+        cell: ({ getValue }) => <span className="text-sm text-muted-foreground">{formatDate(getValue())}</span>,
+      }),
+      columnHelper.display({
+        id: 'actions',
+        header: '',
+        cell: ({ row }) => (
+          <div className="flex justify-end">
+            <Button variant="outline" size="sm" onClick={() => onOpen(row.original.id)}>
+              <ArrowUpRightIcon data-icon="inline-start" className="size-4" />
+              View
+            </Button>
+          </div>
+        ),
+      }),
+    ],
+    [onOpen],
+  );
+
+  const table = useReactTable({
+    data: sessions,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border/60 bg-card/80">
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[720px] text-left">
+          <thead className="border-b border-border/60 bg-muted/30">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <tr key={row.id} className="border-b border-border/50 last:border-b-0">
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id} className="px-4 py-3 align-middle">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/automations/automations-page.tsx
+++ b/apps/web/src/components/automations/automations-page.tsx
@@ -203,12 +203,14 @@ export function AutomationsPage({ automationId }: AutomationsPageProps) {
         providerModels={providerModels}
         isPending={createAutomation.isPending}
         timezone={timezone}
-        onSubmit={async (input) => {
+        onSubmit={async (input, action) => {
           try {
             const created = await createAutomation.mutateAsync(input);
             closeCreateDialog();
             toast.success('Automation created');
-            void navigate({ to: '/automations/$automationId', params: { automationId: created.id } });
+            if (action === 'create-view') {
+              void navigate({ to: '/automations/$automationId', params: { automationId: created.id } });
+            }
           } catch (error) {
             toast.error(error instanceof Error ? error.message : 'Failed to create automation');
           }
@@ -225,7 +227,7 @@ export function AutomationsPage({ automationId }: AutomationsPageProps) {
         providerModels={providerModels}
         isPending={updateAutomation.isPending}
         timezone={timezone}
-        onSubmit={async (input) => {
+        onSubmit={async (input, _action) => {
           if (!editingAutomation) return;
           try {
             await updateAutomation.mutateAsync({ automationId: editingAutomation.id, input });

--- a/apps/web/src/components/automations/automations-page.tsx
+++ b/apps/web/src/components/automations/automations-page.tsx
@@ -10,6 +10,7 @@ import { AutomationDialog } from '@/components/automations/automation-dialog';
 import { AutomationRunsTable } from '@/components/automations/automation-runs-table';
 import { AutomationsTable } from '@/components/automations/automations-table';
 import { Button } from '@/components/ui/button';
+import { getAutomationScheduleLabel } from '@/lib/automations/schedule-label';
 import {
   automationSessionsQueryOptions,
   automationsQueryOptions,
@@ -19,6 +20,7 @@ import {
   useUpdateAutomation,
 } from '@/lib/queries/automations';
 import { visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
+import { settingsQueryOptions } from '@/lib/queries/settings';
 import { useAutomationStore } from '@/stores/automation-store';
 
 type AutomationsPageProps = {
@@ -29,6 +31,7 @@ export function AutomationsPage({ automationId }: AutomationsPageProps) {
   const navigate = useNavigate();
   const { data: automations } = useSuspenseQuery(automationsQueryOptions);
   const { data: providerModels } = useSuspenseQuery(visibleProviderModelsQueryOptions);
+  const { data: settings } = useQuery(settingsQueryOptions);
 
   const createAutomation = useCreateAutomation();
   const updateAutomation = useUpdateAutomation();
@@ -91,6 +94,10 @@ export function AutomationsPage({ automationId }: AutomationsPageProps) {
   const pageDescription = selectedAutomation
     ? 'Automation details and run history.'
     : 'Manage reusable prompts and model presets for recurring tasks.';
+  const timezone = settings?.['profile.timezone']?.trim() || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  const selectedScheduleLabel = selectedAutomation
+    ? getAutomationScheduleLabel(selectedAutomation.schedule)
+    : 'Manual';
 
   return (
     <div className="flex h-full flex-col overflow-y-auto">
@@ -129,6 +136,7 @@ export function AutomationsPage({ automationId }: AutomationsPageProps) {
                       selectedAutomation.modelId}
                   </p>
                   <p className="text-xs text-muted-foreground">{selectedAutomation.runCount} total runs</p>
+                  <p className="text-xs text-muted-foreground">Schedule: {selectedScheduleLabel}</p>
                 </div>
 
                 <div className="flex flex-wrap items-center gap-2">
@@ -194,6 +202,7 @@ export function AutomationsPage({ automationId }: AutomationsPageProps) {
         mode="create"
         providerModels={providerModels}
         isPending={createAutomation.isPending}
+        timezone={timezone}
         onSubmit={async (input) => {
           try {
             const created = await createAutomation.mutateAsync(input);
@@ -215,6 +224,7 @@ export function AutomationsPage({ automationId }: AutomationsPageProps) {
         automation={editingAutomation ?? undefined}
         providerModels={providerModels}
         isPending={updateAutomation.isPending}
+        timezone={timezone}
         onSubmit={async (input) => {
           if (!editingAutomation) return;
           try {

--- a/apps/web/src/components/automations/automations-page.tsx
+++ b/apps/web/src/components/automations/automations-page.tsx
@@ -1,37 +1,40 @@
-import { BotIcon, PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react';
-import * as React from 'react';
+import { BotIcon, PencilIcon, PlayIcon, PlusIcon, Trash2Icon } from 'lucide-react';
 import { toast } from 'sonner';
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 
 import type { Automation } from '@stitch/shared/automations/types';
 
 import { AutomationDialog } from '@/components/automations/automation-dialog';
-import { Badge } from '@/components/ui/badge';
+import { AutomationRunsTable } from '@/components/automations/automation-runs-table';
+import { AutomationsTable } from '@/components/automations/automations-table';
 import { Button } from '@/components/ui/button';
 import {
+  automationSessionsQueryOptions,
   automationsQueryOptions,
   useCreateAutomation,
   useDeleteAutomation,
+  useRunAutomation,
   useUpdateAutomation,
 } from '@/lib/queries/automations';
 import { visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
 import { useAutomationStore } from '@/stores/automation-store';
 
-function formatModelLabel(automation: Automation, modelLabelByKey: Map<string, string>) {
-  return modelLabelByKey.get(`${automation.providerId}:${automation.modelId}`) ?? automation.modelId;
-}
+type AutomationsPageProps = {
+  automationId?: string;
+};
 
-export function AutomationsPage() {
+export function AutomationsPage({ automationId }: AutomationsPageProps) {
+  const navigate = useNavigate();
   const { data: automations } = useSuspenseQuery(automationsQueryOptions);
   const { data: providerModels } = useSuspenseQuery(visibleProviderModelsQueryOptions);
 
   const createAutomation = useCreateAutomation();
   const updateAutomation = useUpdateAutomation();
   const deleteAutomation = useDeleteAutomation();
+  const runAutomation = useRunAutomation();
 
-  const selectedAutomationId = useAutomationStore((state) => state.selectedAutomationId);
-  const setSelectedAutomationId = useAutomationStore((state) => state.setSelectedAutomationId);
   const createDialogOpen = useAutomationStore((state) => state.createDialogOpen);
   const openCreateDialog = useAutomationStore((state) => state.openCreateDialog);
   const closeCreateDialog = useAutomationStore((state) => state.closeCreateDialog);
@@ -39,31 +42,18 @@ export function AutomationsPage() {
   const openEditDialog = useAutomationStore((state) => state.openEditDialog);
   const closeEditDialog = useAutomationStore((state) => state.closeEditDialog);
 
-  React.useEffect(() => {
-    if (automations.length === 0) {
-      setSelectedAutomationId(null);
-      return;
-    }
-
-    const selectedStillExists = automations.some((automation) => automation.id === selectedAutomationId);
-    if (!selectedStillExists) {
-      setSelectedAutomationId(automations[0].id);
-    }
-  }, [automations, selectedAutomationId, setSelectedAutomationId]);
+  const selectedAutomation = automationId
+    ? (automations.find((automation) => automation.id === automationId) ?? null)
+    : null;
 
   const editingAutomation = editingAutomationId
     ? (automations.find((automation) => automation.id === editingAutomationId) ?? null)
     : null;
 
-  const modelLabelByKey = React.useMemo(() => {
-    const map = new Map<string, string>();
-    for (const provider of providerModels) {
-      for (const model of provider.models) {
-        map.set(`${provider.providerId}:${model.id}`, `${provider.providerName} / ${model.name}`);
-      }
-    }
-    return map;
-  }, [providerModels]);
+  const { data: automationSessions = [] } = useQuery({
+    ...automationSessionsQueryOptions(selectedAutomation?.id ?? ''),
+    enabled: selectedAutomation !== null,
+  });
 
   const handleDelete = async (automation: Automation) => {
     const confirmed = window.confirm(`Delete automation "${automation.title}"?`);
@@ -71,25 +61,48 @@ export function AutomationsPage() {
 
     try {
       await deleteAutomation.mutateAsync(automation.id);
+      if (automationId === automation.id) {
+        void navigate({ to: '/automations' });
+      }
       toast.success('Automation deleted');
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to delete automation');
     }
   };
 
+  const handleRun = async (automation: Automation) => {
+    try {
+      const result = await runAutomation.mutateAsync(automation.id);
+      toast.success(`Started ${automation.title}`);
+      void navigate({ to: '/automations/sessions/$id', params: { id: result.sessionId }, viewTransition: true });
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to run automation');
+    }
+  };
+
+  const modelLabelByKey = new Map<string, string>();
+  for (const provider of providerModels) {
+    for (const model of provider.models) {
+      modelLabelByKey.set(`${provider.providerId}:${model.id}`, `${provider.providerName} / ${model.name}`);
+    }
+  }
+
+  const pageTitle = selectedAutomation ? selectedAutomation.title : 'Automations';
+  const pageDescription = selectedAutomation
+    ? 'Automation details and run history.'
+    : 'Manage reusable prompts and model presets for recurring tasks.';
+
   return (
     <div className="flex h-full flex-col overflow-y-auto">
-      <div className="mx-auto w-full max-w-4xl px-6 py-8">
-        <div className="mb-8 flex items-center justify-between gap-3">
+      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col px-6 py-8">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
           <div className="flex items-center gap-3">
             <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
               <BotIcon className="size-5" />
             </div>
             <div>
-              <h1 className="text-xl font-semibold">Automations</h1>
-              <p className="text-sm text-muted-foreground">
-                Save reusable prompts to start sessions with a predefined model and message.
-              </p>
+              <h1 className="text-xl font-semibold">{pageTitle}</h1>
+              <p className="text-sm text-muted-foreground">{pageDescription}</p>
             </div>
           </div>
           <Button onClick={openCreateDialog}>
@@ -105,51 +118,71 @@ export function AutomationsPage() {
               Create your first automation to speed up recurring workflows.
             </p>
           </div>
-        ) : (
-          <div className="space-y-3">
-            {automations.map((automation) => (
-              <div
-                key={automation.id}
-                className={`rounded-xl border bg-card/80 px-4 py-3.5 ${
-                  automation.id === selectedAutomationId
-                    ? 'border-primary/60 shadow-[0_0_0_1px_hsl(var(--primary)/0.25)]'
-                    : 'border-border/60'
-                }`}
-                onClick={() => setSelectedAutomationId(automation.id)}
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0 space-y-2">
-                    <div className="flex items-center gap-2">
-                      <p className="truncate text-sm font-medium">{automation.title}</p>
-                      <Badge variant="secondary" className="text-[11px]">
-                        {formatModelLabel(automation, modelLabelByKey)}
-                      </Badge>
-                    </div>
-                    <p className="line-clamp-2 text-xs text-muted-foreground">{automation.initialMessage}</p>
-                  </div>
-                  <div className="flex shrink-0 items-center gap-1">
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => openEditDialog(automation.id)}
-                      aria-label={`Edit ${automation.title}`}
-                    >
-                      <PencilIcon className="size-3.5" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => void handleDelete(automation)}
-                      aria-label={`Delete ${automation.title}`}
-                      disabled={deleteAutomation.isPending}
-                    >
-                      <Trash2Icon className="size-3.5 text-destructive" />
-                    </Button>
-                  </div>
+        ) : selectedAutomation ? (
+          <div className="space-y-4">
+            <div className="rounded-xl border border-border/60 bg-card/70 p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <p className="text-base font-semibold">{selectedAutomation.title}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {modelLabelByKey.get(`${selectedAutomation.providerId}:${selectedAutomation.modelId}`) ??
+                      selectedAutomation.modelId}
+                  </p>
+                  <p className="text-xs text-muted-foreground">{selectedAutomation.runCount} total runs</p>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    size="sm"
+                    onClick={() => void handleRun(selectedAutomation)}
+                    disabled={runAutomation.isPending}
+                  >
+                    <PlayIcon data-icon="inline-start" className="size-4" />
+                    Run
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => openEditDialog(selectedAutomation.id)}>
+                    <PencilIcon data-icon="inline-start" className="size-4" />
+                    Edit
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void handleDelete(selectedAutomation)}
+                    disabled={deleteAutomation.isPending}
+                  >
+                    <Trash2Icon data-icon="inline-start" className="size-4 text-destructive" />
+                    Delete
+                  </Button>
                 </div>
               </div>
-            ))}
+            </div>
+
+            {automationSessions.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 px-4 py-10 text-center">
+                <p className="text-sm font-medium">No runs yet</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Trigger this automation to create the first run session.
+                </p>
+              </div>
+            ) : (
+              <AutomationRunsTable
+                sessions={automationSessions}
+                onOpen={(sessionId) =>
+                  void navigate({ to: '/automations/sessions/$id', params: { id: sessionId }, viewTransition: true })
+                }
+              />
+            )}
           </div>
+        ) : (
+          <AutomationsTable
+            automations={automations}
+            providerModels={providerModels}
+            runPending={runAutomation.isPending}
+            deletePending={deleteAutomation.isPending}
+            onRun={(automation) => void handleRun(automation)}
+            onEdit={openEditDialog}
+            onDelete={(automation) => void handleDelete(automation)}
+          />
         )}
       </div>
 
@@ -164,9 +197,9 @@ export function AutomationsPage() {
         onSubmit={async (input) => {
           try {
             const created = await createAutomation.mutateAsync(input);
-            setSelectedAutomationId(created.id);
             closeCreateDialog();
             toast.success('Automation created');
+            void navigate({ to: '/automations/$automationId', params: { automationId: created.id } });
           } catch (error) {
             toast.error(error instanceof Error ? error.message : 'Failed to create automation');
           }

--- a/apps/web/src/components/automations/automations-page.tsx
+++ b/apps/web/src/components/automations/automations-page.tsx
@@ -1,0 +1,198 @@
+import { BotIcon, PencilIcon, PlusIcon, Trash2Icon } from 'lucide-react';
+import * as React from 'react';
+import { toast } from 'sonner';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import type { Automation } from '@stitch/shared/automations/types';
+
+import { AutomationDialog } from '@/components/automations/automation-dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  automationsQueryOptions,
+  useCreateAutomation,
+  useDeleteAutomation,
+  useUpdateAutomation,
+} from '@/lib/queries/automations';
+import { visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
+import { useAutomationStore } from '@/stores/automation-store';
+
+function formatModelLabel(automation: Automation, modelLabelByKey: Map<string, string>) {
+  return modelLabelByKey.get(`${automation.providerId}:${automation.modelId}`) ?? automation.modelId;
+}
+
+export function AutomationsPage() {
+  const { data: automations } = useSuspenseQuery(automationsQueryOptions);
+  const { data: providerModels } = useSuspenseQuery(visibleProviderModelsQueryOptions);
+
+  const createAutomation = useCreateAutomation();
+  const updateAutomation = useUpdateAutomation();
+  const deleteAutomation = useDeleteAutomation();
+
+  const selectedAutomationId = useAutomationStore((state) => state.selectedAutomationId);
+  const setSelectedAutomationId = useAutomationStore((state) => state.setSelectedAutomationId);
+  const createDialogOpen = useAutomationStore((state) => state.createDialogOpen);
+  const openCreateDialog = useAutomationStore((state) => state.openCreateDialog);
+  const closeCreateDialog = useAutomationStore((state) => state.closeCreateDialog);
+  const editingAutomationId = useAutomationStore((state) => state.editingAutomationId);
+  const openEditDialog = useAutomationStore((state) => state.openEditDialog);
+  const closeEditDialog = useAutomationStore((state) => state.closeEditDialog);
+
+  React.useEffect(() => {
+    if (automations.length === 0) {
+      setSelectedAutomationId(null);
+      return;
+    }
+
+    const selectedStillExists = automations.some((automation) => automation.id === selectedAutomationId);
+    if (!selectedStillExists) {
+      setSelectedAutomationId(automations[0].id);
+    }
+  }, [automations, selectedAutomationId, setSelectedAutomationId]);
+
+  const editingAutomation = editingAutomationId
+    ? (automations.find((automation) => automation.id === editingAutomationId) ?? null)
+    : null;
+
+  const modelLabelByKey = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const provider of providerModels) {
+      for (const model of provider.models) {
+        map.set(`${provider.providerId}:${model.id}`, `${provider.providerName} / ${model.name}`);
+      }
+    }
+    return map;
+  }, [providerModels]);
+
+  const handleDelete = async (automation: Automation) => {
+    const confirmed = window.confirm(`Delete automation "${automation.title}"?`);
+    if (!confirmed) return;
+
+    try {
+      await deleteAutomation.mutateAsync(automation.id);
+      toast.success('Automation deleted');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to delete automation');
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-y-auto">
+      <div className="mx-auto w-full max-w-4xl px-6 py-8">
+        <div className="mb-8 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <BotIcon className="size-5" />
+            </div>
+            <div>
+              <h1 className="text-xl font-semibold">Automations</h1>
+              <p className="text-sm text-muted-foreground">
+                Save reusable prompts to start sessions with a predefined model and message.
+              </p>
+            </div>
+          </div>
+          <Button onClick={openCreateDialog}>
+            <PlusIcon data-icon="inline-start" className="size-4" />
+            New automation
+          </Button>
+        </div>
+
+        {automations.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 px-4 py-10 text-center">
+            <p className="text-sm font-medium">No automations yet</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Create your first automation to speed up recurring workflows.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {automations.map((automation) => (
+              <div
+                key={automation.id}
+                className={`rounded-xl border bg-card/80 px-4 py-3.5 ${
+                  automation.id === selectedAutomationId
+                    ? 'border-primary/60 shadow-[0_0_0_1px_hsl(var(--primary)/0.25)]'
+                    : 'border-border/60'
+                }`}
+                onClick={() => setSelectedAutomationId(automation.id)}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex items-center gap-2">
+                      <p className="truncate text-sm font-medium">{automation.title}</p>
+                      <Badge variant="secondary" className="text-[11px]">
+                        {formatModelLabel(automation, modelLabelByKey)}
+                      </Badge>
+                    </div>
+                    <p className="line-clamp-2 text-xs text-muted-foreground">{automation.initialMessage}</p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => openEditDialog(automation.id)}
+                      aria-label={`Edit ${automation.title}`}
+                    >
+                      <PencilIcon className="size-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => void handleDelete(automation)}
+                      aria-label={`Delete ${automation.title}`}
+                      disabled={deleteAutomation.isPending}
+                    >
+                      <Trash2Icon className="size-3.5 text-destructive" />
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <AutomationDialog
+        open={createDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) closeCreateDialog();
+        }}
+        mode="create"
+        providerModels={providerModels}
+        isPending={createAutomation.isPending}
+        onSubmit={async (input) => {
+          try {
+            const created = await createAutomation.mutateAsync(input);
+            setSelectedAutomationId(created.id);
+            closeCreateDialog();
+            toast.success('Automation created');
+          } catch (error) {
+            toast.error(error instanceof Error ? error.message : 'Failed to create automation');
+          }
+        }}
+      />
+
+      <AutomationDialog
+        open={editingAutomation !== null}
+        onOpenChange={(open) => {
+          if (!open) closeEditDialog();
+        }}
+        mode="edit"
+        automation={editingAutomation ?? undefined}
+        providerModels={providerModels}
+        isPending={updateAutomation.isPending}
+        onSubmit={async (input) => {
+          if (!editingAutomation) return;
+          try {
+            await updateAutomation.mutateAsync({ automationId: editingAutomation.id, input });
+            closeEditDialog();
+            toast.success('Automation updated');
+          } catch (error) {
+            toast.error(error instanceof Error ? error.message : 'Failed to update automation');
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/automations/automations-sidebar.tsx
+++ b/apps/web/src/components/automations/automations-sidebar.tsx
@@ -1,0 +1,76 @@
+import { BotIcon, PlusIcon } from 'lucide-react';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { Button } from '@/components/ui/button';
+import {
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar';
+import { automationsQueryOptions } from '@/lib/queries/automations';
+import { cn } from '@/lib/utils';
+import { useAutomationStore } from '@/stores/automation-store';
+
+export function AutomationsSidebarContent() {
+  const { data: automations = [] } = useQuery(automationsQueryOptions);
+  const selectedAutomationId = useAutomationStore((state) => state.selectedAutomationId);
+  const setSelectedAutomationId = useAutomationStore((state) => state.setSelectedAutomationId);
+  const openCreateDialog = useAutomationStore((state) => state.openCreateDialog);
+
+  return (
+    <>
+      <SidebarHeader className="pb-0">
+        <div className="flex items-center gap-2 px-2 py-1">
+          <div className="flex min-w-0 flex-1 items-center gap-2 text-sm font-medium">
+            <BotIcon className="size-4" />
+            Automations
+          </div>
+          <Button size="icon-sm" onClick={openCreateDialog} aria-label="Create automation">
+            <PlusIcon className="size-3.5" />
+          </Button>
+        </div>
+      </SidebarHeader>
+
+      <SidebarContent>
+        {automations.length > 0 ? (
+          <SidebarGroup>
+            <SidebarGroupLabel>All</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {automations.map((automation) => (
+                  <SidebarMenuItem key={automation.id}>
+                    <SidebarMenuButton
+                      isActive={automation.id === selectedAutomationId}
+                      onClick={() => setSelectedAutomationId(automation.id)}
+                      className="truncate"
+                    >
+                      <span className={cn('truncate', automation.id === selectedAutomationId && 'font-medium')}>
+                        {automation.title}
+                      </span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-3 px-4 py-12 text-center">
+            <BotIcon className="size-8 text-muted-foreground/40" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-muted-foreground">No automations yet</p>
+              <p className="text-xs text-muted-foreground/70">
+                Create one to prefill and start sessions faster.
+              </p>
+            </div>
+          </div>
+        )}
+      </SidebarContent>
+    </>
+  );
+}

--- a/apps/web/src/components/automations/automations-sidebar.tsx
+++ b/apps/web/src/components/automations/automations-sidebar.tsx
@@ -1,6 +1,7 @@
 import { BotIcon, PlusIcon } from 'lucide-react';
 
 import { useQuery } from '@tanstack/react-query';
+import { Link, useParams } from '@tanstack/react-router';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -14,14 +15,15 @@ import {
   SidebarMenuItem,
 } from '@/components/ui/sidebar';
 import { automationsQueryOptions } from '@/lib/queries/automations';
-import { cn } from '@/lib/utils';
 import { useAutomationStore } from '@/stores/automation-store';
 
 export function AutomationsSidebarContent() {
-  const { data: automations = [] } = useQuery(automationsQueryOptions);
-  const selectedAutomationId = useAutomationStore((state) => state.selectedAutomationId);
-  const setSelectedAutomationId = useAutomationStore((state) => state.setSelectedAutomationId);
+  const params = useParams({ strict: false });
+
   const openCreateDialog = useAutomationStore((state) => state.openCreateDialog);
+
+  const { data: automations = [] } = useQuery(automationsQueryOptions);
+  const selectedAutomationId = typeof params.automationId === 'string' ? params.automationId : null;
 
   return (
     <>
@@ -40,19 +42,22 @@ export function AutomationsSidebarContent() {
       <SidebarContent>
         {automations.length > 0 ? (
           <SidebarGroup>
-            <SidebarGroupLabel>All</SidebarGroupLabel>
+            <SidebarGroupLabel>All automations</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
                 {automations.map((automation) => (
                   <SidebarMenuItem key={automation.id}>
                     <SidebarMenuButton
                       isActive={automation.id === selectedAutomationId}
-                      onClick={() => setSelectedAutomationId(automation.id)}
-                      className="truncate"
+                      render={
+                        <Link
+                          to="/automations/$automationId"
+                          params={{ automationId: automation.id }}
+                          className="truncate"
+                        />
+                      }
                     >
-                      <span className={cn('truncate', automation.id === selectedAutomationId && 'font-medium')}>
-                        {automation.title}
-                      </span>
+                      <span className="truncate">{automation.title}</span>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                 ))}

--- a/apps/web/src/components/automations/automations-table.tsx
+++ b/apps/web/src/components/automations/automations-table.tsx
@@ -15,6 +15,7 @@ import type { Automation } from '@stitch/shared/automations/types';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { getAutomationScheduleLabel } from '@/lib/automations/schedule-label';
 import type { ProviderModels } from '@/lib/queries/providers';
 
 type AutomationsTableProps = {
@@ -86,6 +87,13 @@ export function AutomationsTable({
         header: 'Runs',
         cell: ({ getValue }) => <span className="text-sm tabular-nums">{getValue()}</span>,
       }),
+      columnHelper.display({
+        id: 'schedule',
+        header: 'Schedule',
+        cell: ({ row }) => (
+          <span className="text-sm text-muted-foreground">{getAutomationScheduleLabel(row.original.schedule)}</span>
+        ),
+      }),
       columnHelper.accessor('updatedAt', {
         header: 'Updated',
         cell: ({ getValue }) => <span className="text-sm text-muted-foreground">{formatDate(getValue())}</span>,
@@ -140,7 +148,7 @@ export function AutomationsTable({
   return (
     <div className="overflow-hidden rounded-xl border border-border/60 bg-card/80">
       <div className="overflow-x-auto">
-        <table className="w-full min-w-[760px] text-left">
+        <table className="w-full min-w-[900px] text-left">
           <thead className="border-b border-border/60 bg-muted/30">
             {table.getHeaderGroups().map((headerGroup) => (
               <tr key={headerGroup.id}>

--- a/apps/web/src/components/automations/automations-table.tsx
+++ b/apps/web/src/components/automations/automations-table.tsx
@@ -1,0 +1,170 @@
+import { PlayIcon, PencilIcon, Trash2Icon } from 'lucide-react';
+import * as React from 'react';
+
+import {
+  createColumnHelper,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable,
+} from '@tanstack/react-table';
+import { Link } from '@tanstack/react-router';
+
+import type { Automation } from '@stitch/shared/automations/types';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import type { ProviderModels } from '@/lib/queries/providers';
+
+type AutomationsTableProps = {
+  automations: Automation[];
+  providerModels: ProviderModels[];
+  runPending: boolean;
+  deletePending: boolean;
+  onRun: (automation: Automation) => void;
+  onEdit: (automationId: string) => void;
+  onDelete: (automation: Automation) => void;
+};
+
+const columnHelper = createColumnHelper<Automation>();
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+export function AutomationsTable({
+  automations,
+  providerModels,
+  runPending,
+  deletePending,
+  onRun,
+  onEdit,
+  onDelete,
+}: AutomationsTableProps) {
+  const [sorting, setSorting] = React.useState<SortingState>([{ id: 'updatedAt', desc: true }]);
+
+  const modelLabelByKey = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const provider of providerModels) {
+      for (const model of provider.models) {
+        map.set(`${provider.providerId}:${model.id}`, `${provider.providerName} / ${model.name}`);
+      }
+    }
+    return map;
+  }, [providerModels]);
+
+  const columns = React.useMemo(
+    () => [
+      columnHelper.accessor('title', {
+        header: 'Title',
+        cell: ({ row }) => (
+          <Link
+            to="/automations/$automationId"
+            params={{ automationId: row.original.id }}
+            className="truncate font-medium text-foreground hover:underline"
+          >
+            {row.original.title}
+          </Link>
+        ),
+      }),
+      columnHelper.display({
+        id: 'model',
+        header: 'Model',
+        cell: ({ row }) => {
+          const automation = row.original;
+          const label =
+            modelLabelByKey.get(`${automation.providerId}:${automation.modelId}`) ?? automation.modelId;
+          return (
+            <Badge variant="secondary" className="text-[11px]">
+              {label}
+            </Badge>
+          );
+        },
+      }),
+      columnHelper.accessor('runCount', {
+        header: 'Runs',
+        cell: ({ getValue }) => <span className="text-sm tabular-nums">{getValue()}</span>,
+      }),
+      columnHelper.accessor('updatedAt', {
+        header: 'Updated',
+        cell: ({ getValue }) => <span className="text-sm text-muted-foreground">{formatDate(getValue())}</span>,
+      }),
+      columnHelper.display({
+        id: 'actions',
+        header: '',
+        cell: ({ row }) => (
+          <div className="flex items-center justify-end gap-1">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onRun(row.original)}
+              disabled={runPending}
+              aria-label={`Run ${row.original.title}`}
+            >
+              <PlayIcon className="size-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onEdit(row.original.id)}
+              aria-label={`Edit ${row.original.title}`}
+            >
+              <PencilIcon className="size-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onDelete(row.original)}
+              disabled={deletePending}
+              aria-label={`Delete ${row.original.title}`}
+            >
+              <Trash2Icon className="size-3.5 text-destructive" />
+            </Button>
+          </div>
+        ),
+      }),
+    ],
+    [deletePending, modelLabelByKey, onDelete, onEdit, onRun, runPending],
+  );
+
+  const table = useReactTable({
+    data: automations,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border/60 bg-card/80">
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[760px] text-left">
+          <thead className="border-b border-border/60 bg-muted/30">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <th key={header.id} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <tr key={row.id} className="border-b border-border/50 last:border-b-0">
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id} className="px-4 py-3 align-middle">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/chat-markdown.tsx
+++ b/apps/web/src/components/chat/chat-markdown.tsx
@@ -137,33 +137,26 @@ function SuspenseShikiCodeBlock({
 
   const highlighter = use(getHighlighterPromise(language, theme));
 
-  const highlightedHtml = React.useMemo(() => {
-    try {
-      return highlighter.codeToHtml(code, {
-        lang: language as SupportedLanguage,
-        theme: theme === 'dark' ? 'github-dark' : 'github-light',
-      });
-    } catch (error) {
-      console.warn(
-        `Code highlighting failed for language "${language}", falling back to plain text.`,
-        error instanceof Error ? error.message : error,
-      );
-      return highlighter.codeToHtml(code, {
-        lang: 'text',
-        theme: theme === 'dark' ? 'github-dark' : 'github-light',
-      });
-    }
-  }, [code, highlighter, language, theme]);
+  let highlightedHtml: string;
+  try {
+    highlightedHtml = highlighter.codeToHtml(code, {
+      lang: language as SupportedLanguage,
+      theme: theme === 'dark' ? 'github-dark' : 'github-light',
+    });
+  } catch (error) {
+    console.warn(
+      `Code highlighting failed for language "${language}", falling back to plain text.`,
+      error instanceof Error ? error.message : error,
+    );
+    highlightedHtml = highlighter.codeToHtml(code, {
+      lang: 'text',
+      theme: theme === 'dark' ? 'github-dark' : 'github-light',
+    });
+  }
 
-  React.useEffect(() => {
-    if (!isStreaming) {
-      highlightedCodeCache.set(
-        cacheKey,
-        highlightedHtml,
-        estimateHighlightedSize(highlightedHtml, code),
-      );
-    }
-  }, [cacheKey, code, highlightedHtml, isStreaming]);
+  if (!isStreaming) {
+    highlightedCodeCache.set(cacheKey, highlightedHtml, estimateHighlightedSize(highlightedHtml, code));
+  }
 
   return (
     <div

--- a/apps/web/src/components/chat/message-list/rows.ts
+++ b/apps/web/src/components/chat/message-list/rows.ts
@@ -38,7 +38,15 @@ export function buildRows(
 
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i];
-    if (message.parts.some((part) => part.type === 'session-title')) continue;
+    if (
+      message.parts.some(
+        (part) =>
+          part.type === 'session-title' ||
+          part.type === 'automation-generation',
+      )
+    ) {
+      continue;
+    }
 
     if (message.role === 'user' && message.parts.some((part) => part.type === 'compaction')) {
       const next = messages[i + 1];
@@ -50,7 +58,15 @@ export function buildRows(
   }
 
   for (const message of messages) {
-    if (message.parts.some((part) => part.type === 'session-title')) continue;
+    if (
+      message.parts.some(
+        (part) =>
+          part.type === 'session-title' ||
+          part.type === 'automation-generation',
+      )
+    ) {
+      continue;
+    }
 
     if (message.role === 'user' && message.parts.some((part) => part.type === 'compaction')) {
       const summary = summaryByMarker.get(message.id);

--- a/apps/web/src/components/cron-expression-builder.tsx
+++ b/apps/web/src/components/cron-expression-builder.tsx
@@ -1,0 +1,469 @@
+import * as React from 'react';
+import { Label } from '@/components/ui/label';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
+import { Calendar, Info } from 'lucide-react';
+import { CronExpressionParser } from 'cron-parser';
+import { format } from 'date-fns';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+interface CronExpressionBuilderProps {
+  value: string;
+  onChange: (value: string) => void;
+  timezone?: string;
+  className?: string;
+}
+
+type Frequency = 'hourly' | 'daily' | 'weekly' | 'monthly' | 'custom';
+
+const FREQUENCIES: { value: Frequency; label: string }[] = [
+  { value: 'hourly', label: 'Hourly' },
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'monthly', label: 'Monthly' },
+  // { value: 'custom', label: 'Custom' }, // Custom can be tricky to map back to UI, sticking to standard for now or treating as advanced
+];
+
+const DAYS_OF_WEEK = [
+  { value: '1', label: 'Mon' },
+  { value: '2', label: 'Tue' },
+  { value: '3', label: 'Wed' },
+  { value: '4', label: 'Thu' },
+  { value: '5', label: 'Fri' },
+  { value: '6', label: 'Sat' },
+  { value: '0', label: 'Sun' },
+];
+
+const MONTHS_SHORT = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const MINUTES = Array.from({ length: 12 }, (_, i) => i * 5); // 0, 5, 10...
+const DAYS_OF_MONTH = Array.from({ length: 31 }, (_, i) => i + 1);
+
+export function CronExpressionBuilder({
+  value,
+  onChange,
+  timezone = 'UTC',
+  className,
+}: CronExpressionBuilderProps) {
+  // State
+  const [frequency, setFrequency] = React.useState<Frequency>('daily');
+  const [minutes, setMinutes] = React.useState<number[]>([0]); // Single minute for > hourly
+  const [hours, setHours] = React.useState<number[]>([9]);
+  const [daysOfMonth, setDaysOfMonth] = React.useState<number[]>([1]);
+  const [months, setMonths] = React.useState<number[]>([]); // Empty means *
+  const [daysOfWeek, setDaysOfWeek] = React.useState<number[]>([1]); // Default Mon
+
+  // Parse incoming cron expression
+  React.useEffect(() => {
+    if (!value) return;
+
+    const parts = value.trim().split(' ');
+    if (parts.length < 5) return;
+
+    const [m, h, dom, mon, dow] = parts;
+
+    const parsePart = (part: string, _max: number): number[] => {
+      if (part === '*' || part === '?') return [];
+      return part
+        .split(',')
+        .map((v) => Number.parseInt(v, 10))
+        .filter((v) => !Number.isNaN(v));
+    };
+
+    // Minutes
+    const parsedMinutes = parsePart(m, 59);
+    if (parsedMinutes.length > 0) setMinutes([parsedMinutes[0]]); // Enforce single minute
+
+    // Hours
+    const parsedHours = parsePart(h, 23);
+    setHours(parsedHours.length > 0 ? parsedHours : []);
+
+    // Days of Month
+    const parsedDom = parsePart(dom, 31);
+    setDaysOfMonth(parsedDom.length > 0 ? parsedDom : []);
+
+    // Months
+    const parsedMon = parsePart(mon, 12);
+    setMonths(parsedMon.length > 0 ? parsedMon : []);
+
+    // Days of Week
+    // Handle MON-FRI etc if necessary, but we mostly write numbers
+    // This is a simple parser, might need more robust parsing for complex expressions
+    // For now assuming the builder generates standard numeric lists
+    const parsedDow = parsePart(dow, 7);
+    setDaysOfWeek(parsedDow.length > 0 ? parsedDow : []);
+
+    // Determine Frequency
+    if (h === '*' && dom === '*' && mon === '*' && dow === '*') {
+      setFrequency('hourly');
+    } else if (dom === '*' && mon === '*' && dow === '*') {
+      setFrequency('daily');
+    } else if (dom === '*' && mon === '*' && dow !== '*') {
+      setFrequency('weekly');
+    } else if (dom !== '*' && mon === '*' && dow === '*') {
+      setFrequency('monthly');
+    } else {
+      // Default to daily if it doesn't match perfectly or custom
+      // If it's a specific day of month AND day of week, it's complex, maybe monthly?
+      if (dom !== '*' && dow === '*') setFrequency('monthly');
+      else if (dow !== '*') setFrequency('weekly');
+      else setFrequency('daily');
+    }
+  }, [value]);
+
+  // Construct cron expression
+  const constructCron = React.useCallback(() => {
+    // Helper to format part
+    const formatPart = (vals: number[], allChar = '*') => {
+      if (vals.length === 0) return allChar;
+      return vals.join(',');
+    };
+
+    const mStr = minutes.length > 0 ? minutes[0].toString() : '0';
+
+    let cron = '';
+    switch (frequency) {
+      case 'hourly':
+        cron = `${mStr} * * * *`;
+        break;
+      case 'daily': {
+        const hStr = formatPart(hours);
+        cron = `${mStr} ${hStr} * * *`;
+        break;
+      }
+      case 'weekly': {
+        const hStr = formatPart(hours);
+        const dowStr = formatPart(daysOfWeek);
+        cron = `${mStr} ${hStr} * * ${dowStr}`;
+        break;
+      }
+      case 'monthly': {
+        const hStr = formatPart(hours);
+        const domStr = formatPart(daysOfMonth);
+        const monStr = formatPart(months);
+        cron = `${mStr} ${hStr} ${domStr} ${monStr} *`;
+        break;
+      }
+      default:
+        cron = value; // Fallback
+    }
+
+    // Only update if changed
+    if (cron !== value) {
+      onChange(cron);
+    }
+  }, [
+    frequency,
+    minutes,
+    hours,
+    daysOfWeek,
+    daysOfMonth,
+    months,
+    onChange,
+    value,
+  ]);
+
+  // Update on state change
+  React.useEffect(() => {
+    // We don't want to trigger this immediately on mount/parse, but parsing sets state which triggers this.
+    // However, if parsing sets state to exactly what matches value, constructCron won't call onChange due to check.
+    constructCron();
+  }, [constructCron]);
+
+  // Calculate upcoming executions
+  const upcomingExecutions = React.useMemo(() => {
+    const options = { tz: timezone };
+    try {
+      const interval = CronExpressionParser.parse(value, options);
+      const runs: { date: string; time: string; key: string }[] = [];
+      for (let i = 0; i < 5; i++) {
+        const date = interval.next().toDate();
+        runs.push({
+          date: format(date, 'MMM d, yyyy'),
+          time: format(date, 'h:mm a'),
+          key: date.toISOString(),
+        });
+      }
+      return runs;
+    } catch {
+      return [];
+    }
+  }, [value, timezone]);
+
+  // Renderers for grid sections
+  const renderMinutes = () => (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Label className="text-xs font-semibold uppercase text-muted-foreground">
+          Minute
+        </Label>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>
+              <Info className="h-3 w-3 text-muted-foreground/70" />
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Select which minute past the hour the workflow should run.</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      <ToggleGroup
+        value={[minutes[0]?.toString() ?? '0']}
+        onValueChange={(vals) => {
+          const val = vals[0];
+          if (val) setMinutes([Number.parseInt(val)]);
+        }}
+        className="flex flex-wrap justify-start gap-1"
+      >
+        {MINUTES.map((m) => (
+          <ToggleGroupItem
+            key={m}
+            value={m.toString()}
+            className="h-8 w-9 p-0 text-xs data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+          >
+            {m.toString().padStart(2, '0')}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  );
+
+  const renderHours = () => (
+    <div className="space-y-2">
+      <Label className="text-xs font-semibold uppercase text-muted-foreground">
+        Hours
+      </Label>
+      <ToggleGroup
+        value={hours.map((h) => h.toString())}
+        onValueChange={(vals) => {
+          if (vals.length > 0)
+            setHours(vals.map((v) => Number.parseInt(v)).sort((a, b) => a - b));
+        }}
+        className="flex flex-wrap justify-start gap-1"
+      >
+        {HOURS.map((h) => (
+          <ToggleGroupItem
+            key={h}
+            value={h.toString()}
+            className="h-8 w-9 p-0 text-xs data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+          >
+            {h.toString().padStart(2, '0')}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  );
+
+  const renderWeekdays = () => (
+    <div className="space-y-2">
+      <Label className="text-xs font-semibold uppercase text-muted-foreground">
+        Days of Week
+      </Label>
+      <ToggleGroup
+        value={daysOfWeek.map((d) => d.toString())}
+        onValueChange={(vals) => {
+          if (vals.length > 0)
+            setDaysOfWeek(vals.map((v) => Number.parseInt(v)));
+        }}
+        className="flex flex-wrap justify-start gap-1"
+      >
+        {DAYS_OF_WEEK.map((day) => (
+          <ToggleGroupItem
+            key={day.value}
+            value={day.value}
+            className="h-8 min-w-12 px-2 text-xs data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+          >
+            {day.label}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  );
+
+  const renderDaysOfMonth = () => (
+    <div className="space-y-2">
+      <Label className="text-xs font-semibold uppercase text-muted-foreground">
+        Days of Month
+      </Label>
+      <ToggleGroup
+        value={daysOfMonth.map((d) => d.toString())}
+        onValueChange={(vals) => {
+          if (vals.length > 0)
+            setDaysOfMonth(
+              vals.map((v) => Number.parseInt(v)).sort((a, b) => a - b),
+            );
+        }}
+        className="flex flex-wrap justify-start gap-1"
+      >
+        {DAYS_OF_MONTH.map((d) => (
+          <ToggleGroupItem
+            key={d}
+            value={d.toString()}
+            className="h-8 w-9 p-0 text-xs data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+          >
+            {d}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  );
+
+  const renderMonths = () => (
+    <div className="space-y-2">
+      <Label className="text-xs font-semibold uppercase text-muted-foreground">
+        Months
+      </Label>
+      <ToggleGroup
+        value={months.map((m) => m.toString())}
+        onValueChange={(vals) => {
+          // If empty, it means all months (cron *)
+          setMonths(vals.map((v) => Number.parseInt(v)).sort((a, b) => a - b));
+        }}
+        className="flex flex-wrap justify-start gap-1"
+      >
+        {MONTHS_SHORT.map((m, i) => (
+          <ToggleGroupItem
+            key={m}
+            value={(i + 1).toString()}
+            className="h-8 w-10 p-0 text-xs data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+          >
+            {m}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  );
+
+  return (
+    <div className={cn('flex flex-col gap-4', className)}>
+      {/* Frequency Selector */}
+      <div className="flex flex-col gap-2">
+        <Label>Frequency</Label>
+        <ToggleGroup
+          value={[frequency]}
+          onValueChange={(vals) => {
+            const val = vals[0];
+            if (val) {
+              const newFreq = val as Frequency;
+              setFrequency(newFreq);
+
+              // Ensure required fields are populated when switching
+              if (newFreq === 'monthly' && daysOfMonth.length === 0) {
+                setDaysOfMonth([1]);
+              }
+              if (newFreq === 'weekly' && daysOfWeek.length === 0) {
+                setDaysOfWeek([1]); // Monday
+              }
+            }
+          }}
+          className="justify-start border rounded-md p-1 w-fit"
+        >
+          {FREQUENCIES.map((f) => (
+            <ToggleGroupItem
+              key={f.value}
+              value={f.value}
+              className="h-8 px-3 text-xs data-[state=on]:bg-muted data-[state=on]:text-foreground"
+            >
+              {f.label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+
+      <div className="flex flex-col lg:flex-row gap-6 h-full min-h-0">
+        {/* Main Builder Area */}
+        <ScrollArea className="flex-1 h-100 pr-4">
+          <div className="flex flex-col gap-6 pb-4">
+            {frequency === 'hourly' && <>{renderMinutes()}</>}
+
+            {frequency === 'daily' && (
+              <>
+                {renderHours()}
+                {renderMinutes()}
+              </>
+            )}
+
+            {frequency === 'weekly' && (
+              <>
+                {renderWeekdays()}
+                {renderHours()}
+                {renderMinutes()}
+              </>
+            )}
+
+            {frequency === 'monthly' && (
+              <>
+                {renderMonths()}
+                {renderDaysOfMonth()}
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  {renderHours()}
+                  {renderMinutes()}
+                </div>
+              </>
+            )}
+
+            {/* <div className="bg-muted/50 rounded-md p-3 font-mono text-sm border">
+              {value}
+            </div> */}
+          </div>
+        </ScrollArea>
+
+        {/* Upcoming Executions Sidebar */}
+        <div className="lg:w-64 shrink-0 flex flex-col gap-3 border-l lg:pl-6 border-border/50">
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <Calendar className="h-4 w-4" />
+            <h3 className="text-xs font-semibold uppercase tracking-wider">
+              Upcoming Runs
+            </h3>
+          </div>
+
+          <div className="space-y-2">
+            {upcomingExecutions.length > 0 ? (
+              upcomingExecutions.map((execution) => (
+                <div
+                  key={execution.key}
+                  className="flex flex-col gap-0.5 rounded-md border bg-card/50 p-2.5 text-sm shadow-sm"
+                >
+                  <span className="font-medium text-foreground">
+                    {execution.date}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    at {execution.time}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <p className="text-xs text-muted-foreground italic">
+                No upcoming runs scheduled
+              </p>
+            )}
+          </div>
+          <div className="text-[10px] text-muted-foreground text-right">
+            Timezone: {timezone}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/navigation/activity-bar.tsx
+++ b/apps/web/src/components/navigation/activity-bar.tsx
@@ -1,4 +1,4 @@
-import { BarChart3Icon, MessageSquareIcon, MicIcon, PlugIcon, SettingsIcon } from 'lucide-react';
+import { BarChart3Icon, BotIcon, MessageSquareIcon, MicIcon, PlugIcon, SettingsIcon } from 'lucide-react';
 
 import { useQuery } from '@tanstack/react-query';
 import { Link, useRouterState } from '@tanstack/react-router';
@@ -47,6 +47,13 @@ const ACTIVITY_ITEMS: ActivityItem[] = [
     label: 'Connectors',
     to: '/connectors',
     matchPrefix: '/connectors',
+  },
+  {
+    id: 'automations',
+    icon: <BotIcon className="size-5" />,
+    label: 'Automations',
+    to: '/automations',
+    matchPrefix: '/automations',
   },
 ];
 

--- a/apps/web/src/components/navigation/app-sidebar.tsx
+++ b/apps/web/src/components/navigation/app-sidebar.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link, useParams, useRouterState } from '@tanstack/react-router';
 
 import { AnimatedTitle } from '@/components/animated-title';
+import { AutomationsSidebarContent } from '@/components/automations/automations-sidebar';
 import { RecordingsSidebarContent } from '@/components/recordings/recordings-sidebar';
 import {
   Sidebar,
@@ -119,11 +120,12 @@ function ChatSidebarContent() {
   );
 }
 
-function useActiveContext(): 'chat' | 'recordings' | 'connectors' {
+function useActiveContext(): 'chat' | 'recordings' | 'connectors' | 'automations' {
   const routerState = useRouterState();
   const path = routerState.location.pathname;
   if (path.startsWith('/recordings')) return 'recordings';
   if (path.startsWith('/connectors')) return 'connectors';
+  if (path.startsWith('/automations')) return 'automations';
   return 'chat';
 }
 
@@ -136,7 +138,13 @@ export function AppSidebar() {
 
   return (
     <Sidebar collapsible="offcanvas" className="border-r-0!">
-      {context === 'recordings' ? <RecordingsSidebarContent /> : <ChatSidebarContent />}
+      {context === 'recordings' ? (
+        <RecordingsSidebarContent />
+      ) : context === 'automations' ? (
+        <AutomationsSidebarContent />
+      ) : (
+        <ChatSidebarContent />
+      )}
     </Sidebar>
   );
 }

--- a/apps/web/src/components/navigation/right-click-menu.tsx
+++ b/apps/web/src/components/navigation/right-click-menu.tsx
@@ -7,7 +7,7 @@ import {
   ChevronRight,
   SpellCheck,
 } from 'lucide-react';
-import { useEffect, useCallback, useState, useRef, forwardRef } from 'react';
+import { useEffect, useLayoutEffect, useCallback, useState, useRef, forwardRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import type { ContextMenuParams } from '@/lib/api';
@@ -78,7 +78,7 @@ function SpellingSubmenu({
 }: SpellingSubmenuProps) {
   const [style, setStyle] = useState<React.CSSProperties>({});
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!anchorRef.current) return;
     const rect = anchorRef.current.getBoundingClientRect();
     const submenuWidth = 192;

--- a/apps/web/src/components/onboarding/onboarding-dialog.tsx
+++ b/apps/web/src/components/onboarding/onboarding-dialog.tsx
@@ -78,14 +78,6 @@ function OnboardingProfileStep({
     [detectedTimezone, initialTimezone],
   );
 
-  React.useEffect(() => {
-    setName(initialName);
-  }, [initialName]);
-
-  React.useEffect(() => {
-    setTimezone(initialTimezone || detectedTimezone);
-  }, [detectedTimezone, initialTimezone]);
-
   const trimmed = name.trim();
   const trimmedTimezone = timezone.trim();
   const hasError = touched && trimmed.length === 0;

--- a/apps/web/src/components/recordings/recording-detail.tsx
+++ b/apps/web/src/components/recordings/recording-detail.tsx
@@ -66,10 +66,6 @@ export function RecordingDetail({ meeting, onDelete }: { meeting: Meeting; onDel
   const [selectedModel, setSelectedModel] = React.useState<AudioModelSpec | null>(null);
 
   React.useEffect(() => {
-    setSelectedModel(null);
-  }, [meeting.id]);
-
-  React.useEffect(() => {
     if (selectedModel || audioModels.length === 0) {
       return;
     }

--- a/apps/web/src/components/session/message-queue-panel.tsx
+++ b/apps/web/src/components/session/message-queue-panel.tsx
@@ -2,7 +2,6 @@ import { ArrowUpIcon, PaperclipIcon, PencilIcon, Trash2Icon } from 'lucide-react
 import * as React from 'react';
 
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from '@tanstack/react-router';
 
 import type { QueuedMessage } from '@stitch/shared/chat/queue';
 import type { PrefixedString } from '@stitch/shared/id';
@@ -17,14 +16,14 @@ import { queuedMessagesQueryOptions, useRemoveFromQueue } from '@/lib/queries/qu
 import { cn } from '@/lib/utils';
 
 type MessageQueuePanelProps = {
+  sessionId: string;
   className?: string;
   onEdit: (payload: EditQueuedMessagePayload) => void;
   sendQueuedRef: React.RefObject<SendQueuedMessageFn | null>;
 };
 
-export function MessageQueuePanel({ className, onEdit, sendQueuedRef }: MessageQueuePanelProps) {
-  const { id } = useParams({ from: '/session/$id' });
-  const { data: queuedMessages } = useQuery(queuedMessagesQueryOptions(id));
+export function MessageQueuePanel({ sessionId, className, onEdit, sendQueuedRef }: MessageQueuePanelProps) {
+  const { data: queuedMessages } = useQuery(queuedMessagesQueryOptions(sessionId));
 
   const items = queuedMessages ?? [];
 
@@ -54,7 +53,7 @@ export function MessageQueuePanel({ className, onEdit, sendQueuedRef }: MessageQ
                 <QueuedMessageCard
                   key={item.id}
                   item={item}
-                  sessionId={id}
+                  sessionId={sessionId}
                   onEdit={onEdit}
                   sendQueuedRef={sendQueuedRef}
                 />

--- a/apps/web/src/components/session/session-chat-pane.tsx
+++ b/apps/web/src/components/session/session-chat-pane.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StickToBottom } from 'use-stick-to-bottom';
 
 import { useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { useNavigate, useParams } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 
 import { createMessageId, type PrefixedString } from '@stitch/shared/id';
 
@@ -39,6 +39,7 @@ import { cn } from '@/lib/utils';
 import { useStreamStore } from '@/stores/stream-store';
 
 type SessionChatPaneProps = {
+  sessionId: string;
   onOpenQueue: () => void;
   editPayload: EditQueuedMessagePayload | null;
   onConsumeEditPayload: () => void;
@@ -46,12 +47,13 @@ type SessionChatPaneProps = {
 };
 
 export function SessionChatPane({
+  sessionId,
   onOpenQueue,
   editPayload,
   onConsumeEditPayload,
   sendQueuedRef,
 }: SessionChatPaneProps) {
-  const { id } = useParams({ from: '/session/$id' });
+  const id = sessionId;
   const navigate = useNavigate();
   const { data: session } = useSuspenseQuery(sessionQueryOptions(id));
   const isChildSession = session.parentSessionId !== null;

--- a/apps/web/src/components/session/session-chat-pane/session-message-context.ts
+++ b/apps/web/src/components/session/session-chat-pane/session-message-context.ts
@@ -15,6 +15,7 @@ function shouldSkipMessage(message: SessionMessageContext): boolean {
   if (message.isSummary) return true;
   if (message.parts.some((part) => part.type === 'session-title')) return true;
   if (message.parts.some((part) => part.type === 'compaction')) return true;
+  if (message.parts.some((part) => part.type === 'automation-generation')) return true;
   return false;
 }
 

--- a/apps/web/src/components/session/session-delete-dialog.tsx
+++ b/apps/web/src/components/session/session-delete-dialog.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 
 import type { PrefixedString } from '@stitch/shared/id';
 
@@ -14,18 +14,18 @@ import {
 import { useDeleteSession } from '@/lib/queries/chat';
 
 type SessionDeleteDialogProps = {
+  sessionId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onDeleted?: () => void;
 };
 
-export function SessionDeleteDialog({ open, onOpenChange, onDeleted }: SessionDeleteDialogProps) {
-  const { id } = useParams({ from: '/session/$id' });
+export function SessionDeleteDialog({ sessionId, open, onOpenChange, onDeleted }: SessionDeleteDialogProps) {
   const navigate = useNavigate();
   const deleteSession = useDeleteSession();
 
   async function handleDeleteSession() {
-    await deleteSession.mutateAsync({ sessionId: id as PrefixedString<'ses'> });
+    await deleteSession.mutateAsync({ sessionId: sessionId as PrefixedString<'ses'> });
     onOpenChange(false);
     onDeleted?.();
     void navigate({ to: '/' });

--- a/apps/web/src/components/session/session-page-header.tsx
+++ b/apps/web/src/components/session/session-page-header.tsx
@@ -2,6 +2,7 @@ import {
   ArrowLeftIcon,
   BotIcon,
   EllipsisIcon,
+  SparklesIcon,
   InfoIcon,
   ListOrderedIcon,
   PencilLineIcon,
@@ -30,6 +31,8 @@ type SessionPageHeaderProps = {
   onToggleDetails: () => void;
   onToggleQueue: () => void;
   onDeleteSession: () => void;
+  onGenerateAutomation: () => void;
+  generateAutomationPending?: boolean;
 };
 
 export function SessionPageHeader({
@@ -38,6 +41,8 @@ export function SessionPageHeader({
   onToggleDetails,
   onToggleQueue,
   onDeleteSession,
+  onGenerateAutomation,
+  generateAutomationPending = false,
 }: SessionPageHeaderProps) {
   const { setRenameSessionOpen } = useDialogContext();
   const { data: session } = useSuspenseQuery(sessionQueryOptions(sessionId));
@@ -115,6 +120,10 @@ export function SessionPageHeader({
                 <DropdownMenuItem onClick={() => setRenameSessionOpen(true)}>
                   <PencilLineIcon className="size-4" />
                   Rename
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={onGenerateAutomation} disabled={generateAutomationPending}>
+                  <SparklesIcon className="size-4" />
+                  {generateAutomationPending ? 'Generating...' : 'Generate automation'}
                 </DropdownMenuItem>
                 <DropdownMenuItem variant="destructive" onClick={onDeleteSession}>
                   <Trash2Icon className="size-4" />

--- a/apps/web/src/components/session/session-page-header.tsx
+++ b/apps/web/src/components/session/session-page-header.tsx
@@ -9,7 +9,7 @@ import {
 } from 'lucide-react';
 
 import { useSuspenseQuery, useQuery } from '@tanstack/react-query';
-import { Link, useParams } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
 
 import type { RightPanel } from '@/components/session/session-page-types';
 import { Button } from '@/components/ui/button';
@@ -25,6 +25,7 @@ import { queuedMessagesQueryOptions } from '@/lib/queries/queue';
 import { cn } from '@/lib/utils';
 
 type SessionPageHeaderProps = {
+  sessionId: string;
   rightPanel: RightPanel;
   onToggleDetails: () => void;
   onToggleQueue: () => void;
@@ -32,15 +33,15 @@ type SessionPageHeaderProps = {
 };
 
 export function SessionPageHeader({
+  sessionId,
   rightPanel,
   onToggleDetails,
   onToggleQueue,
   onDeleteSession,
 }: SessionPageHeaderProps) {
   const { setRenameSessionOpen } = useDialogContext();
-  const { id } = useParams({ from: '/session/$id' });
-  const { data: session } = useSuspenseQuery(sessionQueryOptions(id));
-  const { data: queuedMessages } = useQuery(queuedMessagesQueryOptions(id));
+  const { data: session } = useSuspenseQuery(sessionQueryOptions(sessionId));
+  const { data: queuedMessages } = useQuery(queuedMessagesQueryOptions(sessionId));
 
   const queueCount = queuedMessages?.length ?? 0;
   const isChildSession = session.parentSessionId !== null;

--- a/apps/web/src/components/session/session-page.tsx
+++ b/apps/web/src/components/session/session-page.tsx
@@ -20,7 +20,7 @@ type SessionPageProps = {
 
 export function SessionPage({ sessionId }: SessionPageProps) {
   const { mutate: markReadMutate } = useMarkSessionRead();
-  const details = useSessionDetailsStats();
+  const details = useSessionDetailsStats(sessionId);
   const [rightPanel, setRightPanel] = React.useState<RightPanel>('closed');
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const [editPayload, setEditPayload] = React.useState<EditQueuedMessagePayload | null>(null);
@@ -48,6 +48,7 @@ export function SessionPage({ sessionId }: SessionPageProps) {
     <>
       <div className="flex h-full flex-col overflow-hidden">
         <SessionPageHeader
+          sessionId={sessionId}
           rightPanel={rightPanel}
           onToggleDetails={toggleDetails}
           onToggleQueue={toggleQueue}
@@ -60,6 +61,7 @@ export function SessionPage({ sessionId }: SessionPageProps) {
         >
           <ResizablePanel defaultSize={rightPanelOpen ? '70%' : '100%'} minSize="45%">
             <SessionChatPane
+              sessionId={sessionId}
               onOpenQueue={openQueue}
               editPayload={editPayload}
               onConsumeEditPayload={() => setEditPayload(null)}
@@ -76,6 +78,7 @@ export function SessionPage({ sessionId }: SessionPageProps) {
                   <SessionDetailsSheet {...details} className="hidden lg:block" />
                 ) : (
                   <MessageQueuePanel
+                    sessionId={sessionId}
                     className="hidden lg:block"
                     onEdit={setEditPayload}
                     sendQueuedRef={sendQueuedRef}
@@ -88,6 +91,7 @@ export function SessionPage({ sessionId }: SessionPageProps) {
       </div>
 
       <SessionDeleteDialog
+        sessionId={sessionId}
         open={deleteDialogOpen}
         onOpenChange={setDeleteDialogOpen}
         onDeleted={() => setRightPanel('closed')}

--- a/apps/web/src/components/session/session-page.tsx
+++ b/apps/web/src/components/session/session-page.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
+import { toast } from 'sonner';
 
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+
+import type { GeneratedAutomationDraft } from '@stitch/shared/automations/types';
+
+import { AutomationDialog } from '@/components/automations/automation-dialog';
 import { MessageQueuePanel } from '@/components/session/message-queue-panel';
 import { SessionChatPane } from '@/components/session/session-chat-pane';
 import { SessionDeleteDialog } from '@/components/session/session-delete-dialog';
@@ -12,19 +19,31 @@ import type {
 } from '@/components/session/session-page-types';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { useSessionDetailsStats } from '@/hooks/session/use-session-details-stats';
-import { useMarkSessionRead } from '@/lib/queries/chat';
+import { useCreateAutomation } from '@/lib/queries/automations';
+import { useGenerateAutomationDraft, useMarkSessionRead } from '@/lib/queries/chat';
+import { visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
+import { settingsQueryOptions } from '@/lib/queries/settings';
 
 type SessionPageProps = {
   sessionId: string;
 };
 
 export function SessionPage({ sessionId }: SessionPageProps) {
+  const navigate = useNavigate();
   const { mutate: markReadMutate } = useMarkSessionRead();
+  const { data: providerModels } = useSuspenseQuery(visibleProviderModelsQueryOptions);
+  const { data: settings } = useQuery(settingsQueryOptions);
+  const createAutomation = useCreateAutomation();
+  const generateAutomation = useGenerateAutomationDraft();
   const details = useSessionDetailsStats(sessionId);
   const [rightPanel, setRightPanel] = React.useState<RightPanel>('closed');
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
+  const [automationDialogOpen, setAutomationDialogOpen] = React.useState(false);
+  const [generatedDraft, setGeneratedDraft] = React.useState<GeneratedAutomationDraft | null>(null);
   const [editPayload, setEditPayload] = React.useState<EditQueuedMessagePayload | null>(null);
   const sendQueuedRef = React.useRef<SendQueuedMessageFn | null>(null);
+  const timezone =
+    settings?.['profile.timezone']?.trim() || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 
   const rightPanelOpen = rightPanel !== 'closed';
 
@@ -44,6 +63,20 @@ export function SessionPage({ sessionId }: SessionPageProps) {
     markReadMutate(sessionId);
   }, [sessionId, markReadMutate]);
 
+  const handleGenerateAutomation = React.useCallback(async () => {
+    const toastId = toast.loading('Generating automation draft...');
+    try {
+      const draft = await generateAutomation.mutateAsync(sessionId);
+      setGeneratedDraft(draft);
+      setAutomationDialogOpen(true);
+      toast.success('Automation draft ready', { id: toastId });
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to generate automation draft', {
+        id: toastId,
+      });
+    }
+  }, [generateAutomation, sessionId]);
+
   return (
     <>
       <div className="flex h-full flex-col overflow-hidden">
@@ -53,6 +86,8 @@ export function SessionPage({ sessionId }: SessionPageProps) {
           onToggleDetails={toggleDetails}
           onToggleQueue={toggleQueue}
           onDeleteSession={() => setDeleteDialogOpen(true)}
+          onGenerateAutomation={() => void handleGenerateAutomation()}
+          generateAutomationPending={generateAutomation.isPending}
         />
 
         <ResizablePanelGroup
@@ -95,6 +130,34 @@ export function SessionPage({ sessionId }: SessionPageProps) {
         open={deleteDialogOpen}
         onOpenChange={setDeleteDialogOpen}
         onDeleted={() => setRightPanel('closed')}
+      />
+
+      <AutomationDialog
+        open={automationDialogOpen}
+        onOpenChange={(open) => {
+          setAutomationDialogOpen(open);
+          if (!open) {
+            setGeneratedDraft(null);
+          }
+        }}
+        mode="create"
+        prefill={generatedDraft}
+        providerModels={providerModels}
+        isPending={createAutomation.isPending}
+        timezone={timezone}
+        onSubmit={async (input, action) => {
+          try {
+            const created = await createAutomation.mutateAsync(input);
+            setAutomationDialogOpen(false);
+            setGeneratedDraft(null);
+            toast.success('Automation created');
+            if (action === 'create-view') {
+              void navigate({ to: '/automations/$automationId', params: { automationId: created.id } });
+            }
+          } catch (error) {
+            toast.error(error instanceof Error ? error.message : 'Failed to create automation');
+          }
+        }}
       />
     </>
   );

--- a/apps/web/src/components/ui/toggle-group.tsx
+++ b/apps/web/src/components/ui/toggle-group.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group"
+import { type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+  orientation: "horizontal",
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  orientation = "horizontal",
+  children,
+  ...props
+}: ToggleGroupPrimitive.Props &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }) {
+  return (
+    <ToggleGroupPrimitive
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-lg data-[size=sm]:rounded-[min(var(--radius-md),10px)] data-vertical:flex-col data-vertical:items-stretch",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider
+        value={{ variant, size, spacing, orientation }}
+      >
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <TogglePrimitive
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-lg group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-lg group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </TogglePrimitive>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/apps/web/src/components/usage/usage-dashboard-page.tsx
+++ b/apps/web/src/components/usage/usage-dashboard-page.tsx
@@ -41,6 +41,7 @@ const RANGE_LABELS: Record<UsageDateRange, string> = {
 
 const SOURCE_LABELS: Record<string, string> = {
   chat: 'Chat',
+  automation: 'Automation',
   title_generation: 'Title Generation',
   transcription: 'Transcription',
 };

--- a/apps/web/src/hooks/session/use-session-details-stats.ts
+++ b/apps/web/src/hooks/session/use-session-details-stats.ts
@@ -1,5 +1,4 @@
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from '@tanstack/react-router';
 
 import type { SessionStats } from '@stitch/shared/chat/messages';
 
@@ -29,8 +28,7 @@ const EMPTY_STATS: SessionStats = {
   lastActivityAt: null,
 };
 
-export function useSessionDetailsStats(): SessionStats {
-  const { id } = useParams({ from: '/session/$id' });
-  const { data } = useQuery(sessionStatsQueryOptions(id));
+export function useSessionDetailsStats(sessionId: string): SessionStats {
+  const { data } = useQuery(sessionStatsQueryOptions(sessionId));
   return data ?? EMPTY_STATS;
 }

--- a/apps/web/src/lib/automations/schedule-label.ts
+++ b/apps/web/src/lib/automations/schedule-label.ts
@@ -1,0 +1,67 @@
+import type { AutomationSchedule } from '@stitch/shared/automations/types';
+
+const WEEKDAY_LABELS: Record<number, string> = {
+  0: 'Sun',
+  1: 'Mon',
+  2: 'Tue',
+  3: 'Wed',
+  4: 'Thu',
+  5: 'Fri',
+  6: 'Sat',
+};
+
+function formatTime(hourRaw: string, minuteRaw: string): string {
+  const hour = Number.parseInt(hourRaw, 10);
+  const minute = Number.parseInt(minuteRaw, 10);
+  if (!Number.isInteger(hour) || !Number.isInteger(minute)) return `${hourRaw}:${minuteRaw}`;
+  return new Date(2000, 0, 1, hour, minute).toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function toNumberList(raw: string): number[] | null {
+  if (raw === '*') return [];
+  const list = raw.split(',').map((part) => Number.parseInt(part, 10));
+  if (list.some((value) => Number.isNaN(value))) return null;
+  return list;
+}
+
+function formatCron(expression: string): string {
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length !== 5) return `Custom cron: ${expression}`;
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = fields;
+
+  if (hour === '*' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
+    return `Hourly at :${minute.padStart(2, '0')}`;
+  }
+
+  if (dayOfMonth === '*' && month === '*' && dayOfWeek === '*') {
+    return `Daily at ${formatTime(hour, minute)}`;
+  }
+
+  if (dayOfMonth === '*' && month === '*') {
+    const days = toNumberList(dayOfWeek);
+    if (days) {
+      const labels = days.length === 0 ? 'every day' : days.map((day) => WEEKDAY_LABELS[day] ?? `${day}`).join(', ');
+      return `Weekly on ${labels} at ${formatTime(hour, minute)}`;
+    }
+  }
+
+  if (month === '*' && dayOfWeek === '*') {
+    return `Monthly on day ${dayOfMonth} at ${formatTime(hour, minute)}`;
+  }
+
+  return `Custom cron: ${expression}`;
+}
+
+export function getAutomationScheduleLabel(schedule: AutomationSchedule | null): string {
+  if (!schedule) return 'Manual';
+
+  if (schedule.type === 'interval') {
+    return `Every ${schedule.everyMinutes} minute${schedule.everyMinutes === 1 ? '' : 's'}`;
+  }
+
+  return formatCron(schedule.expression);
+}

--- a/apps/web/src/lib/queries/automations.ts
+++ b/apps/web/src/lib/queries/automations.ts
@@ -1,0 +1,93 @@
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type {
+  Automation,
+  CreateAutomationInput,
+  UpdateAutomationInput,
+} from '@stitch/shared/automations/types';
+
+import { serverFetch } from '@/lib/api';
+
+const automationKeys = {
+  all: ['automations'] as const,
+  list: () => [...automationKeys.all, 'list'] as const,
+};
+
+export const automationsQueryOptions = queryOptions({
+  queryKey: automationKeys.list(),
+  staleTime: Infinity,
+  queryFn: async (): Promise<Automation[]> => {
+    const res = await serverFetch('/automations');
+    if (!res.ok) throw new Error('Failed to fetch automations');
+    return res.json() as Promise<Automation[]>;
+  },
+});
+
+export function useCreateAutomation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: CreateAutomationInput): Promise<Automation> => {
+      const res = await serverFetch('/automations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(err.error ?? 'Failed to create automation');
+      }
+
+      return res.json() as Promise<Automation>;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: automationKeys.all });
+    },
+  });
+}
+
+export function useUpdateAutomation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      automationId,
+      input,
+    }: {
+      automationId: string;
+      input: UpdateAutomationInput;
+    }): Promise<Automation> => {
+      const res = await serverFetch(`/automations/${automationId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(err.error ?? 'Failed to update automation');
+      }
+
+      return res.json() as Promise<Automation>;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: automationKeys.all });
+    },
+  });
+}
+
+export function useDeleteAutomation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (automationId: string): Promise<void> => {
+      const res = await serverFetch(`/automations/${automationId}`, { method: 'DELETE' });
+
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(err.error ?? 'Failed to delete automation');
+      }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: automationKeys.all });
+    },
+  });
+}

--- a/apps/web/src/lib/queries/automations.ts
+++ b/apps/web/src/lib/queries/automations.ts
@@ -3,14 +3,17 @@ import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query
 import type {
   Automation,
   CreateAutomationInput,
+  RunAutomationResponse,
   UpdateAutomationInput,
 } from '@stitch/shared/automations/types';
+import type { Session } from '@stitch/shared/chat/messages';
 
 import { serverFetch } from '@/lib/api';
 
 const automationKeys = {
   all: ['automations'] as const,
   list: () => [...automationKeys.all, 'list'] as const,
+  sessions: (automationId: string) => [...automationKeys.all, 'sessions', automationId] as const,
 };
 
 export const automationsQueryOptions = queryOptions({
@@ -88,6 +91,39 @@ export function useDeleteAutomation() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: automationKeys.all });
+    },
+  });
+}
+
+export const automationSessionsQueryOptions = (automationId: string) =>
+  queryOptions({
+    queryKey: automationKeys.sessions(automationId),
+    queryFn: async (): Promise<Session[]> => {
+      const res = await serverFetch(`/automations/${automationId}/sessions`);
+      if (!res.ok) throw new Error('Failed to fetch automation sessions');
+      return res.json() as Promise<Session[]>;
+    },
+    staleTime: 30_000,
+  });
+
+export function useRunAutomation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (automationId: string): Promise<RunAutomationResponse> => {
+      const res = await serverFetch(`/automations/${automationId}/run`, {
+        method: 'POST',
+      });
+
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(err.error ?? 'Failed to run automation');
+      }
+
+      return res.json() as Promise<RunAutomationResponse>;
+    },
+    onSuccess: (_data, automationId) => {
+      void queryClient.invalidateQueries({ queryKey: automationKeys.sessions(automationId) });
+      void queryClient.invalidateQueries({ queryKey: automationKeys.list() });
     },
   });
 }

--- a/apps/web/src/lib/queries/chat.ts
+++ b/apps/web/src/lib/queries/chat.ts
@@ -43,7 +43,7 @@ export const sessionsQueryOptions = queryOptions({
   queryKey: sessionKeys.list(),
   staleTime: Infinity,
   queryFn: async (): Promise<Session[]> => {
-    const res = await serverFetch('/chat/sessions');
+    const res = await serverFetch('/chat/sessions?type=chat');
     if (!res.ok) throw new Error('Failed to fetch sessions');
     return res.json() as Promise<Session[]>;
   },

--- a/apps/web/src/lib/queries/chat.ts
+++ b/apps/web/src/lib/queries/chat.ts
@@ -7,6 +7,9 @@ import {
 import type { InfiniteData } from '@tanstack/react-query';
 
 import type {
+  GeneratedAutomationDraft,
+} from '@stitch/shared/automations/types';
+import type {
   Message,
   Session,
   SessionStats,
@@ -236,6 +239,26 @@ export function useMarkSessionRead() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: sessionKeys.list() });
+    },
+  });
+}
+
+export function useGenerateAutomationDraft() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (sessionId: string): Promise<GeneratedAutomationDraft> => {
+      const res = await serverFetch(`/chat/sessions/${sessionId}/generate-automation`, {
+        method: 'POST',
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(err.error ?? 'Failed to generate automation draft');
+      }
+
+      return res.json() as Promise<GeneratedAutomationDraft>;
+    },
+    onSuccess: (_data, sessionId) => {
+      void queryClient.invalidateQueries({ queryKey: sessionKeys.messages(sessionId) });
     },
   });
 }

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as UsageRouteImport } from './routes/usage'
 import { Route as RecordingsRouteImport } from './routes/recordings'
 import { Route as ConnectorsRouteImport } from './routes/connectors'
+import { Route as AutomationsRouteImport } from './routes/automations'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as RecordingsIndexRouteImport } from './routes/recordings.index'
 import { Route as SessionIdRouteImport } from './routes/session.$id'
@@ -30,6 +31,11 @@ const RecordingsRoute = RecordingsRouteImport.update({
 const ConnectorsRoute = ConnectorsRouteImport.update({
   id: '/connectors',
   path: '/connectors',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AutomationsRoute = AutomationsRouteImport.update({
+  id: '/automations',
+  path: '/automations',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -55,6 +61,7 @@ const RecordingsIdRoute = RecordingsIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/automations': typeof AutomationsRoute
   '/connectors': typeof ConnectorsRoute
   '/recordings': typeof RecordingsRouteWithChildren
   '/usage': typeof UsageRoute
@@ -64,6 +71,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/automations': typeof AutomationsRoute
   '/connectors': typeof ConnectorsRoute
   '/usage': typeof UsageRoute
   '/recordings/$id': typeof RecordingsIdRoute
@@ -73,6 +81,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/automations': typeof AutomationsRoute
   '/connectors': typeof ConnectorsRoute
   '/recordings': typeof RecordingsRouteWithChildren
   '/usage': typeof UsageRoute
@@ -84,6 +93,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/automations'
     | '/connectors'
     | '/recordings'
     | '/usage'
@@ -93,6 +103,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/automations'
     | '/connectors'
     | '/usage'
     | '/recordings/$id'
@@ -101,6 +112,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/automations'
     | '/connectors'
     | '/recordings'
     | '/usage'
@@ -111,6 +123,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AutomationsRoute: typeof AutomationsRoute
   ConnectorsRoute: typeof ConnectorsRoute
   RecordingsRoute: typeof RecordingsRouteWithChildren
   UsageRoute: typeof UsageRoute
@@ -138,6 +151,13 @@ declare module '@tanstack/react-router' {
       path: '/connectors'
       fullPath: '/connectors'
       preLoaderRoute: typeof ConnectorsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/automations': {
+      id: '/automations'
+      path: '/automations'
+      fullPath: '/automations'
+      preLoaderRoute: typeof AutomationsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -187,6 +207,7 @@ const RecordingsRouteWithChildren = RecordingsRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AutomationsRoute: AutomationsRoute,
   ConnectorsRoute: ConnectorsRoute,
   RecordingsRoute: RecordingsRouteWithChildren,
   UsageRoute: UsageRoute,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,8 +15,11 @@ import { Route as ConnectorsRouteImport } from './routes/connectors'
 import { Route as AutomationsRouteImport } from './routes/automations'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as RecordingsIndexRouteImport } from './routes/recordings.index'
+import { Route as AutomationsIndexRouteImport } from './routes/automations.index'
 import { Route as SessionIdRouteImport } from './routes/session.$id'
 import { Route as RecordingsIdRouteImport } from './routes/recordings.$id'
+import { Route as AutomationsAutomationIdRouteImport } from './routes/automations.$automationId'
+import { Route as AutomationsSessionsIdRouteImport } from './routes/automations.sessions.$id'
 
 const UsageRoute = UsageRouteImport.update({
   id: '/usage',
@@ -48,6 +51,11 @@ const RecordingsIndexRoute = RecordingsIndexRouteImport.update({
   path: '/',
   getParentRoute: () => RecordingsRoute,
 } as any)
+const AutomationsIndexRoute = AutomationsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AutomationsRoute,
+} as any)
 const SessionIdRoute = SessionIdRouteImport.update({
   id: '/session/$id',
   path: '/session/$id',
@@ -58,36 +66,54 @@ const RecordingsIdRoute = RecordingsIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => RecordingsRoute,
 } as any)
+const AutomationsAutomationIdRoute = AutomationsAutomationIdRouteImport.update({
+  id: '/$automationId',
+  path: '/$automationId',
+  getParentRoute: () => AutomationsRoute,
+} as any)
+const AutomationsSessionsIdRoute = AutomationsSessionsIdRouteImport.update({
+  id: '/sessions/$id',
+  path: '/sessions/$id',
+  getParentRoute: () => AutomationsRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/automations': typeof AutomationsRoute
+  '/automations': typeof AutomationsRouteWithChildren
   '/connectors': typeof ConnectorsRoute
   '/recordings': typeof RecordingsRouteWithChildren
   '/usage': typeof UsageRoute
+  '/automations/$automationId': typeof AutomationsAutomationIdRoute
   '/recordings/$id': typeof RecordingsIdRoute
   '/session/$id': typeof SessionIdRoute
+  '/automations/': typeof AutomationsIndexRoute
   '/recordings/': typeof RecordingsIndexRoute
+  '/automations/sessions/$id': typeof AutomationsSessionsIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/automations': typeof AutomationsRoute
   '/connectors': typeof ConnectorsRoute
   '/usage': typeof UsageRoute
+  '/automations/$automationId': typeof AutomationsAutomationIdRoute
   '/recordings/$id': typeof RecordingsIdRoute
   '/session/$id': typeof SessionIdRoute
+  '/automations': typeof AutomationsIndexRoute
   '/recordings': typeof RecordingsIndexRoute
+  '/automations/sessions/$id': typeof AutomationsSessionsIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
-  '/automations': typeof AutomationsRoute
+  '/automations': typeof AutomationsRouteWithChildren
   '/connectors': typeof ConnectorsRoute
   '/recordings': typeof RecordingsRouteWithChildren
   '/usage': typeof UsageRoute
+  '/automations/$automationId': typeof AutomationsAutomationIdRoute
   '/recordings/$id': typeof RecordingsIdRoute
   '/session/$id': typeof SessionIdRoute
+  '/automations/': typeof AutomationsIndexRoute
   '/recordings/': typeof RecordingsIndexRoute
+  '/automations/sessions/$id': typeof AutomationsSessionsIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -97,18 +123,23 @@ export interface FileRouteTypes {
     | '/connectors'
     | '/recordings'
     | '/usage'
+    | '/automations/$automationId'
     | '/recordings/$id'
     | '/session/$id'
+    | '/automations/'
     | '/recordings/'
+    | '/automations/sessions/$id'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
-    | '/automations'
     | '/connectors'
     | '/usage'
+    | '/automations/$automationId'
     | '/recordings/$id'
     | '/session/$id'
+    | '/automations'
     | '/recordings'
+    | '/automations/sessions/$id'
   id:
     | '__root__'
     | '/'
@@ -116,14 +147,17 @@ export interface FileRouteTypes {
     | '/connectors'
     | '/recordings'
     | '/usage'
+    | '/automations/$automationId'
     | '/recordings/$id'
     | '/session/$id'
+    | '/automations/'
     | '/recordings/'
+    | '/automations/sessions/$id'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
-  AutomationsRoute: typeof AutomationsRoute
+  AutomationsRoute: typeof AutomationsRouteWithChildren
   ConnectorsRoute: typeof ConnectorsRoute
   RecordingsRoute: typeof RecordingsRouteWithChildren
   UsageRoute: typeof UsageRoute
@@ -174,6 +208,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RecordingsIndexRouteImport
       parentRoute: typeof RecordingsRoute
     }
+    '/automations/': {
+      id: '/automations/'
+      path: '/'
+      fullPath: '/automations/'
+      preLoaderRoute: typeof AutomationsIndexRouteImport
+      parentRoute: typeof AutomationsRoute
+    }
     '/session/$id': {
       id: '/session/$id'
       path: '/session/$id'
@@ -188,8 +229,38 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RecordingsIdRouteImport
       parentRoute: typeof RecordingsRoute
     }
+    '/automations/$automationId': {
+      id: '/automations/$automationId'
+      path: '/$automationId'
+      fullPath: '/automations/$automationId'
+      preLoaderRoute: typeof AutomationsAutomationIdRouteImport
+      parentRoute: typeof AutomationsRoute
+    }
+    '/automations/sessions/$id': {
+      id: '/automations/sessions/$id'
+      path: '/sessions/$id'
+      fullPath: '/automations/sessions/$id'
+      preLoaderRoute: typeof AutomationsSessionsIdRouteImport
+      parentRoute: typeof AutomationsRoute
+    }
   }
 }
+
+interface AutomationsRouteChildren {
+  AutomationsAutomationIdRoute: typeof AutomationsAutomationIdRoute
+  AutomationsIndexRoute: typeof AutomationsIndexRoute
+  AutomationsSessionsIdRoute: typeof AutomationsSessionsIdRoute
+}
+
+const AutomationsRouteChildren: AutomationsRouteChildren = {
+  AutomationsAutomationIdRoute: AutomationsAutomationIdRoute,
+  AutomationsIndexRoute: AutomationsIndexRoute,
+  AutomationsSessionsIdRoute: AutomationsSessionsIdRoute,
+}
+
+const AutomationsRouteWithChildren = AutomationsRoute._addFileChildren(
+  AutomationsRouteChildren,
+)
 
 interface RecordingsRouteChildren {
   RecordingsIdRoute: typeof RecordingsIdRoute
@@ -207,7 +278,7 @@ const RecordingsRouteWithChildren = RecordingsRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-  AutomationsRoute: AutomationsRoute,
+  AutomationsRoute: AutomationsRouteWithChildren,
   ConnectorsRoute: ConnectorsRoute,
   RecordingsRoute: RecordingsRouteWithChildren,
   UsageRoute: UsageRoute,

--- a/apps/web/src/routes/automations.$automationId.tsx
+++ b/apps/web/src/routes/automations.$automationId.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { AutomationsPage } from '@/components/automations/automations-page';
+import { automationSessionsQueryOptions, automationsQueryOptions } from '@/lib/queries/automations';
+import { visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
+
+export const Route = createFileRoute('/automations/$automationId')({
+  loader: ({ context, params }) =>
+    Promise.all([
+      context.queryClient.ensureQueryData(automationsQueryOptions),
+      context.queryClient.ensureQueryData(visibleProviderModelsQueryOptions),
+      context.queryClient.ensureQueryData(automationSessionsQueryOptions(params.automationId)),
+    ]),
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { automationId } = Route.useParams();
+  return <AutomationsPage automationId={automationId} />;
+}

--- a/apps/web/src/routes/automations.index.tsx
+++ b/apps/web/src/routes/automations.index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { AutomationsPage } from '@/components/automations/automations-page';
+
+export const Route = createFileRoute('/automations/')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <AutomationsPage />;
+}

--- a/apps/web/src/routes/automations.sessions.$id.tsx
+++ b/apps/web/src/routes/automations.sessions.$id.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 
 import { SessionPage } from '@/components/session/session-page';
 import { useActions } from '@/lib/actions';
-import { sessionQueryOptions, sessionMessagesInfiniteQueryOptions } from '@/lib/queries/chat';
+import { sessionMessagesInfiniteQueryOptions, sessionQueryOptions } from '@/lib/queries/chat';
 import {
   enabledProviderModelsQueryOptions,
   visibleProviderModelsQueryOptions,
@@ -11,12 +11,12 @@ import { queuedMessagesQueryOptions } from '@/lib/queries/queue';
 import { settingsQueryOptions } from '@/lib/queries/settings';
 import { useSessionHotkeys } from '@/lib/use-session-hotkeys';
 
-export const Route = createFileRoute('/session/$id')({
+export const Route = createFileRoute('/automations/sessions/$id')({
   loader: async ({ context, params }) => {
     const session = await context.queryClient.ensureQueryData(sessionQueryOptions(params.id));
 
-    if (session.type === 'automation') {
-      throw redirect({ to: '/automations/sessions/$id', params: { id: params.id } });
+    if (session.type !== 'automation') {
+      throw redirect({ to: '/session/$id', params: { id: params.id } });
     }
 
     await Promise.all([
@@ -27,12 +27,11 @@ export const Route = createFileRoute('/session/$id')({
       context.queryClient.ensureQueryData(queuedMessagesQueryOptions(params.id)),
     ]);
   },
-  component: SessionRouteComponent,
+  component: RouteComponent,
 });
 
-function SessionRouteComponent() {
+function RouteComponent() {
   const { id } = Route.useParams();
-
   const actions = useActions();
   useSessionHotkeys(actions);
 

--- a/apps/web/src/routes/automations.tsx
+++ b/apps/web/src/routes/automations.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { AutomationsPage } from '@/components/automations/automations-page';
+import { automationsQueryOptions } from '@/lib/queries/automations';
+import { visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
+
+export const Route = createFileRoute('/automations')({
+  loader: ({ context }) =>
+    Promise.all([
+      context.queryClient.ensureQueryData(automationsQueryOptions),
+      context.queryClient.ensureQueryData(visibleProviderModelsQueryOptions),
+    ]),
+  component: AutomationsPage,
+});

--- a/apps/web/src/routes/automations.tsx
+++ b/apps/web/src/routes/automations.tsx
@@ -1,6 +1,5 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Outlet } from '@tanstack/react-router';
 
-import { AutomationsPage } from '@/components/automations/automations-page';
 import { automationsQueryOptions } from '@/lib/queries/automations';
 import { visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
 
@@ -10,5 +9,5 @@ export const Route = createFileRoute('/automations')({
       context.queryClient.ensureQueryData(automationsQueryOptions),
       context.queryClient.ensureQueryData(visibleProviderModelsQueryOptions),
     ]),
-  component: AutomationsPage,
+  component: Outlet,
 });

--- a/apps/web/src/routes/recordings.$id.tsx
+++ b/apps/web/src/routes/recordings.$id.tsx
@@ -34,7 +34,7 @@ function RecordingDetailComponent() {
 
   return (
     <>
-      <RecordingDetail meeting={meeting} onDelete={() => setDeleteDialogOpen(true)} />
+      <RecordingDetail key={meeting.id} meeting={meeting} onDelete={() => setDeleteDialogOpen(true)} />
       <RecordingDeleteDialog
         meetingId={meeting.id}
         open={deleteDialogOpen}

--- a/apps/web/src/stores/automation-store.ts
+++ b/apps/web/src/stores/automation-store.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+
+type AutomationStore = {
+  selectedAutomationId: string | null;
+  createDialogOpen: boolean;
+  editingAutomationId: string | null;
+  setSelectedAutomationId: (id: string | null) => void;
+  openCreateDialog: () => void;
+  closeCreateDialog: () => void;
+  openEditDialog: (id: string) => void;
+  closeEditDialog: () => void;
+};
+
+export const useAutomationStore = create<AutomationStore>((set) => ({
+  selectedAutomationId: null,
+  createDialogOpen: false,
+  editingAutomationId: null,
+  setSelectedAutomationId: (id) => set({ selectedAutomationId: id }),
+  openCreateDialog: () => set({ createDialogOpen: true, editingAutomationId: null }),
+  closeCreateDialog: () => set({ createDialogOpen: false }),
+  openEditDialog: (id) => set({ editingAutomationId: id, selectedAutomationId: id, createDialogOpen: false }),
+  closeEditDialog: () => set({ editingAutomationId: null }),
+}));

--- a/apps/web/src/stores/automation-store.ts
+++ b/apps/web/src/stores/automation-store.ts
@@ -1,10 +1,8 @@
 import { create } from 'zustand';
 
 type AutomationStore = {
-  selectedAutomationId: string | null;
   createDialogOpen: boolean;
   editingAutomationId: string | null;
-  setSelectedAutomationId: (id: string | null) => void;
   openCreateDialog: () => void;
   closeCreateDialog: () => void;
   openEditDialog: (id: string) => void;
@@ -12,12 +10,10 @@ type AutomationStore = {
 };
 
 export const useAutomationStore = create<AutomationStore>((set) => ({
-  selectedAutomationId: null,
   createDialogOpen: false,
   editingAutomationId: null,
-  setSelectedAutomationId: (id) => set({ selectedAutomationId: id }),
   openCreateDialog: () => set({ createDialogOpen: true, editingAutomationId: null }),
   closeCreateDialog: () => set({ createDialogOpen: false }),
-  openEditDialog: (id) => set({ editingAutomationId: id, selectedAutomationId: id, createDialogOpen: false }),
+  openEditDialog: (id) => set({ editingAutomationId: id, createDialogOpen: false }),
   closeEditDialog: () => set({ editingAutomationId: null }),
 }));

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,8 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "cron-parser": "^5.5.0",
+        "date-fns": "^4.1.0",
         "katex": "^0.16.38",
         "lucide-react": "^0.577.0",
         "react": "19.2.4",
@@ -1185,6 +1187,8 @@
 
     "crc": ["crc@3.8.0", "", { "dependencies": { "buffer": "^5.1.0" } }, "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ=="],
 
+    "cron-parser": ["cron-parser@5.5.0", "", { "dependencies": { "luxon": "^3.7.1" } }, "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww=="],
+
     "cross-dirname": ["cross-dirname@0.1.0", "", {}, "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -1194,6 +1198,8 @@
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -1670,6 +1676,8 @@
     "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
     "lucide-react": ["lucide-react@0.577.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "@tanstack/react-hotkeys": "0.4.1",
         "@tanstack/react-query": "5.90.21",
         "@tanstack/react-router": "1.166.7",
+        "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.22",
         "chart.js": "^4.5.1",
         "class-variance-authority": "^0.7.1",
@@ -884,6 +885,8 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.2", "", { "dependencies": { "@tanstack/store": "0.9.2", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Vt5usJE5sHG/cMechQfmwvwne6ktGCELe89Lmvoxe3LKRoFrhPa8OCKWs0NliG8HTJElEIj7PLtaBQIcux5pAQ=="],
 
+    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.13.22", "", { "dependencies": { "@tanstack/virtual-core": "3.13.22" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-EaOrBBJLi3M0bTMQRjGkxLXRw7Gizwntoy5E2Q2UnSbML7Mo2a1P/Hfkw5tw9FLzK62bj34Jl6VNbQfRV6eJcA=="],
 
     "@tanstack/router-core": ["@tanstack/router-core@1.166.7", "", { "dependencies": { "@tanstack/history": "1.161.4", "@tanstack/store": "^0.9.1", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" } }, "sha512-MCc8wYIIcxmbeidM8PL2QeaAjUIHyhEDIZPW6NGfn/uwvyi+K2ucn3AGCxxcXl4JGGm0Mx9+7buYl1v3HdcFrg=="],
@@ -895,6 +898,8 @@
     "@tanstack/router-utils": ["@tanstack/router-utils@1.161.4", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-r8TpjyIZoqrXXaf2DDyjd44gjGBoyE+/oEaaH68yLI9ySPO1gUWmQENZ1MZnmBnpUGN24NOZxdjDLc8npK0SAw=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.2", "", {}, "sha512-K013lUJEFJK2ofFQ/hZKJUmCnpcV00ebLyOyFOWQvyQHUOZp/iYO84BM6aOGiV81JzwbX0APTVmW8YI7yiG5oA=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.22", "", {}, "sha512-isuUGKsc5TAPDoHSbWTbl1SCil54zOS2MiWz/9GCWHPUQOvNTQx8qJEWC7UWR0lShhbK0Lmkcf0SZYxvch7G3g=="],
 

--- a/oxlint.json
+++ b/oxlint.json
@@ -24,7 +24,9 @@
     "react/jsx-no-target-blank": "error",
     "react/no-deprecated": "error",
     "react/react-in-jsx-scope": "off",
-    "react/hooks-extra/no-direct-set-state-in-use-effect": "error"
+    "react/hooks-extra/no-direct-set-state-in-use-effect": "error",
+    "react/rules-of-hooks": "error",
+    "react/exhaustive-deps": "error"
   },
   "ignorePatterns": ["node_modules", "dist", "out", "dist-electron", ".turbo"],
   "overrides": [

--- a/packages/server/drizzle/0007_fluffy_bastion.sql
+++ b/packages/server/drizzle/0007_fluffy_bastion.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `automations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`provider_id` text NOT NULL,
+	`model_id` text NOT NULL,
+	`initial_message` text NOT NULL,
+	`title` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);

--- a/packages/server/drizzle/0008_skinny_iceman.sql
+++ b/packages/server/drizzle/0008_skinny_iceman.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `automations` ADD `run_count` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `sessions` ADD `type` text DEFAULT 'chat' NOT NULL;--> statement-breakpoint
+ALTER TABLE `sessions` ADD `automation_id` text REFERENCES automations(id);

--- a/packages/server/drizzle/0009_outgoing_northstar.sql
+++ b/packages/server/drizzle/0009_outgoing_northstar.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `automations` ADD `schedule` blob;

--- a/packages/server/drizzle/meta/0007_snapshot.json
+++ b/packages/server/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1749 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6cd08a09-e753-480c-b8f7-f531519c20ca",
+  "prevId": "b03354d8-2e40-4bbd-9eea-489353382b39",
+  "tables": {
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "is_attributable": {
+          "name": "is_attributable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_id": {
+          "name": "transcription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_index": {
+          "name": "attempt_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_run_id_idx": {
+          "name": "llm_usage_events_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meetings": {
+      "name": "meetings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_path": {
+          "name": "app_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'detected'"
+        },
+        "recording_file_path": {
+          "name": "recording_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_secs": {
+          "name": "duration_secs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meetings_status_check": {
+          "name": "meetings_status_check",
+          "value": "\"meetings\".\"status\" in ('detected', 'recording', 'completed')"
+        }
+      }
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permission_responses": {
+      "name": "permission_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_reminder": {
+          "name": "system_reminder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_responses_session_id_sessions_id_fk": {
+          "name": "permission_responses_session_id_sessions_id_fk",
+          "tableFrom": "permission_responses",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_messages": {
+      "name": "queued_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "queued_messages_session_id_sessions_id_fk": {
+          "name": "queued_messages_session_id_sessions_id_fk",
+          "tableFrom": "queued_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_transcriptions": {
+      "name": "recording_transcriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recording_transcriptions_meeting_id_meetings_id_fk": {
+          "name": "recording_transcriptions_meeting_id_meetings_id_fk",
+          "tableFrom": "recording_transcriptions",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "transcription_status_check": {
+          "name": "transcription_status_check",
+          "value": "\"recording_transcriptions\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": [
+            "job_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "queue_enabled": {
+          "name": "queue_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": [
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": [
+            "tool_name",
+            "pattern"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/0008_snapshot.json
+++ b/packages/server/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1785 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "08baf21a-459d-467f-947d-0a5672a48e41",
+  "prevId": "6cd08a09-e753-480c-b8f7-f531519c20ca",
+  "tables": {
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "is_attributable": {
+          "name": "is_attributable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_id": {
+          "name": "transcription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_index": {
+          "name": "attempt_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_run_id_idx": {
+          "name": "llm_usage_events_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meetings": {
+      "name": "meetings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_path": {
+          "name": "app_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'detected'"
+        },
+        "recording_file_path": {
+          "name": "recording_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_secs": {
+          "name": "duration_secs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meetings_status_check": {
+          "name": "meetings_status_check",
+          "value": "\"meetings\".\"status\" in ('detected', 'recording', 'completed')"
+        }
+      }
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permission_responses": {
+      "name": "permission_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_reminder": {
+          "name": "system_reminder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_responses_session_id_sessions_id_fk": {
+          "name": "permission_responses_session_id_sessions_id_fk",
+          "tableFrom": "permission_responses",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_messages": {
+      "name": "queued_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "queued_messages_session_id_sessions_id_fk": {
+          "name": "queued_messages_session_id_sessions_id_fk",
+          "tableFrom": "queued_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_transcriptions": {
+      "name": "recording_transcriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recording_transcriptions_meeting_id_meetings_id_fk": {
+          "name": "recording_transcriptions_meeting_id_meetings_id_fk",
+          "tableFrom": "recording_transcriptions",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "transcription_status_check": {
+          "name": "transcription_status_check",
+          "value": "\"recording_transcriptions\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": [
+            "job_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "queue_enabled": {
+          "name": "queue_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": [
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_automation_id_automations_id_fk": {
+          "name": "sessions_automation_id_automations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": [
+            "tool_name",
+            "pattern"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/0009_snapshot.json
+++ b/packages/server/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1792 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "653e21b5-d1e4-4df0-a666-81f9d9ad49ad",
+  "prevId": "08baf21a-459d-467f-947d-0a5672a48e41",
+  "tables": {
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "is_attributable": {
+          "name": "is_attributable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_id": {
+          "name": "transcription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_index": {
+          "name": "attempt_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_run_id_idx": {
+          "name": "llm_usage_events_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meetings": {
+      "name": "meetings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "app_path": {
+          "name": "app_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'detected'"
+        },
+        "recording_file_path": {
+          "name": "recording_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_secs": {
+          "name": "duration_secs",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "meetings_status_check": {
+          "name": "meetings_status_check",
+          "value": "\"meetings\".\"status\" in ('detected', 'recording', 'completed')"
+        }
+      }
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permission_responses": {
+      "name": "permission_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_reminder": {
+          "name": "system_reminder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_responses_session_id_sessions_id_fk": {
+          "name": "permission_responses_session_id_sessions_id_fk",
+          "tableFrom": "permission_responses",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_messages": {
+      "name": "queued_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "queued_messages_session_id_sessions_id_fk": {
+          "name": "queued_messages_session_id_sessions_id_fk",
+          "tableFrom": "queued_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_transcriptions": {
+      "name": "recording_transcriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recording_transcriptions_meeting_id_meetings_id_fk": {
+          "name": "recording_transcriptions_meeting_id_meetings_id_fk",
+          "tableFrom": "recording_transcriptions",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "transcription_status_check": {
+          "name": "transcription_status_check",
+          "value": "\"recording_transcriptions\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": [
+            "job_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "queue_enabled": {
+          "name": "queue_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": [
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_automation_id_automations_id_fk": {
+          "name": "sessions_automation_id_automations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": [
+            "tool_name",
+            "pattern"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1775320909985,
       "tag": "0008_skinny_iceman",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1775323352253,
+      "tag": "0009_outgoing_northstar",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1775258328166,
       "tag": "0006_cold_the_santerians",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1775317825423,
+      "tag": "0007_fluffy_bastion",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1775317825423,
       "tag": "0007_fluffy_bastion",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1775320909985,
+      "tag": "0008_skinny_iceman",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/automations/generation.ts
+++ b/packages/server/src/automations/generation.ts
@@ -1,0 +1,293 @@
+import { generateText, Output } from 'ai';
+import { asc, eq, inArray } from 'drizzle-orm';
+import { z } from 'zod';
+
+import type { Message, StoredPart } from '@stitch/shared/chat/messages';
+import { createMessageId, createPartId } from '@stitch/shared/id';
+import type { PrefixedString } from '@stitch/shared/id';
+import type { GeneratedAutomationDraft } from '@stitch/shared/automations/types';
+
+import { getDb } from '@/db/client.js';
+import { messages, sessions, userSettings } from '@/db/schema.js';
+import { err, ok } from '@/lib/service-result.js';
+import type { ServiceResult } from '@/lib/service-result.js';
+import { buildHistoryMessages } from '@/llm/history-messages.js';
+import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
+import { createProvider } from '@/provider/provider.js';
+import { listToolsets } from '@/tools/toolsets/registry.js';
+import { recordUsageEvent } from '@/usage/ledger.js';
+import { calculateMessageCostUsd } from '@/utils/cost.js';
+
+const draftSchema = z.object({
+  title: z.string().trim().min(1).max(120),
+  toolsets: z.array(z.string().trim().min(1)).max(20),
+  steps: z.array(z.string().trim().min(1)).max(20),
+  prompt: z.string().trim().min(1),
+});
+
+type GenerationMessageContext = Pick<Message, 'providerId' | 'modelId' | 'isSummary'> & {
+  parts: StoredPart[];
+};
+
+function isHiddenFromHistory(message: GenerationMessageContext): boolean {
+  return message.parts.some(
+    (part) =>
+      part.type === 'session-title' ||
+      part.type === 'compaction' ||
+      part.type === 'automation-generation',
+  );
+}
+
+function findLastUsedModel(
+  messageList: GenerationMessageContext[],
+): { providerId: string; modelId: string } | null {
+  for (let index = messageList.length - 1; index >= 0; index--) {
+    const message = messageList[index];
+    if (!message || message.isSummary || isHiddenFromHistory(message)) continue;
+    if (!message.providerId || !message.modelId) continue;
+    return { providerId: message.providerId, modelId: message.modelId };
+  }
+
+  return null;
+}
+
+function dedupeStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const normalized = value.trim();
+    if (!normalized) continue;
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function collectToolsetContext(messageList: GenerationMessageContext[]): {
+  usedToolNames: string[];
+  inferredToolsets: string[];
+  availableToolsets: string[];
+} {
+  const available = listToolsets();
+  const availableToolsets = available.map((toolset) => toolset.id).sort();
+  const toolToToolset = new Map<string, string>();
+
+  for (const toolset of available) {
+    for (const tool of toolset.tools()) {
+      toolToToolset.set(tool.name, toolset.id);
+    }
+  }
+
+  const toolNames: string[] = [];
+  const inferredToolsets = new Set<string>();
+
+  for (const message of messageList) {
+    for (const part of message.parts) {
+      if (part.type !== 'tool-call') continue;
+      toolNames.push(part.toolName);
+      const inferred = toolToToolset.get(part.toolName);
+      if (inferred) inferredToolsets.add(inferred);
+    }
+  }
+
+  return {
+    usedToolNames: dedupeStrings(toolNames),
+    inferredToolsets: [...inferredToolsets].sort(),
+    availableToolsets,
+  };
+}
+
+async function getPromptUserContext(): Promise<{ userName: string | null; userTimezone: string | null }> {
+  const db = getDb();
+  const rows = await db
+    .select({ key: userSettings.key, value: userSettings.value })
+    .from(userSettings)
+    .where(inArray(userSettings.key, ['profile.name', 'profile.timezone']));
+  const byKey = new Map(rows.map((row) => [row.key, row.value.trim()]));
+
+  return {
+    userName: byKey.get('profile.name') || null,
+    userTimezone: byKey.get('profile.timezone') || null,
+  };
+}
+
+function buildAutomationPrompt(input: {
+  availableToolsets: string[];
+  usedToolNames: string[];
+  inferredToolsets: string[];
+}): string {
+  const availableToolsets =
+    input.availableToolsets.length > 0 ? input.availableToolsets.join(', ') : '(none registered)';
+  const usedToolNames = input.usedToolNames.length > 0 ? input.usedToolNames.join(', ') : '(none)';
+  const inferredToolsets = input.inferredToolsets.length > 0 ? input.inferredToolsets.join(', ') : '(none)';
+
+  return [
+    'Review the conversation and create an automation draft.',
+    'Focus on the user goal and their feedback/corrections so instructions are precise and actionable.',
+    'The prompt field must be markdown formatted for readability.',
+    '',
+    `Known toolsets: ${availableToolsets}`,
+    `Observed tool names in this session: ${usedToolNames}`,
+    `Inferred toolsets from observed tools: ${inferredToolsets}`,
+    '',
+    'Rules:',
+    '- title: short and descriptive (max 120 chars).',
+    '- toolsets: only include toolset IDs that are actually relevant.',
+    '- steps: 3-10 concise, ordered steps.',
+    '- prompt: clear reusable automation instructions that reflect user feedback and use markdown formatting.',
+  ].join('\n');
+}
+
+function normalizeDraft(
+  draft: z.infer<typeof draftSchema>,
+  sessionModel: { providerId: string; modelId: string },
+  availableToolsets: string[],
+  inferredToolsets: string[],
+): GeneratedAutomationDraft {
+  const availableSet = new Set(availableToolsets);
+  const toolsets = dedupeStrings(draft.toolsets).filter((toolset) => availableSet.has(toolset));
+
+  return {
+    title: draft.title.trim(),
+    toolsets: toolsets.length > 0 ? toolsets : inferredToolsets,
+    steps: dedupeStrings(draft.steps).slice(0, 20),
+    prompt: draft.prompt.trim(),
+    providerId: sessionModel.providerId,
+    modelId: sessionModel.modelId,
+  };
+}
+
+export async function generateAutomationDraft(
+  sessionId: string,
+): Promise<ServiceResult<GeneratedAutomationDraft>> {
+  const db = getDb();
+  const [session] = await db
+    .select()
+    .from(sessions)
+    .where(eq(sessions.id, sessionId as PrefixedString<'ses'>));
+  if (!session) {
+    return err('Session not found', 404);
+  }
+
+  const messageList = await db
+    .select()
+    .from(messages)
+    .where(eq(messages.sessionId, session.id))
+    .orderBy(asc(messages.createdAt));
+
+  if (messageList.length === 0) {
+    return err('Session has no messages to analyze', 400);
+  }
+
+  const sessionModel = findLastUsedModel(messageList);
+  if (!sessionModel) {
+    return err('Unable to determine model for this session', 400);
+  }
+
+  const promptUserContext = await getPromptUserContext();
+  const toolsetContext = collectToolsetContext(messageList);
+  const llmMessages = buildHistoryMessages(messageList, {
+    useBasePrompt: false,
+    systemPrompt: null,
+    userName: promptUserContext.userName,
+    userTimezone: promptUserContext.userTimezone,
+  });
+
+  const resolved = await resolveCheapModel({
+    providerIdKey: 'model.title.providerId',
+    modelIdKey: 'model.title.modelId',
+    fallbackProviderId: sessionModel.providerId,
+    fallbackModelId: sessionModel.modelId,
+  });
+
+  if (!resolved) {
+    return err('No configured provider found for automation generation', 400);
+  }
+
+  const generationMessageId = createMessageId();
+  const start = Date.now();
+  const model = createProvider(resolved.credentials)(resolved.modelId);
+
+  const result = await generateText({
+    model,
+    messages: [
+      ...llmMessages,
+      {
+        role: 'user',
+        content: buildAutomationPrompt(toolsetContext),
+      },
+    ],
+    maxOutputTokens: 1800,
+    output: Output.object({ schema: draftSchema }),
+  });
+
+  const draft = normalizeDraft(
+    result.output,
+    sessionModel,
+    toolsetContext.availableToolsets,
+    toolsetContext.inferredToolsets,
+  );
+
+  const usage = result.usage ?? null;
+  const costUsd = usage
+    ? await calculateMessageCostUsd({
+        providerId: resolved.providerId,
+        modelId: resolved.modelId,
+        usage,
+      })
+    : 0;
+
+  const generationPart: StoredPart = {
+    type: 'automation-generation',
+    id: createPartId(),
+    title: draft.title,
+    toolsets: draft.toolsets,
+    steps: draft.steps,
+    prompt: draft.prompt,
+    providerId: draft.providerId,
+    modelId: draft.modelId,
+    startedAt: start,
+    endedAt: Date.now(),
+  };
+
+  await db.insert(messages).values({
+    id: generationMessageId,
+    sessionId: session.id,
+    role: 'assistant',
+    parts: [generationPart],
+    modelId: resolved.modelId,
+    providerId: resolved.providerId,
+    usage: usage ?? undefined,
+    costUsd,
+    finishReason: 'stop',
+    isSummary: false,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    startedAt: start,
+    duration: Date.now() - start,
+  });
+
+  if (usage) {
+    await recordUsageEvent({
+      runId: generationMessageId,
+      source: 'automation_generation',
+      status: 'succeeded',
+      sessionId: session.id,
+      messageId: generationMessageId,
+      providerId: resolved.providerId,
+      modelId: resolved.modelId,
+      usage,
+      costUsd,
+      metadata: {
+        phase: 'automation-generation',
+      },
+      startedAt: start,
+      endedAt: Date.now(),
+      durationMs: Date.now() - start,
+    });
+  }
+
+  return ok(draft);
+}

--- a/packages/server/src/automations/scheduler.ts
+++ b/packages/server/src/automations/scheduler.ts
@@ -1,0 +1,62 @@
+import type { JobSchedule } from '@stitch/scheduler';
+import type { Automation, AutomationSchedule } from '@stitch/shared/automations/types';
+
+import { registerSchedulerJob, unregisterSchedulerJob } from '@/scheduler/runtime.js';
+
+import { listAutomations, runAutomation } from './service.js';
+
+const AUTOMATION_JOB_KEY_PREFIX = 'automation:';
+
+function getAutomationJobKey(automationId: string): string {
+  return `${AUTOMATION_JOB_KEY_PREFIX}${automationId}`;
+}
+
+function toSchedulerSchedule(schedule: AutomationSchedule): JobSchedule {
+  if (schedule.type === 'interval') {
+    return {
+      type: 'interval',
+      everyMs: schedule.everyMinutes * 60_000,
+    };
+  }
+
+  return {
+    type: 'cron',
+    expression: schedule.expression,
+    timezone: 'local',
+  };
+}
+
+async function registerAutomationJob(automation: Automation): Promise<void> {
+  if (!automation.schedule) return;
+
+  await registerSchedulerJob({
+    key: getAutomationJobKey(automation.id),
+    schedule: toSchedulerSchedule(automation.schedule),
+    callback: async () => {
+      const result = await runAutomation(automation.id);
+      if ('error' in result) {
+        throw new Error(result.error);
+      }
+    },
+    maxConcurrency: 1,
+    queueEnabled: true,
+    catchup: 'one',
+  });
+}
+
+export async function syncAutomationSchedule(automation: Automation): Promise<void> {
+  const key = getAutomationJobKey(automation.id);
+  await unregisterSchedulerJob(key);
+
+  if (!automation.schedule) return;
+  await registerAutomationJob(automation);
+}
+
+export async function unregisterAutomationSchedule(automationId: string): Promise<void> {
+  await unregisterSchedulerJob(getAutomationJobKey(automationId));
+}
+
+export async function syncAllAutomationSchedules(): Promise<void> {
+  const rows = await listAutomations();
+  await Promise.all(rows.map((automation) => syncAutomationSchedule(automation)));
+}

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -1,11 +1,18 @@
-import { asc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, sql } from 'drizzle-orm';
 
-import { createAutomationId } from '@stitch/shared/id';
-import type { Automation, CreateAutomationInput, UpdateAutomationInput } from '@stitch/shared/automations/types';
+import type { Session } from '@stitch/shared/chat/messages';
+import { createAutomationId, createMessageId } from '@stitch/shared/id';
+import type {
+  Automation,
+  CreateAutomationInput,
+  RunAutomationResponse,
+  UpdateAutomationInput,
+} from '@stitch/shared/automations/types';
 import type { PrefixedString } from '@stitch/shared/id';
 
+import { createSession, sendMessage } from '@/chat/service.js';
 import { getDb } from '@/db/client.js';
-import { automations, providerConfig } from '@/db/schema.js';
+import { automations, providerConfig, sessions } from '@/db/schema.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { isAllowedProvider } from '@/provider/models.js';
@@ -139,4 +146,83 @@ export async function deleteAutomation(automationId: string): Promise<ServiceRes
   }
 
   return ok(null);
+}
+
+export async function listAutomationSessions(automationId: string): Promise<ServiceResult<Session[]>> {
+  const db = getDb();
+  const [existing] = await db
+    .select({ id: automations.id })
+    .from(automations)
+    .where(eq(automations.id, automationId as PrefixedString<'auto'>));
+  if (!existing) {
+    return err('Automation not found', 404);
+  }
+
+  const rows = await db
+    .select()
+    .from(sessions)
+    .where(
+      and(
+        eq(sessions.type, 'automation'),
+        eq(sessions.automationId, automationId as PrefixedString<'auto'>),
+      ),
+    )
+    .orderBy(desc(sessions.updatedAt));
+
+  return ok(rows);
+}
+
+export async function runAutomation(automationId: string): Promise<ServiceResult<RunAutomationResponse>> {
+  const db = getDb();
+
+  const [automation] = await db
+    .select()
+    .from(automations)
+    .where(eq(automations.id, automationId as PrefixedString<'auto'>));
+  if (!automation) {
+    return err('Automation not found', 404);
+  }
+
+  const validation = await validateProviderModel(automation.providerId, automation.modelId);
+  if ('error' in validation) {
+    return validation;
+  }
+
+  const [updatedAutomation] = await db
+    .update(automations)
+    .set({
+      runCount: sql`${automations.runCount} + 1`,
+      updatedAt: Date.now(),
+    })
+    .where(eq(automations.id, automation.id))
+    .returning({ runCount: automations.runCount });
+
+  if (!updatedAutomation) {
+    return err('Automation not found', 404);
+  }
+
+  const title = `${automation.title} #${updatedAutomation.runCount}`;
+  const session = await createSession({
+    title,
+    type: 'automation',
+    automationId: automation.id,
+  });
+
+  const assistantMessageId = createMessageId();
+  const sendResult = await sendMessage({
+    sessionId: session.id,
+    content: automation.initialMessage,
+    providerId: automation.providerId,
+    modelId: automation.modelId,
+    assistantMessageId,
+  });
+  if ('error' in sendResult) {
+    return sendResult;
+  }
+
+  return ok({
+    sessionId: session.id,
+    assistantMessageId,
+    userMessageId: sendResult.data.userMessageId as PrefixedString<'msg'>,
+  });
 }

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -1,0 +1,142 @@
+import { asc, eq } from 'drizzle-orm';
+
+import { createAutomationId } from '@stitch/shared/id';
+import type { Automation, CreateAutomationInput, UpdateAutomationInput } from '@stitch/shared/automations/types';
+import type { PrefixedString } from '@stitch/shared/id';
+
+import { getDb } from '@/db/client.js';
+import { automations, providerConfig } from '@/db/schema.js';
+import { err, ok } from '@/lib/service-result.js';
+import type { ServiceResult } from '@/lib/service-result.js';
+import { isAllowedProvider } from '@/provider/models.js';
+import * as Models from '@/provider/models.js';
+
+type AutomationRow = Automation;
+
+async function validateProviderModel(providerId: string, modelId: string): Promise<ServiceResult<null>> {
+  if (!isAllowedProvider(providerId)) {
+    return err('Provider not found', 404);
+  }
+
+  const providers = await Models.get();
+  const provider = providers[providerId];
+  if (!provider) {
+    return err('Provider not found', 404);
+  }
+
+  if (!provider.models[modelId]) {
+    return err('Model not found for provider', 400);
+  }
+
+  const db = getDb();
+  const [configuredProvider] = await db
+    .select({ providerId: providerConfig.providerId })
+    .from(providerConfig)
+    .where(eq(providerConfig.providerId, providerId));
+  if (!configuredProvider) {
+    return err('Provider is not configured', 400);
+  }
+
+  return ok(null);
+}
+
+function normalizeText(value: string): string {
+  return value.trim();
+}
+
+export async function listAutomations(): Promise<AutomationRow[]> {
+  const db = getDb();
+  return db.select().from(automations).orderBy(asc(automations.createdAt));
+}
+
+export async function createAutomation(input: CreateAutomationInput): Promise<ServiceResult<AutomationRow>> {
+  const providerId = normalizeText(input.providerId);
+  const modelId = normalizeText(input.modelId);
+  const title = normalizeText(input.title);
+  const initialMessage = normalizeText(input.initialMessage);
+
+  if (!providerId || !modelId || !title || !initialMessage) {
+    return err('providerId, modelId, title, and initialMessage are required', 400);
+  }
+
+  const validation = await validateProviderModel(providerId, modelId);
+  if ('error' in validation) {
+    return validation;
+  }
+
+  const db = getDb();
+  const id = createAutomationId();
+  const [created] = await db
+    .insert(automations)
+    .values({
+      id,
+      providerId,
+      modelId,
+      title,
+      initialMessage,
+    })
+    .returning();
+
+  return ok(created);
+}
+
+export async function updateAutomation(
+  automationId: string,
+  input: UpdateAutomationInput,
+): Promise<ServiceResult<AutomationRow>> {
+  const db = getDb();
+  const [existing] = await db
+    .select()
+    .from(automations)
+    .where(eq(automations.id, automationId as PrefixedString<'auto'>));
+  if (!existing) {
+    return err('Automation not found', 404);
+  }
+
+  const providerId = input.providerId !== undefined ? normalizeText(input.providerId) : existing.providerId;
+  const modelId = input.modelId !== undefined ? normalizeText(input.modelId) : existing.modelId;
+  const title = input.title !== undefined ? normalizeText(input.title) : existing.title;
+  const initialMessage =
+    input.initialMessage !== undefined ? normalizeText(input.initialMessage) : existing.initialMessage;
+
+  if (!providerId || !modelId || !title || !initialMessage) {
+    return err('providerId, modelId, title, and initialMessage are required', 400);
+  }
+
+  const validation = await validateProviderModel(providerId, modelId);
+  if ('error' in validation) {
+    return validation;
+  }
+
+  const [updated] = await db
+    .update(automations)
+    .set({
+      providerId,
+      modelId,
+      title,
+      initialMessage,
+      updatedAt: Date.now(),
+    })
+    .where(eq(automations.id, automationId as PrefixedString<'auto'>))
+    .returning();
+
+  if (!updated) {
+    return err('Automation not found', 404);
+  }
+
+  return ok(updated);
+}
+
+export async function deleteAutomation(automationId: string): Promise<ServiceResult<null>> {
+  const db = getDb();
+  const deleted = await db
+    .delete(automations)
+    .where(eq(automations.id, automationId as PrefixedString<'auto'>))
+    .returning({ id: automations.id });
+
+  if (deleted.length === 0) {
+    return err('Automation not found', 404);
+  }
+
+  return ok(null);
+}

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -4,6 +4,8 @@ import type { Session } from '@stitch/shared/chat/messages';
 import { createAutomationId, createMessageId } from '@stitch/shared/id';
 import type {
   Automation,
+  AutomationSchedule,
+  AutomationScheduleBlob,
   CreateAutomationInput,
   RunAutomationResponse,
   UpdateAutomationInput,
@@ -18,6 +20,7 @@ import type { ServiceResult } from '@/lib/service-result.js';
 import { isAllowedProvider } from '@/provider/models.js';
 import * as Models from '@/provider/models.js';
 
+type AutomationDbRow = typeof automations.$inferSelect;
 type AutomationRow = Automation;
 
 async function validateProviderModel(providerId: string, modelId: string): Promise<ServiceResult<null>> {
@@ -51,9 +54,99 @@ function normalizeText(value: string): string {
   return value.trim();
 }
 
+function parseCronField(raw: string, min: number, max: number): boolean {
+  const parts = raw.split(',');
+  if (parts.length === 0) return false;
+
+  for (const part of parts) {
+    if (part === '*') continue;
+
+    if (part.startsWith('*/')) {
+      const step = Number(part.slice(2));
+      if (!Number.isInteger(step) || step <= 0) return false;
+      continue;
+    }
+
+    if (part.includes('-')) {
+      const [startRaw, endRaw] = part.split('-');
+      const start = Number(startRaw);
+      const end = Number(endRaw);
+      if (!Number.isInteger(start) || !Number.isInteger(end)) return false;
+      if (start < min || end > max || start > end) return false;
+      continue;
+    }
+
+    const value = Number(part);
+    if (!Number.isInteger(value) || value < min || value > max) return false;
+  }
+
+  return true;
+}
+
+function validateAutomationSchedule(schedule: AutomationSchedule | null): ServiceResult<AutomationSchedule | null> {
+  if (schedule === null) return ok(null);
+
+  if (schedule.type === 'interval') {
+    if (!Number.isInteger(schedule.everyMinutes) || schedule.everyMinutes < 1) {
+      return err('Interval schedule must be at least 1 minute', 400);
+    }
+
+    return ok({
+      type: 'interval',
+      everyMinutes: schedule.everyMinutes,
+    });
+  }
+
+  const expression = normalizeText(schedule.expression);
+  const fields = expression.split(/\s+/);
+  if (fields.length !== 5) {
+    return err('Cron expression must have 5 fields', 400);
+  }
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = fields;
+  const valid =
+    parseCronField(minute, 0, 59) &&
+    parseCronField(hour, 0, 23) &&
+    parseCronField(dayOfMonth, 1, 31) &&
+    parseCronField(month, 1, 12) &&
+    parseCronField(dayOfWeek, 0, 6);
+
+  if (!valid) {
+    return err('Invalid cron expression', 400);
+  }
+
+  return ok({
+    type: 'cron',
+    expression,
+  });
+}
+
+function serializeAutomationSchedule(schedule: AutomationSchedule | null): AutomationScheduleBlob | null {
+  if (schedule === null) return null;
+
+  return {
+    version: 1,
+    schedule,
+  };
+}
+
+function deserializeAutomationSchedule(blob: AutomationScheduleBlob | null): AutomationSchedule | null {
+  if (blob === null) return null;
+  if (blob.version !== 1) return null;
+  return blob.schedule;
+}
+
+function toAutomationRow(row: AutomationDbRow): AutomationRow {
+  return {
+    ...row,
+    schedule: deserializeAutomationSchedule(row.schedule),
+  };
+}
+
 export async function listAutomations(): Promise<AutomationRow[]> {
   const db = getDb();
-  return db.select().from(automations).orderBy(asc(automations.createdAt));
+  const rows = await db.select().from(automations).orderBy(asc(automations.createdAt));
+  return rows.map(toAutomationRow);
 }
 
 export async function createAutomation(input: CreateAutomationInput): Promise<ServiceResult<AutomationRow>> {
@@ -61,9 +154,15 @@ export async function createAutomation(input: CreateAutomationInput): Promise<Se
   const modelId = normalizeText(input.modelId);
   const title = normalizeText(input.title);
   const initialMessage = normalizeText(input.initialMessage);
+  const scheduleInput = input.schedule ?? null;
 
   if (!providerId || !modelId || !title || !initialMessage) {
     return err('providerId, modelId, title, and initialMessage are required', 400);
+  }
+
+  const scheduleResult = validateAutomationSchedule(scheduleInput);
+  if ('error' in scheduleResult) {
+    return scheduleResult;
   }
 
   const validation = await validateProviderModel(providerId, modelId);
@@ -81,10 +180,11 @@ export async function createAutomation(input: CreateAutomationInput): Promise<Se
       modelId,
       title,
       initialMessage,
+      schedule: serializeAutomationSchedule(scheduleResult.data),
     })
     .returning();
 
-  return ok(created);
+  return ok(toAutomationRow(created));
 }
 
 export async function updateAutomation(
@@ -105,9 +205,16 @@ export async function updateAutomation(
   const title = input.title !== undefined ? normalizeText(input.title) : existing.title;
   const initialMessage =
     input.initialMessage !== undefined ? normalizeText(input.initialMessage) : existing.initialMessage;
+  const scheduleInput =
+    input.schedule !== undefined ? input.schedule : deserializeAutomationSchedule(existing.schedule);
 
   if (!providerId || !modelId || !title || !initialMessage) {
     return err('providerId, modelId, title, and initialMessage are required', 400);
+  }
+
+  const scheduleResult = validateAutomationSchedule(scheduleInput);
+  if ('error' in scheduleResult) {
+    return scheduleResult;
   }
 
   const validation = await validateProviderModel(providerId, modelId);
@@ -122,6 +229,7 @@ export async function updateAutomation(
       modelId,
       title,
       initialMessage,
+      schedule: serializeAutomationSchedule(scheduleResult.data),
       updatedAt: Date.now(),
     })
     .where(eq(automations.id, automationId as PrefixedString<'auto'>))
@@ -131,7 +239,7 @@ export async function updateAutomation(
     return err('Automation not found', 404);
   }
 
-  return ok(updated);
+  return ok(toAutomationRow(updated));
 }
 
 export async function deleteAutomation(automationId: string): Promise<ServiceResult<null>> {

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -31,6 +31,8 @@ const DEFAULT_PAGE_SIZE = 50;
 
 type CreateSessionInput = {
   title?: string;
+  type?: 'chat' | 'automation';
+  automationId?: PrefixedString<'auto'>;
   parentSessionId?: string;
 };
 
@@ -57,6 +59,8 @@ export async function createSession(input: CreateSessionInput) {
   await db.insert(sessions).values({
     id,
     title,
+    type: input.type ?? 'chat',
+    automationId: input.automationId ?? null,
     parentSessionId: (input.parentSessionId ?? null) as PrefixedString<'ses'> | null,
     createdAt: now,
     updatedAt: now,
@@ -66,9 +70,9 @@ export async function createSession(input: CreateSessionInput) {
   return session;
 }
 
-export async function listSessions() {
+export async function listSessions(type: 'chat' | 'automation' = 'chat') {
   const db = getDb();
-  return db.select().from(sessions).orderBy(asc(sessions.createdAt));
+  return db.select().from(sessions).where(eq(sessions.type, type)).orderBy(asc(sessions.createdAt));
 }
 
 export async function getSessionById(sessionId: PrefixedString<'ses'>) {

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -55,6 +55,20 @@ export const keyboardShortcuts = sqliteTable('keyboard_shortcuts', {
     .$defaultFn(() => Date.now()),
 });
 
+export const automations = sqliteTable('automations', {
+  id: text('id').$type<PrefixedString<'auto'>>().primaryKey(),
+  providerId: text('provider_id').notNull(),
+  modelId: text('model_id').notNull(),
+  initialMessage: text('initial_message').notNull(),
+  title: text('title').notNull(),
+  createdAt: integer('created_at', { mode: 'number' })
+    .notNull()
+    .$defaultFn(() => Date.now()),
+  updatedAt: integer('updated_at', { mode: 'number' })
+    .notNull()
+    .$defaultFn(() => Date.now()),
+});
+
 export const providerConfig = sqliteTable('provider_config', {
   providerId: text('provider_id').primaryKey(),
   credentials: blob('credentials', { mode: 'json' }).$type<ProviderCredentials>().notNull(),

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -61,6 +61,7 @@ export const automations = sqliteTable('automations', {
   modelId: text('model_id').notNull(),
   initialMessage: text('initial_message').notNull(),
   title: text('title').notNull(),
+  runCount: integer('run_count').notNull().default(0),
   createdAt: integer('created_at', { mode: 'number' })
     .notNull()
     .$defaultFn(() => Date.now()),
@@ -83,6 +84,10 @@ export const providerConfig = sqliteTable('provider_config', {
 export const sessions = sqliteTable('sessions', {
   id: text('id').$type<PrefixedString<'ses'>>().primaryKey(),
   title: text('title'),
+  type: text('type', { enum: ['chat', 'automation'] }).notNull().default('chat'),
+  automationId: text('automation_id')
+    .$type<PrefixedString<'auto'> | null>()
+    .references(() => automations.id, { onDelete: 'set null' }),
   parentSessionId: text('parent_session_id')
     .$type<PrefixedString<'ses'> | null>()
     .references((): ReturnType<typeof text> => sessions.id),

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -25,6 +25,7 @@ import type {
 import type { QuestionInfo, QuestionRequestStatus } from '@stitch/shared/questions/types';
 import type { SettingsKey } from '@stitch/shared/settings/types';
 import type { ShortcutActionId, ShortcutCategory } from '@stitch/shared/shortcuts/types';
+import type { AutomationScheduleBlob } from '@stitch/shared/automations/types';
 
 import type { ProviderCredentials } from '@/provider/provider.js';
 import type { LanguageModelUsage } from 'ai';
@@ -61,6 +62,7 @@ export const automations = sqliteTable('automations', {
   modelId: text('model_id').notNull(),
   initialMessage: text('initial_message').notNull(),
   title: text('title').notNull(),
+  schedule: blob('schedule', { mode: 'json' }).$type<AutomationScheduleBlob | null>(),
   runCount: integer('run_count').notNull().default(0),
   createdAt: integer('created_at', { mode: 'number' })
     .notNull()

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,6 +5,7 @@ import { cors } from 'hono/cors';
 import { init } from '@/init.js';
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
+import { automationsRouter } from '@/routes/automations.js';
 import { browserRouter } from '@/routes/browser.js';
 import { chatRouter } from '@/routes/chat.js';
 import { configRouter } from '@/routes/config.js';
@@ -47,6 +48,7 @@ const app = new Hono();
 
 app.use(cors());
 app.get('/health', (c) => c.json({ status: 'ok', paths: PATHS }));
+app.route('/automations', automationsRouter);
 app.route('/browser', browserRouter);
 app.route('/chat', chatRouter);
 app.route('/chat', questionsRouter);

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -7,6 +7,7 @@ import { initMeetingService } from '@/meeting/service.js';
 import { recoverStaleTranscriptions } from '@/meeting/transcription-service.js';
 import { startScheduler } from '@/scheduler/runtime.js';
 import { registerProviderToolsets } from '@/tools/providers/index.js';
+import { syncAllAutomationSchedules } from '@/automations/scheduler.js';
 
 const log = Log.create({ service: 'init' });
 
@@ -28,6 +29,7 @@ export async function init() {
   await initConnectorRuntime();
 
   await startScheduler();
+  await syncAllAutomationSchedules();
 
   log.info('server initialized');
 }

--- a/packages/server/src/llm/history-messages.ts
+++ b/packages/server/src/llm/history-messages.ts
@@ -80,6 +80,11 @@ export function buildHistoryMessages(
       continue;
     }
 
+    const hasAutomationGeneration = msg.parts.some((p) => p.type === 'automation-generation');
+    if (hasAutomationGeneration) {
+      continue;
+    }
+
     if (msg.role === 'user') {
       const hasCompaction = msg.parts.some((p) => p.type === 'compaction');
       if (hasCompaction) continue;

--- a/packages/server/src/routes/automations.ts
+++ b/packages/server/src/routes/automations.ts
@@ -7,7 +7,9 @@ import type { CreateAutomationInput, UpdateAutomationInput } from '@stitch/share
 import {
   createAutomation,
   deleteAutomation,
+  listAutomationSessions,
   listAutomations,
+  runAutomation,
   updateAutomation,
 } from '@/automations/service.js';
 import { isServiceError } from '@/lib/service-result.js';
@@ -61,4 +63,24 @@ automationsRouter.delete('/:id', async (c) => {
   }
 
   return c.body(null, 204);
+});
+
+automationsRouter.get('/:id/sessions', async (c) => {
+  const id = c.req.param('id');
+  const result = await listAutomationSessions(id);
+  if (isServiceError(result)) {
+    return c.json({ error: result.error }, result.status);
+  }
+
+  return c.json(result.data);
+});
+
+automationsRouter.post('/:id/run', async (c) => {
+  const id = c.req.param('id');
+  const result = await runAutomation(id);
+  if (isServiceError(result)) {
+    return c.json({ error: result.error }, result.status);
+  }
+
+  return c.json(result.data, 201);
 });

--- a/packages/server/src/routes/automations.ts
+++ b/packages/server/src/routes/automations.ts
@@ -1,0 +1,64 @@
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { z } from 'zod';
+
+import type { CreateAutomationInput, UpdateAutomationInput } from '@stitch/shared/automations/types';
+
+import {
+  createAutomation,
+  deleteAutomation,
+  listAutomations,
+  updateAutomation,
+} from '@/automations/service.js';
+import { isServiceError } from '@/lib/service-result.js';
+
+const createAutomationSchema = z.object({
+  providerId: z.string().trim().min(1),
+  modelId: z.string().trim().min(1),
+  title: z.string().trim().min(1),
+  initialMessage: z.string().trim().min(1),
+});
+
+const updateAutomationSchema = createAutomationSchema
+  .partial()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
+export const automationsRouter = new Hono();
+
+automationsRouter.get('/', async (c) => {
+  const result = await listAutomations();
+  return c.json(result);
+});
+
+automationsRouter.post('/', zValidator('json', createAutomationSchema), async (c) => {
+  const body = c.req.valid('json') as CreateAutomationInput;
+  const result = await createAutomation(body);
+  if (isServiceError(result)) {
+    return c.json({ error: result.error }, result.status);
+  }
+
+  return c.json(result.data, 201);
+});
+
+automationsRouter.patch('/:id', zValidator('json', updateAutomationSchema), async (c) => {
+  const id = c.req.param('id');
+  const body = c.req.valid('json') as UpdateAutomationInput;
+  const result = await updateAutomation(id, body);
+  if (isServiceError(result)) {
+    return c.json({ error: result.error }, result.status);
+  }
+
+  return c.json(result.data);
+});
+
+automationsRouter.delete('/:id', async (c) => {
+  const id = c.req.param('id');
+  const result = await deleteAutomation(id);
+  if (isServiceError(result)) {
+    return c.json({ error: result.error }, result.status);
+  }
+
+  return c.body(null, 204);
+});

--- a/packages/server/src/routes/automations.ts
+++ b/packages/server/src/routes/automations.ts
@@ -12,13 +12,31 @@ import {
   runAutomation,
   updateAutomation,
 } from '@/automations/service.js';
+import {
+  syncAutomationSchedule,
+  unregisterAutomationSchedule,
+} from '@/automations/scheduler.js';
 import { isServiceError } from '@/lib/service-result.js';
+
+const scheduleSchema = z
+  .discriminatedUnion('type', [
+    z.object({
+      type: z.literal('interval'),
+      everyMinutes: z.number().int().min(1),
+    }),
+    z.object({
+      type: z.literal('cron'),
+      expression: z.string().trim().min(1),
+    }),
+  ])
+  .nullable();
 
 const createAutomationSchema = z.object({
   providerId: z.string().trim().min(1),
   modelId: z.string().trim().min(1),
   title: z.string().trim().min(1),
   initialMessage: z.string().trim().min(1),
+  schedule: scheduleSchema.optional().default(null),
 });
 
 const updateAutomationSchema = createAutomationSchema
@@ -41,6 +59,13 @@ automationsRouter.post('/', zValidator('json', createAutomationSchema), async (c
     return c.json({ error: result.error }, result.status);
   }
 
+  try {
+    await syncAutomationSchedule(result.data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to schedule automation';
+    return c.json({ error: message }, 500);
+  }
+
   return c.json(result.data, 201);
 });
 
@@ -52,6 +77,13 @@ automationsRouter.patch('/:id', zValidator('json', updateAutomationSchema), asyn
     return c.json({ error: result.error }, result.status);
   }
 
+  try {
+    await syncAutomationSchedule(result.data);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to schedule automation';
+    return c.json({ error: message }, 500);
+  }
+
   return c.json(result.data);
 });
 
@@ -60,6 +92,13 @@ automationsRouter.delete('/:id', async (c) => {
   const result = await deleteAutomation(id);
   if (isServiceError(result)) {
     return c.json({ error: result.error }, result.status);
+  }
+
+  try {
+    await unregisterAutomationSchedule(id);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to unschedule automation';
+    return c.json({ error: message }, 500);
   }
 
   return c.body(null, 204);

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -3,6 +3,9 @@ import { Hono } from 'hono';
 import type { PrefixedString } from '@stitch/shared/id';
 
 import {
+  generateAutomationDraft,
+} from '@/automations/generation.js';
+import {
   abortSessionRun,
   createSession,
   deleteSession,
@@ -174,4 +177,15 @@ chatRouter.post('/sessions/:id/compact', async (c) => {
   }
 
   return c.json(result.data, 202);
+});
+
+chatRouter.post('/sessions/:id/generate-automation', async (c) => {
+  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
+
+  const result = await generateAutomationDraft(sessionId);
+  if (isServiceError(result)) {
+    return c.json({ error: result.error, details: result.details }, result.status);
+  }
+
+  return c.json(result.data, 201);
 });

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -29,7 +29,9 @@ chatRouter.post('/sessions', async (c) => {
 });
 
 chatRouter.get('/sessions', async (c) => {
-  const rows = await listSessions();
+  const type = c.req.query('type');
+  const sessionType = type === 'automation' ? 'automation' : 'chat';
+  const rows = await listSessions(sessionType);
   return c.json(rows);
 });
 

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -2,6 +2,7 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { z } from 'zod';
 
+import { syncAllAutomationSchedules } from '@/automations/scheduler.js';
 import { isServiceError } from '@/lib/service-result.js';
 import { deleteSetting, listSettings, saveSetting } from '@/settings/service.js';
 
@@ -22,6 +23,15 @@ settingsRouter.put('/:key', zValidator('json', settingValueSchema), async (c) =>
     return c.json({ error: result.error }, result.status);
   }
 
+  if (key === 'profile.timezone') {
+    try {
+      await syncAllAutomationSchedules();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to reschedule automations';
+      return c.json({ error: message }, 500);
+    }
+  }
+
   return c.body(null, 204);
 });
 
@@ -30,6 +40,15 @@ settingsRouter.delete('/:key', async (c) => {
   const result = await deleteSetting(key);
   if (isServiceError(result)) {
     return c.json({ error: result.error }, result.status);
+  }
+
+  if (key === 'profile.timezone') {
+    try {
+      await syncAllAutomationSchedules();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to reschedule automations';
+      return c.json({ error: message }, 500);
+    }
   }
 
   return c.body(null, 204);

--- a/packages/server/src/scheduler/runtime.ts
+++ b/packages/server/src/scheduler/runtime.ts
@@ -1,4 +1,5 @@
 import { createScheduler } from '@stitch/scheduler';
+import type { JobSchedule, RegisteredJob } from '@stitch/scheduler';
 
 import { refreshExpiringTokens } from '@/connectors/auth/token-refresh.js';
 import * as Log from '@/lib/log.js';
@@ -85,4 +86,38 @@ export async function stopScheduler(): Promise<void> {
   if (!scheduler) return;
   await scheduler.stop();
   scheduler = null;
+}
+
+export async function registerSchedulerJob(input: {
+  key: string;
+  schedule: JobSchedule;
+  callback: RegisteredJob['callback'];
+  immediate?: boolean;
+  maxConcurrency?: number;
+  queueEnabled?: boolean;
+  catchup?: RegisteredJob['catchup'];
+  catchupMaxRuns?: number;
+}): Promise<void> {
+  if (!scheduler) {
+    throw new Error('Scheduler is not started');
+  }
+
+  await scheduler.registerJob({
+    key: input.key,
+    schedule: input.schedule,
+    callback: input.callback,
+    immediate: input.immediate,
+    maxConcurrency: input.maxConcurrency,
+    queueEnabled: input.queueEnabled,
+    catchup: input.catchup,
+    catchupMaxRuns: input.catchupMaxRuns,
+  });
+}
+
+export async function unregisterSchedulerJob(key: string): Promise<void> {
+  if (!scheduler) {
+    throw new Error('Scheduler is not started');
+  }
+
+  await scheduler.unregisterJob(key);
 }

--- a/packages/server/src/usage/service.ts
+++ b/packages/server/src/usage/service.ts
@@ -10,7 +10,7 @@ import {
 } from '@stitch/shared/usage/types';
 
 import { getDb } from '@/db/client.js';
-import { llmUsageEvents } from '@/db/schema.js';
+import { llmUsageEvents, sessions } from '@/db/schema.js';
 import type { LanguageModelUsage } from 'ai';
 
 type GetUsageDashboardInput = {
@@ -273,13 +273,17 @@ async function resolveWindow(input: GetUsageDashboardInput): Promise<TimeWindow>
   return { from, to };
 }
 
-function normalizeEventSource(source: string): UsageSource {
+function normalizeEventSource(source: string, sessionType: 'chat' | 'automation' | null): UsageSource {
   if (source === 'title_generation') {
     return 'title_generation';
   }
 
   if (source.startsWith('transcription')) {
     return 'transcription';
+  }
+
+  if (sessionType === 'automation') {
+    return 'automation';
   }
 
   return 'chat';
@@ -336,8 +340,10 @@ export async function getUsageDashboard(
       providerId: llmUsageEvents.providerId,
       modelId: llmUsageEvents.modelId,
       source: llmUsageEvents.source,
+      sessionType: sessions.type,
     })
     .from(llmUsageEvents)
+    .leftJoin(sessions, eq(llmUsageEvents.sessionId, sessions.id))
     .where(and(...eventConditions));
 
   const usedProviderIds = new Set<string>();
@@ -387,7 +393,7 @@ export async function getUsageDashboard(
 
     addUsageRow({
       createdAt: row.createdAt,
-      source: normalizeEventSource(row.source),
+      source: normalizeEventSource(row.source, row.sessionType ?? null),
       usage: row.usage,
       costUsd: row.costUsd,
     });

--- a/packages/shared/__test__/id.test.ts
+++ b/packages/shared/__test__/id.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import {
+  createAutomationId,
   createPermissionRuleId,
   createMessageId,
   createPartId,
@@ -27,6 +28,7 @@ describe('id helpers', () => {
       { create: createQuestionId, prefix: 'quest' },
       { create: createPermissionResponseId, prefix: 'permres' },
       { create: createPermissionRuleId, prefix: 'perm' },
+      { create: createAutomationId, prefix: 'auto' },
     ] as const;
 
     for (const { create, prefix } of cases) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     "./appearance/types": "./src/appearance/types.ts",
+    "./automations/types": "./src/automations/types.ts",
     "./chat/errors": "./src/chat/errors.ts",
     "./chat/messages": "./src/chat/messages.ts",
     "./chat/queue": "./src/chat/queue.ts",

--- a/packages/shared/src/automations/types.ts
+++ b/packages/shared/src/automations/types.ts
@@ -6,16 +6,37 @@ export type Automation = {
   modelId: string;
   initialMessage: string;
   title: string;
+  schedule: AutomationSchedule | null;
   runCount: number;
   createdAt: number;
   updatedAt: number;
 };
+
+export type AutomationIntervalSchedule = {
+  type: 'interval';
+  everyMinutes: number;
+};
+
+export type AutomationCronSchedule = {
+  type: 'cron';
+  expression: string;
+};
+
+export type AutomationSchedule = AutomationIntervalSchedule | AutomationCronSchedule;
+
+export type AutomationScheduleBlobV1 = {
+  version: 1;
+  schedule: AutomationSchedule;
+};
+
+export type AutomationScheduleBlob = AutomationScheduleBlobV1;
 
 export type CreateAutomationInput = {
   providerId: string;
   modelId: string;
   initialMessage: string;
   title: string;
+  schedule: AutomationSchedule | null;
 };
 
 export type UpdateAutomationInput = Partial<CreateAutomationInput>;

--- a/packages/shared/src/automations/types.ts
+++ b/packages/shared/src/automations/types.ts
@@ -1,0 +1,20 @@
+import type { PrefixedString } from '@stitch/shared/id';
+
+export type Automation = {
+  id: PrefixedString<'auto'>;
+  providerId: string;
+  modelId: string;
+  initialMessage: string;
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type CreateAutomationInput = {
+  providerId: string;
+  modelId: string;
+  initialMessage: string;
+  title: string;
+};
+
+export type UpdateAutomationInput = Partial<CreateAutomationInput>;

--- a/packages/shared/src/automations/types.ts
+++ b/packages/shared/src/automations/types.ts
@@ -46,3 +46,12 @@ export type RunAutomationResponse = {
   assistantMessageId: PrefixedString<'msg'>;
   userMessageId: PrefixedString<'msg'>;
 };
+
+export type GeneratedAutomationDraft = {
+  title: string;
+  toolsets: string[];
+  steps: string[];
+  prompt: string;
+  providerId: string;
+  modelId: string;
+};

--- a/packages/shared/src/automations/types.ts
+++ b/packages/shared/src/automations/types.ts
@@ -6,6 +6,7 @@ export type Automation = {
   modelId: string;
   initialMessage: string;
   title: string;
+  runCount: number;
   createdAt: number;
   updatedAt: number;
 };
@@ -18,3 +19,9 @@ export type CreateAutomationInput = {
 };
 
 export type UpdateAutomationInput = Partial<CreateAutomationInput>;
+
+export type RunAutomationResponse = {
+  sessionId: PrefixedString<'ses'>;
+  assistantMessageId: PrefixedString<'msg'>;
+  userMessageId: PrefixedString<'msg'>;
+};

--- a/packages/shared/src/chat/messages.ts
+++ b/packages/shared/src/chat/messages.ts
@@ -110,6 +110,8 @@ export type Message = {
 export type Session = {
   id: PrefixedString<'ses'>;
   title: string | null;
+  type: 'chat' | 'automation';
+  automationId: PrefixedString<'auto'> | null;
   parentSessionId: PrefixedString<'ses'> | null;
   isUnread: boolean;
   createdAt: number;

--- a/packages/shared/src/chat/messages.ts
+++ b/packages/shared/src/chat/messages.ts
@@ -70,6 +70,16 @@ export type StreamErrorPart = {
   details?: StreamErrorDetails;
 };
 
+export type AutomationGenerationPart = {
+  type: 'automation-generation';
+  title: string;
+  toolsets: string[];
+  steps: string[];
+  prompt: string;
+  providerId: string;
+  modelId: string;
+};
+
 export type AllPart =
   | TextStartPart
   | TextDeltaPart
@@ -84,6 +94,7 @@ export type AllPart =
   | CompactionPart
   | SessionTitlePart
   | StreamErrorPart
+  | AutomationGenerationPart
   | UserImagePart
   | UserFilePart
   | UserTextFilePart;

--- a/packages/shared/src/id/index.ts
+++ b/packages/shared/src/id/index.ts
@@ -13,6 +13,7 @@ export const ID_PREFIXES = {
   recording: 'rec',
   transcription: 'transcr',
   connectorInstance: 'conn',
+  automation: 'auto',
   scheduledJob: 'schjob',
   scheduledJobRun: 'schrun',
 } as const;
@@ -72,6 +73,7 @@ export const createQueuedMessageId = createIdFactory(ID_PREFIXES.queuedMessage);
 export const createRecordingId = createIdFactory(ID_PREFIXES.recording);
 export const createTranscriptionId = createIdFactory(ID_PREFIXES.transcription);
 export const createConnectorInstanceId = createIdFactory(ID_PREFIXES.connectorInstance);
+export const createAutomationId = createIdFactory(ID_PREFIXES.automation);
 export const createScheduledJobId = createIdFactory(ID_PREFIXES.scheduledJob);
 export const createScheduledJobRunId = createIdFactory(ID_PREFIXES.scheduledJobRun);
 

--- a/packages/shared/src/usage/types.ts
+++ b/packages/shared/src/usage/types.ts
@@ -1,4 +1,4 @@
-export const USAGE_SOURCES = ['chat', 'title_generation', 'transcription'] as const;
+export const USAGE_SOURCES = ['chat', 'automation', 'title_generation', 'transcription'] as const;
 
 export type UsageSource = (typeof USAGE_SOURCES)[number] | (string & {});
 

--- a/packages/shared/src/usage/types.ts
+++ b/packages/shared/src/usage/types.ts
@@ -1,4 +1,10 @@
-export const USAGE_SOURCES = ['chat', 'automation', 'title_generation', 'transcription'] as const;
+export const USAGE_SOURCES = [
+  'chat',
+  'automation',
+  'automation_generation',
+  'title_generation',
+  'transcription',
+] as const;
 
 export type UsageSource = (typeof USAGE_SOURCES)[number] | (string & {});
 


### PR DESCRIPTION
## 🚀 Change Summary
This PR introduces a full automations workspace in the app, including create/edit/run flows, schedule configuration, and automation session views. It also adds chat-to-automation generation so users can turn an existing session into a reusable automation draft with prefilled prompt/model context.

### ✨ New Features
- **Automations Workspace**: Added automations routes, sidebar/table/detail screens, and management flows for creating, editing, running, and deleting automations.
- **Scheduling Support**: Added interval and cron scheduling in the automation dialog, persisted schedule data in shared/server types, and wired scheduler runtime sync for startup/settings/automation lifecycle changes.
- **Generate Automation from Chat Session**: Added a session action that generates an automation draft from conversation history, captures toolset/steps/prompt, opens a prefilled automation dialog, and supports both **Create** and **Create and View** actions.
- **Prompt Authoring UX**: Added markdown-aware prompt preview mode in the automation dialog for clearer prompt validation before saving.

### 🛠 Improvements & Refactors
- Added reusable schedule-label formatting utilities and improved schedule visibility across table/detail/dialog surfaces.
- Introduced runtime scheduler job register/unregister helpers to support dynamic automation scheduling.
- Added persisted custom chat part storage for automation-generation metadata, aligned with existing compaction-style storage patterns.

### 🐛 Bug Fixes
- Fixed select/value display and dialog layout clipping issues in automation editing UI.
- Ensured generated automation drafts always use the source session's model/provider rather than the generation model.

### 📚 Documentation
- Added/updated contribution guidance and PR template structure in repository docs.