### PR TITLE
fix(onboarding): invalidate embedding model cache on provider save

### DIFF
--- a/apps/web/src/lib/mutations/provider-config.ts
+++ b/apps/web/src/lib/mutations/provider-config.ts
@@ -28,6 +28,8 @@ async function invalidateProviderQueries(queryClient: QueryClient): Promise<void
     queryClient.invalidateQueries({ queryKey: providerKeys.list() }),
     queryClient.invalidateQueries({ queryKey: providerKeys.enabledModels() }),
     queryClient.invalidateQueries({ queryKey: providerKeys.visibleModels() }),
+    queryClient.invalidateQueries({ queryKey: providerKeys.embeddingModels() }),
+    queryClient.invalidateQueries({ queryKey: providerKeys.audioModels() }),
   ]);
 }
 


### PR DESCRIPTION
## Change Summary

Fixes a bug in the onboarding flow where navigating back from the memory step to add a provider with embedding models would still show 'No embedding models' on return, because the embedding model query cache was never invalidated.

### Bug Fixes

- **Stale embedding model cache in onboarding**: `invalidateProviderQueries` now invalidates `embeddingModels` and `audioModels` caches in addition to the existing `list`, `enabledModels`, and `visibleModels` caches. Previously, saving a provider config left these caches stale (1-hour staleTime), so the memory step would show an empty model list even after a new provider with embedding models was connected.