### PR TITLE
improvement(desktop): reduce Windows install footprint

### DIFF
--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -16,6 +16,7 @@ const hasAudioCaptureResource = existsSync(audioCaptureResource.from);
 const config: Configuration = {
   appId: 'com.stitch.desktop',
   productName: 'Stitch',
+  electronLanguages: ['en-US'],
   publish: [
     {
       provider: 'github',

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "vitest run",
     "dev": "NODE_ENV=development bun --watch src/index.ts",
-    "build": "bun build src/index.ts --compile --outfile dist/stitch-server",
-    "build:x64": "bun build src/index.ts --compile --target=bun-darwin-x64 --outfile dist/stitch-server",
+    "build": "bun build src/index.ts --compile --minify --outfile dist/stitch-server",
+    "build:x64": "bun build src/index.ts --compile --minify --target=bun-darwin-x64 --outfile dist/stitch-server",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## 🚀 Change Summary

Reduces the packaged desktop installer size by trimming unnecessary Electron locale files and enabling minification on the Bun sidecar build.

### 🛠 Improvements & Refactors
- **Electron locale trimming**: Restrict bundled locales to `en-US` only via `electronLanguages`, removing ~40+ unused locale paks from the installer
- **Sidecar minification**: Add `--minify` flag to the server `bun build` commands, shrinking the compiled sidecar binary