### PR TITLE
fix: correct paths-filter negation pattern to properly skip CI for ignored paths

### DIFF
--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           filters: |
             ci:
+              - '**'
               - '!apps/website/**'
               - '!**/*.md'
               - '!LICENSE'


### PR DESCRIPTION
## Change Summary

Fixes the `dorny/paths-filter` negation pattern introduced in #46 that caused CI to always run even for website-only PRs.

### Problem
`dorny/paths-filter` requires a positive match pattern before negations will work. The previous config had only negation lines (`!apps/website/**` etc.) with no leading `**`, so the filter had no positive matches to negate against and always returned `true`.

### Fix
Added `**` as the first pattern so negations correctly exclude the ignored paths, making CI skip properly for website/docs-only PRs.