### PR TITLE
Improve prompt robustness for transcription and automation extraction

### DIFF
--- a/packages/server/src/automations/generation.ts
+++ b/packages/server/src/automations/generation.ts
@@ -126,6 +126,8 @@ function buildAutomationPrompt(input: {
   return [
     'Review the conversation and create an automation draft.',
     'Focus on the user goal and their feedback/corrections so instructions are precise and actionable.',
+    'Treat explicit user corrections, dislikes, and "do not" guidance as hard constraints.',
+    'When guidance conflicts, prioritize the latest explicit user instruction.',
     'The prompt field must be markdown formatted for readability.',
     '',
     `Known toolsets: ${availableToolsets}`,
@@ -137,6 +139,8 @@ function buildAutomationPrompt(input: {
     '- toolsets: only include toolset IDs that are actually relevant.',
     '- steps: 3-10 concise, ordered steps.',
     '- prompt: clear reusable automation instructions that reflect user feedback and use markdown formatting.',
+    '- prompt: include both positive goals (what to do) and explicit exclusions (what to avoid) from user guidance.',
+    '- prompt: do not reintroduce approaches the user rejected unless they later reversed that decision.',
   ].join('\n');
 }
 

--- a/packages/server/src/meeting/transcription-system-prompt.md
+++ b/packages/server/src/meeting/transcription-system-prompt.md
@@ -18,10 +18,13 @@ Do not invent content that is not present in the audio.
 - Return `transcript` as an array of objects, each with:
   - `speaker`: speaker label (see Speaker Identification below).
   - `content`: the spoken utterance text for that turn.
+- If the recording has no intelligible human speech (only silence, static, hum, keyboard sounds, music, room noise, or heavily distorted audio), return `transcript: []`.
+- Prefer an empty transcript over guessed words when confidence is low.
 - Keep speaker labels consistent throughout the full transcript.
 - Preserve meaning and important wording while using clean punctuation and sentence boundaries.
 - Do not merge different speakers into one transcript item.
 - If audio is unclear, use `[inaudible]` or `[unclear]` instead of guessing.
+- Do not convert non-speech sounds into words (for example, do not transcribe coughs, clicks, laughter-only segments, or background TV/music as dialogue).
 - Keep specialized terms, acronyms, product names, and technical language as spoken.
 - Do not include narrative commentary outside transcript utterances.
 
@@ -40,3 +43,4 @@ Do not invent content that is not present in the audio.
 
 - Output must conform to the schema field exactly: `transcript`.
 - Never fabricate speakers or content.
+- If there is insufficient speech evidence to produce a faithful transcript, output `transcript: []`.

--- a/packages/server/src/recordings/analysis-service.ts
+++ b/packages/server/src/recordings/analysis-service.ts
@@ -596,7 +596,10 @@ async function runRecordingAnalysis(
           role: 'user',
           content: [
             { type: 'file', data: audioData, mediaType: 'audio/ogg' },
-            { type: 'text', text: 'Please transcribe this recording.' },
+            {
+              type: 'text',
+              text: 'Please transcribe this recording. If there is no intelligible speech, return an empty transcript array.',
+            },
           ],
         },
       ],
@@ -605,7 +608,7 @@ async function runRecordingAnalysis(
 
     const transcript = normalizeTranscript(transcriptionResult.output?.transcript ?? []);
     if (transcript.length === 0) {
-      throw new Error('Transcription returned no speaker turns');
+      throw new Error('No intelligible speech detected in recording');
     }
 
     const transcriptionUsage = transcriptionResult.usage ?? ZERO_USAGE;


### PR DESCRIPTION
## 🚀 Change Summary
Improve prompt robustness in recording transcription and automation draft generation so silence/noise is less likely to produce hallucinated transcript text and user negative guidance is consistently reflected in generated automation prompts.

### ✨ New Features
- **No-speech guardrails in transcription prompt**: Adds explicit instructions to return an empty transcript when audio has no intelligible speech and to avoid turning non-speech noise into words.
- **Constraint-aware automation prompting**: Treats explicit user corrections and "do not" guidance as hard constraints, prioritizes latest explicit guidance, and includes exclusions in generated automation instructions.

### 🛠 Improvements & Refactors
- Reinforced transcription request-level instruction to return an empty transcript array when speech is unintelligible.
- Clarified empty-transcript failure messaging to reflect no intelligible speech detection.

### 🐛 Bug Fixes
- Reduces hallucinated transcription output for silence/background-noise recordings by tightening prompt constraints.
