### PR TITLE
fix(tools): surface tool failures during streaming

### DIFF
--- a/packages/server/__test__/llm/stream/stream-accumulator.test.ts
+++ b/packages/server/__test__/llm/stream/stream-accumulator.test.ts
@@ -204,6 +204,26 @@ describe('StreamAccumulator', () => {
       expect(toolStateCalls[1][1]).toMatchObject({ status: 'completed' });
     });
 
+    test('broadcasts error status when a tool-result contains an error payload', async () => {
+      const acc = createAccumulator();
+
+      await acc.handlePart({
+        type: 'tool-result',
+        toolCallId: 'call_1',
+        toolName: 'browser',
+        input: { action: 'snapshot' },
+        output: { error: 'Navigation failed' },
+      });
+
+      const toolStateCalls = getBroadcastCalls('stream-tool-state');
+      expect(toolStateCalls).toHaveLength(1);
+      expect(toolStateCalls[0][1]).toMatchObject({
+        status: 'error',
+        toolName: 'browser',
+        error: 'Navigation failed',
+      });
+    });
+
     test('broadcasts stream-tool-state pending for tool-input-start', async () => {
       const acc = createAccumulator();
 

--- a/packages/server/__test__/tools/browser.test.ts
+++ b/packages/server/__test__/tools/browser.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'vitest';
 
 // Test the abort rethrow logic in isolation — we want to confirm that the
 // execute handler rethrows DOMException AbortErrors and converts other errors
-// to { error } objects.
+// to thrown Error objects.
 //
 // We test this by calling the inner logic directly rather than using
 // module mocking, which avoids ESM cache invalidation issues in tests.
@@ -13,7 +13,7 @@ async function executeWithAbort(action: () => Promise<unknown>): Promise<unknown
   } catch (error) {
     if (error instanceof DOMException && error.name === 'AbortError') throw error;
     const message = error instanceof Error ? error.message : String(error);
-    return { error: message };
+    throw new Error(message);
   }
 }
 
@@ -25,9 +25,10 @@ describe('browser tool abort contract', () => {
     );
   });
 
-  test('converts non-abort errors to { error } objects', async () => {
-    const result = await executeWithAbort(() => Promise.reject(new Error('CDP connection failed')));
-    expect(result).toMatchObject({ error: 'CDP connection failed' });
+  test('converts non-abort errors to thrown Error', async () => {
+    await expect(executeWithAbort(() => Promise.reject(new Error('CDP connection failed')))).rejects.toThrow(
+      'CDP connection failed',
+    );
   });
 
   test('returns result when action succeeds', async () => {

--- a/packages/server/__test__/tools/toolset-management.test.ts
+++ b/packages/server/__test__/tools/toolset-management.test.ts
@@ -97,4 +97,22 @@ describe('toolset management tools', () => {
       prompts: [{ name: 'demo', description: 'Demo prompt' }],
     });
   });
+
+  test('list_toolsets throws when unknown toolsetId is requested', async () => {
+    const manager = createManager();
+    const tools = createToolsetTools(manager);
+
+    await expect(
+      tools.list_toolsets.execute?.({ toolsetId: 'missing-toolset' }, {} as never),
+    ).rejects.toThrow('Unknown toolset');
+  });
+
+  test('activate_toolset throws when unknown toolsetId is requested', async () => {
+    const manager = createManager();
+    const tools = createToolsetTools(manager);
+
+    await expect(
+      tools.activate_toolset.execute?.({ toolsetId: 'missing-toolset' }, {} as never),
+    ).rejects.toThrow('Unknown toolset');
+  });
 });

--- a/packages/server/__test__/tools/wrappers.test.ts
+++ b/packages/server/__test__/tools/wrappers.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, test } from 'vitest';
 import { z } from 'zod';
 
 import { PATHS } from '@/lib/paths.js';
