### PR TITLE
fix(desktop): sign audio-capture sidecar binaries to fix macOS screen recording permission denial

### DIFF
--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -82,7 +82,11 @@ const config: Configuration = {
     artifactName: '${productName}-macos-${arch}.${ext}',
     icon: 'resources/icon.icns',
     category: 'public.app-category.developer-tools',
-    binaries: ['Contents/Resources/stitch-server'],
+    binaries: [
+      'Contents/Resources/stitch-server',
+      'Contents/Resources/audio-capture/stitch-audio-capture',
+      'Contents/Resources/audio-capture/stitch-meeting-watch',
+    ],
     target: ['dmg', 'zip'],
   },
   linux: {


### PR DESCRIPTION
## 🚀 Change Summary

Fixes a bug where the Stitch packaged app reports "Screen recording access is denied" even when the user has granted Stitch screen recording permission in macOS System Settings > Privacy & Security > Screen & System Audio Recording. The issue persists across app and computer restarts.

### 🐛 Bug Fix

- **Code-sign `stitch-audio-capture` and `stitch-meeting-watch` sidecar binaries on macOS**: Added both binaries to the `mac.binaries` array in the electron-builder configuration so they are signed with the same Apple Developer identity as the main app.

### Root Cause

The recording permission check flow works as follows:

1. The Electron app spawns the bundled `stitch-server` binary
2. When the user clicks "Start recording", the frontend calls `GET /recordings/permissions`
3. The server spawns the `stitch-audio-capture` binary from `Contents/Resources/audio-capture/`
4. That binary calls the macOS C function `CGPreflightScreenCaptureAccess()` to check if screen recording permission has been granted
5. The result (`"granted"` or `"denied"`) is sent back up the chain to the frontend

The critical issue is in step 4: `CGPreflightScreenCaptureAccess()` checks whether **the calling process** has screen recording permission. macOS associates permissions with an app's **code signature** (team ID + bundle ID).

Previously, only `stitch-server` was listed in `mac.binaries`:

```typescript
binaries: ['Contents/Resources/stitch-server'],
```

The `stitch-audio-capture` and `stitch-meeting-watch` binaries were included in the app bundle via `extraResources` but were **never code-signed** with the Stitch app's team identity. When the unsigned `stitch-audio-capture` binary called `CGPreflightScreenCaptureAccess()`, macOS could not associate it with the "Stitch" entry in Privacy settings — it was effectively an unknown binary requesting screen recording access, so macOS returned `denied`.

### Why This Fix Works

When electron-builder processes the `mac.binaries` array, it signs each listed binary with the same Apple Developer identity and team ID used for the main Electron app. After this change:

1. `stitch-audio-capture` is signed with the same team ID as `Stitch.app`
2. macOS recognizes the binary as part of the Stitch app bundle
3. The screen recording permission granted to "Stitch" in System Settings correctly propagates to the sidecar binary
4. `CGPreflightScreenCaptureAccess()` returns `true`

### Post-Update Note

After installing a build with this fix, users may need to remove "Stitch" from the Screen & System Audio Recording list in System Settings and re-add it, since macOS caches the code signature hash and the newly signed binary will have a different hash.