### PR TITLE
feat(mcp-registry): add MCP registry workspace and website artifact

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,4 +1,4 @@
-name: deploy-mcp-registry
+name: deploy-cloudflare
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-mcp-registry.yml
+++ b/.github/workflows/deploy-mcp-registry.yml
@@ -1,0 +1,39 @@
+name: deploy-mcp-registry
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure workflow is dispatched from master
+        run: |
+          if [ "${{ github.ref_name }}" != "master" ]; then
+            echo "This workflow must be run from the master branch."
+            exit 1
+          fi
+
+  deploy:
+    needs: guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Build MCP registry artifact
+        run: node scripts/build-mcp-registry.mjs
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy apps/website/dist --project-name=stitch --branch=master

--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -26,6 +26,7 @@ jobs:
             ci:
               - '**'
               - '!apps/website/**'
+              - '!registries/**'
               - '!**/*.md'
               - '!LICENSE'
               - '!.opencode/**'

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@stitch/website",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "bun run ../../scripts/build-mcp-registry.mjs"
+  }
+}

--- a/apps/website/wrangler.toml
+++ b/apps/website/wrangler.toml
@@ -1,0 +1,3 @@
+name = "stitch-website"
+compatibility_date = "2026-04-13"
+pages_build_output_dir = "dist"

--- a/apps/website/wrangler.toml
+++ b/apps/website/wrangler.toml
@@ -1,6 +1,3 @@
 name = "stitch-website"
 compatibility_date = "2026-04-13"
 pages_build_output_dir = "dist"
-
-[build]
-command = "node scripts/build-mcp-registry.mjs"

--- a/apps/website/wrangler.toml
+++ b/apps/website/wrangler.toml
@@ -1,3 +1,6 @@
 name = "stitch-website"
 compatibility_date = "2026-04-13"
 pages_build_output_dir = "dist"
+
+[build]
+command = "node scripts/build-mcp-registry.mjs"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "workspaces": [
     "apps/*",
+    "registries/*",
     "packages/*",
     "connectors/*"
   ],
@@ -15,7 +16,8 @@
     "typecheck": "turbo typecheck",
     "test": "turbo test",
     "knip": "knip",
-    "check": "bun run scripts/check.ts"
+    "check": "bun run scripts/check.ts",
+    "website:build": "bun run --cwd apps/website build"
   },
   "devDependencies": {
     "knip": "latest",

--- a/registries/mcp/package.json
+++ b/registries/mcp/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@stitch/registry-mcp",
+  "private": true,
+  "type": "module"
+}

