### PR TITLE
Schedule automatic update check every 4 hours

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -14,6 +14,7 @@ const WINDOW_ICON_NAME = 'icon.png';
 const DEV_SERVER_POLL_MS = 200;
 const DEV_SERVER_TIMEOUT_MS = 30_000;
 const DEV_APP_NAME = 'stitch-dev';
+const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1_000;
 
 function configureAppIdentityForEnvironment(): void {
   if (app.isPackaged) {
@@ -253,6 +254,9 @@ void app.whenReady().then(async () => {
     setTimeout(() => {
       void updater.checkForUpdates();
     }, 15_000);
+    setInterval(() => {
+      void updater.checkForUpdates();
+    }, UPDATE_CHECK_INTERVAL_MS);
 
     // Initialize system tray
     const getWindow = () => mainWindow;


### PR DESCRIPTION
## Change Summary

Adds a recurring background job to the desktop main process that automatically checks for updates every 4 hours, ensuring users receive timely update notifications without manual intervention.

### New Features
- **Scheduled Update Checks**: The app now checks for updates every 4 hours via setInterval in the Electron main process, complementing the existing one-shot check that runs 15 seconds after startup.