### PR TITLE
fix: resolve 'Failed to delete automation' caused by FK constraint and error handling bugs

### DIFF
--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -233,9 +233,16 @@ export async function updateAutomation(
 
 export async function deleteAutomation(automationId: string): Promise<ServiceResult<null>> {
   const db = getDb();
+  const typedId = automationId as PrefixedString<'auto'>;
+
+  await db
+    .update(sessions)
+    .set({ automationId: null })
+    .where(eq(sessions.automationId, typedId));
+
   const deleted = await db
     .delete(automations)
-    .where(eq(automations.id, automationId as PrefixedString<'auto'>))
+    .where(eq(automations.id, typedId))
     .returning({ id: automations.id });
 
   if (deleted.length === 0) {

--- a/packages/server/src/routes/automations.ts
+++ b/packages/server/src/routes/automations.ts
@@ -88,12 +88,7 @@ automationsRouter.delete('/:id', async (c) => {
     return c.json({ error: result.error }, result.status);
   }
 
-  try {
-    await unregisterAutomationSchedule(id);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to unschedule automation';
-    return c.json({ error: message }, 500);
-  }
+  await unregisterAutomationSchedule(id).catch(() => {});
 
   return c.body(null, 204);
 });

--- a/packages/server/src/scheduler/runtime.ts
+++ b/packages/server/src/scheduler/runtime.ts
@@ -115,9 +115,7 @@ export async function registerSchedulerJob(input: {
 }
 
 export async function unregisterSchedulerJob(key: string): Promise<void> {
-  if (!scheduler) {
-    throw new Error('Scheduler is not started');
-  }
+  if (!scheduler) return;
 
   await scheduler.unregisterJob(key);
 }


### PR DESCRIPTION
## 🚀 Change Summary

Fixes the "Failed to delete automation" error that occurred every time a user attempted to delete an automation that had been run at least once. Three bugs contributed to the failure — a missing FK cascade in a migration, an error-handling path that masked successful deletes, and an overly strict null guard in the scheduler.

### 🐛 Bug Fixes

- **Fix FK constraint blocking automation deletion**: Migration `0008` added `sessions.automation_id REFERENCES automations(id)` without an `ON DELETE SET NULL` clause, despite the Drizzle schema declaring `{ onDelete: 'set null' }`. SQLite defaults to `RESTRICT`, so any automation with associated sessions could never be deleted. Since SQLite does not support `ALTER COLUMN` to retroactively fix a foreign key constraint, the fix nullifies `sessions.automationId` at the application level before deleting the automation row.

- **Fix scheduler cleanup failure overwriting successful delete response**: The DELETE handler deleted the automation from the database first, then attempted to unregister its scheduler job. If the scheduler step threw, the handler returned a 500 error even though the row was already gone — leaving the client showing an error while the data was actually deleted, and the query cache was never invalidated so the UI continued displaying the removed automation. Scheduler cleanup is now best-effort via `.catch(() => {})`.

- **Fix `unregisterSchedulerJob` throwing when scheduler is null**: `unregisterSchedulerJob` threw `"Scheduler is not started"` if the scheduler had not been initialized. For an unregister/cleanup operation there is nothing to clean up when the scheduler is not running, so this now returns as a no-op instead of throwing.