### PR TITLE
fix(chat): add thin scrollbar for overflowing input

### DIFF
--- a/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
@@ -161,7 +161,7 @@ export function ChatInputInner({
         className={cn(
           'w-full resize-none bg-transparent px-4 pt-4 pb-2 text-sm leading-relaxed outline-none',
           'placeholder:text-muted-foreground/60',
-          'max-h-48 overflow-y-auto',
+          'max-h-48 overflow-y-auto thin-scrollbar',
           'field-sizing-content',
           disabled && 'cursor-not-allowed',
         )}

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -141,6 +141,28 @@
 }
 
 @layer utilities {
+  .thin-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+  }
+
+  .thin-scrollbar::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .thin-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .thin-scrollbar::-webkit-scrollbar-thumb {
+    background-color: var(--border);
+    border-radius: 9999px;
+  }
+
+  .thin-scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: var(--muted-foreground);
+  }
+
   .shadow-success-glow {
     box-shadow: 0 0 8px var(--success);
   }


### PR DESCRIPTION
## 🚀 Change Summary
Adds a subtle thin scrollbar style to the main chat composer textarea when content overflows, improving readability and polish while keeping the existing theme tokens and component structure intact.

### ✨ New Features
- **Reusable Thin Scrollbar Utility**: Introduces a 	hin-scrollbar utility class in global styles with cross-browser support (Firefox and WebKit-based browsers).

### 🛠 Improvements & Refactors
- Applies the new scrollbar utility to the main chat input textarea so overflow mode uses a slim, rounded scrollbar that matches existing semantic color tokens.

### 🐛 Bug Fixes
- None.

### 📚 Documentation
- None.