### PR TITLE
fix(ci): refresh bun lockfile for windows frozen installs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/desktop": {
       "name": "@stitch/desktop",
-      "version": "0.2.1",
+      "version": "0.2.6",
       "dependencies": {
         "electron-updater": "^6.8.3",
         "tree-kill": "1.2.2",
@@ -29,7 +29,7 @@
     },
     "apps/web": {
       "name": "@stitch/web",
-      "version": "0.2.1",
+      "version": "0.2.6",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@stitch/shared": "workspace:*",
@@ -79,6 +79,9 @@
         "vite": "8.0.0",
         "vitest": "catalog:testing",
       },
+    },
+    "apps/website": {
+      "name": "@stitch/website",
     },
     "connectors/google": {
       "name": "@stitch-connectors/google",
@@ -173,6 +176,9 @@
         "vitest": "catalog:testing",
         "zod": "catalog:",
       },
+    },
+    "registries/mcp": {
+      "name": "@stitch/registry-mcp",
     },
   },
   "catalog": {
@@ -887,6 +893,8 @@
 
     "@stitch/desktop": ["@stitch/desktop@workspace:apps/desktop"],
 
+    "@stitch/registry-mcp": ["@stitch/registry-mcp@workspace:registries/mcp"],
+
     "@stitch/scheduler": ["@stitch/scheduler@workspace:packages/scheduler"],
 
     "@stitch/server": ["@stitch/server@workspace:packages/server"],
@@ -894,6 +902,8 @@
     "@stitch/shared": ["@stitch/shared@workspace:packages/shared"],
 
     "@stitch/web": ["@stitch/web@workspace:apps/web"],
+
+    "@stitch/website": ["@stitch/website@workspace:apps/website"],
 
     "@swc/helpers": ["@swc/helpers@0.5.21", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg=="],
 


### PR DESCRIPTION
## 🚀 Change Summary
Refreshes `bun.lock` so `bun install --frozen-lockfile` succeeds on Windows CI and release workflows can proceed.

### 🛠 Improvements & Refactors
- Regenerated `bun.lock` with Bun 1.3.8 to align workspace entries and package versions with the current monorepo state.
- Removes lockfile drift that caused the Windows `check` job to fail during setup.