### PR TITLE
improvement(ci): cache warming, skip redundant installs, and reduce unnecessary CI runs

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -10,6 +10,7 @@ runs:
         bun-version: '1.3.8'
 
     - name: Cache node_modules
+      id: cache-node-modules
       uses: actions/cache@v5
       with:
         path: |
@@ -22,5 +23,6 @@ runs:
           ${{ runner.os }}-node_modules-
 
     - name: Install dependencies
+      if: steps.cache-node-modules.outputs.cache-hit != 'true'
       shell: bash
       run: bun install --frozen-lockfile

--- a/.github/workflow-smoke-test.md
+++ b/.github/workflow-smoke-test.md
@@ -1,3 +1,0 @@
-This file exists only to validate GitHub PR workflows.
-
-Safe to remove after CI and branch protections are verified.

--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - 'apps/website/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.opencode/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/CODEOWNERS'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -1,0 +1,28 @@
+name: warm-cache
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'bun.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  warm:
+    name: warm cache (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun


### PR DESCRIPTION
## Change Summary

Reduces CI run time on Windows by up to ~3 minutes by skipping bun install when node_modules is already cached, seeds the shared master cache so all PRs benefit, and avoids running checks entirely for non-code changes.

### New Features
- **Cache warming workflow**: New warm-cache.yml triggers on bun.lock changes to master and on workflow_dispatch, seeding the shared master cache for both windows-latest and macos-latest so all PR branches can restore from it instead of running a cold install

### Improvements
- **Skip bun install on cache hit**: setup-bun action now gates bun install behind cache-hit != 'true' — on an exact cache match the install step is skipped entirely (~163s saved on Windows, ~10s on macOS)
- **pr-master path exclusions**: Added paths-ignore to skip CI for changes to apps/website, markdown files, LICENSE, .opencode, .github/ISSUE_TEMPLATE, and .github/CODEOWNERS

### Bug Fixes
- Removed .github/workflow-smoke-test.md which was left over from initial CI setup

## Notes

After merging, manually trigger the warm-cache workflow once from the Actions UI to pre-warm the master cache for both platforms. Without this one-time step the cache will not be available to PRs until the next bun.lock change.