### PR TITLE
fix(server): make code-mode toolset filtering use toolset definitions

### DIFF
--- a/packages/server/__test__/code-mode/filter.test.ts
+++ b/packages/server/__test__/code-mode/filter.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { applyToolFilter } from '@/code-mode/filter.js';
+import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
+import type { Toolset } from '@/tools/toolsets/types.js';
+import type { Tool } from 'ai';
+
+function clearToolsets(): void {
+  for (const id of listToolsetIds()) {
+    unregisterToolset(id);
+  }
+}
+
+function registerTestToolset(id: string, toolNames: string[]): void {
+  const toolset: Toolset = {
+    id,
+    name: id,
+    description: `${id} test toolset`,
+    tools: () => toolNames.map((name) => ({ name, description: `${name} test tool` })),
+    activate: async () => ({}),
+  };
+
+  registerToolset(toolset);
+}
+
+function buildTools(toolNames: string[]): Record<string, Tool> {
+  const tools: Record<string, Tool> = {};
+  for (const toolName of toolNames) {
+    tools[toolName] = {} as Tool;
+  }
+  return tools;
+}
+
+describe('applyToolFilter', () => {
+  beforeEach(() => {
+    clearToolsets();
+  });
+
+  test('excludes tools from excluded toolset IDs', () => {
+    registerTestToolset('browser', ['browser']);
+    registerTestToolset('mcp:mcp_abcdefghijklmnopqrstuvwxyz', ['mcp_abcdefghijklmnopqrstuvwxyz_search']);
+
+    const input = buildTools(['browser', 'mcp_abcdefghijklmnopqrstuvwxyz_search', 'read']);
+    const result = applyToolFilter(input, {
+      excludeToolsets: ['mcp:mcp_abcdefghijklmnopqrstuvwxyz'],
+    });
+
+    expect(Object.keys(result)).toEqual(['read']);
+  });
+
+  test('supports trailing-colon toolset IDs for compatibility', () => {
+    registerTestToolset('browser', ['browser']);
+
+    const input = buildTools(['browser', 'glob']);
+    const result = applyToolFilter(input, {
+      excludeToolsets: ['browser:'],
+    });
+
+    expect(Object.keys(result)).toEqual(['glob']);
+  });
+
+  test('excludes only named tools for excludeToolsInToolset', () => {
+    registerTestToolset('mcp:mcp_abcdefghijklmnopqrstuvwxyz', [
+      'mcp_abcdefghijklmnopqrstuvwxyz_search',
+      'mcp_abcdefghijklmnopqrstuvwxyz_fetch',
+    ]);
+
+    const input = buildTools([
+      'mcp_abcdefghijklmnopqrstuvwxyz_search',
+      'mcp_abcdefghijklmnopqrstuvwxyz_fetch',
+      'read',
+    ]);
+    const result = applyToolFilter(input, {
+      excludeToolsInToolset: {
+        'mcp:mcp_abcdefghijklmnopqrstuvwxyz': ['mcp_abcdefghijklmnopqrstuvwxyz_search'],
+      },
+    });
+
+    expect(Object.keys(result)).toEqual(['mcp_abcdefghijklmnopqrstuvwxyz_fetch', 'read']);
+  });
+});

--- a/packages/server/src/code-mode/filter.ts
+++ b/packages/server/src/code-mode/filter.ts
@@ -1,5 +1,7 @@
 import type { Tool } from 'ai';
 
+import { listToolsets } from '@/tools/toolsets/registry.js';
+
 const ALWAYS_EXCLUDED_TOOLS = new Set([
   'question',
   'task',
@@ -11,6 +13,10 @@ const ALWAYS_EXCLUDED_TOOLS = new Set([
 ]);
 
 const ALWAYS_EXCLUDED_TOOLSETS = new Set(['browser', 'agenda']);
+
+function normalizeToolsetId(toolsetId: string): string {
+  return toolsetId.endsWith(':') ? toolsetId.slice(0, -1) : toolsetId;
+}
 
 export type CodeModeToolFilter = {
   excludeToolsets?: string[];
@@ -30,14 +36,40 @@ export function applyToolFilter(
 
   const specificExclusions = new Set<string>(excludeTools);
 
-  const excludedToolsetPrefixes = [
-    ...ALWAYS_EXCLUDED_TOOLSETS,
-    ...excludeToolsets,
-  ].map((id) => (id.endsWith(':') ? id : `${id}:`));
+  const toolNamesByToolset = new Map<string, Set<string>>();
+  for (const toolset of listToolsets()) {
+    toolNamesByToolset.set(
+      toolset.id,
+      new Set(toolset.tools().map((toolSummary) => toolSummary.name)),
+    );
+  }
 
-  for (const toolNames of Object.values(excludeToolsInToolset)) {
-    for (const name of toolNames) {
-      specificExclusions.add(name);
+  const excludedToolsetIds = new Set<string>(
+    [...ALWAYS_EXCLUDED_TOOLSETS, ...excludeToolsets].map(normalizeToolsetId),
+  );
+
+  for (const excludedToolsetId of excludedToolsetIds) {
+    const toolNames = toolNamesByToolset.get(excludedToolsetId);
+    if (!toolNames) continue;
+    for (const toolName of toolNames) {
+      specificExclusions.add(toolName);
+    }
+  }
+
+  for (const [toolsetId, toolNames] of Object.entries(excludeToolsInToolset)) {
+    const normalizedToolsetId = normalizeToolsetId(toolsetId);
+    const knownToolNames = toolNamesByToolset.get(normalizedToolsetId);
+    if (!knownToolNames) {
+      for (const toolName of toolNames) {
+        specificExclusions.add(toolName);
+      }
+      continue;
+    }
+
+    for (const toolName of toolNames) {
+      if (knownToolNames.has(toolName)) {
+        specificExclusions.add(toolName);
+      }
     }
   }
 
@@ -45,8 +77,6 @@ export function applyToolFilter(
 
   for (const [name, tool] of Object.entries(tools)) {
     if (ALWAYS_EXCLUDED_TOOLS.has(name)) continue;
-    if (excludedToolsetPrefixes.some((prefix) => name.startsWith(prefix)))
-      continue;
     if (specificExclusions.has(name)) continue;
     result[name] = tool;
   }


### PR DESCRIPTION
## 🚀 Change Summary
Code mode tool filtering now resolves exclusions from registered toolset definitions instead of relying on 	oolset: name prefixes, so MCP toolsets and other non-colon tool names are filtered correctly.

### ✨ New Features
- **Code mode toolset-aware filtering**: pplyToolFilter now maps toolset IDs to declared tool names via the toolset registry and excludes tools by actual membership.
- **Compatibility normalization**: Toolset IDs with a trailing colon (for example rowser:) are normalized to preserve existing usage.

### 🛠 Improvements & Refactors
- Replaced prefix-based filtering with explicit toolset-to-tool resolution for xcludeToolsets and xcludeToolsInToolset.
- Added fallback behavior for unknown toolset IDs in xcludeToolsInToolset so direct tool-name exclusions still apply.

### 🐛 Bug Fixes
- Fixed an issue where filtering by toolset ID could fail when tool names did not start with <toolsetId>: (notably MCP tools named like <serverId>_<toolName>).

### 📚 Documentation
- Added targeted unit tests for code mode tool filtering behavior, including MCP-style IDs and trailing-colon compatibility.