### PR TITLE
improvement(cache): prune old image/file attachments to preserve prompt cache prefix

### DIFF
--- a/packages/server/__test__/llm/compaction.test.ts
+++ b/packages/server/__test__/llm/compaction.test.ts
@@ -348,4 +348,134 @@ describe('buildHistoryMessages', () => {
       'buildHistoryMessages requires at least one message',
     );
   });
+
+  function imagePart(dataUrl = 'data:image/png;base64,AAAA', mime = 'image/png'): StoredPart {
+    return {
+      type: 'user-image',
+      id: 'prt_img' as StoredPart['id'],
+      dataUrl,
+      mime,
+      ...timing,
+    } as StoredPart;
+  }
+
+  function filePart(
+    dataUrl = 'data:application/pdf;base64,BBBB',
+    mime = 'application/pdf',
+    filename = 'doc.pdf',
+  ): StoredPart {
+    return {
+      type: 'user-file',
+      id: 'prt_file' as StoredPart['id'],
+      dataUrl,
+      mime,
+      filename,
+      ...timing,
+    } as StoredPart;
+  }
+
+  function userMsg(parts: StoredPart[]) {
+    return { role: 'user' as const, isSummary: false, modelId: 'test', parts };
+  }
+
+  function assistantMsg(text: string) {
+    return {
+      role: 'assistant' as const,
+      isSummary: false,
+      modelId: 'test',
+      parts: [textPart(text)],
+    };
+  }
+
+  test('preserves images within the last 3 assistant turns', () => {
+    const msgs = [
+      userMsg([textPart('look at this'), imagePart()]),
+      assistantMsg('I see the image'),
+      userMsg([textPart('and this'), imagePart()]),
+      assistantMsg('Got it'),
+      userMsg([textPart('last one')]),
+      assistantMsg('Done'),
+    ];
+
+    const result = buildHistoryMessages(msgs);
+    const userMessages = result.filter((m) => m.role === 'user');
+
+    for (const um of userMessages) {
+      if (typeof um.content === 'string') continue;
+      const parts = um.content as Array<{ type: string; text?: string }>;
+      const placeholders = parts.filter(
+        (p) => p.type === 'text' && p.text?.includes('already processed'),
+      );
+      expect(placeholders).toHaveLength(0);
+    }
+
+    const firstContent = userMessages[0].content as Array<{ type: string }>;
+    const realImages = firstContent.filter((p) => p.type === 'image');
+    expect(realImages).toHaveLength(1);
+  });
+
+  test('prunes images older than 3 assistant turns', () => {
+    const msgs = [
+      userMsg([textPart('old image'), imagePart('data:image/png;base64,OLD')]),
+      assistantMsg('turn 1'),
+      userMsg([textPart('msg 2')]),
+      assistantMsg('turn 2'),
+      userMsg([textPart('msg 3')]),
+      assistantMsg('turn 3'),
+      userMsg([textPart('recent image'), imagePart('data:image/png;base64,NEW')]),
+      assistantMsg('turn 4'),
+    ];
+
+    const result = buildHistoryMessages(msgs);
+    const userMessages = result.filter((m) => m.role === 'user');
+
+    const firstUserContent = userMessages[0].content as Array<{ type: string; text?: string }>;
+    const imagePlaceholders = firstUserContent.filter(
+      (p) => p.type === 'text' && p.text?.includes('already processed'),
+    );
+    expect(imagePlaceholders).toHaveLength(1);
+
+    const lastImageUser = userMessages[userMessages.length - 1];
+    const lastContent = lastImageUser.content as Array<{ type: string }>;
+    const realImages = lastContent.filter((p) => p.type === 'image');
+    expect(realImages).toHaveLength(1);
+  });
+
+  test('prunes file attachments older than 3 assistant turns', () => {
+    const msgs = [
+      userMsg([textPart('old file'), filePart()]),
+      assistantMsg('turn 1'),
+      userMsg([textPart('msg 2')]),
+      assistantMsg('turn 2'),
+      userMsg([textPart('msg 3')]),
+      assistantMsg('turn 3'),
+      userMsg([textPart('msg 4')]),
+      assistantMsg('turn 4'),
+    ];
+
+    const result = buildHistoryMessages(msgs);
+    const userMessages = result.filter((m) => m.role === 'user');
+
+    const firstUserContent = userMessages[0].content as Array<{ type: string; text?: string }>;
+    const filePlaceholders = firstUserContent.filter(
+      (p) => p.type === 'text' && p.text?.includes('"doc.pdf" already processed'),
+    );
+    expect(filePlaceholders).toHaveLength(1);
+  });
+
+  test('keeps all images when fewer than 3 assistant turns exist', () => {
+    const msgs = [
+      userMsg([textPart('image here'), imagePart()]),
+      assistantMsg('turn 1'),
+      userMsg([textPart('another')]),
+      assistantMsg('turn 2'),
+    ];
+
+    const result = buildHistoryMessages(msgs);
+    const userMessages = result.filter((m) => m.role === 'user');
+
+    const firstContent = userMessages[0].content as Array<{ type: string }>;
+    const realImages = firstContent.filter((p) => p.type === 'image');
+    expect(realImages).toHaveLength(1);
+  });
 });

