### PR TITLE
improvement: enhance visibility of cron builder and automation dialog tabs in dark mode

### DIFF
--- a/apps/web/src/components/automations/automation-dialog.tsx
+++ b/apps/web/src/components/automations/automation-dialog.tsx
@@ -262,19 +262,20 @@ export function AutomationDialog({
               >
                 Preview
               </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant={editorView === 'schedule' ? 'default' : 'ghost'}
-                onClick={() => {
-                  if (!isScheduled) return;
-                  setEditorView('schedule');
-                }}
-                disabled={!isScheduled}
-                className={editorView === 'schedule' ? 'bg-background text-foreground shadow-sm hover:bg-background' : ''}
-              >
-                Schedule
-              </Button>
+              {isScheduled && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={editorView === 'schedule' ? 'default' : 'ghost'}
+                  onClick={() => {
+                    if (!isScheduled) return;
+                    setEditorView('schedule');
+                  }}
+                  className={editorView === 'schedule' ? 'bg-background text-foreground shadow-sm hover:bg-background' : ''}
+                >
+                  Schedule
+                </Button>
+              )}
             </div>
 
             {editorView === 'preview' ? (

--- a/apps/web/src/components/automations/automation-dialog.tsx
+++ b/apps/web/src/components/automations/automation-dialog.tsx
@@ -243,32 +243,35 @@ export function AutomationDialog({
           </div>
 
           <div className="flex min-h-0 flex-col px-6 py-5">
-            <div className="mb-3 inline-flex w-fit gap-1 rounded-lg border border-border/60 bg-muted/20 p-1">
+            <div className="mb-3 inline-flex w-fit gap-1 rounded-[min(var(--radius-md),10px)] border border-border/60 bg-muted/30 p-1">
               <Button
                 type="button"
                 size="sm"
-                variant={editorView === 'prompt' ? 'secondary' : 'ghost'}
+                variant={editorView === 'prompt' ? 'default' : 'ghost'}
                 onClick={() => setEditorView('prompt')}
+                className={editorView === 'prompt' ? 'bg-background text-foreground shadow-sm hover:bg-background' : ''}
               >
                 Prompt
               </Button>
               <Button
                 type="button"
                 size="sm"
-                variant={editorView === 'preview' ? 'secondary' : 'ghost'}
+                variant={editorView === 'preview' ? 'default' : 'ghost'}
                 onClick={() => setEditorView('preview')}
+                className={editorView === 'preview' ? 'bg-background text-foreground shadow-sm hover:bg-background' : ''}
               >
                 Preview
               </Button>
               <Button
                 type="button"
                 size="sm"
-                variant={editorView === 'schedule' ? 'secondary' : 'ghost'}
+                variant={editorView === 'schedule' ? 'default' : 'ghost'}
                 onClick={() => {
                   if (!isScheduled) return;
                   setEditorView('schedule');
                 }}
                 disabled={!isScheduled}
+                className={editorView === 'schedule' ? 'bg-background text-foreground shadow-sm hover:bg-background' : ''}
               >
                 Schedule
               </Button>

--- a/apps/web/src/components/cron-expression-builder.tsx
+++ b/apps/web/src/components/cron-expression-builder.tsx
@@ -248,7 +248,7 @@ export function CronExpressionBuilder({
           <ToggleGroupItem
             key={m}
             value={m.toString()}
-            className="h-8 w-9 p-0 text-xs data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+            className="h-8 w-9 p-0 text-xs hover:bg-accent hover:text-accent-foreground aria-pressed:bg-primary! aria-pressed:text-primary-foreground! aria-pressed:shadow-sm"
           >
             {m.toString().padStart(2, '0')}
           </ToggleGroupItem>
@@ -275,7 +275,7 @@ export function CronExpressionBuilder({
           <ToggleGroupItem
             key={h}
             value={h.toString()}
-            className="h-8 w-9 p-0 text-xs data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+            className="h-8 w-9 p-0 text-xs hover:bg-accent hover:text-accent-foreground aria-pressed:bg-primary! aria-pressed:text-primary-foreground! aria-pressed:shadow-sm"
           >
             {h.toString().padStart(2, '0')}
           </ToggleGroupItem>
@@ -302,7 +302,7 @@ export function CronExpressionBuilder({
           <ToggleGroupItem
             key={day.value}
             value={day.value}
-            className="h-8 min-w-12 px-2 text-xs data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+            className="h-8 min-w-12 px-2 text-xs hover:bg-accent hover:text-accent-foreground aria-pressed:bg-primary! aria-pressed:text-primary-foreground! aria-pressed:shadow-sm"
           >
             {day.label}
           </ToggleGroupItem>
@@ -331,7 +331,7 @@ export function CronExpressionBuilder({
           <ToggleGroupItem
             key={d}
             value={d.toString()}
-            className="h-8 w-9 p-0 text-xs data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+            className="h-8 w-9 p-0 text-xs hover:bg-accent hover:text-accent-foreground aria-pressed:bg-primary! aria-pressed:text-primary-foreground! aria-pressed:shadow-sm"
           >
             {d}
           </ToggleGroupItem>
@@ -358,7 +358,7 @@ export function CronExpressionBuilder({
           <ToggleGroupItem
             key={m}
             value={(i + 1).toString()}
-            className="h-8 w-10 p-0 text-xs data-[state=on]:bg-primary data-[state=on]:text-primary-foreground"
+            className="h-8 w-10 p-0 text-xs hover:bg-accent hover:text-accent-foreground aria-pressed:bg-primary! aria-pressed:text-primary-foreground! aria-pressed:shadow-sm"
           >
             {m}
           </ToggleGroupItem>
@@ -389,13 +389,13 @@ export function CronExpressionBuilder({
               }
             }
           }}
-          className="justify-start border rounded-md p-1 w-fit"
+          className="justify-start border bg-muted/30 rounded-md p-1 w-fit"
         >
           {FREQUENCIES.map((f) => (
             <ToggleGroupItem
               key={f.value}
               value={f.value}
-              className="h-8 px-3 text-xs data-[state=on]:bg-muted data-[state=on]:text-foreground"
+              className="h-8 px-3 text-xs hover:bg-accent hover:text-accent-foreground aria-pressed:bg-background! aria-pressed:text-foreground! aria-pressed:shadow-sm rounded-sm"
             >
               {f.label}
             </ToggleGroupItem>


### PR DESCRIPTION
## 🚀 Change Summary

This PR improves the visibility of selected states in the Cron Expression Builder and the Automation Dialog's tab switcher (Prompt/Preview/Schedule), ensuring clear contrast and visual hierarchy, particularly when using dark mode themes.

Fixes #101

### 🛠 Improvements & Refactors
- **Cron Expression Builder**: Updated the \ToggleGroupItem\ components to use explicitly styled hover states and high-contrast selected states (\ria-pressed\) instead of relying on default low-contrast variants.
- **Automation Dialog Tabs**: Converted the Prompt/Preview/Schedule selector into a distinct, iOS-style segmented control with a shadowed active state.
- **Dynamic Tab Visibility**: Hid the \
Schedule\ tab in the Automation Dialog when the trigger mode is set to Manual to reduce UI clutter.
