### PR TITLE
fix(sidecar): pass STITCH_AUDIO_CAPTURE_BIN to server process when packaged

### DIFF
--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -77,14 +77,22 @@ export async function spawnServer(port: number): Promise<string> {
 
   console.log(`[sidecar] spawning: ${cmd} ${args.join(' ')}`);
 
+  const sidecarEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    NODE_ENV: app.isPackaged ? 'production' : 'development',
+    STITCH_APP_NAME: app.isPackaged ? 'stitch' : 'stitch-dev',
+  };
+
+  if (app.isPackaged) {
+    const suffix = process.platform === 'win32' ? '.exe' : '';
+    const audioCaptureBin = join(process.resourcesPath, 'audio-capture', `stitch-audio-capture${suffix}`);
+    sidecarEnv.STITCH_AUDIO_CAPTURE_BIN = audioCaptureBin;
+  }
+
   serverProcess = spawn(cmd, args, {
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
-    env: {
-      ...process.env,
-      NODE_ENV: app.isPackaged ? 'production' : 'development',
-      STITCH_APP_NAME: app.isPackaged ? 'stitch' : 'stitch-dev',
-    },
+    env: sidecarEnv,
     ...(cwd && { cwd }),
   });
 


### PR DESCRIPTION
## Change Summary

Fixes recording failing in the packaged app with 'Native audio capture binary was not found' despite the binary being present in the installed resources.

### Bug Fixes
- **Audio capture binary not found in packaged app**: The `stitch-server` runs as a standalone child process without access to `process.resourcesPath` (an Electron-only property). This meant `resolveNativeBinaryPath()` could never locate the bundled binary at `resources/audio-capture/stitch-audio-capture[.exe]`. The Electron main process now sets `STITCH_AUDIO_CAPTURE_BIN` in the sidecar's environment when running packaged, pointing to the exact binary path — works for both Windows (`.exe`) and macOS.