### PR TITLE
improvement(perf): optimize doomloop, permission, and question systems

### DIFF
--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -56,17 +56,19 @@ export async function createSession(input: CreateSessionInput) {
   const title =
     input.title ?? `New Session ${new Date(now).toLocaleString('en-US', { hour12: false })}`;
 
-  await db.insert(sessions).values({
-    id,
-    title,
-    type: input.type ?? 'chat',
-    automationId: input.automationId ?? null,
-    parentSessionId: (input.parentSessionId ?? null) as PrefixedString<'ses'> | null,
-    createdAt: now,
-    updatedAt: now,
-  });
+  const [session] = await db
+    .insert(sessions)
+    .values({
+      id,
+      title,
+      type: input.type ?? 'chat',
+      automationId: input.automationId ?? null,
+      parentSessionId: (input.parentSessionId ?? null) as PrefixedString<'ses'> | null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
 
-  const [session] = await db.select().from(sessions).where(eq(sessions.id, id));
   return session;
 }
 
@@ -154,9 +156,10 @@ async function maybeGenerateTitle(input: {
   const db = getDb();
 
   const existingMessages = await db
-    .select()
+    .select({ id: messages.id })
     .from(messages)
-    .where(eq(messages.sessionId, input.sessionId));
+    .where(eq(messages.sessionId, input.sessionId))
+    .limit(1);
   if (existingMessages.length > 0) {
     return;
   }
@@ -378,22 +381,22 @@ export async function abortSessionRun(sessionId: PrefixedString<'ses'>) {
   log.info({ event: 'stream.abort.requested', sessionId }, 'stream abort requested');
   AbortRegistry.abort(sessionId);
   cancelDecision(sessionId);
-  await abortQuestions(sessionId);
-  await abortPermissionResponses(sessionId);
 
-  // Cascade abort to any active child sessions
   const db = getDb();
   const childSessions = await db
     .select({ id: sessions.id })
     .from(sessions)
     .where(eq(sessions.parentSessionId, sessionId));
 
-  for (const child of childSessions) {
-    AbortRegistry.abort(child.id);
-    cancelDecision(child.id);
-    await abortQuestions(child.id);
-    await abortPermissionResponses(child.id);
-  }
+  await Promise.all([
+    abortQuestions(sessionId),
+    abortPermissionResponses(sessionId),
+    ...childSessions.map(async (child) => {
+      AbortRegistry.abort(child.id);
+      cancelDecision(child.id);
+      await Promise.all([abortQuestions(child.id), abortPermissionResponses(child.id)]);
+    }),
+  ]);
 }
 
 function getSplitTitle(baseTitle: string, n: number): string {
@@ -445,28 +448,30 @@ export async function splitSession(
   const newSessionId = createSessionId();
   const now = Date.now();
 
-  await db.insert(sessions).values({
-    id: newSessionId,
-    title: newTitle,
-    parentSessionId: sessionId,
-    createdAt: now,
-    updatedAt: now,
-  });
+  const [newSession] = await db
+    .insert(sessions)
+    .values({
+      id: newSessionId,
+      title: newTitle,
+      parentSessionId: sessionId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
 
-  for (const msg of priorMessages) {
-    const newMsgId = createMessageId();
-    await db.insert(messages).values({
-      ...msg,
-      id: newMsgId,
-      sessionId: newSessionId,
-      usage: undefined,
-      costUsd: 0,
-      createdAt: msg.createdAt,
-      updatedAt: msg.updatedAt,
-    });
+  if (priorMessages.length > 0) {
+    await db.insert(messages).values(
+      priorMessages.map((msg) => ({
+        ...msg,
+        id: createMessageId(),
+        sessionId: newSessionId,
+        usage: undefined,
+        costUsd: 0,
+        createdAt: msg.createdAt,
+        updatedAt: msg.updatedAt,
+      })),
+    );
   }
-
-  const [newSession] = await db.select().from(sessions).where(eq(sessions.id, newSessionId));
 
   const prefillText = splitMsg.parts
     .filter((p): p is StoredPart & { type: 'text-delta'; text: string } => p.type === 'text-delta')
@@ -523,11 +528,24 @@ export async function getSessionStats(
     return err('Session not found', 404);
   }
 
-  const sessionMessages = await db
-    .select()
-    .from(messages)
-    .where(eq(messages.sessionId, sessionId))
-    .orderBy(asc(messages.createdAt));
+  const [sessionMessages, childSessions] = await Promise.all([
+    db
+      .select({
+        costUsd: messages.costUsd,
+        usage: messages.usage,
+        role: messages.role,
+        parts: messages.parts,
+        providerId: messages.providerId,
+        modelId: messages.modelId,
+      })
+      .from(messages)
+      .where(eq(messages.sessionId, sessionId))
+      .orderBy(asc(messages.createdAt)),
+    db
+      .select({ id: sessions.id })
+      .from(sessions)
+      .where(eq(sessions.parentSessionId, sessionId)),
+  ]);
 
   const currentSessionCostUsd = sessionMessages.reduce((acc, m) => acc + (m.costUsd ?? 0), 0);
   const currentSessionTokens = sessionMessages.reduce(
@@ -536,12 +554,6 @@ export async function getSessionStats(
   );
   const userMessageCount = sessionMessages.filter((m) => m.role === 'user').length;
   const assistantMessageCount = sessionMessages.filter((m) => m.role === 'assistant').length;
-
-  // Aggregate cost from child sessions (spawned by the task tool)
-  const childSessions = await db
-    .select({ id: sessions.id })
-    .from(sessions)
-    .where(eq(sessions.parentSessionId, sessionId));
 
   let childSessionsCostUsd = 0;
   let childSessionsTokens = 0;

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -677,12 +677,13 @@ class StreamRunner {
         .map((p) => p.toolCallId),
     );
 
-    for (const part of this.state.accumulatedParts) {
-      if (part.type !== 'tool-call' || toolCallIds.has(part.toolCallId)) {
-        continue;
-      }
+    const now = this.deps.now();
+    const unresolvedParts = this.state.accumulatedParts.filter(
+      (part): part is StoredPart & { type: 'tool-call' } =>
+        part.type === 'tool-call' && !toolCallIds.has(part.toolCallId),
+    );
 
-      const now = this.deps.now();
+    for (const part of unresolvedParts) {
       this.state.accumulatedParts.push({
         type: 'tool-result',
         id: createPartId(),
@@ -693,16 +694,20 @@ class StreamRunner {
         startedAt: now,
         endedAt: now,
       } as StoredPart);
-
-      await this.deps.broadcast('stream-tool-state', {
-        sessionId: this.ctx.sessionId,
-        messageId: this.ctx.assistantMessageId,
-        toolCallId: part.toolCallId,
-        toolName: part.toolName,
-        status: 'error',
-        error: 'Aborted',
-      });
     }
+
+    await Promise.all(
+      unresolvedParts.map((part) =>
+        this.deps.broadcast('stream-tool-state', {
+          sessionId: this.ctx.sessionId,
+          messageId: this.ctx.assistantMessageId,
+          toolCallId: part.toolCallId,
+          toolName: part.toolName,
+          status: 'error',
+          error: 'Aborted',
+        }),
+      ),
+    );
   }
 
   private async handlePermissionRejected(error: unknown): Promise<void> {
@@ -740,16 +745,18 @@ class StreamRunner {
         p.type === 'tool-call' && !resolvedToolCallIds.has(p.toolCallId),
     );
 
-    for (const call of unresolvedToolCalls) {
-      await this.deps.broadcast('stream-tool-state', {
-        sessionId: this.ctx.sessionId,
-        messageId: this.ctx.assistantMessageId,
-        toolCallId: call.toolCallId,
-        toolName: call.toolName,
-        status: 'error',
-        error: 'Blocked before completion',
-      });
-    }
+    await Promise.all(
+      unresolvedToolCalls.map((call) =>
+        this.deps.broadcast('stream-tool-state', {
+          sessionId: this.ctx.sessionId,
+          messageId: this.ctx.assistantMessageId,
+          toolCallId: call.toolCallId,
+          toolName: call.toolName,
+          status: 'error',
+          error: 'Blocked before completion',
+        }),
+      ),
+    );
   }
 
   private handleContextOverflow(): void {

--- a/packages/server/src/permission/service.ts
+++ b/packages/server/src/permission/service.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 import type { PrefixedString } from '@stitch/shared/id';
 import { createPermissionResponseId, createPermissionRuleId } from '@stitch/shared/id';
@@ -52,36 +52,23 @@ export async function upsertPerm(opts: {
   const db = getDb();
   const now = Date.now();
 
-  const where =
-    opts.pattern === null
-      ? and(eq(toolPermissions.toolName, opts.toolName), isNull(toolPermissions.pattern))
-      : and(eq(toolPermissions.toolName, opts.toolName), eq(toolPermissions.pattern, opts.pattern));
-
-  const existing = await db
-    .select({ id: toolPermissions.id })
-    .from(toolPermissions)
-    .where(where)
-    .then((rows) => rows[0]);
-
-  if (existing) {
-    await db
-      .update(toolPermissions)
-      .set({
+  await db
+    .insert(toolPermissions)
+    .values({
+      id: createPermissionRuleId(),
+      toolName: opts.toolName,
+      permission: opts.permission,
+      pattern: opts.pattern,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [toolPermissions.toolName, toolPermissions.pattern],
+      set: {
         permission: opts.permission,
         updatedAt: now,
-      })
-      .where(eq(toolPermissions.id, existing.id));
-    return;
-  }
-
-  await db.insert(toolPermissions).values({
-    id: createPermissionRuleId(),
-    toolName: opts.toolName,
-    permission: opts.permission,
-    pattern: opts.pattern,
-    createdAt: now,
-    updatedAt: now,
-  });
+      },
+    });
 }
 
 export async function getPerms(): Promise<ToolPermission[]> {
@@ -123,20 +110,22 @@ export async function requestPermissionResponse(opts: {
   const id = createPermissionResponseId();
   const now = Date.now();
 
-  await db.insert(permissionResponses).values({
-    id,
-    sessionId: opts.sessionId,
-    messageId: opts.messageId,
-    toolCallId: opts.toolCallId,
-    toolName: opts.toolName,
-    toolInput: opts.toolInput,
-    systemReminder: opts.systemReminder,
-    suggestion: opts.suggestion ?? null,
-    status: 'pending',
-    createdAt: now,
-  });
+  const [row] = await db
+    .insert(permissionResponses)
+    .values({
+      id,
+      sessionId: opts.sessionId,
+      messageId: opts.messageId,
+      toolCallId: opts.toolCallId,
+      toolName: opts.toolName,
+      toolInput: opts.toolInput,
+      systemReminder: opts.systemReminder,
+      suggestion: opts.suggestion ?? null,
+      status: 'pending',
+      createdAt: now,
+    })
+    .returning();
 
-  const [row] = await db.select().from(permissionResponses).where(eq(permissionResponses.id, id));
   if (!row) throw new Error('Permission response not found after create');
 
   await broadcast('permission-response-requested', {
@@ -211,19 +200,15 @@ async function resolvePermissionResponse(opts: {
     });
   }
 
-  await db
+  const [permissionResponse] = await db
     .update(permissionResponses)
     .set({
       status: opts.status,
       entry: opts.entry ?? null,
       resolvedAt: now,
     })
-    .where(eq(permissionResponses.id, opts.permissionResponseId));
-
-  const [permissionResponse] = await db
-    .select()
-    .from(permissionResponses)
-    .where(eq(permissionResponses.id, opts.permissionResponseId));
+    .where(eq(permissionResponses.id, opts.permissionResponseId))
+    .returning();
 
   await broadcast('permission-response-resolved', {
     permissionResponseId: opts.permissionResponseId,
@@ -293,52 +278,55 @@ export async function getPendingPermissionResponses(
   const rows = await db
     .select()
     .from(permissionResponses)
-    .where(eq(permissionResponses.sessionId, sessionId));
+    .where(and(eq(permissionResponses.sessionId, sessionId), eq(permissionResponses.status, 'pending')));
 
-  return rows.filter((p) => p.status === 'pending').map(toPermissionResponse);
+  return rows.map(toPermissionResponse);
 }
 
 export async function abortPermissionResponses(sessionId: PrefixedString<'ses'>): Promise<void> {
   const db = getDb();
   const now = Date.now();
-  const all = await db
+
+  const pending = await db
     .select()
     .from(permissionResponses)
-    .where(eq(permissionResponses.sessionId, sessionId));
-  const pending = all.filter((p) => p.status === 'pending');
+    .where(and(eq(permissionResponses.sessionId, sessionId), eq(permissionResponses.status, 'pending')));
+
   if (pending.length === 0) return;
 
   await db
     .update(permissionResponses)
     .set({ status: 'rejected', resolvedAt: now })
-    .where(eq(permissionResponses.sessionId, sessionId));
+    .where(and(eq(permissionResponses.sessionId, sessionId), eq(permissionResponses.status, 'pending')));
 
-  for (const row of pending) {
-    const id = row.id;
-    const entry = pendingPermissionResponses.get(id);
-    const streamRunId = entry?.streamRunId;
-    if (entry) {
-      entry.reject(
-        new PermissionResponseAbortedError('Permission response aborted by session abort'),
-      );
-      pendingPermissionResponses.delete(id);
-    }
+  await Promise.all(
+    pending.map(async (row) => {
+      const id = row.id;
+      const entry = pendingPermissionResponses.get(id);
+      const streamRunId = entry?.streamRunId;
+      if (entry) {
+        entry.reject(
+          new PermissionResponseAbortedError('Permission response aborted by session abort'),
+        );
+        pendingPermissionResponses.delete(id);
+      }
 
-    await broadcast('permission-response-resolved', {
-      permissionResponseId: row.id,
-      sessionId,
-    });
-
-    log.info(
-      {
-        event: 'stream.permission.aborted',
-        streamRunId,
-        sessionId,
+      await broadcast('permission-response-resolved', {
         permissionResponseId: row.id,
-      },
-      'permission aborted',
-    );
-  }
+        sessionId,
+      });
+
+      log.info(
+        {
+          event: 'stream.permission.aborted',
+          streamRunId,
+          sessionId,
+          permissionResponseId: row.id,
+        },
+        'permission aborted',
+      );
+    }),
+  );
 
   log.info(
     {

--- a/packages/server/src/question/service.ts
+++ b/packages/server/src/question/service.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 import type { PrefixedString } from '@stitch/shared/id';
 import { createQuestionId } from '@stitch/shared/id';
@@ -55,17 +55,19 @@ export async function askQuestion(opts: {
     'asking question',
   );
 
-  await db.insert(questions).values({
-    id,
-    sessionId: opts.sessionId,
-    questions: opts.questions,
-    status: 'pending',
-    toolCallId: opts.toolCallId,
-    messageId: opts.messageId,
-    createdAt: now,
-  });
+  const [row] = await db
+    .insert(questions)
+    .values({
+      id,
+      sessionId: opts.sessionId,
+      questions: opts.questions,
+      status: 'pending',
+      toolCallId: opts.toolCallId,
+      messageId: opts.messageId,
+      createdAt: now,
+    })
+    .returning();
 
-  const [row] = await db.select().from(questions).where(eq(questions.id, id));
   if (!row) {
     throw new Error(`Question not found after create: ${id}`);
   }
@@ -75,10 +77,7 @@ export async function askQuestion(opts: {
   });
 
   return new Promise((resolve, reject) => {
-    let pollInterval: ReturnType<typeof setInterval>;
-
     const cleanup = () => {
-      clearInterval(pollInterval);
       pendingQuestions.delete(id);
     };
 
@@ -96,32 +95,6 @@ export async function askQuestion(opts: {
     }
 
     pendingQuestions.set(id, { resolve, reject, streamRunId: opts.streamRunId });
-
-    pollInterval = setInterval(async () => {
-      const db = getDb();
-      const [q] = await db.select().from(questions).where(eq(questions.id, id));
-
-      if (!q) {
-        opts.abortSignal?.removeEventListener('abort', abortHandler);
-        cleanup();
-        reject(new Error('Question not found'));
-        return;
-      }
-
-      if (q.status === 'answered') {
-        opts.abortSignal?.removeEventListener('abort', abortHandler);
-        cleanup();
-        resolve(q.answers ?? []);
-        return;
-      }
-
-      if (q.status === 'rejected') {
-        opts.abortSignal?.removeEventListener('abort', abortHandler);
-        cleanup();
-        reject(new Error('Question rejected by user'));
-        return;
-      }
-    }, 1000);
   });
 }
 
@@ -132,16 +105,16 @@ export async function replyQuestion(
   const db = getDb();
   const now = Date.now();
 
-  await db
+  const [question] = await db
     .update(questions)
     .set({
       answers,
       status: 'answered',
       answeredAt: now,
     })
-    .where(eq(questions.id, questionId));
+    .where(eq(questions.id, questionId))
+    .returning();
 
-  const [question] = await db.select().from(questions).where(eq(questions.id, questionId));
   if (!question) {
     throw new Error(`Question not found: ${questionId}`);
   }
@@ -218,9 +191,12 @@ export async function getPendingQuestions(
   sessionId: PrefixedString<'ses'>,
 ): Promise<QuestionRequest[]> {
   const db = getDb();
-  const rows = await db.select().from(questions).where(eq(questions.sessionId, sessionId));
+  const rows = await db
+    .select()
+    .from(questions)
+    .where(and(eq(questions.sessionId, sessionId), eq(questions.status, 'pending')));
 
-  return rows.filter((q) => q.status === 'pending').map(toQuestionRequest);
+  return rows.map(toQuestionRequest);
 }
 
 /**
@@ -231,35 +207,39 @@ export async function abortQuestions(sessionId: PrefixedString<'ses'>): Promise<
   const db = getDb();
   const now = Date.now();
 
-  const pending = await db.select().from(questions).where(eq(questions.sessionId, sessionId));
+  const pendingRows = await db
+    .select()
+    .from(questions)
+    .where(and(eq(questions.sessionId, sessionId), eq(questions.status, 'pending')));
 
-  const pendingRows = pending.filter((q) => q.status === 'pending');
   if (pendingRows.length === 0) return;
 
   await db
     .update(questions)
     .set({ status: 'rejected', answeredAt: now })
-    .where(eq(questions.sessionId, sessionId));
+    .where(and(eq(questions.sessionId, sessionId), eq(questions.status, 'pending')));
 
-  for (const q of pendingRows) {
-    const entry = pendingQuestions.get(q.id);
-    const streamRunId = entry?.streamRunId;
-    if (entry) {
-      entry.reject(new QuestionAbortedError('Question aborted by session abort'));
-      pendingQuestions.delete(q.id);
-    }
-    await broadcast('question-rejected', { questionId: q.id, sessionId });
+  await Promise.all(
+    pendingRows.map(async (q) => {
+      const entry = pendingQuestions.get(q.id);
+      const streamRunId = entry?.streamRunId;
+      if (entry) {
+        entry.reject(new QuestionAbortedError('Question aborted by session abort'));
+        pendingQuestions.delete(q.id);
+      }
+      await broadcast('question-rejected', { questionId: q.id, sessionId });
 
-    log.info(
-      {
-        event: 'stream.question.aborted',
-        streamRunId,
-        sessionId,
-        questionId: q.id,
-      },
-      'question aborted',
-    );
-  }
+      log.info(
+        {
+          event: 'stream.question.aborted',
+          streamRunId,
+          sessionId,
+          questionId: q.id,
+        },
+        'question aborted',
+      );
+    }),
+  );
 
   log.info({ sessionId, count: pendingRows.length }, 'aborted pending questions');
 }

--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -30,7 +30,7 @@ permissionsRouter.get('/sessions/:id/permission-responses', async (c) => {
   const db = getDb();
   const sessionId = c.req.param('id') as PrefixedString<'ses'>;
 
-  const [session] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+  const [session] = await db.select({ id: sessions.id }).from(sessions).where(eq(sessions.id, sessionId));
   if (!session) return c.json({ error: 'Session not found' }, 404);
 
   const rows = await getPendingPermissionResponses(sessionId);

--- a/packages/server/src/routes/questions.ts
+++ b/packages/server/src/routes/questions.ts
@@ -39,7 +39,7 @@ questionsRouter.get('/sessions/:id/questions', async (c) => {
   const db = getDb();
   const sessionId = c.req.param('id') as PrefixedString<'ses'>;
 
-  const [session] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+  const [session] = await db.select({ id: sessions.id }).from(sessions).where(eq(sessions.id, sessionId));
   if (!session) return c.json({ error: 'Session not found' }, 404);
 
   const rows = await getPendingQuestions(sessionId);
@@ -54,7 +54,7 @@ questionsRouter.post(
     const db = getDb();
     const sessionId = c.req.param('id') as PrefixedString<'ses'>;
 
-    const [session] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+    const [session] = await db.select({ id: sessions.id }).from(sessions).where(eq(sessions.id, sessionId));
     if (!session) return c.json({ error: 'Session not found' }, 404);
 
     const body = c.req.valid('json');
@@ -62,17 +62,18 @@ questionsRouter.post(
     const id = createQuestionId();
     const now = Date.now();
 
-    await db.insert(questions).values({
-      id,
-      sessionId,
-      questions: body.questions,
-      status: 'pending',
-      toolCallId: body.toolCallId,
-      messageId: body.messageId,
-      createdAt: now,
-    });
-
-    const [row] = await db.select().from(questions).where(eq(questions.id, id));
+    const [row] = await db
+      .insert(questions)
+      .values({
+        id,
+        sessionId,
+        questions: body.questions,
+        status: 'pending',
+        toolCallId: body.toolCallId,
+        messageId: body.messageId,
+        createdAt: now,
+      })
+      .returning();
 
     return c.json(row, 201);
   },


### PR DESCRIPTION
## Change Summary

Eliminates a set of performance inefficiencies across the doomloop, permission, and question systems - reducing unnecessary database round-trips, fixing a race condition, removing a redundant polling loop, and parallelizing independent async work.

### Improvements & Refactors

- **Eliminated insert/update + re-select round-trips**: askQuestion, replyQuestion, requestPermissionResponse, resolvePermissionResponse, createSession, and splitSession all previously wrote a row then immediately re-fetched it. All now use .returning() for a single round-trip.

- **Removed redundant 1s polling loop**: askQuestion ran a setInterval that polled the DB every second as a safety net. Since replyQuestion, rejectQuestion, and abortQuestions already resolve the in-memory Promise directly via the pendingQuestions Map, this added constant unnecessary load with no benefit.

- **Atomic upsert in upsertPerm**: Replaced a select-then-insert/update pattern (race condition under concurrent requests) with a single insert().onConflictDoUpdate() targeting the unique (toolName, pattern) index.

- **Parallelized independent DB queries**: getSessionStats now fetches session messages and child sessions concurrently via Promise.all instead of sequentially.

- **Parallelized abort broadcasts**: abortQuestions, abortPermissionResponses, handleAbort, and handlePermissionRejected all had serial await broadcast() calls inside loops. All now use Promise.all.

- **SQL-level filtering**: getPendingQuestions and getPendingPermissionResponses pushed status=pending into the SQL where clause, removing in-memory .filter() calls that over-fetched all rows. Same fix applied to abortQuestions and abortPermissionResponses.

- **Batch insert in splitSession**: Per-message db.insert() calls inside a loop replaced with a single db.insert().values([...]).

- **Reduced over-fetching**: Session existence checks in routes now select only id. maybeGenerateTitle existence check uses select({ id }).limit(1). getSessionStats messages query projects only the columns it actually uses.