### PR TITLE
fix(ci): setup bun before Cloudflare deploy action

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build MCP registry artifact
         run: node scripts/build-mcp-registry.mjs
 
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:


### PR DESCRIPTION
## 🚀 Change Summary
Fixes the manual Cloudflare deploy workflow by ensuring Bun is available before invoking the Wrangler GitHub Action.

### 🛠 Improvements & Refactors
- Adds the shared `setup-bun` action to `.github/workflows/deploy-cloudflare.yml` before the deploy step
- Prevents workflow failure from `Unable to locate executable file: bun` in `cloudflare/wrangler-action@v3`