-import { withTruncation } from '@/tools/runtime/wrappers.js';
+import { withToolResultHandling, withTruncation } from '@/tools/runtime/wrappers.js';
 
 describe('withTruncation', () => {
   test('returns compact result when truncation is triggered', async () => {
@@ -49,5 +49,59 @@ describe('withTruncation', () => {
     const result = await wrapped.execute?.({}, {} as never);
 
     expect(result).toEqual({ output: 'small output' });
+  });
+});
+
+describe('withToolResultHandling', () => {
+  test('throws when tool returns an error-shaped result', async () => {
+    const wrapped = withToolResultHandling(
+      tool({
+        description: 'test tool',
+        inputSchema: z.object({}),
+        execute: async () => ({ error: 'boom' }),
+      }),
+    );
+
+    await expect(wrapped.execute?.({}, {} as never)).rejects.toThrow('boom');
+  });
+
+  test('unwraps data result payloads', async () => {
+    const wrapped = withToolResultHandling(
+      tool({
+        description: 'test tool',
+        inputSchema: z.object({}),
+        execute: async () => ({ data: { ok: true } }),
+      }),
+    );
+
+    await expect(wrapped.execute?.({}, {} as never)).resolves.toEqual({ ok: true });
+  });
+
+  test('preserves plain legacy results', async () => {
+    const wrapped = withToolResultHandling(
+      tool({
+        description: 'test tool',
+        inputSchema: z.object({}),
+        execute: async () => ({ output: 'hello' }),
+      }),
+    );
+
+    await expect(wrapped.execute?.({}, {} as never)).resolves.toEqual({ output: 'hello' });
+  });
+
+  test('does not treat generic objects containing error as tool failures', async () => {
+    const wrapped = withToolResultHandling(
+      tool({
+        description: 'test tool',
+        inputSchema: z.object({}),
+        execute: async () => ({ error: 'non-fatal', matches: [], total: 0 }),
+      }),
+    );
+
+    await expect(wrapped.execute?.({}, {} as never)).resolves.toEqual({
+      error: 'non-fatal',
+      matches: [],
+      total: 0,
+    });
   });
 });

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -31,6 +31,7 @@ import { processMemories } from '@/memory/processor.js';
 import { createTaskTool } from '@/tools/core/task.js';
 import { createToolsetTools } from '@/tools/core/toolset-management.js';
 import { createTools, MAX_STEPS, MAX_STEPS_WARNING } from '@/tools/runtime/registry.js';
+import { withToolResultHandling, withToolResultHandlingRecord } from '@/tools/runtime/wrappers.js';
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { recordUsageEvent } from '@/usage/ledger.js';
 import { calculateMessageCostUsd } from '@/utils/cost.js';
@@ -1271,17 +1272,19 @@ export async function runStream(opts: {
   const coreStitchTools = createTools(toolContext);
 
   // Build meta-tools (bound to this session's toolset manager)
-  const toolsetMetaTools = createToolsetTools(toolsetManager);
+  const toolsetMetaTools = withToolResultHandlingRecord(createToolsetTools(toolsetManager));
 
   // Build task tool (bound to this session's context)
-  const taskTool = createTaskTool(toolContext, {
-    parentSessionId: opts.sessionId,
-    parentAbortSignal: opts.abortSignal,
-    credentials: opts.credentials,
-    modelId: opts.modelId,
-    providerId: opts.credentials.providerId,
-    toolsetManager,
-  });
+  const taskTool = withToolResultHandling(
+    createTaskTool(toolContext, {
+      parentSessionId: opts.sessionId,
+      parentAbortSignal: opts.abortSignal,
+      credentials: opts.credentials,
+      modelId: opts.modelId,
+      providerId: opts.credentials.providerId,
+      toolsetManager,
+    }),
+  );
 
   // Combine all always-active tools
   const coreTools: Record<string, Tool> = {

--- a/packages/server/src/llm/stream/stream-accumulator.ts
+++ b/packages/server/src/llm/stream/stream-accumulator.ts
@@ -1,6 +1,7 @@
 import type { PartId, StoredPart } from '@stitch/shared/chat/messages';
 import type { PrefixedString } from '@stitch/shared/id';
 import { createPartId } from '@stitch/shared/id';
+import { isToolErrorResult } from '@stitch/shared/tools/types';
 
 import * as Log from '@/lib/log.js';
 import * as Sse from '@/lib/sse.js';
@@ -250,15 +251,16 @@ export class StreamAccumulator {
         const partId = createPartId();
         const truncationMeta = this.getToolTruncationMeta(part.output);
         const sanitizedOutput = this.stripToolTruncationMeta(part.output);
+        const fallbackError = isToolErrorResult(sanitizedOutput) ? sanitizedOutput.error : undefined;
 
         await this.broadcast('stream-tool-state', {
           sessionId: this.sessionId,
           messageId: this.messageId,
           toolCallId: part.toolCallId,
           toolName: part.toolName,
-          status: 'completed',
+          status: fallbackError ? 'error' : 'completed',
           input: part.input,
-          output: sanitizedOutput,
+          ...(fallbackError ? { error: fallbackError } : { output: sanitizedOutput }),
         });
 
         this.accumulatedParts.push({

--- a/packages/server/src/tools/core/browser.ts
+++ b/packages/server/src/tools/core/browser.ts
@@ -544,7 +544,7 @@ function createBrowserTool() {
       } catch (error) {
         if (error instanceof DOMException && error.name === 'AbortError') throw error;
         const message = error instanceof Error ? error.message : String(error);
-        return { error: message };
+        throw new Error(message);
       }
     },
   });

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -33,9 +33,9 @@ export function createToolsetTools(manager: ToolsetManager) {
 
       const toolset = getToolset(toolsetId);
       if (!toolset) {
-        return {
-          error: `Unknown toolset: "${toolsetId}". Use list_toolsets with no arguments to see available IDs.`,
-        };
+        throw new Error(
+          `Unknown toolset: "${toolsetId}". Use list_toolsets with no arguments to see available IDs.`,
+        );
       }
 
       const tools = toolset.tools();
@@ -83,9 +83,9 @@ export function createToolsetTools(manager: ToolsetManager) {
 
       const toolNames = await manager.activate(toolsetId);
       if (toolNames === null) {
-        return {
-          error: `Unknown toolset: "${toolsetId}". Use list_toolsets with no arguments to see available IDs.`,
-        };
+        throw new Error(
+          `Unknown toolset: "${toolsetId}". Use list_toolsets with no arguments to see available IDs.`,
+        );
       }
 
       const toolset = getToolset(toolsetId);

--- a/packages/server/src/tools/runtime/registry.ts
+++ b/packages/server/src/tools/runtime/registry.ts
@@ -37,6 +37,7 @@ import {
   createRegisteredTool as createWriteRegisteredTool,
   DISPLAY_NAME as WRITE_DISPLAY_NAME,
 } from '@/tools/core/write.js';
+import { withToolResultHandlingRecord } from '@/tools/runtime/wrappers.js';
 
 export const MAX_STEPS = 25;
 
@@ -97,10 +98,12 @@ export function createTools(context: {
   messageId: PrefixedString<'msg'>;
   streamRunId: string;
 }) {
-  return Object.fromEntries(
-    Object.entries(STITCH_TOOL_MODULES).map(([name, mod]) => [
-      name,
-      mod.createRegisteredTool(context),
-    ]),
+  return withToolResultHandlingRecord(
+    Object.fromEntries(
+      Object.entries(STITCH_TOOL_MODULES).map(([name, mod]) => [
+        name,
+        mod.createRegisteredTool(context),
+      ]),
+    ),
   );
 }

--- a/packages/server/src/tools/runtime/wrappers.ts
+++ b/packages/server/src/tools/runtime/wrappers.ts
@@ -1,5 +1,6 @@
 import type { PrefixedString } from '@stitch/shared/id';
 import type { PermissionSuggestion } from '@stitch/shared/permissions/types';
+import { isToolDataResult, isToolErrorResult } from '@stitch/shared/tools/types';
 
 import * as Log from '@/lib/log.js';
 import { PermissionRejectedError, StreamProtocolViolationError } from '@/llm/stream/errors.js';
@@ -138,4 +139,31 @@ export function withPermissionGate<T extends Tool>(
   };
 
   return { ...t, execute: wrappedExecute } as T;
+}
+
+export function withToolResultHandling<T extends Tool>(t: T): T {
+  const originalExecute = t.execute;
+  if (!originalExecute) return t;
+
+  const wrappedExecute = async (...args: Parameters<typeof originalExecute>) => {
+    const result = await originalExecute(...args);
+
+    if (isToolErrorResult(result)) {
+      throw new Error(result.error);
+    }
+
+    if (isToolDataResult(result)) {
+      return result.data;
+    }
+
+    return result;
+  };
+
+  return { ...t, execute: wrappedExecute } as T;
+}
+
+export function withToolResultHandlingRecord<T extends Record<string, Tool>>(tools: T): T {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, tool]) => [name, withToolResultHandling(tool)]),
+  ) as T;
 }

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -1,4 +1,5 @@
 import * as Log from '@/lib/log.js';
+import { withToolResultHandlingRecord } from '@/tools/runtime/wrappers.js';
 import type { ToolContext } from '@/tools/runtime/wrappers.js';
 import { getToolset, listToolsets } from '@/tools/toolsets/registry.js';
 import type { ConnectorIconSource } from '@stitch/shared/connectors/types';
@@ -39,7 +40,7 @@ export class ToolsetManager {
       return null;
     }
 
-    const tools = await toolset.activate(this.context);
+    const tools = withToolResultHandlingRecord(await toolset.activate(this.context));
     this.activeIds.add(toolsetId);
     this.activeToolCache.set(toolsetId, tools);
 

--- a/packages/shared/src/tools/types.ts
+++ b/packages/shared/src/tools/types.ts
@@ -1,3 +1,40 @@
 export const TOOL_TYPES = ['stitch', 'mcp', 'plugin'] as const;
 
 export type ToolType = (typeof TOOL_TYPES)[number];
+
+export type ToolDataResult<T = unknown> = {
+  data: T;
+  error?: never;
+  details?: never;
+};
+
+export type ToolErrorResult = {
+  error: string;
+  details?: unknown;
+  data?: never;
+};
+
+export type ToolResult<T = unknown> = ToolDataResult<T> | ToolErrorResult;
+
+export function isToolErrorResult(value: unknown): value is ToolErrorResult {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as { error?: unknown; details?: unknown };
+  if (typeof candidate.error !== 'string' || candidate.error.length === 0) {
+    return false;
+  }
+
+  const keys = Object.keys(value as Record<string, unknown>);
+  return keys.every((key) => key === 'error' || key === 'details');
+}
+
+export function isToolDataResult<T = unknown>(value: unknown): value is ToolDataResult<T> {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as { data?: unknown; error?: unknown };
+  return 'data' in candidate && !('error' in candidate);
+}


### PR DESCRIPTION
## 🚀 Change Summary
Tool failures now transition to error state immediately during streaming instead of waiting for the full assistant turn to finish.

### 🛠 Improvements & Refactors
- Added a shared tool result contract (ToolResult) with type guards in packages/shared/src/tools/types.ts.
- Introduced runtime normalization wrappers to handle result envelopes consistently across core tools, toolsets, MCP tools, connector tools, task, and toolset meta-tools.
- Updated stream accumulation to treat canonical error-shaped tool results as rror status when broadcasting tool state.

### 🐛 Bug Fixes
- Replaced remaining top-level { error: string } soft-failure returns in tool implementations with thrown errors so failures are surfaced as real tool errors while streaming.
- Added/updated tests for wrappers, toolset-management unknown toolset behavior, browser error behavior, and stream tool-state error broadcasting.