--- a/packages/server/src/llm/history-messages.ts
+++ b/packages/server/src/llm/history-messages.ts
@@ -7,6 +7,9 @@ import type { ModelMessage } from 'ai';
 
 const log = Log.create({ service: 'history-messages' });
 
+const PRESERVE_RECENT_ASSISTANT_TURNS = 3;
+const IMAGE_PRUNED_PLACEHOLDER = '[Image already processed by model]';
+
 const DEFAULT_TOOL_RESULT_BUDGET_TOKENS = 1_000;
 const TOOL_RESULT_BUDGET_TOKENS: Record<string, number> = {
   browser: 600,
@@ -74,7 +77,21 @@ export function buildHistoryMessages(
 
   const llmMessages: ModelMessage[] = [];
 
-  for (const msg of msgs) {
+  let assistantTurnsSeen = 0;
+  let attachmentCutoffIndex = 0;
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    if (msgs[i].role === 'assistant' && !msgs[i].isSummary) {
+      assistantTurnsSeen++;
+      if (assistantTurnsSeen > PRESERVE_RECENT_ASSISTANT_TURNS) {
+        attachmentCutoffIndex = i;
+        break;
+      }
+    }
+  }
+
+  for (let msgIdx = 0; msgIdx < msgs.length; msgIdx++) {
+    const msg = msgs[msgIdx];
+    const shouldPruneAttachments = msgIdx < attachmentCutoffIndex;
     const hasSessionTitle = msg.parts.some((p) => p.type === 'session-title');
     if (hasSessionTitle) {
       continue;
@@ -125,23 +142,36 @@ export function buildHistoryMessages(
         content.push({ type: 'text', text });
       }
 
-      for (const img of imageParts) {
-        const base64 = img.dataUrl.includes(',') ? img.dataUrl.split(',')[1] : img.dataUrl;
-        content.push({
-          type: 'image',
-          image: base64,
-          mediaType: img.mime,
-        });
-      }
+      if (shouldPruneAttachments) {
+        for (const _img of imageParts) {
+          content.push({ type: 'text', text: IMAGE_PRUNED_PLACEHOLDER });
+        }
+        for (const file of fileParts) {
+          const label = file.filename ? `"${file.filename}"` : 'attachment';
+          content.push({
+            type: 'text',
+            text: `[File ${label} already processed by model]`,
+          });
+        }
+      } else {
+        for (const img of imageParts) {
+          const base64 = img.dataUrl.includes(',') ? img.dataUrl.split(',')[1] : img.dataUrl;
+          content.push({
+            type: 'image',
+            image: base64,
+            mediaType: img.mime,
+          });
+        }
 
-      for (const file of fileParts) {
-        const base64 = file.dataUrl.includes(',') ? file.dataUrl.split(',')[1] : file.dataUrl;
-        content.push({
-          type: 'file',
-          data: base64,
-          mediaType: file.mime,
-          filename: file.filename,
-        });
+        for (const file of fileParts) {
+          const base64 = file.dataUrl.includes(',') ? file.dataUrl.split(',')[1] : file.dataUrl;
+          content.push({
+            type: 'file',
+            data: base64,
+            mediaType: file.mime,
+            filename: file.filename,
+          });
+        }
       }
 
       for (const tf of textFileParts) {


### PR DESCRIPTION
## Change Summary
Adds cache-aware image and file attachment pruning to buildHistoryMessages. Attachments older than 3 assistant turns are replaced with lightweight text placeholders, reclaiming context while keeping recent messages byte-identical to preserve the prompt cache prefix.

### New Features
- **Attachment pruning in history replay**: Image and file parts older than 3 assistant turns are replaced with placeholder text during history construction
- Cache prefix remains stable across turns since only the tail of the message history changes

### Improvements
- buildHistoryMessages now computes an attachment cutoff index via a reverse scan of assistant turns before iterating messages