### PR TITLE
fix(desktop): use --x64 flag instead of --arch x64 for electron-builder

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
     "build:sidecar": "bun run --filter @stitch/server build",
     "build:sidecar:x64": "bun run --filter @stitch/server build:x64",
     "package": "bun run build:web && bun run build && bun run build:sidecar && electron-builder --config electron-builder.config.ts",
-    "package:x64": "bun run build:web && bun run build && bun run build:sidecar:x64 && electron-builder --config electron-builder.config.ts --arch x64",
+    "package:x64": "bun run build:web && bun run build && bun run build:sidecar:x64 && electron-builder --config electron-builder.config.ts --x64",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Change Summary

Fixes the macOS Intel (x64) release build failing with `Unknown argument: arch`.

### Bug Fixes
- **macOS x64 build crashes with exit code 1**: `electron-builder` does not accept `--arch x64` — the correct flag is the standalone boolean `--x64`. Changed `package:x64` script accordingly.