### PR TITLE
improvement(server): harden Lance migration lineage and scaffolding

### DIFF
--- a/packages/server/__test__/db/lance-migrations.test.ts
+++ b/packages/server/__test__/db/lance-migrations.test.ts
@@ -1,0 +1,168 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { Field, Int32, Schema, Utf8 } from 'apache-arrow';
+import * as lancedb from '@lancedb/lancedb';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { migration0001AddPinnedColumn } from '@/db/lance-migrations/0001-add-pinned-column.js';
+import { runPendingMigrations } from '@/db/lance-migrations.js';
+import { getConnection } from '@/memory/store/connection.js';
+
+vi.mock('@/memory/store/connection.js', () => ({
+  getConnection: vi.fn(),
+}));
+
+type MigrationRow = {
+  version: number;
+  id: string;
+  prevId: string | null;
+  name: string;
+  checksum: string;
+  status: 'applied' | 'failed';
+  error: string | null;
+  appliedAt: number;
+};
+
+function createMockDb(initialRows: MigrationRow[] = []) {
+  const rows = new Map<number, MigrationRow>(initialRows.map((row) => [row.version, row]));
+
+  return {
+    db: {
+      select: () => ({
+        from: () => ({
+          all: () => Array.from(rows.values()),
+        }),
+      }),
+      insert: () => ({
+        values: (value: MigrationRow) => ({
+          onConflictDoUpdate: ({ set }: { set: Partial<MigrationRow> }) => ({
+            run: () => {
+              const existing = rows.get(value.version);
+              if (existing) {
+                rows.set(value.version, { ...existing, ...set });
+                return;
+              }
+
+              rows.set(value.version, value);
+            },
+          }),
+          run: () => {
+            rows.set(value.version, value);
+          },
+        }),
+      }),
+    },
+    rows,
+  };
+}
+
+async function withTempWorkspace(
+  fn: (ctx: { tempDir: string }) => Promise<void>,
+) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stitch-lance-migration-'));
+
+  try {
+    await fn({ tempDir });
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function createSemanticTable(tempDir: string, withPinned = false): Promise<lancedb.Connection> {
+  const connection = await lancedb.connect(path.join(tempDir, 'memory.lance'));
+
+  const fields: Field[] = [new Field('id', new Utf8(), false)];
+  if (withPinned) {
+    fields.push(new Field('pinned', new Int32(), false));
+  }
+
+  await connection.createEmptyTable('semantic_memories', new Schema(fields));
+  return connection;
+}
+
+describe('runPendingMigrations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('applies pending migration with real LanceDB and records success', async () => {
+    await withTempWorkspace(async ({ tempDir }) => {
+      const connection = await createSemanticTable(tempDir);
+      vi.mocked(getConnection).mockResolvedValue(connection as never);
+      const { db, rows } = createMockDb();
+
+      await runPendingMigrations(db as never);
+
+      const row = rows.get(1);
+      const checksum = row?.checksum;
+
+      expect(row?.['status']).toBe('applied');
+      expect(row?.['id']).toBe(migration0001AddPinnedColumn.id);
+      expect(row?.['prevId']).toBe(migration0001AddPinnedColumn.prevId);
+      expect(row?.['name']).toBe('add_pinned_column');
+      expect(typeof checksum).toBe('string');
+      expect(typeof checksum === 'string' && checksum.startsWith('sha256:')).toBe(true);
+
+      const semanticTable = await connection.openTable('semantic_memories');
+      const schema = await semanticTable.schema();
+      expect(schema.fields.some((field) => field.name === 'pinned')).toBe(true);
+    });
+  });
+
+  test('records applied when column already exists in real LanceDB schema', async () => {
+    await withTempWorkspace(async ({ tempDir }) => {
+      const connection = await createSemanticTable(tempDir, true);
+      vi.mocked(getConnection).mockResolvedValue(connection as never);
+      const { db, rows } = createMockDb();
+
+      await runPendingMigrations(db as never);
+      await runPendingMigrations(db as never);
+
+      expect(rows.size).toBe(1);
+    });
+  });
+
+  test('fails fast on checksum mismatch', async () => {
+    await withTempWorkspace(async ({ tempDir }) => {
+      const connection = await lancedb.connect(path.join(tempDir, 'memory.lance'));
+      vi.mocked(getConnection).mockResolvedValue(connection as never);
+      const { db } = createMockDb([
+        {
+          version: 1,
+          id: migration0001AddPinnedColumn.id,
+          prevId: migration0001AddPinnedColumn.prevId,
+          name: 'add_pinned_column',
+          checksum: 'sha256:old',
+          status: 'applied',
+          error: null,
+          appliedAt: Date.now(),
+        },
+      ]);
+
+      await expect(runPendingMigrations(db as never)).rejects.toThrow('checksum mismatch');
+    });
+  });
+
+  test('fails fast on prevId mismatch', async () => {
+    await withTempWorkspace(async ({ tempDir }) => {
+      const connection = await lancedb.connect(path.join(tempDir, 'memory.lance'));
+      vi.mocked(getConnection).mockResolvedValue(connection as never);
+      const { db } = createMockDb([
+        {
+          version: 1,
+          id: migration0001AddPinnedColumn.id,
+          prevId: 'wrong-prev-id',
+          name: 'add_pinned_column',
+          checksum: migration0001AddPinnedColumn.checksum,
+          status: 'applied',
+          error: null,
+          appliedAt: Date.now(),
+        },
+      ]);
+
+      await expect(runPendingMigrations(db as never)).rejects.toThrow('prevId mismatch');
+    });
+  });
+});