--- a/registries/mcp/schema/mcp-server.schema.json
+++ b/registries/mcp/schema/mcp-server.schema.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usestitch.ai/schemas/mcp-server.schema.json",
+  "title": "Stitch MCP Marketplace Server",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "name",
+    "description",
+    "docsUrl",
+    "tags",
+    "install"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON Schema reference for editor tooling"
+    },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-_]*$",
+      "description": "Stable marketplace identifier"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Display name shown in the marketplace"
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "homepageUrl": {
+      "type": "string",
+      "format": "uri"
+    },
+    "docsUrl": {
+      "type": "string",
+      "format": "uri"
+    },
+    "tags": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "install": {
+      "$ref": "#/$defs/mcpInstallConfig"
+    }
+  },
+  "$defs": {
+    "mcpInstallConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "transport",
+        "url",
+        "authConfig"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Default name prefilled in Stitch"
+        },
+        "transport": {
+          "type": "string",
+          "enum": [
+            "stdio",
+            "http"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "authConfig": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "type": {
+                  "const": "none"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "apiKey"
+              ],
+              "properties": {
+                "type": {
+                  "const": "api_key"
+                },
+                "apiKey": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "type",
+                "headers"
+              ],
+              "properties": {
+                "type": {
+                  "const": "headers"
+                },
+                "headers": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "optionalAuthConfigs": {
+          "type": "array",
+          "description": "Additional auth presets a user may choose instead of the default authConfig",
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "const": "none"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "type",
+                  "apiKey"
+                ],
+                "properties": {
+                  "type": {
+                    "const": "api_key"
+                  },
+                  "apiKey": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "type",
+                  "headers"
+                ],
+                "properties": {
+                  "type": {
+                    "const": "headers"
+                  },
+                  "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/registries/mcp/servers/deepwiki.json
+++ b/registries/mcp/servers/deepwiki.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://usestitch.ai/schemas/mcp-server.schema.json",
+  "id": "deepwiki",
+  "name": "DeepWiki",
+  "description": "Read DeepWiki docs and ask repository-grounded questions.",
+  "homepageUrl": "https://docs.devin.ai/work-with-devin/deepwiki",
+  "docsUrl": "https://docs.devin.ai/work-with-devin/deepwiki-mcp",
+  "tags": [
+    "documentation",
+    "repositories",
+    "research"
+  ],
+  "install": {
+    "name": "DeepWiki",
+    "transport": "http",
+    "url": "https://mcp.deepwiki.com/mcp",
+    "authConfig": {
+      "type": "none"
+    }
+  }
+}

--- a/registries/mcp/servers/exa.json
+++ b/registries/mcp/servers/exa.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://usestitch.ai/schemas/mcp-server.schema.json",
+  "id": "exa",
+  "name": "Exa",
+  "description": "Web and code search tools from Exa via remote MCP.",
+  "homepageUrl": "https://exa.ai",
+  "docsUrl": "https://exa.ai/docs/reference/exa-mcp",
+  "tags": [
+    "search",
+    "web",
+    "research"
+  ],
+  "install": {
+    "name": "Exa",
+    "transport": "http",
+    "url": "https://mcp.exa.ai/mcp",
+    "authConfig": {
+      "type": "none"
+    },
+    "optionalAuthConfigs": [
+      {
+        "type": "headers",
+        "headers": {
+          "x-api-key": "YOUR_EXA_API_KEY"
+        }
+      }
+    ]
+  }
+}

--- a/scripts/build-mcp-registry.mjs
+++ b/scripts/build-mcp-registry.mjs
@@ -1,0 +1,114 @@
+import { cpSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+const registryDir = join(rootDir, 'registries', 'mcp');
+const serversDir = join(registryDir, 'servers');
+const schemaDir = join(registryDir, 'schema');
+const outputDir = join(rootDir, 'apps', 'website', 'dist');
+const outputFile = join(outputDir, 'mcp-registry.json');
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function assertAuthConfig(authConfig, filePath) {
+  assert(authConfig && typeof authConfig === 'object', `${filePath}: install.authConfig is required`);
+  assert(typeof authConfig.type === 'string', `${filePath}: install.authConfig.type must be a string`);
+
+  if (authConfig.type === 'none') {
+    return;
+  }
+
+  if (authConfig.type === 'api_key') {
+    assert(typeof authConfig.apiKey === 'string' && authConfig.apiKey.length > 0, `${filePath}: api_key auth requires apiKey`);
+    return;
+  }
+
+  if (authConfig.type === 'headers') {
+    assert(authConfig.headers && typeof authConfig.headers === 'object', `${filePath}: headers auth requires headers object`);
+    for (const [header, value] of Object.entries(authConfig.headers)) {
+      assert(typeof header === 'string' && header.length > 0, `${filePath}: header names must be non-empty strings`);
+      assert(typeof value === 'string', `${filePath}: header values must be strings`);
+    }
+    return;
+  }
+
+  throw new Error(`${filePath}: unsupported auth type ${String(authConfig.type)}`);
+}
+
+function assertServerConfig(server, filePath) {
+  assert(server && typeof server === 'object', `${filePath}: config must be an object`);
+  assert(typeof server.id === 'string' && server.id.length > 0, `${filePath}: id is required`);
+  assert(typeof server.name === 'string' && server.name.length > 0, `${filePath}: name is required`);
+  assert(typeof server.description === 'string' && server.description.length > 0, `${filePath}: description is required`);
+  assert(typeof server.docsUrl === 'string' && server.docsUrl.length > 0, `${filePath}: docsUrl is required`);
+  assert(Array.isArray(server.tags) && server.tags.length > 0, `${filePath}: tags must be a non-empty array`);
+
+  const install = server.install;
+  assert(install && typeof install === 'object', `${filePath}: install is required`);
+  assert(typeof install.name === 'string' && install.name.length > 0, `${filePath}: install.name is required`);
+  assert(install.transport === 'http' || install.transport === 'stdio', `${filePath}: install.transport must be http or stdio`);
+  assert(typeof install.url === 'string' && install.url.length > 0, `${filePath}: install.url is required`);
+  assertAuthConfig(install.authConfig, filePath);
+
+  if (install.optionalAuthConfigs !== undefined) {
+    assert(Array.isArray(install.optionalAuthConfigs), `${filePath}: install.optionalAuthConfigs must be an array`);
+    for (const authConfig of install.optionalAuthConfigs) {
+      assertAuthConfig(authConfig, filePath);
+    }
+  }
+}
+
+function loadServerConfigs() {
+  const files = readdirSync(serversDir)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => join(serversDir, name));
+
+  const servers = files.map((filePath) => {
+    const parsed = readJson(filePath);
+    assertServerConfig(parsed, filePath);
+    return parsed;
+  });
+
+  const ids = new Set();
+  for (const server of servers) {
+    assert(!ids.has(server.id), `Duplicate server id: ${server.id}`);
+    ids.add(server.id);
+  }
+
+  return servers.toSorted((a, b) => a.name.localeCompare(b.name));
+}
+
+function writeOutput(servers) {
+  mkdirSync(outputDir, { recursive: true });
+  mkdirSync(join(outputDir, 'schemas'), { recursive: true });
+
+  cpSync(join(rootDir, 'apps', 'website', 'index.html'), join(outputDir, 'index.html'));
+  cpSync(join(schemaDir, 'mcp-server.schema.json'), join(outputDir, 'schemas', 'mcp-server.schema.json'));
+
+  const payload = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    servers,
+  };
+
+  writeFileSync(outputFile, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function main() {
+  const servers = loadServerConfigs();
+  writeOutput(servers);
+  console.log(`Built MCP registry with ${servers.length} server(s): ${outputFile}`);
+}
+
+main();


### PR DESCRIPTION
## 🚀 Change Summary
Adds the initial MCP registry system as a first-class workspace, with schema-validated server definitions that are built into static website artifacts for marketplace consumption.

### ✨ New Features
- **MCP registry workspace**: Introduces `registries/mcp` with a dedicated JSON schema and server definitions for Exa and DeepWiki
- **Hosted registry artifacts**: Adds a website build pipeline that emits `/mcp-registry.json` and hosts schema files at `/schemas/mcp-server.schema.json`
- **Optional auth presets**: Supports optional auth configurations in registry entries (e.g. Exa can run with no auth or optional `x-api-key` header)

### 🛠 Improvements & Refactors
- Adds a root `website:build` script and an `apps/website` package build script to generate publishable Cloudflare Pages output
- Adds `apps/website/wrangler.toml` to configure Pages output directory
- Updates `pr-master` path filtering to skip CI when changes are limited to `registries/**` and other ignored paths