### PR TITLE
improvement(ci): cache node_modules and fix turbo cache key

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -9,18 +9,17 @@ runs:
       with:
         bun-version: '1.3.8'
 
-    - name: Get Bun cache directory
-      id: bun-cache
-      shell: bash
-      run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
-
-    - name: Cache Bun dependencies
+    - name: Cache node_modules
       uses: actions/cache@v4
       with:
-        path: ${{ steps.bun-cache.outputs.dir }}
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+        path: |
+          node_modules
+          apps/*/node_modules
+          packages/*/node_modules
+          connectors/*/node_modules
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('**/bun.lock') }}
         restore-keys: |
-          ${{ runner.os }}-bun-
+          ${{ runner.os }}-node_modules-
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ hashFiles('**/bun.lock', 'turbo.json') }}
+          key: ${{ runner.os }}-turbo-${{ hashFiles('turbo.json') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
 


### PR DESCRIPTION
## Change Summary

Improves GitHub Actions CI caching so that setup time is actually reduced on cache hits, particularly on Windows runners where `bun install` was consistently taking 70-170s despite a cache being present.

### Improvements

- **Cache node_modules directly**: Replaces the Bun global package cache (~200MB tarball cache) with a direct node_modules cache keyed on bun.lock. On a hit, `bun install` skips extraction entirely and runs near-instantly. Expected savings: ~60-80s on Windows, ~15s on macOS per run.
- **Fix Turbo cache key**: Removes bun.lock from the Turbo cache key hash - dependency changes should not invalidate Turbo task results. The key now only hashes turbo.json, allowing Turbo's own input hashing to determine what needs re-running across PRs with different lockfiles.