### PR TITLE
fix(desktop): prevent server crash on app restart and upgrade

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -42,18 +42,18 @@ let serverUrl: string | null = null;
 let isQuitting = false;
 let isShuttingDown = false;
 
-function shutdownRuntime(): void {
+async function shutdownRuntime(): Promise<void> {
   if (isShuttingDown) return;
   isShuttingDown = true;
   destroyTray();
-  killServer();
+  await killServer();
 }
 
 const updater = createUpdater({
   getWindow: () => mainWindow,
-  prepareForInstall: () => {
+  prepareForInstall: async () => {
     isQuitting = true;
-    shutdownRuntime();
+    await shutdownRuntime();
   },
 });
 
@@ -273,16 +273,19 @@ void app.whenReady().then(async () => {
       }
     });
   } catch (error) {
-    shutdownRuntime();
+    await shutdownRuntime();
     const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
     dialog.showErrorBox('Stitch failed to start', detail);
     app.exit(1);
   }
 });
 
-app.on('before-quit', () => {
+app.on('before-quit', (event) => {
   isQuitting = true;
-  shutdownRuntime();
+  if (!isShuttingDown) {
+    event.preventDefault();
+    void shutdownRuntime().then(() => app.quit());
+  }
 });
 
 // The tray keeps the app alive even when the window is hidden.

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -1,5 +1,5 @@
 import { app } from 'electron';
-import { spawn, type ChildProcess } from 'node:child_process';
+import { execSync, spawn, type ChildProcess } from 'node:child_process';
 import { createServer } from 'node:net';
 import { join, resolve } from 'node:path';
 import treeKill from 'tree-kill';
@@ -71,7 +71,45 @@ async function waitForHealthy(url: string): Promise<void> {
   throw new Error(`Server failed to become healthy within ${HEALTH_TIMEOUT_MS}ms`);
 }
 
+function killStaleServers(): Promise<void> {
+  try {
+    const cmd =
+      process.platform === 'win32'
+        ? 'tasklist /FI "IMAGENAME eq stitch-server.exe" /FO CSV /NH'
+        : 'pgrep -f stitch-server';
+
+    const output = execSync(cmd, { encoding: 'utf8', timeout: 3_000 }).trim();
+    if (!output) return Promise.resolve();
+
+    const pids =
+      process.platform === 'win32'
+        ? output
+            .split('\n')
+            .map((line) => parseInt(line.split(',')[1]?.replace(/"/g, '') ?? '', 10))
+            .filter(Number.isFinite)
+        : output.split('\n').map((s) => parseInt(s, 10)).filter(Number.isFinite);
+
+    for (const pid of pids) {
+      try {
+        process.kill(pid, 'SIGTERM');
+      } catch {
+        // already dead or not owned
+      }
+    }
+
+    if (pids.length > 0) {
+      console.log(`[sidecar] killed ${pids.length} stale stitch-server process(es)`);
+    }
+  } catch {
+    // pgrep returns exit code 1 when no matches — ignore
+  }
+
+  return Promise.resolve();
+}
+
 export async function spawnServer(port: number): Promise<string> {
+  await killStaleServers();
+
   const { cmd, args, cwd } = getSidecarCommand(port);
   const url = `http://${HOSTNAME}:${port}`;
 
@@ -120,8 +158,39 @@ export async function spawnServer(port: number): Promise<string> {
   return url;
 }
 
-export function killServer(): void {
-  if (!serverProcess?.pid) return;
-  treeKill(serverProcess.pid);
+const KILL_TIMEOUT_MS = 5_000;
+
+export async function killServer(): Promise<void> {
+  const proc = serverProcess;
+  if (!proc?.pid) return;
+
   serverProcess = null;
+
+  const pid = proc.pid;
+
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        // already dead
+      }
+      resolve();
+    }, KILL_TIMEOUT_MS);
+
+    proc.once('exit', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+
+    treeKill(pid, 'SIGTERM', (err) => {
+      if (err) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          // already dead
+        }
+      }
+    });
+  });
 }

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -21,7 +21,7 @@ type UpdaterState = {
 
 type UpdaterOptions = {
   getWindow: () => BrowserWindow | null;
-  prepareForInstall: () => void;
+  prepareForInstall: () => void | Promise<void>;
 };
 
 const UPDATER_EVENT_CHANNEL = 'updater:event';
@@ -106,12 +106,12 @@ export function createUpdater(options: UpdaterOptions) {
     return state;
   }
 
-  function installUpdate(): boolean {
+  async function installUpdate(): Promise<boolean> {
     if (!app.isPackaged || state.status !== 'downloaded') {
       return false;
     }
 
-    options.prepareForInstall();
+    await options.prepareForInstall();
     autoUpdater.quitAndInstall(false, true);
     return true;
   }

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -9,12 +9,14 @@ import * as schema from '@/db/schema.js';
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
+import type { Database } from 'bun:sqlite';
 
 type Db = BunSQLiteDatabase<typeof schema>;
 
 const log = Log.create({ service: 'db' });
 
 let _db: Db | undefined;
+let _sqlite: Database | undefined;
 
 function getDatabasePath(): string {
   return process.env['STITCH_DB_PATH']?.trim() || PATHS.filePaths.db;
@@ -91,6 +93,7 @@ export async function initDb(): Promise<void> {
   sqlite.run('PRAGMA busy_timeout = 5000');
   sqlite.run('PRAGMA foreign_keys = ON');
 
+  _sqlite = sqlite;
   _db = drizzle({ client: sqlite, schema }) as Db;
   migrate(_db, { migrationsFolder: migrationsDir });
 
@@ -98,4 +101,24 @@ export async function initDb(): Promise<void> {
   seedSettings(_db);
 
   log.info({ path: dbPath, migrationsDir, runtime: 'bun-sqlite' }, 'database initialized');
+}
+
+export function closeDb(): void {
+  if (!_sqlite) return;
+
+  try {
+    _sqlite.run('PRAGMA wal_checkpoint(TRUNCATE)');
+  } catch {
+    // best-effort WAL checkpoint
+  }
+
+  try {
+    _sqlite.close();
+  } catch {
+    // best-effort close
+  }
+
+  _sqlite = undefined;
+  _db = undefined;
+  log.info('database closed');
 }

--- a/packages/server/src/shutdown.ts
+++ b/packages/server/src/shutdown.ts
@@ -1,4 +1,5 @@
 import { shutdownConnectorRuntime } from '@/connectors/runtime.js';
+import { closeDb } from '@/db/client.js';
 import * as Log from '@/lib/log.js';
 import { stopMeetingDetection } from '@/recordings/meeting-detection.js';
 import { stopScheduler } from '@/scheduler/runtime.js';
@@ -10,6 +11,7 @@ async function shutdown(signal: string) {
   await stopScheduler();
   stopMeetingDetection();
   await shutdownConnectorRuntime();
+  closeDb();
   process.exit(0);
 }
 


### PR DESCRIPTION
## 🚀 Change Summary

Fixes a critical bug where Stitch becomes unusable after upgrading or restarting — showing "Server exited before becoming healthy (code=1)". Three independent issues combine to cause this on both macOS and Windows.

### 🐛 Bug Fixes

- **Await server process death before relaunching**: `killServer()` was fire-and-forget, so during auto-updates the new server would launch while the old one still held the SQLite DB lock. It now waits for confirmed process exit with a 5-second SIGKILL escalation.
- **Close SQLite database on shutdown**: The server exited without closing the DB connection or checkpointing the WAL, leaving sidecar files that a new binary version could fail to replay. Added `closeDb()` which flushes WAL via `PRAGMA wal_checkpoint(TRUNCATE)` and closes the connection before exit.
- **Kill orphaned server processes on startup**: If the Electron host dies without cleaning up (force-quit, SIGKILL during update, power loss), stale stitch-server processes linger. `spawnServer()` now runs a best-effort cleanup of orphaned processes before launching a new one.