### PR TITLE
fix: render compaction summary as formatted markdown

### DIFF
--- a/apps/web/src/components/chat/message-bubble/compaction-divider.tsx
+++ b/apps/web/src/components/chat/message-bubble/compaction-divider.tsx
@@ -10,10 +10,17 @@ type CompactionDividerProps = {
   summaryParts?: StoredPart[];
 };
 
+function stripOuterCodeFence(text: string): string {
+  const trimmed = text.trim();
+  const match = trimmed.match(/^```(?:\w*\n)?([\s\S]*?)```$/);
+  return match ? (match[1]?.trim() ?? trimmed) : trimmed;
+}
+
 export function CompactionDivider({ summaryParts }: CompactionDividerProps) {
   const [open, setOpen] = React.useState(false);
 
-  const summaryText = summaryParts ? extractTextFromParts(summaryParts) : '';
+  const raw = summaryParts ? extractTextFromParts(summaryParts) : '';
+  const summaryText = stripOuterCodeFence(raw);
   const hasSummary = !!summaryText;
 
   return (
@@ -39,7 +46,7 @@ export function CompactionDivider({ summaryParts }: CompactionDividerProps) {
         <div className="h-px flex-1 bg-border/60" />
       </div>
       {open && hasSummary && (
-        <div className="mt-2 rounded-lg border border-border/40 bg-muted/30 px-4 py-3">
+        <div className="w-full">
           <ChatMarkdown text={summaryText} />
         </div>
       )}

--- a/apps/web/src/lib/actions.ts
+++ b/apps/web/src/lib/actions.ts
@@ -1,4 +1,4 @@
-import { useMatchRoute, useNavigate } from '@tanstack/react-router';
+import { useNavigate, useParams } from '@tanstack/react-router';
 
 import type { ShortcutActionId } from '@stitch/shared/shortcuts/types';
 
@@ -14,9 +14,8 @@ export interface Action {
 
 export function useActions(): Action[] {
   const navigate = useNavigate();
-  const matchRoute = useMatchRoute();
-  const sessionMatch = matchRoute({ to: '/session/$id' });
-  const sessionId = sessionMatch ? sessionMatch.id : undefined;
+  const params = useParams({ strict: false });
+  const sessionId = params?.id;
   const {
     commandPaletteOpen,
     setCommandPaletteOpen,

--- a/packages/server/src/llm/compaction.ts
+++ b/packages/server/src/llm/compaction.ts
@@ -187,8 +187,8 @@ const COMPACTION_PROMPT = `Provide a detailed prompt for continuing our conversa
 Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.
 The summary that you construct will be used so a future run can continue the work.
 
-When constructing the summary, try to stick to this template:
----
+Use the following markdown sections in your response. Do not wrap your response in a code block.
+
 ## Goal
 
 [What goal(s) is the user trying to accomplish?]
@@ -209,7 +209,6 @@ When constructing the summary, try to stick to this template:
 ## Relevant files / directories
 
 [Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
----
 
 Keep your summary under 1500 words. Prioritize actionable information over completeness.
 If the conversation is very long, focus on the most recent work and goals.`;


### PR DESCRIPTION
## Change Summary

Fixes the session compaction summary rendering as a raw monospace code block instead of formatted markdown.

### Bug Fixes
- **Compaction summary rendered in a box**: The compaction prompt used `---` delimiters around the template which caused the LLM to wrap its output in a code fence, rendering as a `<pre>` block with a scrollbar instead of formatted prose
- **Prompt fix**: Removed `---` delimiters and added an explicit instruction not to wrap the response in a code block
- **Defensive FE fix**: Added `stripOuterCodeFence` in `CompactionDivider` to strip any wrapping code fence before passing text to `ChatMarkdown`, as a fallback for any existing stored summaries
- **Container removed**: Expanded summary now renders flush with the chat like a regular assistant message instead of inside a bordered box

Closes #98