### PR TITLE
Recordings UI improvements: sidebar, audio player, and list enhancements

### DIFF
--- a/apps/web/src/components/navigation/app-sidebar.tsx
+++ b/apps/web/src/components/navigation/app-sidebar.tsx
@@ -6,6 +6,7 @@ import { Link, useParams, useRouterState } from '@tanstack/react-router';
 
 import { AnimatedTitle } from '@/components/animated-title';
 import { AutomationsSidebarContent } from '@/components/automations/automations-sidebar';
+import { RecordingsSidebarContent } from '@/components/recordings/recordings-sidebar';
 import {
   Sidebar,
   SidebarContent,
@@ -134,13 +135,22 @@ function useActiveContext(): 'chat' | 'connectors' | 'automations' | 'memories' 
 export function AppSidebar() {
   const context = useActiveContext();
 
-  if (context === 'connectors' || context === 'memories' || context === 'usage' || context==='recordings') {
+  if (context === 'connectors' || context === 'memories' || context === 'usage') {
     return null;
   }
 
+  const content =
+    context === 'automations' ? (
+      <AutomationsSidebarContent />
+    ) : context === 'recordings' ? (
+      <RecordingsSidebarContent />
+    ) : (
+      <ChatSidebarContent />
+    );
+
   return (
     <Sidebar collapsible="offcanvas" className="border-r-0!">
-      {context === 'automations' ? <AutomationsSidebarContent /> : <ChatSidebarContent />}
+      {content}
     </Sidebar>
   );
 }

--- a/apps/web/src/components/recordings/analysis/analysis-header.tsx
+++ b/apps/web/src/components/recordings/analysis/analysis-header.tsx
@@ -1,7 +1,145 @@
-import { FileTextIcon, Loader2Icon, SparklesIcon } from 'lucide-react';
+import { FileTextIcon, Loader2Icon, PauseIcon, PlayIcon, RotateCcwIcon, SparklesIcon, Trash2Icon } from 'lucide-react';
+import * as React from 'react';
+import { toast } from 'sonner';
+
 import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { getServerUrl } from '@/lib/api';
+
 import type { RecordingAnalysis, Recording } from '@stitch/shared/recordings/types';
+
 import { statusClassName, statusLabel } from './utils';
+
+function formatDuration(durationMs: number | null): string {
+  if (durationMs === null) return '--';
+
+  const totalSeconds = Math.floor(durationMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+function AudioPlayer({ recordingId, durationMs }: { recordingId: string; durationMs: number | null }) {
+  const audioRef = React.useRef<HTMLAudioElement | null>(null);
+  const [isPlaying, setIsPlaying] = React.useState(false);
+  const [currentTime, setCurrentTime] = React.useState(0);
+  const [src, setSrc] = React.useState<string | null>(null);
+  const actualDuration = durationMs ? durationMs / 1000 : 0;
+
+  React.useEffect(() => {
+    let active = true;
+    void getServerUrl().then((url) => {
+      if (active) {
+        setSrc(`${url}/recordings/${recordingId}/audio`);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [recordingId]);
+
+  React.useEffect(() => {
+    if (!src) {
+      audioRef.current?.pause();
+      audioRef.current = null;
+      setIsPlaying(false);
+      setCurrentTime(0);
+      return;
+    }
+
+    const audio = new Audio(src);
+    const handleTimeUpdate = () => {
+      setCurrentTime(audio.currentTime);
+    };
+    const handleEnded = () => {
+      setIsPlaying(false);
+      setCurrentTime(actualDuration);
+    };
+    const handlePause = () => {
+      setIsPlaying(false);
+    };
+    const handlePlay = () => {
+      setIsPlaying(true);
+    };
+
+    audio.addEventListener('timeupdate', handleTimeUpdate);
+    audio.addEventListener('ended', handleEnded);
+    audio.addEventListener('pause', handlePause);
+    audio.addEventListener('play', handlePlay);
+
+    audioRef.current = audio;
+
+    return () => {
+      audio.pause();
+      audio.removeEventListener('timeupdate', handleTimeUpdate);
+      audio.removeEventListener('ended', handleEnded);
+      audio.removeEventListener('pause', handlePause);
+      audio.removeEventListener('play', handlePlay);
+    };
+  }, [src, actualDuration]);
+
+  const progressValue = actualDuration > 0 ? Math.min((currentTime / actualDuration) * 100, 100) : 0;
+
+  const start = React.useCallback(() => {
+    if (!audioRef.current) return;
+    void audioRef.current.play().catch(() => {
+      toast.error('Could not start playback');
+    });
+  }, []);
+
+  const stop = React.useCallback(() => {
+    if (!audioRef.current) return;
+    audioRef.current.pause();
+  }, []);
+
+  const reset = React.useCallback(() => {
+    if (!audioRef.current) return;
+    audioRef.current.pause();
+    audioRef.current.currentTime = 0;
+    setCurrentTime(0);
+  }, []);
+
+  if (!src) return null;
+
+  return (
+    <div className="flex h-8 w-48 items-center gap-1 rounded-lg border border-border/60 bg-background px-1.5 shadow-sm">
+      <Button
+        type="button"
+        size="icon-sm"
+        variant="ghost"
+        onClick={isPlaying ? stop : start}
+        aria-label={isPlaying ? 'Pause playback' : 'Play recording'}
+        className="shrink-0"
+      >
+        {isPlaying ? <PauseIcon className="size-4" /> : <PlayIcon className="size-4" />}
+      </Button>
+      <div className="flex min-w-0 flex-1 flex-col justify-center gap-0.5">
+        <Progress value={progressValue} className="mt-0.5 h-1.5" aria-label="Playback progress" />
+        <div className="flex items-center justify-between text-[10px] tabular-nums leading-none text-muted-foreground">
+          <span>{formatDuration(currentTime * 1000)}</span>
+          <span>{formatDuration(actualDuration * 1000)}</span>
+        </div>
+      </div>
+      <Button
+        type="button"
+        size="icon-sm"
+        variant="ghost"
+        onClick={reset}
+        disabled={currentTime === 0 && !isPlaying}
+        aria-label="Reset playback"
+        className="shrink-0"
+      >
+        <RotateCcwIcon className="size-3.5" />
+      </Button>
+    </div>
+  );
+}
 
 interface AnalysisHeaderProps {
   analysis: RecordingAnalysis | null | undefined;
@@ -9,8 +147,10 @@ interface AnalysisHeaderProps {
   isRunning: boolean;
   isStarting: boolean;
   isCancelling: boolean;
+  isDeleting: boolean;
   onStartAnalysis: () => void;
   onCancelAnalysis: () => void;
+  onDelete: () => void;
 }
 
 export function AnalysisHeader({
@@ -19,9 +159,13 @@ export function AnalysisHeader({
   isRunning,
   isStarting,
   isCancelling,
+  isDeleting,
   onStartAnalysis,
   onCancelAnalysis,
+  onDelete,
 }: AnalysisHeaderProps) {
+  const showPlayer = recording?.status === 'completed' && recording.id;
+
   return (
     <div className="flex shrink-0 flex-wrap items-center justify-between gap-3">
       <div className="flex items-center gap-4">
@@ -32,19 +176,12 @@ export function AnalysisHeader({
           <h1 className="text-xl font-semibold tracking-tight text-foreground">
             {analysis?.title || recording?.title || 'Recording analysis'}
           </h1>
-          <p className="mt-0.5 text-sm text-muted-foreground">
-            Summary, extracted topics, decisions, and full transcript.
-          </p>
         </div>
       </div>
       <div className="flex items-center gap-3">
-        <span
-          className={`inline-flex items-center rounded-md px-2.5 py-1 text-xs font-semibold tracking-wide ${statusClassName(
-            analysis?.status
-          )}`}
-        >
-          {statusLabel(analysis?.status)}
-        </span>
+        {showPlayer ? (
+          <AudioPlayer recordingId={recording.id} durationMs={recording.durationMs} />
+        ) : null}
         <Button
           onClick={onStartAnalysis}
           disabled={isStarting || isRunning}
@@ -54,9 +191,23 @@ export function AnalysisHeader({
           {isStarting || isRunning ? (
             <Loader2Icon data-icon="inline-start" className="size-4 animate-spin" />
           ) : (
-            <SparklesIcon data-icon="inline-start" className="size-4 text-primary" />
+            <SparklesIcon data-icon="inline-start" className="size-4" />
           )}
           {analysis ? 'Re-run analysis' : 'Analyze recording'}
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={onDelete}
+          disabled={isDeleting || isRunning}
+          aria-label="Delete recording"
+          className="shadow-sm text-destructive hover:text-destructive"
+        >
+          {isDeleting ? (
+            <Loader2Icon className="size-4 animate-spin" />
+          ) : (
+            <Trash2Icon className="size-4" />
+          )}
         </Button>
         {isRunning && (
           <Button

--- a/apps/web/src/components/recordings/analysis/summary-section.tsx
+++ b/apps/web/src/components/recordings/analysis/summary-section.tsx
@@ -13,10 +13,13 @@ export function SummarySection({ analysis, isRunning }: SummarySectionProps) {
   const allActionItems = analysis?.topicSections.flatMap((s) => s.actionItems) ?? [];
   const allOpenQuestions = analysis?.topicSections.flatMap((s) => s.openQuestions) ?? [];
 
+  const hasAnyMetrics = allDecisions.length > 0 || allActionItems.length > 0 || allBlockers.length > 0 || allOpenQuestions.length > 0;
+
   return (
     <section className="flex flex-col gap-5">
-      {/* Metric Cards Top Row */}
-      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+      {/* Metric Cards Top Row - only show if any metric has a value */}
+      {hasAnyMetrics ? (
+        <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         {/* Decisions Metric */}
         <div className="flex flex-col justify-center rounded-xl border border-border/60 bg-card p-4 shadow-sm">
           <div className="flex items-center gap-2 text-muted-foreground">
@@ -60,7 +63,8 @@ export function SummarySection({ analysis, isRunning }: SummarySectionProps) {
             {allOpenQuestions.length}
           </p>
         </div>
-      </div>
+        </div>
+      ) : null}
 
       {/* Main Summary Content */}
       <div className="rounded-xl border border-border/60 bg-card p-5 shadow-sm">

--- a/apps/web/src/components/recordings/analysis/topic-card.tsx
+++ b/apps/web/src/components/recordings/analysis/topic-card.tsx
@@ -18,7 +18,7 @@ export function TopicCard({ section }: { section: RecordingAnalysisTopicSection 
         <h3 className="text-lg font-semibold tracking-tight text-foreground">{section.name}</h3>
         <p className="mt-1 flex items-center text-xs text-muted-foreground">
           <ClockIcon className="mr-1.5 size-3" />
-          Turns {section.startTurn}–{section.endTurn}
+          Turns {section.startTurn + 1}–{section.endTurn + 1}
         </p>
       </div>
 

--- a/apps/web/src/components/recordings/recording-analysis-page.tsx
+++ b/apps/web/src/components/recordings/recording-analysis-page.tsx
@@ -1,11 +1,23 @@
+import * as React from 'react';
 import { toast } from 'sonner';
 import { useSuspenseQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
 
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   recordingAnalysisQueryOptions,
   recordingsQueryOptions,
   useCancelRecordingAnalysis,
+  useDeleteRecording,
   useStartRecordingAnalysis,
 } from '@/lib/queries/recordings';
 
@@ -20,6 +32,9 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
   
   const startAnalysis = useStartRecordingAnalysis();
   const cancelAnalysis = useCancelRecordingAnalysis();
+  const deleteRecording = useDeleteRecording();
+  const navigate = useNavigate();
+  const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
 
   const analysis = analysisResponse.analysis;
   const recording = recordings.recordings.find((item) => item.id === recordingId);
@@ -49,8 +64,22 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
         isRunning={isRunning}
         isStarting={startAnalysis.isPending}
         isCancelling={cancelAnalysis.isPending}
+        isDeleting={deleteRecording.isPending}
         onStartAnalysis={handleStartAnalysis}
         onCancelAnalysis={handleCancelAnalysis}
+        onDelete={() => {
+          if (recording?.durationMs !== null && recording?.durationMs !== undefined && recording.durationMs <= 30_000) {
+            void deleteRecording.mutateAsync(recordingId).then(
+              () => {
+                toast.success('Recording deleted');
+                void navigate({ to: '/recordings' });
+              },
+              (error: unknown) => toast.error(error instanceof Error ? error.message : 'Failed to delete recording'),
+            );
+          } else {
+            setShowDeleteConfirm(true);
+          }
+        }}
       />
 
       {analysis?.error && analysis.error !== 'Analysis cancelled by user' ? (
@@ -65,7 +94,7 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
         {/* Left Column - Summary & Topics (Scrollable) */}
         <div className="flex min-h-0 flex-col lg:col-span-8 xl:col-span-8 2xl:col-span-9">
           <ScrollArea className="flex-1 rounded-xl" style={{ height: 0 }}>
-            <div className="space-y-8 pb-12 pr-4">
+            <div className="space-y-8 pb-12 pr-2">
               <SummarySection analysis={analysis} isRunning={isRunning} />
               <TopicList sections={analysis?.topicSections} isRunning={isRunning} />
             </div>
@@ -78,6 +107,38 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
         </div>
         
       </div>
+
+      <Dialog open={showDeleteConfirm} onOpenChange={(open) => !open && setShowDeleteConfirm(false)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete recording?</DialogTitle>
+            <DialogDescription>
+              This permanently deletes &quot;{recording?.title}&quot; and its local audio file.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowDeleteConfirm(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                void deleteRecording.mutateAsync(recordingId).then(
+                  () => {
+                    setShowDeleteConfirm(false);
+                    toast.success('Recording deleted');
+                    void navigate({ to: '/recordings' });
+                  },
+                  (error: unknown) => toast.error(error instanceof Error ? error.message : 'Failed to delete recording'),
+                );
+              }}
+              disabled={deleteRecording.isPending}
+            >
+              {deleteRecording.isPending ? 'Deleting...' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web/src/components/recordings/recordings-page.tsx
+++ b/apps/web/src/components/recordings/recordings-page.tsx
@@ -14,7 +14,7 @@ import * as React from 'react';
 import { toast } from 'sonner';
 
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import {
   createColumnHelper,
   flexRender,
@@ -186,7 +186,7 @@ function RecordingPreview({ src, durationMs }: { src: string | null; durationMs:
   }
 
   return (
-    <div className="flex w-48 items-center gap-1">
+    <div className="flex w-48 items-center gap-1" onClick={(e) => e.stopPropagation()}>
       <Button
         type="button"
         size="icon-sm"
@@ -233,7 +233,8 @@ function RecordingCopyButton({ value }: { value: string }) {
       type="button"
       variant="ghost"
       size="icon-sm"
-      onClick={() => {
+      onClick={(e) => {
+        e.stopPropagation();
         void navigator.clipboard.writeText(value).then(
           () => {
             setCopied(true);
@@ -273,6 +274,7 @@ export function RecordingsPage() {
   const [tick, setTick] = React.useState(Date.now());
   const [baseUrl, setBaseUrl] = React.useState<string | null>(null);
   const [recordingToDelete, setRecordingToDelete] = React.useState<Recording | null>(null);
+  const navigate = useNavigate();
 
   useQuery({
     ...recordingsQueryOptions({ page, pageSize }),
@@ -297,6 +299,7 @@ export function RecordingsPage() {
       return;
     }
 
+    setTick(Date.now());
     const id = setInterval(() => {
       setTick(Date.now());
     }, 1_000);
@@ -306,7 +309,7 @@ export function RecordingsPage() {
 
   const activeRecording = data.recordings.find((recording) => recording.id === data.activeRecordingId);
 
-  const activeDuration = activeRecording ? tick - activeRecording.startedAt : null;
+  const activeDuration = activeRecording ? Math.max(0, tick - activeRecording.startedAt) : null;
 
   const columns = React.useMemo(
     () => [
@@ -326,7 +329,7 @@ export function RecordingsPage() {
         cell: ({ getValue }) => <PlatformBadge platform={getValue()} />,
       }),
       columnHelper.accessor('status', {
-        header: 'Status',
+        header: 'Capturing',
         cell: ({ getValue }) => <span className="text-xs capitalize text-muted-foreground">{getValue()}</span>,
       }),
       columnHelper.accessor('startedAt', {
@@ -366,20 +369,22 @@ export function RecordingsPage() {
         cell: ({ row }) => (
           <div className="flex items-center justify-end gap-1 -mr-1.5">
             <RecordingCopyButton value={row.original.filePath} />
-            <Link
-              to="/recordings/$id"
-              params={{ id: row.original.id }}
-              className={buttonVariants({ variant: 'ghost', size: 'icon-sm' })}
-              title="View analysis"
-              aria-label="View analysis"
-            >
-              <FileTextIcon className="size-4" />
-            </Link>
             <Button
               type="button"
               variant="ghost"
               size="icon-sm"
-              onClick={() => setRecordingToDelete(row.original)}
+              onClick={(e) => {
+                e.stopPropagation();
+                const rec = row.original;
+                if (rec.durationMs !== null && rec.durationMs <= 30_000) {
+                  void deleteRecording.mutateAsync(rec.id).then(
+                    () => toast.success('Recording deleted'),
+                    (error: unknown) => toast.error(error instanceof Error ? error.message : 'Failed to delete recording'),
+                  );
+                } else {
+                  setRecordingToDelete(rec);
+                }
+              }}
               title="Delete recording"
               aria-label="Delete recording"
               disabled={row.original.id === data.activeRecordingId}
@@ -441,16 +446,16 @@ export function RecordingsPage() {
         </div>
 
         <div className="rounded-xl border border-border/60 bg-card/70 p-4">
-          <div className="flex flex-wrap items-end gap-3">
-            <div className="min-w-72 flex-1 space-y-2">
-              <label htmlFor="recording-title" className="text-xs font-medium text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="min-w-72 flex-1">
+              <label htmlFor="recording-title" className="sr-only">
                 Recording title
               </label>
               <Input
                 id="recording-title"
                 value={title}
                 onChange={(event) => setTitle(event.target.value)}
-                placeholder="Weekly Product Sync"
+                placeholder="Recording title e.g. Weekly Product Sync"
                 disabled={Boolean(activeRecording)}
               />
             </div>
@@ -531,7 +536,11 @@ export function RecordingsPage() {
                   </tr>
                 ) : (
                   table.getRowModel().rows.map((row) => (
-                    <tr key={row.id} className="group align-middle transition-colors hover:bg-muted/40">
+                    <tr
+                      key={row.id}
+                      className="group cursor-pointer align-middle transition-colors hover:bg-muted/40"
+                      onClick={() => void navigate({ to: '/recordings/$id', params: { id: row.original.id } })}
+                    >
                       {row.getVisibleCells().map((cell) => (
                         <td
                           key={cell.id}

--- a/apps/web/src/components/recordings/recordings-sidebar.tsx
+++ b/apps/web/src/components/recordings/recordings-sidebar.tsx
@@ -1,0 +1,136 @@
+import { LibraryIcon, MicIcon } from 'lucide-react';
+
+import { useQuery } from '@tanstack/react-query';
+import { Link, useParams, useRouterState } from '@tanstack/react-router';
+
+import {
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar';
+import { recordingsQueryOptions } from '@/lib/queries/recordings';
+
+function formatDate(ts: number): string {
+  return new Date(ts).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}
+
+function formatDuration(durationMs: number | null): string {
+  if (durationMs === null) return '--';
+
+  const totalSeconds = Math.floor(durationMs / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${String(minutes).padStart(2, '0')}m`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes} mins`;
+  }
+
+  return `${seconds} secs`;
+}
+
+export function RecordingsSidebarContent() {
+  const params = useParams({ strict: false });
+  const routerState = useRouterState();
+  const selectedRecordingId = typeof params.id === 'string' ? params.id : null;
+  const isOnIndex = routerState.location.pathname === '/recordings';
+
+  const { data } = useQuery(recordingsQueryOptions({ page: 1, pageSize: 100 }));
+  const recordings = data?.recordings ?? [];
+
+  return (
+    <>
+      <SidebarHeader className="pb-0">
+        <SidebarMenuButton
+          isActive={isOnIndex}
+          render={
+            <Link to="/recordings" className="flex items-center gap-2 font-medium" />
+          }
+        >
+          <LibraryIcon className="size-4" />
+          All Recordings
+        </SidebarMenuButton>
+      </SidebarHeader>
+
+      <SidebarContent>
+        {recordings.length > 0 ? (
+          <SidebarGroup>
+            <SidebarGroupLabel>Recent</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {recordings.map((recording) => {
+                  const displayTitle = recording.analysisTitle || recording.title;
+                  const isAnalyzed = recording.analysisTitle !== null;
+                  return (
+                    <SidebarMenuItem key={recording.id}>
+                      <SidebarMenuButton
+                        isActive={recording.id === selectedRecordingId}
+                        className="h-auto py-1.5"
+                        render={
+                          <Link
+                            to="/recordings/$id"
+                            params={{ id: recording.id }}
+                            className="flex items-center gap-2"
+                          />
+                        }
+                      >
+                        <MicIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center justify-between gap-2">
+                            <span className="truncate text-sm">{displayTitle}</span>
+                            <span className="shrink-0 text-[10px] text-muted-foreground">
+                              {formatDate(recording.startedAt)}
+                            </span>
+                          </div>
+                          <div className="flex items-center justify-between gap-2 text-[10px] text-muted-foreground">
+                            <span>
+                              {formatDuration(recording.durationMs)}
+                              {' · '}
+                              <span className={isAnalyzed ? 'text-success' : undefined}>
+                                {isAnalyzed ? 'Analyzed' : 'Not analyzed'}
+                              </span>
+                            </span>
+                            <span>{formatTime(recording.startedAt)}</span>
+                          </div>
+                        </div>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-3 px-4 py-12 text-center">
+            <MicIcon className="size-8 text-muted-foreground/40" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-muted-foreground">No recordings yet</p>
+              <p className="text-xs text-muted-foreground/70">
+                Start a recording to capture meeting audio.
+              </p>
+            </div>
+          </div>
+        )}
+      </SidebarContent>
+    </>
+  );
+}

--- a/packages/server/src/recordings/service.ts
+++ b/packages/server/src/recordings/service.ts
@@ -34,8 +34,15 @@ const log = Log.create({ service: 'recordings' });
 
 function defaultTitle(): string {
   const now = new Date();
-  const date = now.toISOString().slice(0, 19).replace('T', ' ');
-  return `Meeting recording ${date}`;
+  const month = now.toLocaleDateString(undefined, { month: 'short' });
+  const day = now.getDate();
+  const year = now.getFullYear();
+  const timePart = now.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZoneName: 'short',
+  });
+  return `${month} ${day} ${year} ${timePart}`;
 }
 
 function toRecording(row: RecordingRow, analysisTitle: string | null = null): Recording {


### PR DESCRIPTION
## 🚀 Change Summary

Comprehensive UX improvements to the recordings feature — adding an expandable sidebar for quick navigation, inline audio playback on the analysis page, and making the recordings list more interactive and informative.

### ✨ New Features
- **Recordings Sidebar**: Expandable/collapsible sidebar (matching chat sidebar pattern) showing all recordings with duration, analysis status, and timestamps
- **Inline Audio Player**: Play/pause/reset audio directly from the recording analysis header with a progress bar and time display
- **Delete from Analysis Page**: Delete recordings directly from the analysis view with a confirmation dialog for recordings over 30 seconds

### 🛠 Improvements & Refactors
- Clickable table rows in the recordings list that navigate to the analysis page
- Renamed Status column to Capturing and removed redundant View Analysis button
- Hide metric cards (Decisions, Action Items, Risks, Open Questions) when all values are zero
- Cleaned up analysis header: removed subtitle, removed status badges for completed/processing/failed states
- Default recording titles now use local time format (e.g. "Apr 10 2026 7:48 PM EDT")
- Updated input placeholder to include example title
- 1-indexed turn numbers in topic analysis cards

### 🐛 Bug Fixes
- Fixed active recording timer briefly showing negative values when starting a new recording
- Fixed sparkles icon being invisible on the dark "Analyze recording" button