### PR TITLE
improvement(compaction): optimise compaction pipeline and fix command palette

### DIFF
--- a/apps/web/src/components/chat/message-list/rows.ts
+++ b/apps/web/src/components/chat/message-list/rows.ts
@@ -33,7 +33,6 @@ export function buildRows(
     rows.push({ kind: 'load-more' });
   }
 
-  const summaryByMarker = new Map<string, Message>();
   const pairedSummaryIds = new Set<string>();
 
   for (let i = 0; i < messages.length; i++) {
@@ -50,27 +49,12 @@ export function buildRows(
 
     if (message.role === 'user' && message.parts.some((part) => part.type === 'compaction')) {
       const next = messages[i + 1];
+      let summaryParts: Message['parts'] | undefined;
       if (next?.isSummary) {
-        summaryByMarker.set(message.id, next);
+        summaryParts = next.parts;
         pairedSummaryIds.add(next.id);
       }
-    }
-  }
-
-  for (const message of messages) {
-    if (
-      message.parts.some(
-        (part) =>
-          part.type === 'session-title' ||
-          part.type === 'automation-generation',
-      )
-    ) {
-      continue;
-    }
-
-    if (message.role === 'user' && message.parts.some((part) => part.type === 'compaction')) {
-      const summary = summaryByMarker.get(message.id);
-      rows.push({ kind: 'compaction', id: message.id, summaryParts: summary?.parts });
+      rows.push({ kind: 'compaction', id: message.id, summaryParts });
       continue;
     }
 

--- a/apps/web/src/components/navigation/command-palette.tsx
+++ b/apps/web/src/components/navigation/command-palette.tsx
@@ -16,12 +16,15 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { useDialogContext } from '@/context/dialog-context';
-import { useActions, type Action } from '@/lib/actions';
+import type { Action } from '@/lib/actions';
 import { useShortcuts } from '@/lib/shortcuts';
 
-export function CommandPalette() {
+type CommandPaletteProps = {
+  actions: Action[];
+};
+
+export function CommandPalette({ actions }: CommandPaletteProps) {
   const { commandPaletteOpen, setCommandPaletteOpen } = useDialogContext();
-  const actions = useActions();
   const shortcuts = useShortcuts();
 
   function handleSelect(action: Action) {
@@ -44,7 +47,7 @@ export function CommandPalette() {
           <CommandList>
             <CommandEmpty>No results found.</CommandEmpty>
             <CommandGroup heading="Actions">
-              {actions.map((action) => {
+              {actions.filter((a) => a.id !== 'command-palette').map((action) => {
                 const info = shortcuts.get(action.id);
                 const hotkey = info?.hotkey ?? null;
                 const isLeaderShortcut = typeof hotkey === 'string' && hotkey.startsWith('LEADER+');

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -86,7 +86,7 @@ function RootLayout() {
           </RightClickMenu>
         </div>
       </div>
-      <CommandPalette />
+      <CommandPalette actions={actions} />
       <SettingsDialog />
       <OnboardingDialog />
       <RenameSessionDialog />

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -388,12 +388,13 @@ export async function abortSessionRun(sessionId: PrefixedString<'ses'>) {
     .from(sessions)
     .where(eq(sessions.parentSessionId, sessionId));
 
-  for (const child of childSessions) {
-    AbortRegistry.abort(child.id);
-    cancelDecision(child.id);
-    await abortQuestions(child.id);
-    await abortPermissionResponses(child.id);
-  }
+  await Promise.all(
+    childSessions.map(async (child) => {
+      AbortRegistry.abort(child.id);
+      cancelDecision(child.id);
+      await Promise.all([abortQuestions(child.id), abortPermissionResponses(child.id)]);
+    }),
+  );
 }
 
 function getSplitTitle(baseTitle: string, n: number): string {
@@ -490,8 +491,9 @@ export async function requestCompaction(
     .select()
     .from(messages)
     .where(eq(messages.sessionId, sessionId))
-    .orderBy(asc(messages.createdAt))
-    .then((rows) => rows.at(-1));
+    .orderBy(desc(messages.createdAt))
+    .limit(1)
+    .then((rows) => rows[0]);
 
   if (!lastMessage) {
     return err('Session has no messages to compact', 400);

--- a/packages/server/src/llm/compaction.ts
+++ b/packages/server/src/llm/compaction.ts
@@ -37,6 +37,8 @@ type CompactionSettings = {
   reserved?: number;
 };
 
+type StoredMessage = typeof messages.$inferSelect;
+
 function parseBooleanSetting(value: string | undefined): boolean | undefined {
   if (value === 'true') return true;
   if (value === 'false') return false;
@@ -107,17 +109,7 @@ export function isOverflow(
  * that exceed the PRUNE_PROTECT token threshold. This reclaims context
  * space without a full compaction summary.
  */
-async function prune(sessionId: PrefixedString<'ses'>): Promise<number> {
-  log.info({ sessionId }, 'pruning');
-
-  const db = getDb();
-  const now = Date.now();
-  const msgs = await db
-    .select()
-    .from(messages)
-    .where(eq(messages.sessionId, sessionId))
-    .orderBy(asc(messages.createdAt));
-
+async function prune(msgs: StoredMessage[]): Promise<number> {
   let total = 0;
   let pruned = 0;
   const toPrune: Array<{ messageId: PrefixedString<'msg'>; partIndex: number }> = [];
@@ -155,28 +147,34 @@ async function prune(sessionId: PrefixedString<'ses'>): Promise<number> {
       arr.push(entry.partIndex);
     }
 
-    await Promise.all(
-      Array.from(grouped.entries()).map(async ([messageId, partIndices]) => {
-        const [msg] = await db.select().from(messages).where(eq(messages.id, messageId));
-        if (!msg) return;
+    const msgById = new Map(msgs.map((m) => [m.id, m]));
+    const db = getDb();
+    const now = Date.now();
 
-        const updatedParts = [...msg.parts];
-        for (const partIndex of partIndices) {
-          const part = updatedParts[partIndex];
-          if (part?.type === 'tool-result') {
-            updatedParts[partIndex] = {
-              ...part,
-              output: '[Old tool result content cleared]',
-            } as StoredPart;
+    await db.transaction(async (tx) => {
+      await Promise.all(
+        Array.from(grouped.entries()).map(async ([messageId, partIndices]) => {
+          const msg = msgById.get(messageId);
+          if (!msg) return;
+
+          const updatedParts = [...msg.parts];
+          for (const partIndex of partIndices) {
+            const part = updatedParts[partIndex];
+            if (part?.type === 'tool-result') {
+              updatedParts[partIndex] = {
+                ...part,
+                output: '[Old tool result content cleared]',
+              } as StoredPart;
+            }
           }
-        }
 
-        await db
-          .update(messages)
-          .set({ parts: updatedParts, updatedAt: now })
-          .where(eq(messages.id, messageId));
-      }),
-    );
+          await tx
+            .update(messages)
+            .set({ parts: updatedParts, updatedAt: now })
+            .where(eq(messages.id, messageId));
+        }),
+      );
+    });
 
     log.info({ count: toPrune.length }, 'pruned');
   }
@@ -261,6 +259,7 @@ export async function compact(input: {
   auto: boolean;
   overflow?: boolean;
   severity?: CompactionSeverity;
+  compactionSettings?: CompactionSettings;
 }): Promise<'continue' | 'error'> {
   const { sessionId } = input;
   const severity: CompactionSeverity = input.severity ?? (input.overflow ? 'overflow' : 'normal');
@@ -276,7 +275,11 @@ export async function compact(input: {
   try {
     log.info({ sessionId, auto: input.auto }, 'compaction starting');
 
-    const compactionSettings = await getCompactionSettings();
+    const [compactionSettings, promptUserContext, resolved] = await Promise.all([
+      input.compactionSettings ?? getCompactionSettings(),
+      getPromptUserContext(),
+      resolveCompactionModel(input.providerId, input.modelId),
+    ]);
 
     await Sse.broadcast('compaction-start', { sessionId, messageId: summaryMessageId });
 
@@ -293,35 +296,30 @@ export async function compact(input: {
       endedAt: now,
     } as StoredPart;
 
-    await db.transaction(async (tx) => {
-      await tx.insert(messages).values({
-        id: compactionMarkerId,
-        sessionId,
-        role: 'user',
-        parts: [compactionPart],
-        modelId: input.modelId,
-        providerId: input.providerId,
-        costUsd: 0,
-        createdAt: now,
-        updatedAt: now,
-        startedAt: now,
-        duration: null,
-      });
-
-      if (compactionSettings.prune) {
-        await prune(sessionId);
-      }
+    await db.insert(messages).values({
+      id: compactionMarkerId,
+      sessionId,
+      role: 'user',
+      parts: [compactionPart],
+      modelId: input.modelId,
+      providerId: input.providerId,
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+      startedAt: now,
+      duration: null,
     });
-
-    const resolved = await resolveCompactionModel(input.providerId, input.modelId);
-    const provider = createProvider(resolved.credentials);
-    const model = provider(resolved.modelId);
 
     const allMsgs = await db
       .select()
       .from(messages)
       .where(eq(messages.sessionId, sessionId))
       .orderBy(asc(messages.createdAt));
+
+    if (compactionSettings.prune) {
+      log.info({ sessionId }, 'pruning');
+      await prune(allMsgs);
+    }
 
     const markerIndex = allMsgs.findIndex((m) => m.id === compactionMarkerId);
     const historyMsgs = allMsgs.slice(0, markerIndex);
@@ -335,13 +333,15 @@ export async function compact(input: {
     }
     const relevantMsgs = historyMsgs.slice(startIndex);
 
-    const promptUserContext = await getPromptUserContext();
     const historyMessages = buildHistoryMessages(relevantMsgs, {
       useBasePrompt: true,
       systemPrompt: null,
       userName: promptUserContext.userName,
       userTimezone: promptUserContext.userTimezone,
     });
+
+    const provider = createProvider(resolved.credentials);
+    const model = provider(resolved.modelId);
 
     const llmMessages: ModelMessage[] = [
       ...historyMessages,
@@ -506,11 +506,17 @@ export async function buildCompactedHistory(
   },
 ): Promise<ModelMessage[]> {
   const db = getDb();
-  const msgs = await db
-    .select()
-    .from(messages)
-    .where(eq(messages.sessionId, sessionId))
-    .orderBy(asc(messages.createdAt));
+
+  const [msgs, promptUserContext] = await Promise.all([
+    db
+      .select()
+      .from(messages)
+      .where(eq(messages.sessionId, sessionId))
+      .orderBy(asc(messages.createdAt)),
+    promptConfig?.userName !== undefined && promptConfig?.userTimezone !== undefined
+      ? Promise.resolve({ userName: promptConfig.userName ?? null, userTimezone: promptConfig.userTimezone ?? null })
+      : getPromptUserContext(),
+  ]);
 
   // Find the last compaction boundary (summary message)
   let startIndex = 0;
@@ -521,12 +527,11 @@ export async function buildCompactedHistory(
     }
   }
 
-  const promptUserContext = await getPromptUserContext();
   return buildHistoryMessages(msgs.slice(startIndex), {
     useBasePrompt: promptConfig?.useBasePrompt ?? true,
     systemPrompt: promptConfig?.systemPrompt ?? null,
-    userName: promptConfig?.userName ?? promptUserContext.userName,
-    userTimezone: promptConfig?.userTimezone ?? promptUserContext.userTimezone,
+    userName: promptUserContext.userName,
+    userTimezone: promptUserContext.userTimezone,
   });
 }
 

--- a/packages/server/src/llm/history-messages.ts
+++ b/packages/server/src/llm/history-messages.ts
@@ -18,6 +18,15 @@ const TOOL_RESULT_BUDGET_TOKENS: Record<string, number> = {
 };
 const TOOL_RESULT_PREVIEW_CHARS = 1_600;
 
+function isToolResultError(output: unknown): boolean {
+  return (
+    output !== null &&
+    output !== undefined &&
+    typeof output === 'object' &&
+    'error' in (output)
+  );
+}
+
 function toPreviewText(value: unknown): string {
   if (typeof value === 'string') {
     return value.slice(0, TOOL_RESULT_PREVIEW_CHARS);
@@ -36,12 +45,7 @@ function toPreviewText(value: unknown): string {
 
 function compactToolResultOutput(part: StoredPart & { type: 'tool-result' }): unknown {
   const output = part.output;
-  const isError =
-    output !== null &&
-    output !== undefined &&
-    typeof output === 'object' &&
-    'error' in (output as object);
-  if (isError) {
+  if (isToolResultError(output)) {
     return output;
   }
 
@@ -250,18 +254,13 @@ export function buildHistoryMessages(
           content: toolResultParts
             .filter((tr) => matchedToolCallIds.has(tr.toolCallId))
             .map((tr) => {
-              const isError =
-                tr.output !== null &&
-                tr.output !== undefined &&
-                typeof tr.output === 'object' &&
-                'error' in (tr.output as object);
               const compactedOutput = compactToolResultOutput(tr);
 
               return {
                 type: 'tool-result' as const,
                 toolCallId: tr.toolCallId,
                 toolName: tr.toolName,
-                output: isError
+                output: isToolResultError(tr.output)
                   ? { type: 'error-json' as const, value: compactedOutput as never }
                   : { type: 'json' as const, value: compactedOutput as never },
               };

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -172,6 +172,7 @@ type StreamRunnerState = {
   lastStepToolCallCount: number;
   lastStepResponseMessageCount: number;
   peakStepUsage: LanguageModelUsage;
+  compactionSettings: Parameters<typeof compact>[0]['compactionSettings'];
 };
 
 const UNKNOWN_RECOVERY_LIMIT = 1;
@@ -236,6 +237,7 @@ class StreamRunner {
       lastStepToolCallCount: 0,
       lastStepResponseMessageCount: 0,
       peakStepUsage: Usage.ZERO_USAGE,
+      compactionSettings: undefined,
     };
 
     this.deps = { ...DEFAULT_DEPS, ...deps };
@@ -621,6 +623,7 @@ class StreamRunner {
       return;
     }
 
+    this.state.compactionSettings = compactionSettings;
     this.setNeedsCompaction(true, 'token-overflow');
     log.info(
       {
@@ -1077,6 +1080,7 @@ class StreamRunner {
       modelId: this.ctx.modelId,
       auto: true,
       overflow: this.state.contextOverflow,
+      compactionSettings: this.state.compactionSettings,
     });
 
     if (result === 'error') {


### PR DESCRIPTION
## Change Summary

Eliminates redundant DB queries and serial async bottlenecks in the compaction system, and fixes a routing bug that prevented session-specific actions (compact, stop stream) from appearing in the command palette.

### New Features
- **Compact session in command palette**: Fixed command palette not showing session-scoped actions (compact session, stop stream) — actions are now passed as a prop from the root layout so route matching works correctly. Also removes the self-referential Command palette entry from the list.

### Improvements and Refactors
- **Eliminated N+1 DB queries in prune()**: Pre-fetched messages are now passed into prune() and reused via a lookup map, removing one full table scan and N individual re-fetches per pruned message
- **Single message fetch for prune + history**: compact() now performs one SELECT after the marker insert, shared by both prune() and history building
- **Parallelised compaction startup**: getCompactionSettings(), getPromptUserContext(), and resolveCompactionModel() now run concurrently via Promise.all
- **Avoided double getCompactionSettings() fetch**: The runner passes its already-resolved settings into compact(), skipping the redundant DB round-trip
- **Prune updates wrapped in a transaction**: All UPDATE statements in prune() now run in a single transaction instead of individual autocommit writes
- **Prune decoupled from marker insert transaction**: prune() was being called inside a transaction it did not participate in; it now runs sequentially after the insert with its own proper transaction
- **isToolResultError helper extracted**: Deduplicates the identical inline error-shape check that appeared twice in history-messages.ts
- **requestCompaction uses desc + limit(1)**: Previously fetched all messages to get the last one; now fetches only the single latest row
- **buildRows() single-pass**: Collapsed from two iterations over the messages array into one
- **abortSessionRun() child abort parallelised**: Child session aborts now run concurrently, with abortQuestions and abortPermissionResponses also parallelised per child