### PR TITLE
improvement(recordings): add markdown copy button for analysis page

### DIFF
--- a/apps/web/src/components/recordings/analysis/analysis-header.tsx
+++ b/apps/web/src/components/recordings/analysis/analysis-header.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner';
 import type { RecordingAnalysis, Recording } from '@stitch/shared/recordings/types';
 
 import { Button } from '@/components/ui/button';
+import { CopyButton } from '@/components/ui/copy-button';
 import { Progress } from '@/components/ui/progress';
 import { getServerUrl } from '@/lib/api';
 
@@ -156,6 +157,7 @@ function AudioPlayer({
 
 interface AnalysisHeaderProps {
   analysis: RecordingAnalysis | null | undefined;
+  analysisMarkdown: string | null;
   recording: Recording | undefined;
   isRunning: boolean;
   isStarting: boolean;
@@ -168,6 +170,7 @@ interface AnalysisHeaderProps {
 
 export function AnalysisHeader({
   analysis,
+  analysisMarkdown,
   recording,
   isRunning,
   isStarting,
@@ -194,6 +197,14 @@ export function AnalysisHeader({
       <div className="flex items-center gap-3">
         {showPlayer ? (
           <AudioPlayer recordingId={recording.id} durationMs={recording.durationMs} />
+        ) : null}
+        {analysisMarkdown ? (
+          <CopyButton
+            value={analysisMarkdown}
+            copyLabel="Copy analysis markdown"
+            copiedLabel="Copied analysis"
+            className="shadow-sm"
+          />
         ) : null}
         <Button
           onClick={onStartAnalysis}

--- a/apps/web/src/components/recordings/recording-analysis-page.tsx
+++ b/apps/web/src/components/recordings/recording-analysis-page.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { toast } from 'sonner';
 
+import type { Recording, RecordingAnalysis } from '@stitch/shared/recordings/types';
+
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 
@@ -27,6 +29,106 @@ import {
   useStartRecordingAnalysis,
 } from '@/lib/queries/recordings';
 
+const ACTION_STATUS_LABEL: Record<string, string> = {
+  todo: 'To do',
+  in_progress: 'In progress',
+  done: 'Done',
+  unknown: 'Unknown',
+};
+
+function pushList(lines: string[], title: string, items: string[]): void {
+  if (!items.length) return;
+  lines.push(`**${title}**`);
+  lines.push(...items.map((item) => `- ${item}`));
+  lines.push('');
+}
+
+function buildAnalysisMarkdown(
+  analysis: RecordingAnalysis | null | undefined,
+  recording: Recording | undefined,
+): string | null {
+  if (!analysis) return null;
+
+  const lines: string[] = [];
+  const title = analysis.title || recording?.title || 'Recording analysis';
+
+  lines.push(`# ${title}`);
+  lines.push('');
+
+  if (analysis.summary.trim()) {
+    lines.push('## Executive Summary');
+    lines.push('');
+    lines.push(analysis.summary.trim());
+    lines.push('');
+  }
+
+  if (analysis.topicSections.length) {
+    lines.push('## Topic Analysis');
+    lines.push('');
+
+    analysis.topicSections.forEach((section, index) => {
+      lines.push(`### ${index + 1}. ${section.name}`);
+      lines.push('');
+      lines.push(`**Turns:** ${section.startTurn + 1}-${section.endTurn + 1}`);
+      lines.push('');
+
+      if (section.analysis.trim()) {
+        lines.push(section.analysis.trim());
+        lines.push('');
+      }
+
+      pushList(lines, 'Decisions', section.decisions);
+
+      if (section.actionItems.length) {
+        const actionItems = section.actionItems.map((item) => {
+          const metadata = [
+            `assignee: ${item.assignee ?? 'Unassigned'}`,
+            item.dueDate ? `due: ${item.dueDate}` : null,
+            `status: ${ACTION_STATUS_LABEL[item.status] ?? item.status}`,
+          ].filter(Boolean);
+
+          return `${item.task} (${metadata.join('; ')})`;
+        });
+
+        pushList(lines, 'Action Items', actionItems);
+      }
+
+      if (section.blockers.length) {
+        const blockers = section.blockers.map((blocker) => {
+          const metadata = [
+            `assignee: ${blocker.assignee ?? 'Unassigned'}`,
+            `impact: ${blocker.impact ?? 'Unknown'}`,
+          ];
+          return `${blocker.description} (${metadata.join('; ')})`;
+        });
+
+        pushList(lines, 'Risks & Blockers', blockers);
+      }
+
+      pushList(lines, 'Open Questions', section.openQuestions);
+      pushList(lines, 'Next Steps', section.nextSteps);
+    });
+  }
+
+  if (analysis.blockers.length) {
+    const blockers = analysis.blockers.map((blocker) => {
+      const metadata = [
+        `assignee: ${blocker.assignee ?? 'Unassigned'}`,
+        `impact: ${blocker.impact ?? 'Unknown'}`,
+      ];
+
+      return `${blocker.description} (${metadata.join('; ')})`;
+    });
+
+    lines.push('## Overall Risks & Blockers');
+    lines.push('');
+    lines.push(...blockers.map((blocker) => `- ${blocker}`));
+    lines.push('');
+  }
+
+  return lines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+}
+
 export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) {
   const { data: analysisResponse } = useSuspenseQuery(recordingAnalysisQueryOptions(recordingId));
   const { data: recordings } = useSuspenseQuery(recordingsQueryOptions({ page: 1, pageSize: 100 }));
@@ -39,6 +141,10 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
 
   const analysis = analysisResponse.analysis;
   const recording = recordings.recordings.find((item) => item.id === recordingId);
+  const analysisMarkdown = React.useMemo(
+    () => buildAnalysisMarkdown(analysis, recording),
+    [analysis, recording],
+  );
 
   const isRunning = analysis?.status === 'pending' || analysis?.status === 'processing';
 
@@ -63,6 +169,7 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
       {/* Header */}
       <AnalysisHeader
         analysis={analysis}
+        analysisMarkdown={analysisMarkdown}
         recording={recording}
         isRunning={isRunning}
         isStarting={startAnalysis.isPending}

--- a/apps/web/src/components/ui/copy-button.tsx
+++ b/apps/web/src/components/ui/copy-button.tsx
@@ -1,0 +1,59 @@
+import { CheckIcon, CopyIcon } from 'lucide-react';
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type CopyButtonProps = Omit<React.ComponentProps<typeof Button>, 'children' | 'onClick'> & {
+  value: string;
+  copyLabel?: string;
+  copiedLabel?: string;
+};
+
+export function CopyButton({
+  value,
+  copyLabel = 'Copy',
+  copiedLabel = 'Copied',
+  className,
+  variant = 'outline',
+  size = 'icon-xs',
+  ...props
+}: CopyButtonProps) {
+  const [copied, setCopied] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!copied) return;
+    const timeoutId = setTimeout(() => setCopied(false), 1000);
+    return () => clearTimeout(timeoutId);
+  }, [copied]);
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      onClick={() => {
+        void navigator.clipboard.writeText(value).then(() => setCopied(true));
+      }}
+      className={cn('text-muted-foreground hover:text-foreground', className)}
+      title={copied ? copiedLabel : copyLabel}
+      aria-label={copied ? copiedLabel : copyLabel}
+      {...props}
+    >
+      <span className="relative inline-flex size-3">
+        <CopyIcon
+          className={cn(
+            'absolute inset-0 size-3 transition-all duration-200',
+            copied ? 'scale-75 opacity-0' : 'scale-100 opacity-100',
+          )}
+        />
+        <CheckIcon
+          className={cn(
+            'text-success absolute inset-0 size-3 transition-all duration-200',
+            copied ? 'scale-100 opacity-100' : 'scale-75 opacity-0',
+          )}
+        />
+      </span>
+    </Button>
+  );
+}


### PR DESCRIPTION
## 🚀 Change Summary
Adds a copy action to the recording analysis page so users can copy a clean markdown report (excluding transcript content) and reuse it in docs, tickets, or follow-ups.

### ✨ New Features
- **Reusable Copy Button UI Primitive**: Introduces `CopyButton` in `apps/web/src/components/ui/copy-button.tsx` with consistent copied-state feedback for broader app reuse.
- **Markdown Export on Recording Analysis**: Adds a one-click copy control in the analysis header to copy structured markdown generated from summary, topic sections, decisions, action items, blockers, open questions, and next steps.

### 🛠 Improvements & Refactors
- Moves the recording analysis copy interaction to the shared UI layer and wires the analysis page/header to pass and render markdown content in a normalized format.