--- a/packages/server/drizzle/0016_loose_devos.sql
+++ b/packages/server/drizzle/0016_loose_devos.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `lance_migrations` ADD `id` text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE `lance_migrations` ADD `prev_id` text;--> statement-breakpoint
+ALTER TABLE `lance_migrations` ADD `checksum` text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE `lance_migrations` ADD `status` text DEFAULT 'applied' NOT NULL;--> statement-breakpoint
+ALTER TABLE `lance_migrations` ADD `error` text;

--- a/packages/server/drizzle/meta/0016_snapshot.json
+++ b/packages/server/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,2309 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "db466c03-19ee-4eac-8d42-c28587436c4c",
+  "prevId": "8976c798-764b-4b06-9bde-788c52afeeb7",
+  "tables": {
+    "agenda_item_events": {
+      "name": "agenda_item_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_item_events_item_id_idx": {
+          "name": "agenda_item_events_item_id_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        },
+        "agenda_item_events_created_at_idx": {
+          "name": "agenda_item_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_item_events_item_id_agenda_items_id_fk": {
+          "name": "agenda_item_events_item_id_agenda_items_id_fk",
+          "tableFrom": "agenda_item_events",
+          "tableTo": "agenda_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_item_events_type_check": {
+          "name": "agenda_item_events_type_check",
+          "value": "\"agenda_item_events\".\"type\" in ('created', 'status_change', 'updated', 'comment')"
+        }
+      }
+    },
+    "agenda_items": {
+      "name": "agenda_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'todo'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_items_list_id_idx": {
+          "name": "agenda_items_list_id_idx",
+          "columns": [
+            "list_id"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_status_idx": {
+          "name": "agenda_items_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_due_at_idx": {
+          "name": "agenda_items_due_at_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_created_at_idx": {
+          "name": "agenda_items_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_items_list_id_agenda_lists_id_fk": {
+          "name": "agenda_items_list_id_agenda_lists_id_fk",
+          "tableFrom": "agenda_items",
+          "tableTo": "agenda_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_items_type_check": {
+          "name": "agenda_items_type_check",
+          "value": "\"agenda_items\".\"type\" in ('todo', 'reminder', 'checkup')"
+        },
+        "agenda_items_status_check": {
+          "name": "agenda_items_status_check",
+          "value": "\"agenda_items\".\"status\" in ('open', 'in_progress', 'done', 'cancelled')"
+        },
+        "agenda_items_priority_check": {
+          "name": "agenda_items_priority_check",
+          "value": "\"agenda_items\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      }
+    },
+    "agenda_lists": {
+      "name": "agenda_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_lists_name_uidx": {
+          "name": "agenda_lists_name_uidx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "agenda_lists_created_at_idx": {
+          "name": "agenda_lists_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lance_migrations": {
+      "name": "lance_migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "prev_id": {
+          "name": "prev_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'applied'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "is_attributable": {
+          "name": "is_attributable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_index": {
+          "name": "attempt_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_run_id_idx": {
+          "name": "llm_usage_events_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permission_responses": {
+      "name": "permission_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_reminder": {
+          "name": "system_reminder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_responses_session_id_sessions_id_fk": {
+          "name": "permission_responses_session_id_sessions_id_fk",
+          "tableFrom": "permission_responses",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_messages": {
+      "name": "queued_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "queued_messages_session_id_sessions_id_fk": {
+          "name": "queued_messages_session_id_sessions_id_fk",
+          "tableFrom": "queued_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_analyses": {
+      "name": "recording_analyses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_sections": {
+          "name": "topic_sections",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockers": {
+          "name": "blockers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_provider_id": {
+          "name": "transcription_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_model_id": {
+          "name": "transcription_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_provider_id": {
+          "name": "analysis_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_model_id": {
+          "name": "analysis_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recording_analyses_recording_id_uidx": {
+          "name": "recording_analyses_recording_id_uidx",
+          "columns": [
+            "recording_id"
+          ],
+          "isUnique": true
+        },
+        "recording_analyses_status_idx": {
+          "name": "recording_analyses_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recording_analyses_recording_id_recordings_id_fk": {
+          "name": "recording_analyses_recording_id_recordings_id_fk",
+          "tableFrom": "recording_analyses",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recording_analyses_status_check": {
+          "name": "recording_analyses_status_check",
+          "value": "\"recording_analyses\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "recordings": {
+      "name": "recordings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'recording'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'audio/ogg'"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recordings_created_at_idx": {
+          "name": "recordings_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "recordings_status_idx": {
+          "name": "recordings_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recordings_status_check": {
+          "name": "recordings_status_check",
+          "value": "\"recordings\".\"status\" in ('recording', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": [
+            "job_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "queue_enabled": {
+          "name": "queue_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": [
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_automation_id_automations_id_fk": {
+          "name": "sessions_automation_id_automations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": [
+            "tool_name",
+            "pattern"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1776105631471,
       "tag": "0015_slimy_randall_flagg",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1776139705558,
+      "tag": "0016_loose_devos",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,7 +9,8 @@
     "dev": "NODE_ENV=development bun --watch src/index.ts",
     "build": "bun build src/index.ts --compile --minify --outfile dist/stitch-server",
     "build:x64": "bun build src/index.ts --compile --minify --target=bun-darwin-x64 --outfile dist/stitch-server",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lance:migration:new": "bun scripts/new-lance-migration.ts"
   },
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "catalog:ai",

--- a/packages/server/scripts/new-lance-migration.ts
+++ b/packages/server/scripts/new-lance-migration.ts
@@ -1,0 +1,151 @@
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type Args = {
+  name: string;
+  tableName: string;
+};
+
+function toPascalCase(value: string): string {
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part[0].toUpperCase() + part.slice(1).toLowerCase())
+    .join('');
+}
+
+function toKebabCase(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function toSnakeCase(value: string): string {
+  return value.replace(/-/g, '_');
+}
+
+function getChecksum(version: number, name: string, tableName: string): string {
+  const input = `${version}:${name}:${tableName}`;
+  return `sha256:${createHash('sha256').update(input).digest('hex')}`;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Partial<Args> = {
+    tableName: 'semantic_memories',
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const part = argv[i];
+    if (part === '--name' && argv[i + 1]) {
+      args.name = argv[i + 1];
+      i++;
+      continue;
+    }
+
+    if (part === '--table' && argv[i + 1]) {
+      args.tableName = argv[i + 1];
+      i++;
+    }
+  }
+
+  if (!args.name) {
+    throw new Error('Usage: bun run lance:migration:new --name <migration-name> [--table <table-name>]');
+  }
+
+  return args as Args;
+}
+
+function getConstName(versionTag: string, slug: string): string {
+  return `migration${versionTag}${toPascalCase(slug)}`;
+}
+
+async function getLastMigrationId(migrationsDir: string): Promise<string | null> {
+  const files = (await fs.readdir(migrationsDir))
+    .filter((file) => /^\d{4}-.+\.ts$/.test(file))
+    .sort((a, b) => a.localeCompare(b));
+
+  const last = files.at(-1);
+  if (!last) return null;
+
+  const content = await fs.readFile(path.join(migrationsDir, last), 'utf-8');
+  const match = content.match(/\bid:\s*'([^']+)'/);
+  if (!match) {
+    throw new Error(`Failed to extract id from ${last}`);
+  }
+
+  return match[1] ?? null;
+}
+
+async function rewriteManifest(migrationsDir: string): Promise<void> {
+  const allFiles = await fs.readdir(migrationsDir);
+  const migrationFiles = allFiles
+    .filter((file) => /^\d{4}-.+\.ts$/.test(file))
+    .sort((a, b) => a.localeCompare(b));
+
+  const imports = migrationFiles
+    .map((file) => {
+      const versionTag = file.slice(0, 4);
+      const slug = file.slice(5, -3);
+      const constName = getConstName(versionTag, slug);
+      const importPath = file.slice(0, -3);
+      return `import { ${constName} } from '@/db/lance-migrations/${importPath}.js';`;
+    })
+    .join('\n');
+
+  const ordered = migrationFiles
+    .map((file) => {
+      const versionTag = file.slice(0, 4);
+      const slug = file.slice(5, -3);
+      return getConstName(versionTag, slug);
+    })
+    .join(', ');
+
+  const manifest = `${imports}\nimport type { LanceMigrationDefinition } from '@/db/lance-migrations/types.js';\n\nexport const MIGRATIONS: LanceMigrationDefinition[] = [${ordered}];\n`;
+
+  await fs.writeFile(path.join(migrationsDir, 'manifest.ts'), manifest, 'utf-8');
+}
+
+async function main() {
+  const { name, tableName } = parseArgs(process.argv.slice(2));
+  const slug = toKebabCase(name);
+  const migrationName = toSnakeCase(slug);
+
+  if (!slug) {
+    throw new Error('Migration name must contain letters or numbers');
+  }
+
+  const migrationsDir = fileURLToPath(new URL('../src/db/lance-migrations', import.meta.url));
+  const existingFiles = await fs.readdir(migrationsDir);
+  const lastVersion = existingFiles
+    .map((file) => {
+      const match = file.match(/^(\d{4})-.+\.ts$/);
+      return match ? Number(match[1]) : 0;
+    })
+    .reduce((max, value) => Math.max(max, value), 0);
+
+  const version = lastVersion + 1;
+  const versionTag = String(version).padStart(4, '0');
+  const constName = getConstName(versionTag, slug);
+  const id = randomUUID();
+  const prevId = await getLastMigrationId(migrationsDir);
+  const checksum = getChecksum(version, migrationName, tableName);
+  const targetFile = path.join(migrationsDir, `${versionTag}-${slug}.ts`);
+
+  const content = `import type { LanceMigrationDefinition } from '@/db/lance-migrations/types.js';\n\nexport const ${constName}: LanceMigrationDefinition = {\n  id: '${id}',\n  prevId: ${prevId ? `'${prevId}'` : 'null'},\n  version: ${version},\n  name: '${migrationName}',\n  checksum: '${checksum}',\n  tableName: '${tableName}',\n  up: async (_table) => {\n    throw new Error('Implement migration before running it');\n  },\n};\n`;
+
+  await fs.writeFile(targetFile, content, 'utf-8');
+  await rewriteManifest(migrationsDir);
+
+  console.log(`Created ${path.basename(targetFile)}`);
+  console.log(`- version: ${version}`);
+  console.log(`- id: ${id}`);
+  console.log(`- prevId: ${prevId ?? 'null'}`);
+  console.log(`- name: ${migrationName}`);
+  console.log(`- checksum: ${checksum}`);
+}
+
+await main();

--- a/packages/server/src/db/lance-migrations.ts
+++ b/packages/server/src/db/lance-migrations.ts
@@ -1,64 +1,197 @@
-import { max } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 
+import { MIGRATIONS } from '@/db/lance-migrations/manifest.js';
+import type { LanceMigrationDefinition } from '@/db/lance-migrations/types.js';
 import * as schema from '@/db/schema.js';
 import { lanceMigrations } from '@/db/schema.js';
 import * as Log from '@/lib/log.js';
 import { getConnection } from '@/memory/store/connection.js';
-import type { Table as LanceTable } from '@lancedb/lancedb';
 
 const log = Log.create({ service: 'lance-migrations' });
 
 type Db = BunSQLiteDatabase<typeof schema>;
 
-type LanceMigration = {
-  version: number;
-  name: string;
-  tableName: string;
-  up: (table: LanceTable) => Promise<void>;
-};
+function ensureMigrationsAreValid(migrations: LanceMigrationDefinition[]): void {
+  const versions = new Set<number>();
+  const ids = new Set<string>();
+  let previous: LanceMigrationDefinition | null = null;
 
-// Central registry of all LanceDB table migrations, ordered by version.
-const MIGRATIONS: LanceMigration[] = [
-  {
-    version: 1,
-    name: 'add_pinned_column',
-    tableName: 'semantic_memories',
-    up: async (table) => {
-      await table.addColumns([{ name: 'pinned', valueSql: '0' }]);
-    },
-  },
-];
+  for (const migration of migrations) {
+    if (versions.has(migration.version)) {
+      throw new Error(`Duplicate Lance migration version: ${migration.version}`);
+    }
+
+    if (ids.has(migration.id)) {
+      throw new Error(`Duplicate Lance migration id: ${migration.id}`);
+    }
+
+    if (previous) {
+      if (migration.version !== previous.version + 1) {
+        throw new Error(
+          `Lance migration version gap detected between v${previous.version} and v${migration.version}`,
+        );
+      }
+
+      if (migration.prevId !== previous.id) {
+        throw new Error(
+          `Lance migration chain broken at v${migration.version}: expected prevId ${previous.id}, found ${migration.prevId}`,
+        );
+      }
+    } else if (migration.prevId !== null) {
+      throw new Error(`First Lance migration must have prevId=null (v${migration.version})`);
+    }
+
+    versions.add(migration.version);
+    ids.add(migration.id);
+    previous = migration;
+  }
+}
+
+async function markApplied(db: Db, migration: LanceMigrationDefinition): Promise<void> {
+  db.insert(lanceMigrations)
+    .values({
+      version: migration.version,
+      id: migration.id,
+      prevId: migration.prevId,
+      name: migration.name,
+      checksum: migration.checksum,
+      status: 'applied',
+      error: null,
+      appliedAt: Date.now(),
+    })
+    .onConflictDoUpdate({
+      target: lanceMigrations.version,
+      set: {
+        id: migration.id,
+        prevId: migration.prevId,
+        name: migration.name,
+        checksum: migration.checksum,
+        status: 'applied',
+        error: null,
+      },
+    })
+    .run();
+}
+
+function assertChecksumMatches(
+  existing: (typeof lanceMigrations.$inferSelect) | undefined,
+  migration: LanceMigrationDefinition,
+): void {
+  if (!existing) return;
+
+  if (existing.id && existing.id !== migration.id) {
+    throw new Error(
+      `Lance migration id mismatch for v${migration.version} (${migration.name}). ` +
+        `Expected ${migration.id}, found ${existing.id}.`,
+    );
+  }
+
+  if (existing.prevId !== null && existing.prevId !== migration.prevId) {
+    throw new Error(
+      `Lance migration prevId mismatch for v${migration.version} (${migration.name}). ` +
+        `Expected ${migration.prevId}, found ${existing.prevId}.`,
+    );
+  }
+
+  if (existing.checksum && existing.checksum !== migration.checksum) {
+    throw new Error(
+      `Lance migration checksum mismatch for v${migration.version} (${migration.name}). ` +
+        `Expected ${migration.checksum}, found ${existing.checksum}. ` +
+        'This usually means an already-applied migration file was edited.',
+    );
+  }
+}
 
 export async function runPendingMigrations(db: Db): Promise<void> {
-  const result = db
-    .select({ maxVersion: max(lanceMigrations.version) })
-    .from(lanceMigrations)
-    .get();
-  const currentVersion = result?.maxVersion ?? 0;
+  const orderedMigrations = [...MIGRATIONS].sort((a, b) => a.version - b.version);
+  ensureMigrationsAreValid(orderedMigrations);
 
-  const pending = MIGRATIONS.filter((m) => m.version > currentVersion);
-  if (pending.length === 0) return;
+  if (orderedMigrations.length === 0) return;
+
+  const existingRows = db.select().from(lanceMigrations).all();
+  const existingByVersion = new Map(existingRows.map((row) => [row.version, row]));
+  const definedVersions = new Set(orderedMigrations.map((m) => m.version));
+
+  for (const row of existingRows) {
+    if (row.status === 'applied' && !definedVersions.has(row.version)) {
+      throw new Error(
+        `Lance migration history contains unknown applied version: v${row.version}. ` +
+          'Migration files may be missing or reordered.',
+      );
+    }
+  }
 
   const lanceDb = await getConnection();
   const existingTables = new Set(await lanceDb.tableNames());
 
-  for (const migration of pending) {
-    // Skip if the target table doesn't exist yet — it will be created fresh with the current schema.
+  for (const migration of orderedMigrations) {
+    const existing = existingByVersion.get(migration.version);
+    assertChecksumMatches(existing, migration);
+
+    if (existing?.status === 'applied') {
+      if (
+        !existing.id ||
+        !existing.checksum ||
+        existing.prevId !== migration.prevId
+      ) {
+        await markApplied(db, migration);
+      }
+      continue;
+    }
+
+    log.info({ version: migration.version, name: migration.name }, 'running lance migration');
+
     if (!existingTables.has(migration.tableName)) {
       log.info(
         { version: migration.version, name: migration.name, tableName: migration.tableName },
         'skipping lance migration — table not yet created',
       );
+      await markApplied(db, migration);
       continue;
     }
 
-    log.info({ version: migration.version, name: migration.name }, 'running lance migration');
     const table = await lanceDb.openTable(migration.tableName);
-    await migration.up(table);
-    db.insert(lanceMigrations)
-      .values({ version: migration.version, name: migration.name, appliedAt: Date.now() })
-      .run();
-    log.info({ version: migration.version, name: migration.name }, 'lance migration applied');
+
+    if (migration.isApplied && (await migration.isApplied(table))) {
+      log.info(
+        { version: migration.version, name: migration.name, tableName: migration.tableName },
+        'lance migration already applied; recording version',
+      );
+      await markApplied(db, migration);
+      continue;
+    }
+
+    try {
+      await migration.up(table);
+      await markApplied(db, migration);
+      log.info({ version: migration.version, name: migration.name }, 'lance migration applied');
+    } catch (error) {
+      db.insert(lanceMigrations)
+        .values({
+          version: migration.version,
+          id: migration.id,
+          prevId: migration.prevId,
+          name: migration.name,
+          checksum: migration.checksum,
+          status: 'failed',
+          error: error instanceof Error ? error.message : String(error),
+          appliedAt: Date.now(),
+        })
+        .onConflictDoUpdate({
+          target: lanceMigrations.version,
+          set: {
+            id: migration.id,
+            prevId: migration.prevId,
+            name: migration.name,
+            checksum: migration.checksum,
+            status: 'failed',
+            error: error instanceof Error ? error.message : String(error),
+          },
+        })
+        .run();
+
+      throw error;
+    }
+
   }
 }

--- a/packages/server/src/db/lance-migrations/0001-add-pinned-column.ts
+++ b/packages/server/src/db/lance-migrations/0001-add-pinned-column.ts
@@ -1,0 +1,17 @@
+import type { LanceMigrationDefinition } from '@/db/lance-migrations/types.js';
+
+export const migration0001AddPinnedColumn: LanceMigrationDefinition = {
+  id: 'c0e2cb95-fb7c-4f4f-84af-81863f8fe31e',
+  prevId: null,
+  version: 1,
+  name: 'add_pinned_column',
+  checksum: 'sha256:a2192b6f41efd198f4c7dd6f4f2e4f62995d2085ca163e254a497c7f9f980548',
+  tableName: 'semantic_memories',
+  isApplied: async (table) => {
+    const schema = await table.schema();
+    return schema.fields.some((field) => field.name === 'pinned');
+  },
+  up: async (table) => {
+    await table.addColumns([{ name: 'pinned', valueSql: '0' }]);
+  },
+};

--- a/packages/server/src/db/lance-migrations/manifest.ts
+++ b/packages/server/src/db/lance-migrations/manifest.ts
@@ -1,0 +1,4 @@
+import { migration0001AddPinnedColumn } from '@/db/lance-migrations/0001-add-pinned-column.js';
+import type { LanceMigrationDefinition } from '@/db/lance-migrations/types.js';
+
+export const MIGRATIONS: LanceMigrationDefinition[] = [migration0001AddPinnedColumn];

--- a/packages/server/src/db/lance-migrations/types.ts
+++ b/packages/server/src/db/lance-migrations/types.ts
@@ -1,0 +1,12 @@
+import type { Table as LanceTable } from '@lancedb/lancedb';
+
+export type LanceMigrationDefinition = {
+  id: string;
+  prevId: string | null;
+  version: number;
+  name: string;
+  checksum: string;
+  tableName: string;
+  isApplied?: (table: LanceTable) => Promise<boolean>;
+  up: (table: LanceTable) => Promise<void>;
+};

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -290,7 +290,12 @@ export const queuedMessages = sqliteTable('queued_messages', {
 
 export const lanceMigrations = sqliteTable('lance_migrations', {
   version: integer('version').primaryKey(),
+  id: text('id').notNull().default(''),
+  prevId: text('prev_id'),
   name: text('name').notNull(),
+  checksum: text('checksum').notNull().default(''),
+  status: text('status', { enum: ['applied', 'failed'] }).notNull().default('applied'),
+  error: text('error'),
   appliedAt: integer('applied_at', { mode: 'number' }).notNull(),
 });
 


### PR DESCRIPTION
## 🚀 Change Summary
This improves LanceDB migration reliability in production by introducing lineage-aware migration metadata and validation, so startup now detects reordered/edited migration history early and applies pending migrations more safely.

### ✨ New Features
- **Lineage-aware Lance migrations**: Added migration `id` and `prevId` chain metadata with strict validation for duplicate ids, version gaps, and broken predecessor links.
- **Lance migration scaffolding command**: Added `bun run lance:migration:new` to generate numbered migration files with stable checksum metadata and automatic manifest updates.

### 🛠 Improvements & Refactors
- **Hardened migration runner**: Refactored Lance migration execution to persist and validate `id`, `prevId`, `checksum`, `status`, and `error` in `lance_migrations`, with fast-fail checks on checksum/id/prevId mismatches and unknown applied versions.
- **Schema + migration journal updates**: Added Drizzle migration and snapshot updates for the expanded `lance_migrations` table.
- **Real integration-style coverage**: Added Lance migration tests that exercise real LanceDB tables in temp directories and verify apply/idempotency/integrity failure paths.

### 🐛 Bug Fixes
- **Startup migration resilience**: Prevents silently running against inconsistent migration history by surfacing clear integrity errors before server startup continues.