### PR TITLE
chore(ci): align PR and release workflow checks by OS

### DIFF
--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -33,15 +33,9 @@ jobs:
               - '!.github/CODEOWNERS'
 
   check:
-    name: check (${{ matrix.os }})
+    name: check (linux)
     needs: filter
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - windows-latest
-          - macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         if: needs.filter.outputs.run-ci == 'true'
@@ -71,6 +65,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
+      - name: Run typecheck
+        if: needs.filter.outputs.run-ci == 'true'
+        run: bun run typecheck
+
       - name: Run tests
         if: needs.filter.outputs.run-ci == 'true'
         run: bun run test
@@ -78,7 +76,3 @@ jobs:
       - name: Run Rust tests
         if: needs.filter.outputs.run-ci == 'true'
         run: cargo test --manifest-path packages/audio-native/Cargo.toml
-
-      - name: Run typecheck
-        if: needs.filter.outputs.run-ci == 'true'
-        run: bun run typecheck

--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -49,6 +49,10 @@ jobs:
         if: needs.filter.outputs.run-ci == 'true'
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Linux Rust test dependencies
+        if: needs.filter.outputs.run-ci == 'true' && runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev pkg-config
+
       - name: Cache Rust dependencies
         if: needs.filter.outputs.run-ci == 'true'
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,8 +117,55 @@ jobs:
           git push origin HEAD:master
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-  build:
+  check:
+    name: check (${{ matrix.os }})
     needs: version
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - windows-latest
+          - macos-latest
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.version.outputs.commit }}
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/audio-native
+          shared-key: release-check-${{ runner.os }}
+
+      - name: Cache Turbo artifacts
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('**/bun.lock', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
+      - name: Run typecheck
+        run: bun run typecheck
+
+      - name: Run tests
+        run: bun run test
+
+      - name: Run Rust tests
+        run: cargo test --manifest-path packages/audio-native/Cargo.toml
+
+  build:
+    needs:
+      - version
+      - check
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         os:
+          - ubuntu-latest
           - windows-latest
           - macos-latest
     steps:


### PR DESCRIPTION
## 🚀 Change Summary
This updates CI workflow coverage so PR and release validation run on the intended OS targets while keeping release automation manual.

### ✨ New Features
- **Release pre-build validation matrix**: Adds a `check` stage to `release.yml` that runs typecheck, test, and cargo test on both Windows and macOS before package builds start.

### 🛠 Improvements & Refactors
- **pr-master simplification**: Reduces `pr-master` checks to a single Linux runner for faster feedback while retaining typecheck, test, and cargo test.
- **Warm-cache coverage**: Expands warm-cache to include Linux in addition to Windows and macOS.

### 🐛 Bug Fixes
- N/A

### 📚 Documentation
- N/A