### PR TITLE
fix(ci): cache bun global install dir on Windows to fix 2m install time

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -9,7 +9,17 @@ runs:
       with:
         bun-version: '1.3.8'
 
-    - name: Cache node_modules
+    - name: Cache bun global install cache (Windows)
+      id: cache-bun-global
+      if: runner.os == 'Windows'
+      uses: actions/cache@v5
+      with:
+        path: C:\Users\runneradmin\AppData\Local\bun\install\cache
+        key: ${{ runner.os }}-bun-global-${{ hashFiles('**/bun.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-global-
+
+    - name: Cache node_modules (non-Windows)
       id: cache-node-modules
       if: runner.os != 'Windows'
       uses: actions/cache@v5


### PR DESCRIPTION
## Change Summary

Fixes the Windows CI job taking ~2 minutes on every run due to `bun install` downloading and installing all 2110 packages from scratch each time.

### Bug Fixes
- **Windows bun install takes 127s per run**: The `node_modules` cache was intentionally skipped on Windows (due to symlink/junction restore failures), leaving no caching at all. Now caches bun's global install directory (`%LOCALAPPDATA%\bun\install\cache`) instead - this path contains no symlinks so `actions/cache` restores it cleanly, and `bun install` with a warm local cache reconstructs `node_modules` in ~2-3s.