### PR TITLE
fix(providers): use dropdown selector for Amazon Bedrock region with backend enum validation

### DIFF
--- a/apps/web/src/components/provider-config/field-group.tsx
+++ b/apps/web/src/components/provider-config/field-group.tsx
@@ -11,51 +11,20 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
-const AWS_BEDROCK_REGIONS = [
-  { value: 'us-east-1', label: 'US East (N. Virginia)' },
-  { value: 'us-east-2', label: 'US East (Ohio)' },
-  { value: 'us-west-1', label: 'US West (N. California)' },
-  { value: 'us-west-2', label: 'US West (Oregon)' },
-  { value: 'eu-west-1', label: 'Europe (Ireland)' },
-  { value: 'eu-west-2', label: 'Europe (London)' },
-  { value: 'eu-west-3', label: 'Europe (Paris)' },
-  { value: 'eu-central-1', label: 'Europe (Frankfurt)' },
-  { value: 'eu-central-2', label: 'Europe (Zurich)' },
-  { value: 'eu-north-1', label: 'Europe (Stockholm)' },
-  { value: 'ap-east-1', label: 'Asia Pacific (Hong Kong)' },
-  { value: 'ap-south-1', label: 'Asia Pacific (Mumbai)' },
-  { value: 'ap-south-2', label: 'Asia Pacific (Hyderabad)' },
-  { value: 'ap-southeast-1', label: 'Asia Pacific (Singapore)' },
-  { value: 'ap-southeast-2', label: 'Asia Pacific (Sydney)' },
-  { value: 'ap-southeast-3', label: 'Asia Pacific (Jakarta)' },
-  { value: 'ap-northeast-1', label: 'Asia Pacific (Tokyo)' },
-  { value: 'ap-northeast-2', label: 'Asia Pacific (Seoul)' },
-  { value: 'ap-northeast-3', label: 'Asia Pacific (Osaka)' },
-  { value: 'ca-central-1', label: 'Canada (Central)' },
-  { value: 'sa-east-1', label: 'South America (São Paulo)' },
-  { value: 'me-west-1', label: 'Middle East (UAE)' },
-  { value: 'me-central-1', label: 'Middle East (UAE)' },
-  { value: 'af-south-1', label: 'Africa (Cape Town)' },
-];
-
 export function FieldGroup({
   fields,
   providerId,
   values,
   onChange,
-  enableBedrockRegionSelect = false,
 }: {
   fields: FieldDef[];
   providerId: string;
   values: FieldValues;
   onChange: (key: string, value: string) => void;
-  enableBedrockRegionSelect?: boolean;
 }) {
   if (fields.length === 0) {
     return null;
   }
-
-  const isBedrock = enableBedrockRegionSelect && providerId.startsWith('amazon-bedrock');
 
   return (
     <div className="flex flex-col gap-3">
@@ -67,18 +36,20 @@ export function FieldGroup({
               <span className="ml-1 text-xs text-muted-foreground">(optional)</span>
             ) : null}
           </Label>
-          {isBedrock && field.key === 'region' ? (
+          {field.type === 'select' ? (
             <Select
               value={values[field.key] ?? ''}
               onValueChange={(value) => onChange(field.key, value || '')}
             >
               <SelectTrigger id={`${providerId}-${field.key}`} className="w-full">
-                <SelectValue placeholder={field.placeholder} />
+                <SelectValue placeholder={field.placeholder}>
+                  {field.options.find((o) => o.value === values[field.key])?.label ?? values[field.key]}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent className="max-h-80 max-w-none">
-                {AWS_BEDROCK_REGIONS.map((region) => (
-                  <SelectItem key={region.value} value={region.value}>
-                    {region.label} ({region.value})
+                {field.options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/apps/web/src/components/settings/provider-config.tsx
+++ b/apps/web/src/components/settings/provider-config.tsx
@@ -157,7 +157,6 @@ export function ProviderConfig({ provider, onBack }: Props) {
             providerId={provider.id}
             values={extraFields}
             onChange={handleExtraFieldChange}
-            enableBedrockRegionSelect
           />
         )}
 
@@ -184,7 +183,6 @@ export function ProviderConfig({ provider, onBack }: Props) {
                         [m.method]: { ...prev[m.method], [key]: value },
                       }))
                     }
-                    enableBedrockRegionSelect
                   />
                 ) : (
                   <NoFieldsNote method={m.method} />
@@ -200,7 +198,6 @@ export function ProviderConfig({ provider, onBack }: Props) {
               providerId={provider.id}
               values={currentMethodFields}
               onChange={handleMethodFieldChange}
-              enableBedrockRegionSelect
             />
           ) : (
             <NoFieldsNote method={activeMethodDef.method} />

--- a/packages/server/src/llm/provider/provider.ts
+++ b/packages/server/src/llm/provider/provider.ts
@@ -8,10 +8,13 @@ import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { createGateway } from 'ai';
 import { z } from 'zod';
+import { AWS_BEDROCK_REGIONS } from '@stitch/shared/providers/types';
+
+const AWS_REGION_VALUES = AWS_BEDROCK_REGIONS.map((r) => r.value) as [string, ...string[]];
 
 const BedrockCredentialsSchema = z.object({
   providerId: z.literal('amazon-bedrock'),
-  region: z.string().optional(),
+  region: z.enum(AWS_REGION_VALUES).optional(),
   auth: z.discriminatedUnion('method', [
     z.object({ method: z.literal('api-key'), apiKey: z.string() }),
     z.object({

--- a/packages/shared/src/providers/catalog.ts
+++ b/packages/shared/src/providers/catalog.ts
@@ -1,3 +1,4 @@
+import { AWS_BEDROCK_REGIONS } from './types.js';
 import type { ProviderId, ProviderMeta } from './types.js';
 
 export const PROVIDER_META: Record<ProviderId, ProviderMeta> = {
@@ -121,6 +122,8 @@ export const PROVIDER_META: Record<ProviderId, ProviderMeta> = {
         placeholder: 'Select a region',
         required: true,
         secret: false,
+        type: 'select',
+        options: AWS_BEDROCK_REGIONS.map((r) => ({ value: r.value, label: `${r.label} (${r.value})` })),
       },
     ],
     authMethods: [

--- a/packages/shared/src/providers/types.ts
+++ b/packages/shared/src/providers/types.ts
@@ -1,10 +1,45 @@
-export type FieldDef = {
+export const AWS_BEDROCK_REGIONS = [
+  { value: 'us-east-1', label: 'US East (N. Virginia)' },
+  { value: 'us-east-2', label: 'US East (Ohio)' },
+  { value: 'us-west-1', label: 'US West (N. California)' },
+  { value: 'us-west-2', label: 'US West (Oregon)' },
+  { value: 'eu-west-1', label: 'Europe (Ireland)' },
+  { value: 'eu-west-2', label: 'Europe (London)' },
+  { value: 'eu-west-3', label: 'Europe (Paris)' },
+  { value: 'eu-central-1', label: 'Europe (Frankfurt)' },
+  { value: 'eu-central-2', label: 'Europe (Zurich)' },
+  { value: 'eu-north-1', label: 'Europe (Stockholm)' },
+  { value: 'ap-east-1', label: 'Asia Pacific (Hong Kong)' },
+  { value: 'ap-south-1', label: 'Asia Pacific (Mumbai)' },
+  { value: 'ap-south-2', label: 'Asia Pacific (Hyderabad)' },
+  { value: 'ap-southeast-1', label: 'Asia Pacific (Singapore)' },
+  { value: 'ap-southeast-2', label: 'Asia Pacific (Sydney)' },
+  { value: 'ap-southeast-3', label: 'Asia Pacific (Jakarta)' },
+  { value: 'ap-northeast-1', label: 'Asia Pacific (Tokyo)' },
+  { value: 'ap-northeast-2', label: 'Asia Pacific (Seoul)' },
+  { value: 'ap-northeast-3', label: 'Asia Pacific (Osaka)' },
+  { value: 'ca-central-1', label: 'Canada (Central)' },
+  { value: 'sa-east-1', label: 'South America (São Paulo)' },
+  { value: 'me-west-1', label: 'Middle East (UAE)' },
+  { value: 'me-central-1', label: 'Middle East (UAE)' },
+  { value: 'af-south-1', label: 'Africa (Cape Town)' },
+] as const;
+
+export type AwsBedrockRegion = (typeof AWS_BEDROCK_REGIONS)[number]['value'];
+
+type BaseFieldDef = {
   key: string;
   label: string;
   placeholder?: string;
   required: boolean;
   secret: boolean;
 };
+
+type SelectOption = { value: string; label: string };
+
+export type FieldDef =
+  | (BaseFieldDef & { type?: 'text' })
+  | (BaseFieldDef & { type: 'select'; options: SelectOption[] });
 
 export type AuthMethodDef = {
   method: string;


### PR DESCRIPTION
## Change Summary

Replaces the free-text region input for Amazon Bedrock with a dropdown selector, ensuring users can only pick a valid AWS region. The backend now validates the submitted region against the same known-regions list.

### New Features
- **Region Dropdown**: Amazon Bedrock region is now a dropdown showing \Region Name (region-code)\ instead of a plain text input

### Improvements & Refactors
- \AWS_BEDROCK_REGIONS\ constant and the \FieldDef\ discriminated union (adding \	ype: 'select'\ with \options\) moved to \@stitch/shared\ so the catalog, UI, and backend all share a single source of truth
- \ield-group.tsx\ now renders a \Select\ for any field with \	ype === 'select'\, removing the previous \nableBedrockRegionSelect\ prop hack
- Selected label is explicitly resolved in the trigger so the human-readable name displays correctly when the dropdown is closed

### Bug Fixes
- Backend \BedrockCredentialsSchema\ now uses \z.enum\ over the known region values instead of \z.string()\, rejecting invalid region codes at the validation boundary