### PR TITLE
fix(release): remove macOS Intel path from release and download UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,11 +133,6 @@ jobs:
             arch: arm64
             rust_target: aarch64-apple-darwin
             package_script: package
-          - runner: macos-14
-            os: macos
-            arch: x64
-            rust_target: x86_64-apple-darwin
-            package_script: package:x64
     steps:
       - name: Checkout release commit
         uses: actions/checkout@v5

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -893,13 +893,9 @@
           <a class="btn btn-primary" href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-windows-setup.exe">
             Windows
           </a>
-          <details class="btn-group">
-            <summary>macOS</summary>
-            <div class="btn-dropdown">
-              <a href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-macos-arm64.dmg">Apple Silicon</a>
-              <a href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-macos-x64.dmg">Intel</a>
-            </div>
-          </details>
+          <a class="btn" href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-macos-arm64.dmg">
+            macOS
+          </a>
         </div>
         <p class="hero-meta">
           Free &amp; open source &nbsp;&middot;&nbsp;
@@ -1234,13 +1230,9 @@
           <a class="btn btn-primary" href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-windows-setup.exe">
             Windows
           </a>
-          <details class="btn-group">
-            <summary>macOS</summary>
-            <div class="btn-dropdown">
-              <a href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-macos-arm64.dmg">Apple Silicon</a>
-              <a href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-macos-x64.dmg">Intel</a>
-            </div>
-          </details>
+          <a class="btn" href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-macos-arm64.dmg">
+            macOS
+          </a>
           <a class="btn" href="https://github.com/UseStitch/stitch">GitHub</a>
         </div>
       </div>


### PR DESCRIPTION
## 🚀 Change Summary
This updates release distribution to ship a single macOS artifact path and aligns website download actions with that packaging change.

### 🛠 Improvements & Refactors
- Removed the macOS Intel (x64) build target from the release workflow matrix so only Apple Silicon (arm64) artifacts are produced
- Replaced macOS dropdown selectors in the website hero and CTA with a single direct macOS download button matching the release asset