### PR TITLE
fix(desktop): disable auto-updater on macOS due to code signing failure

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -250,13 +250,15 @@ void app.whenReady().then(async () => {
 
     await createWindow();
 
-    updater.init();
-    setTimeout(() => {
-      void updater.checkForUpdates();
-    }, 15_000);
-    setInterval(() => {
-      void updater.checkForUpdates();
-    }, UPDATE_CHECK_INTERVAL_MS);
+    if (process.platform !== 'darwin') {
+      updater.init();
+      setTimeout(() => {
+        void updater.checkForUpdates();
+      }, 15_000);
+      setInterval(() => {
+        void updater.checkForUpdates();
+      }, UPDATE_CHECK_INTERVAL_MS);
+    }
 
     // Initialize system tray
     const getWindow = () => mainWindow;

--- a/apps/web/src/components/settings/general.tsx
+++ b/apps/web/src/components/settings/general.tsx
@@ -232,7 +232,38 @@ function updaterStatusLabel(status: string, progress?: number): string {
   return 'Check for updates manually.';
 }
 
+const RELEASES_URL = 'https://github.com/UseStitch/stitch/releases/latest';
+
 function AppUpdatesContent() {
+  const isMac = window.electron?.platform === 'darwin';
+
+  if (isMac) {
+    return (
+      <div className="flex items-center justify-between gap-4 py-3">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <Label className="text-sm font-medium">Desktop app updates</Label>
+          <p className="text-xs text-muted-foreground">
+            Auto-updates are not available on macOS. Download the latest version from the releases
+            page.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={() => void window.api?.shell?.openExternal(RELEASES_URL)}
+        >
+          Download update
+        </Button>
+      </div>
+    );
+  }
+
+  return <AutoUpdatesContent />;
+}
+
+function AutoUpdatesContent() {
   const updater = useUpdaterStore((state) => state.updater);
   const setInstalling = useUpdaterStore((state) => state.setInstalling);
   const [checkPending, setCheckPending] = React.useState(false);


### PR DESCRIPTION
## 🚀 Change Summary

Disables the auto-updater on macOS to prevent the ShipIt code signature validation error (`code failed to satisfy specified code requirement(s)`). Until an Apple Developer account is set up for proper signing and notarization, macOS users are directed to download updates manually from GitHub releases.

### 🐛 Bug Fixes
- **macOS update crash**: Auto-updates via ShipIt/Squirrel fail on macOS because the app bundle is not signed with a Developer ID certificate or notarized. The updater is now skipped entirely on darwin, eliminating the error.

### 🛠 Improvements & Refactors
- **macOS settings UI**: The App Updates section in Settings > General now shows a "Download update" button on macOS that opens the GitHub releases page, instead of the non-functional auto-update controls.
- **Extracted `AutoUpdatesContent` component**: The existing auto-update UI (check/install buttons) is moved into its own component, used on Windows/Linux where auto-updates continue to work as before.