### PR TITLE
fix: AWS provider region required + fix broken disconnect

### DIFF
--- a/apps/web/src/components/onboarding/onboarding-dialog.tsx
+++ b/apps/web/src/components/onboarding/onboarding-dialog.tsx
@@ -178,6 +178,7 @@ function OnboardingProviderConfig({
   const [activeTab, setActiveTab] = React.useState(defaultMethod);
   const [fieldsByMethod, setFieldsByMethod] = React.useState<Record<string, FieldValues>>({});
   const [extraFields, setExtraFields] = React.useState<FieldValues>({});
+  const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>({});
 
   React.useEffect(() => {
     if (!existingConfig || !meta) return;
@@ -220,14 +221,52 @@ function OnboardingProviderConfig({
       ...prev,
       [activeTab]: { ...prev[activeTab], [key]: value },
     }));
+    if (fieldErrors[key]) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    }
   }
 
   function handleExtraFieldChange(key: string, value: string) {
     setExtraFields((prev) => ({ ...prev, [key]: value }));
+    if (fieldErrors[key]) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    }
   }
 
   function handleSave() {
     if (!meta) return;
+
+    const errors: Record<string, string> = {};
+
+    for (const field of meta.extraFields) {
+      if (field.required && !extraFields[field.key]) {
+        errors[field.key] = `${field.label} is required`;
+      }
+    }
+
+    const methodDef = enabledAuthMethods.find((m) => m.method === activeTab);
+    if (methodDef) {
+      for (const field of methodDef.fields) {
+        if (field.required && !currentMethodFields[field.key]) {
+          errors[field.key] = `${field.label} is required`;
+        }
+      }
+    }
+
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    setFieldErrors({});
     const body = buildProviderConfigBody({
       activeTab,
       enabledAuthMethods,
@@ -270,6 +309,7 @@ function OnboardingProviderConfig({
             fields={meta.extraFields}
             providerId={provider.id}
             values={extraFields}
+            errors={fieldErrors}
             onChange={handleExtraFieldChange}
           />
         )}
@@ -290,6 +330,7 @@ function OnboardingProviderConfig({
                     fields={m.fields}
                     providerId={`${provider.id}-${m.method}`}
                     values={fieldsByMethod[m.method] ?? {}}
+                    errors={fieldErrors}
                     onChange={(key, value) =>
                       setFieldsByMethod((prev) => ({
                         ...prev,
@@ -310,6 +351,7 @@ function OnboardingProviderConfig({
               fields={activeMethodDef.fields}
               providerId={provider.id}
               values={currentMethodFields}
+              errors={fieldErrors}
               onChange={handleMethodFieldChange}
             />
           ) : (

--- a/apps/web/src/components/settings/providers/field-group.tsx
+++ b/apps/web/src/components/settings/providers/field-group.tsx
@@ -15,11 +15,13 @@ export function FieldGroup({
   fields,
   providerId,
   values,
+  errors = {},
   onChange,
 }: {
   fields: FieldDef[];
   providerId: string;
   values: FieldValues;
+  errors?: Record<string, string>;
   onChange: (key: string, value: string) => void;
 }) {
   if (fields.length === 0) {
@@ -41,7 +43,10 @@ export function FieldGroup({
               value={values[field.key] ?? ''}
               onValueChange={(value) => onChange(field.key, value || '')}
             >
-              <SelectTrigger id={`${providerId}-${field.key}`} className="w-full">
+              <SelectTrigger
+                id={`${providerId}-${field.key}`}
+                className={`w-full${errors[field.key] ? ' border-destructive' : ''}`}
+              >
                 <SelectValue placeholder={field.placeholder}>
                   {field.options.find((o) => o.value === values[field.key])?.label ?? values[field.key]}
                 </SelectValue>
@@ -60,9 +65,13 @@ export function FieldGroup({
               type={field.secret ? 'password' : 'text'}
               placeholder={field.placeholder}
               value={values[field.key] ?? ''}
+              className={errors[field.key] ? 'border-destructive' : undefined}
               onChange={(event) => onChange(field.key, event.target.value)}
             />
           )}
+          {errors[field.key] ? (
+            <p className="text-xs text-destructive">{errors[field.key]}</p>
+          ) : null}
         </div>
       ))}
     </div>

--- a/apps/web/src/components/settings/providers/provider-config.tsx
+++ b/apps/web/src/components/settings/providers/provider-config.tsx
@@ -48,6 +48,7 @@ export function ProviderConfig({ provider, onBack }: Props) {
   const [activeTab, setActiveTab] = React.useState(defaultMethod);
   const [fieldsByMethod, setFieldsByMethod] = React.useState<Record<string, FieldValues>>({});
   const [extraFields, setExtraFields] = React.useState<FieldValues>({});
+  const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>({});
 
   React.useEffect(() => {
     if (!existingConfig || !meta) return;
@@ -98,14 +99,52 @@ export function ProviderConfig({ provider, onBack }: Props) {
       ...prev,
       [activeTab]: { ...prev[activeTab], [key]: value },
     }));
+    if (fieldErrors[key]) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    }
   }
 
   function handleExtraFieldChange(key: string, value: string) {
     setExtraFields((prev) => ({ ...prev, [key]: value }));
+    if (fieldErrors[key]) {
+      setFieldErrors((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    }
   }
 
   function handleSave() {
     if (!meta) return;
+
+    const errors: Record<string, string> = {};
+
+    for (const field of meta.extraFields) {
+      if (field.required && !extraFields[field.key]) {
+        errors[field.key] = `${field.label} is required`;
+      }
+    }
+
+    const methodDef = enabledAuthMethods.find((m) => m.method === activeTab);
+    if (methodDef) {
+      for (const field of methodDef.fields) {
+        if (field.required && !currentMethodFields[field.key]) {
+          errors[field.key] = `${field.label} is required`;
+        }
+      }
+    }
+
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    setFieldErrors({});
     const body = buildProviderConfigBody({
       activeTab,
       enabledAuthMethods,
@@ -156,6 +195,7 @@ export function ProviderConfig({ provider, onBack }: Props) {
             fields={meta.extraFields}
             providerId={provider.id}
             values={extraFields}
+            errors={fieldErrors}
             onChange={handleExtraFieldChange}
           />
         )}
@@ -177,6 +217,7 @@ export function ProviderConfig({ provider, onBack }: Props) {
                     fields={m.fields}
                     providerId={`${provider.id}-${m.method}`}
                     values={fieldsByMethod[m.method] ?? {}}
+                    errors={fieldErrors}
                     onChange={(key, value) =>
                       setFieldsByMethod((prev) => ({
                         ...prev,
@@ -197,6 +238,7 @@ export function ProviderConfig({ provider, onBack }: Props) {
               fields={activeMethodDef.fields}
               providerId={provider.id}
               values={currentMethodFields}
+              errors={fieldErrors}
               onChange={handleMethodFieldChange}
             />
           ) : (

--- a/apps/web/src/components/settings/providers/provider-row.tsx
+++ b/apps/web/src/components/settings/providers/provider-row.tsx
@@ -1,15 +1,15 @@
 import { PlusIcon } from 'lucide-react';
 import * as React from 'react';
 
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { PROVIDER_META } from '@stitch/shared/providers/catalog';
 import { PROVIDER_IDS, type ProviderId } from '@stitch/shared/providers/types';
 
 import { ProviderLogo } from '@/components/settings/providers/provider-logo';
 import { Button } from '@/components/ui/button';
-import { serverFetch } from '@/lib/api';
-import { type ProviderSummary, providerKeys } from '@/lib/queries/providers';
+import { useDeleteProviderConfigMutation } from '@/lib/mutations/provider-config';
+import { type ProviderSummary } from '@/lib/queries/providers';
 
 type Props = {
   provider: ProviderSummary;
@@ -22,14 +22,11 @@ export function ProviderRow({ provider, onSelect }: Props) {
     : undefined;
   const queryClient = useQueryClient();
 
-  const deleteMutation = useMutation({
-    mutationFn: async () => {
-      const res = await serverFetch(`/provider/${provider.id}/config`, { method: 'DELETE' });
-      if (!res.ok) throw new Error('Failed to disconnect');
-    },
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: providerKeys.all });
-    },
+  const deleteMutation = useDeleteProviderConfigMutation({
+    providerId: provider.id,
+    queryClient,
+    successMessage: `${meta?.displayName ?? 'Provider'} disconnected`,
+    errorMessage: 'Failed to disconnect',
   });
 
   if (!meta) return null;

--- a/packages/server/src/llm/provider/provider.ts
+++ b/packages/server/src/llm/provider/provider.ts
@@ -14,7 +14,7 @@ const AWS_REGION_VALUES = AWS_BEDROCK_REGIONS.map((r) => r.value) as [string, ..
 
 const BedrockCredentialsSchema = z.object({
   providerId: z.literal('amazon-bedrock'),
-  region: z.enum(AWS_REGION_VALUES).optional(),
+  region: z.enum(AWS_REGION_VALUES),
   auth: z.discriminatedUnion('method', [
     z.object({ method: z.literal('api-key'), apiKey: z.string() }),
     z.object({


### PR DESCRIPTION
## 🚀 Change Summary

Fixes issue #88 — AWS (Amazon Bedrock) provider could be saved without a region, resulting in a broken provider config, and the disconnect button silently failed due to a wrong API path.

### 🐛 Bug Fixes
- **Region required for Amazon Bedrock**: Backend schema now rejects payloads missing a region (z.enum instead of .optional()); frontend blocks form submission with inline validation errors in both the Settings and Onboarding flows
- **Silent disconnect failure in provider list**: ProviderRow had an inline delete mutation using the wrong URL (/provider/ instead of /llm/provider/) and no onError handler — replaced with the shared useDeleteProviderConfigMutation which has the correct path, error toast, and full query invalidation

### 🛠 Improvements & Refactors
- FieldGroup component now accepts an errors prop to display per-field validation messages with destructive border styling
- Consolidated provider disconnect logic — ProviderRow now uses the shared useDeleteProviderConfigMutation instead of a duplicate inline mutation