### PR TITLE
fix: memory & usage ServiceResult normalization + auto-save detail sheets

### DIFF
--- a/apps/web/src/components/agenda/agenda-item-detail.tsx
+++ b/apps/web/src/components/agenda/agenda-item-detail.tsx
@@ -47,6 +47,8 @@ import {
 } from '@/lib/queries/agenda';
 import { cn } from '@/lib/utils';
 
+const DEBOUNCE_MS = 600;
+
 type Props = {
   item: AgendaItem | null;
   open: boolean;
@@ -77,6 +79,13 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
   const [confirmDeleteOpen, setConfirmDeleteOpen] = React.useState(false);
   const [datePickerOpen, setDatePickerOpen] = React.useState(false);
 
+  const updateMutation = useUpdateAgendaItem();
+  const deleteMutation = useDeleteAgendaItem();
+
+  // Keep a stable ref to the item so callbacks can access it without stale closures
+  const itemRef = React.useRef(item);
+  itemRef.current = item;
+
   React.useEffect(() => {
     if (item) {
       setTitle(item.title);
@@ -85,10 +94,7 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
       setPriority(item.priority);
       setDueDate(item.dueAt ? new Date(item.dueAt) : undefined);
     }
-  }, [item, timeZone]);
-
-  const updateMutation = useUpdateAgendaItem();
-  const deleteMutation = useDeleteAgendaItem();
+  }, [item]);
 
   function dateToMs(date: Date): number {
     const y = date.getFullYear();
@@ -97,22 +103,91 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
     return new Date(y, m, d, 12, 0, 0).getTime();
   }
 
-  function handleSave() {
-    if (!item) return;
-    const newDueMs = dueDate ? dateToMs(dueDate) : null;
-    updateMutation.mutate(
-      {
-        id: item.id,
-        updates: {
-          title: title !== item.title ? title : undefined,
-          description: description !== item.description ? description : undefined,
-          status: status !== item.status ? status : undefined,
-          priority: priority !== item.priority ? priority : undefined,
-          dueAt: newDueMs !== item.dueAt ? newDueMs : undefined,
-        },
-      },
-      { onSuccess: () => onOpenChange(false) },
-    );
+  function save(updates: {
+    title?: string;
+    description?: string;
+    status?: AgendaItemStatus;
+    priority?: AgendaItemPriority;
+    dueAt?: number | null;
+  }) {
+    if (!itemRef.current) return;
+    updateMutation.mutate({ id: itemRef.current.id, updates });
+  }
+
+  // Debounced save for text fields
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function saveDebounced(updates: { title?: string; description?: string }) {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => save(updates), DEBOUNCE_MS);
+  }
+
+  // Flush any pending debounced save when the sheet closes
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+      const current = itemRef.current;
+      if (current) {
+        const pendingTitle = title !== current.title ? title : undefined;
+        const pendingDescription = description !== current.description ? description : undefined;
+        if (pendingTitle !== undefined || pendingDescription !== undefined) {
+          save({ title: pendingTitle, description: pendingDescription });
+        }
+      }
+    }
+    onOpenChange(nextOpen);
+  }
+
+  function handleTitleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const next = e.target.value;
+    setTitle(next);
+    if (itemRef.current && next !== itemRef.current.title) {
+      saveDebounced({ title: next, description: undefined });
+    }
+  }
+
+  function handleDescriptionChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const next = e.target.value;
+    setDescription(next);
+    if (itemRef.current && next !== itemRef.current.description) {
+      saveDebounced({ title: undefined, description: next });
+    }
+  }
+
+  function handleStatusChange(v: string | null) {
+    if (!v) return;
+    const next = v as AgendaItemStatus;
+    setStatus(next);
+    if (itemRef.current && next !== itemRef.current.status) {
+      save({ status: next });
+    }
+  }
+
+  function handlePriorityChange(v: string | null) {
+    if (!v) return;
+    const next = v as AgendaItemPriority;
+    setPriority(next);
+    if (itemRef.current && next !== itemRef.current.priority) {
+      save({ priority: next });
+    }
+  }
+
+  function handleDateSelect(date: Date | undefined) {
+    setDueDate(date);
+    setDatePickerOpen(false);
+    if (!itemRef.current) return;
+    const newDueMs = date ? dateToMs(date) : null;
+    if (newDueMs !== itemRef.current.dueAt) {
+      save({ dueAt: newDueMs });
+    }
+  }
+
+  function handleClearDate() {
+    setDueDate(undefined);
+    if (itemRef.current && itemRef.current.dueAt !== null) {
+      save({ dueAt: null });
+    }
   }
 
   function handleDelete() {
@@ -125,19 +200,11 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
     });
   }
 
-  const isDirty =
-    item &&
-    (title !== item.title ||
-      description !== item.description ||
-      status !== item.status ||
-      priority !== item.priority ||
-      (dueDate ? dateToMs(dueDate) : null) !== item.dueAt);
-
   if (!item) return null;
 
   return (
     <>
-      <Sheet open={open} onOpenChange={onOpenChange}>
+      <Sheet open={open} onOpenChange={handleOpenChange}>
         <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-lg">
           <SheetHeader>
             <SheetTitle>Agenda Item</SheetTitle>
@@ -162,7 +229,7 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
               <Label>Title</Label>
               <Input
                 value={title}
-                onChange={(e) => setTitle(e.target.value)}
+                onChange={handleTitleChange}
                 placeholder="Item title..."
               />
             </div>
@@ -172,7 +239,7 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
               <Label>Description</Label>
               <Textarea
                 value={description}
-                onChange={(e) => setDescription(e.target.value)}
+                onChange={handleDescriptionChange}
                 className="min-h-20 resize-none"
                 placeholder="Details..."
               />
@@ -182,7 +249,7 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
             <div className="grid grid-cols-2 gap-3">
               <div className="flex flex-col gap-1.5">
                 <Label>Status</Label>
-                <Select value={status} onValueChange={(v) => setStatus(v as AgendaItemStatus)}>
+                <Select value={status} onValueChange={handleStatusChange}>
                   <SelectTrigger className="w-full">
                     {STATUS_LABELS[status]}
                   </SelectTrigger>
@@ -198,10 +265,7 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
 
               <div className="flex flex-col gap-1.5">
                 <Label>Priority</Label>
-                <Select
-                  value={priority}
-                  onValueChange={(v) => setPriority(v as AgendaItemPriority)}
-                >
+                <Select value={priority} onValueChange={handlePriorityChange}>
                   <SelectTrigger className="w-full">
                     {PRIORITY_LABELS[priority]}
                   </SelectTrigger>
@@ -236,7 +300,7 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
                       variant="ghost"
                       size="icon-xs"
                       className="shrink-0 text-muted-foreground hover:text-foreground"
-                      onClick={() => setDueDate(undefined)}
+                      onClick={handleClearDate}
                     >
                       <XIcon className="size-3" />
                     </Button>
@@ -246,10 +310,7 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
                   <Calendar
                     mode="single"
                     selected={dueDate}
-                    onSelect={(date) => {
-                      setDueDate(date);
-                      setDatePickerOpen(false);
-                    }}
+                    onSelect={handleDateSelect}
                     defaultMonth={dueDate}
                   />
                 </PopoverContent>
@@ -267,18 +328,9 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
               <Trash2Icon className="size-3.5" />
               Delete
             </Button>
-            <div className="flex gap-2">
-              <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button
-                size="sm"
-                onClick={handleSave}
-                disabled={!isDirty || updateMutation.isPending}
-              >
-                {updateMutation.isPending ? 'Saving...' : 'Save'}
-              </Button>
-            </div>
+            {updateMutation.isPending && (
+              <span className="text-xs text-muted-foreground">Saving…</span>
+            )}
           </SheetFooter>
         </SheetContent>
       </Sheet>

--- a/apps/web/src/components/memories/constants.ts
+++ b/apps/web/src/components/memories/constants.ts
@@ -22,9 +22,3 @@ export const CONFIDENCE_LABELS: Record<MemoryConfidence, string> = {
   inferred: 'Inferred',
   confirmed: 'Confirmed',
 };
-
-export const CONFIDENCE_VARIANTS: Record<MemoryConfidence, 'default' | 'secondary' | 'outline'> = {
-  stated: 'default',
-  inferred: 'secondary',
-  confirmed: 'outline',
-};

--- a/apps/web/src/components/memories/memory-detail-sheet.tsx
+++ b/apps/web/src/components/memories/memory-detail-sheet.tsx
@@ -5,7 +5,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   CATEGORY_LABELS,
   CONFIDENCE_LABELS,
-  CONFIDENCE_VARIANTS,
 } from '@/components/memories/constants';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -29,6 +28,8 @@ import { Textarea } from '@/components/ui/textarea';
 import type { MemoryCategory, MemoryConfidence, SemanticMemory } from '@/lib/queries/memories';
 import { deleteMemoryMutationOptions, updateMemoryMutationOptions } from '@/lib/queries/memories';
 
+const DEBOUNCE_MS = 600;
+
 type Props = {
   memory: SemanticMemory | null;
   open: boolean;
@@ -42,6 +43,12 @@ export function MemoryDetailSheet({ memory, open, onOpenChange }: Props) {
   const [confidence, setConfidence] = React.useState<MemoryConfidence>('stated');
   const [confirmDeleteOpen, setConfirmDeleteOpen] = React.useState(false);
 
+  const updateMutation = useMutation(updateMemoryMutationOptions(queryClient));
+  const deleteMutation = useMutation(deleteMemoryMutationOptions(queryClient));
+
+  const memoryRef = React.useRef(memory);
+  memoryRef.current = memory;
+
   React.useEffect(() => {
     if (memory) {
       setContent(memory.content);
@@ -50,22 +57,58 @@ export function MemoryDetailSheet({ memory, open, onOpenChange }: Props) {
     }
   }, [memory]);
 
-  const updateMutation = useMutation(updateMemoryMutationOptions(queryClient));
-  const deleteMutation = useMutation(deleteMemoryMutationOptions(queryClient));
+  function save(updates: {
+    content?: string;
+    category?: MemoryCategory;
+    confidence?: MemoryConfidence;
+  }) {
+    if (!memoryRef.current) return;
+    updateMutation.mutate({ id: memoryRef.current.id, updates });
+  }
 
-  function handleSave() {
-    if (!memory) return;
-    updateMutation.mutate(
-      {
-        id: memory.id,
-        updates: {
-          content: content !== memory.content ? content : undefined,
-          category: category !== memory.category ? category : undefined,
-          confidence: confidence !== memory.confidence ? confidence : undefined,
-        },
-      },
-      { onSuccess: () => onOpenChange(false) },
-    );
+  const debounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function saveDebounced(nextContent: string) {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => save({ content: nextContent }), DEBOUNCE_MS);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+      const current = memoryRef.current;
+      if (current && content !== current.content) {
+        save({ content });
+      }
+    }
+    onOpenChange(nextOpen);
+  }
+
+  function handleContentChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const next = e.target.value;
+    setContent(next);
+    if (memoryRef.current && next !== memoryRef.current.content) {
+      saveDebounced(next);
+    }
+  }
+
+  function handleCategoryChange(v: string | null) {
+    if (!v) return;
+    const next = v as MemoryCategory;
+    setCategory(next);
+    if (memoryRef.current && next !== memoryRef.current.category) {
+      save({ category: next });
+    }
+  }
+
+  function handleConfidenceChange(v: string | null) {
+    if (!v) return;
+    const next = v as MemoryConfidence;
+    setConfidence(next);
+    if (memoryRef.current && next !== memoryRef.current.confidence) {
+      save({ confidence: next });
+    }
   }
 
   function handleDelete() {
@@ -78,11 +121,6 @@ export function MemoryDetailSheet({ memory, open, onOpenChange }: Props) {
     });
   }
 
-  const isDirty =
-    memory &&
-    (content !== memory.content ||
-      category !== memory.category ||
-      confidence !== memory.confidence);
   const selectedCategoryLabel = CATEGORY_LABELS[category];
   const selectedConfidenceLabel = CONFIDENCE_LABELS[confidence];
 
@@ -90,7 +128,7 @@ export function MemoryDetailSheet({ memory, open, onOpenChange }: Props) {
 
   return (
     <>
-      <Sheet open={open} onOpenChange={onOpenChange}>
+      <Sheet open={open} onOpenChange={handleOpenChange}>
         <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-lg">
           <SheetHeader>
             <SheetTitle>Memory</SheetTitle>
@@ -102,7 +140,7 @@ export function MemoryDetailSheet({ memory, open, onOpenChange }: Props) {
               <Label>Content</Label>
               <Textarea
                 value={content}
-                onChange={(e) => setContent(e.target.value)}
+                onChange={handleContentChange}
                 className="min-h-28 resize-none"
                 placeholder="Memory content..."
               />
@@ -111,7 +149,7 @@ export function MemoryDetailSheet({ memory, open, onOpenChange }: Props) {
             {/* Category */}
             <div className="flex flex-col gap-1.5">
               <Label>Category</Label>
-              <Select value={category} onValueChange={(v) => setCategory(v as MemoryCategory)}>
+              <Select value={category} onValueChange={handleCategoryChange}>
                 <SelectTrigger className="w-full">
                   <SelectValue>{selectedCategoryLabel}</SelectValue>
                 </SelectTrigger>
@@ -128,19 +166,14 @@ export function MemoryDetailSheet({ memory, open, onOpenChange }: Props) {
             {/* Confidence */}
             <div className="flex flex-col gap-1.5">
               <Label>Confidence</Label>
-              <Select
-                value={confidence}
-                onValueChange={(v) => setConfidence(v as MemoryConfidence)}
-              >
+              <Select value={confidence} onValueChange={handleConfidenceChange}>
                 <SelectTrigger className="w-full">
                   <SelectValue>{selectedConfidenceLabel}</SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {(Object.keys(CONFIDENCE_LABELS) as MemoryConfidence[]).map((conf) => (
                     <SelectItem key={conf} value={conf}>
-                      <div className="flex items-center gap-2">
-                        <Badge variant={CONFIDENCE_VARIANTS[conf]}>{CONFIDENCE_LABELS[conf]}</Badge>
-                      </div>
+                      {CONFIDENCE_LABELS[conf]}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -183,18 +216,9 @@ export function MemoryDetailSheet({ memory, open, onOpenChange }: Props) {
             >
               Delete
             </Button>
-            <div className="flex gap-2">
-              <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
-                Cancel
-              </Button>
-              <Button
-                size="sm"
-                onClick={handleSave}
-                disabled={!isDirty || updateMutation.isPending}
-              >
-                {updateMutation.isPending ? 'Saving…' : 'Save'}
-              </Button>
-            </div>
+            {updateMutation.isPending && (
+              <span className="text-xs text-muted-foreground">Saving…</span>
+            )}
           </SheetFooter>
         </SheetContent>
       </Sheet>

--- a/packages/server/src/memory/maintenance.ts
+++ b/packages/server/src/memory/maintenance.ts
@@ -1,5 +1,7 @@
 import { getMemoryConfig, isMemoryActive } from '@/memory/config.js';
 import { deduplicateMemories, getMemoryStats, pruneStaleMemories } from '@/memory/service.js';
+import type { MemoryStats } from '@/memory/service.js';
+import { isServiceError } from '@/lib/service-result.js';
 import * as Log from '@/lib/log.js';
 
 const log = Log.create({ service: 'memory-maintenance' });
@@ -7,7 +9,7 @@ const log = Log.create({ service: 'memory-maintenance' });
 type MaintenanceResult = {
   pruned: number;
   deduplicated: number;
-  stats: Awaited<ReturnType<typeof getMemoryStats>>;
+  stats: MemoryStats | null;
 };
 
 export async function runMemoryMaintenance(): Promise<MaintenanceResult> {
@@ -23,10 +25,12 @@ export async function runMemoryMaintenance(): Promise<MaintenanceResult> {
   // Phase 1: Autoprune stale/low-value memories if enabled
   let pruned = 0;
   if (config.autoprune) {
-    const beforeStats = await getMemoryStats();
+    const beforeResult = await getMemoryStats();
     await pruneStaleMemories({ maxMemories: config.maxMemories, staleDays: config.staleDays });
-    const afterStats = await getMemoryStats();
-    pruned = Math.max(0, beforeStats.total - afterStats.total);
+    const afterResult = await getMemoryStats();
+    const beforeTotal = isServiceError(beforeResult) ? 0 : beforeResult.data.total;
+    const afterTotal = isServiceError(afterResult) ? 0 : afterResult.data.total;
+    pruned = Math.max(0, beforeTotal - afterTotal);
     log.info({ pruned }, 'memory maintenance: pruning complete');
   }
 
@@ -35,18 +39,21 @@ export async function runMemoryMaintenance(): Promise<MaintenanceResult> {
   log.info({ deduplicated }, 'memory maintenance: dedup sweep complete');
 
   // Phase 3: Emit stats
-  const stats = await getMemoryStats();
-  log.info(
-    {
-      total: stats.total,
-      pinned: stats.pinned,
-      stale: stats.stale,
-      byCategory: stats.byCategory,
-      byConfidence: stats.byConfidence,
-      avgAccessCount: stats.avgAccessCount,
-    },
-    'memory maintenance: stats',
-  );
+  const statsResult = await getMemoryStats();
+  const stats = isServiceError(statsResult) ? null : statsResult.data;
+  if (stats) {
+    log.info(
+      {
+        total: stats.total,
+        pinned: stats.pinned,
+        stale: stats.stale,
+        byCategory: stats.byCategory,
+        byConfidence: stats.byConfidence,
+        avgAccessCount: stats.avgAccessCount,
+      },
+      'memory maintenance: stats',
+    );
+  }
 
   return { pruned, deduplicated, stats };
 }

--- a/packages/server/src/memory/processor.ts
+++ b/packages/server/src/memory/processor.ts
@@ -7,6 +7,7 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { getDb } from '@/db/client.js';
 import { sessions } from '@/db/schema.js';
 import * as Log from '@/lib/log.js';
+import { isServiceError } from '@/lib/service-result.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
 import { getMemoryConfig, isMemoryActive } from '@/memory/config.js';
@@ -162,7 +163,7 @@ export async function processMemories(input: {
           query: fact.content,
           page: 1,
           pageSize: 5,
-        }).then((result) => result.memories),
+        }).then((result) => (isServiceError(result) ? [] : result.data.memories)),
       ),
     );
 

--- a/packages/server/src/memory/retriever.ts
+++ b/packages/server/src/memory/retriever.ts
@@ -1,5 +1,6 @@
 import * as Log from '@/lib/log.js';
 import { getMemoryConfig, isMemoryActive } from '@/memory/config.js';
+import { isServiceError } from '@/lib/service-result.js';
 import { searchSemanticMemories, touchSemanticMemories } from '@/memory/service.js';
 import type { MemorySource } from '@/memory/types.js';
 
@@ -34,12 +35,15 @@ export async function retrieveMemoryContext(
   const config = await getMemoryConfig();
   if (!isMemoryActive(config)) return null;
 
-  const semantic = await searchSemanticMemories({
+  const semanticResult = await searchSemanticMemories({
     query,
     page: 1,
     pageSize: config.retrievalMaxResults * 2, // Fetch more for blended scoring
     sourceFilter,
   });
+
+  if (isServiceError(semanticResult)) return null;
+  const semantic = semanticResult.data;
 
   // Apply base threshold filter first
   let candidates = semantic.memories.filter((m) => m.score >= config.retrievalMinScore);

--- a/packages/server/src/memory/service.ts
+++ b/packages/server/src/memory/service.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 
 import * as Log from '@/lib/log.js';
+import { ok, err } from '@/lib/service-result.js';
+import type { ServiceResult } from '@/lib/service-result.js';
 import type { MemoryEmbedder } from '@/memory/embedding/embedder.js';
 import { createEmbedder } from '@/memory/embedding/factory.js';
 import { getSemanticTable } from '@/memory/store/tables.js';
@@ -13,6 +15,17 @@ import type {
   ExtractedFact,
 } from '@/memory/types.js';
 import type { VectorQuery } from '@lancedb/lancedb';
+
+export type MemoryStats = {
+  total: number;
+  pinned: number;
+  stale: number;
+  byCategory: Record<string, number>;
+  byConfidence: Record<string, number>;
+  avgAccessCount: number;
+  oldestCreatedAt: string | null;
+  newestCreatedAt: string | null;
+};
 
 const log = Log.create({ service: 'memory-service' });
 const MAX_SEARCH_RESULTS = 1000;
@@ -78,7 +91,7 @@ type SemanticMemoryUpdate = {
 export async function updateSemanticMemory(
   id: string,
   updates: SemanticMemoryUpdate,
-): Promise<void> {
+): Promise<ServiceResult<void>> {
   const embedder = await getEmbedder();
   const table = await getSemanticTable(embedder.dimensions);
   const timestamp = now();
@@ -102,8 +115,7 @@ export async function updateSemanticMemory(
       .where(`id = '${escapeSql(id)}'`)
       .toArray();
     if (existing.length === 0) {
-      log.warn({ id }, 'semantic memory not found for update');
-      return;
+      return err('Memory not found', 404);
     }
     const row = existing[0];
 
@@ -129,17 +141,19 @@ export async function updateSemanticMemory(
   }
 
   log.info({ id }, 'updated semantic memory');
+  return ok(undefined);
 }
 
-export async function deleteSemanticMemory(id: string): Promise<void> {
+export async function deleteSemanticMemory(id: string): Promise<ServiceResult<void>> {
   const embedder = await getEmbedder();
   const table = await getSemanticTable(embedder.dimensions);
   await table.delete(`id = '${escapeSql(id)}'`);
   log.info({ id }, 'deleted semantic memory');
+  return ok(undefined);
 }
 
-export async function deleteSemanticMemories(ids: string[]): Promise<void> {
-  if (ids.length === 0) return;
+export async function deleteSemanticMemories(ids: string[]): Promise<ServiceResult<void>> {
+  if (ids.length === 0) return ok(undefined);
 
   const embedder = await getEmbedder();
   const table = await getSemanticTable(embedder.dimensions);
@@ -147,6 +161,7 @@ export async function deleteSemanticMemories(ids: string[]): Promise<void> {
   const escapedList = ids.map((id) => `'${escapeSql(id)}'`).join(', ');
   await table.delete(`id IN (${escapedList})`);
   log.info({ count: ids.length }, 'bulk deleted semantic memories');
+  return ok(undefined);
 }
 
 export async function searchSemanticMemories(input: {
@@ -155,19 +170,19 @@ export async function searchSemanticMemories(input: {
   pageSize: number;
   sourceFilter?: MemorySource;
   categoryFilter?: MemoryCategory;
-}): Promise<SearchSemanticMemoriesResponse> {
+}): Promise<ServiceResult<SearchSemanticMemoriesResponse>> {
   const embedder = await getEmbedder();
   const table = await getSemanticTable(embedder.dimensions);
 
   const [count, vector] = await Promise.all([table.countRows(), embedder.embed(input.query)]);
   if (count === 0) {
-    return {
+    return ok({
       memories: [],
       page: input.page,
       pageSize: input.pageSize,
       total: 0,
       totalPages: 0,
-    };
+    });
   }
 
   let search = (table.search(vector) as VectorQuery)
@@ -193,7 +208,7 @@ export async function searchSemanticMemories(input: {
   const total = results.length;
   const totalPages = total === 0 ? 0 : Math.ceil(total / input.pageSize);
 
-  return {
+  return ok({
     memories: pageRows.map((r: Record<string, unknown>) => ({
       id: r.id as string,
       content: r.content as string,
@@ -212,7 +227,7 @@ export async function searchSemanticMemories(input: {
     pageSize: input.pageSize,
     total,
     totalPages,
-  };
+  });
 }
 
 export async function getAllSemanticMemories(input: {
@@ -220,7 +235,7 @@ export async function getAllSemanticMemories(input: {
   pageSize: number;
   sourceFilter?: MemorySource;
   categoryFilter?: MemoryCategory;
-}): Promise<ListSemanticMemoriesResponse> {
+}): Promise<ServiceResult<ListSemanticMemoriesResponse>> {
   const embedder = await getEmbedder();
   const table = await getSemanticTable(embedder.dimensions);
 
@@ -244,7 +259,7 @@ export async function getAllSemanticMemories(input: {
   const total = rows.length;
   const totalPages = total === 0 ? 0 : Math.ceil(total / input.pageSize);
 
-  return {
+  return ok({
     memories: pageRows.map((r) => ({
       id: r.id as string,
       content: r.content as string,
@@ -262,7 +277,7 @@ export async function getAllSemanticMemories(input: {
     pageSize: input.pageSize,
     total,
     totalPages,
-  };
+  });
 }
 
 export async function touchSemanticMemories(ids: string[]): Promise<void> {
@@ -282,7 +297,7 @@ export async function touchSemanticMemories(ids: string[]): Promise<void> {
   });
 }
 
-export async function pinSemanticMemory(id: string, pinned: boolean): Promise<void> {
+export async function pinSemanticMemory(id: string, pinned: boolean): Promise<ServiceResult<void>> {
   const embedder = await getEmbedder();
   const table = await getSemanticTable(embedder.dimensions);
   
@@ -293,6 +308,7 @@ export async function pinSemanticMemory(id: string, pinned: boolean): Promise<vo
     where: `id = '${escapeSql(id)}'`,
   });
   log.info({ id, pinned }, 'updated memory pin status');
+  return ok(undefined);
 }
 
 function getRecencyFactor(dateStr: string): number {
@@ -308,12 +324,12 @@ function getConfidenceFactor(confidence: string): number {
   return 0.6; // inferred
 }
 
-export async function pruneStaleMemories(config: { maxMemories: number; staleDays: number }): Promise<void> {
+export async function pruneStaleMemories(config: { maxMemories: number; staleDays: number }): Promise<ServiceResult<void>> {
   const embedder = await getEmbedder();
   const table = await getSemanticTable(embedder.dimensions);
   
   const count = await table.countRows();
-  if (count <= config.maxMemories) return;
+  if (count <= config.maxMemories) return ok(undefined);
 
   const rows = await table.query().toArray();
   
@@ -362,6 +378,8 @@ export async function pruneStaleMemories(config: { maxMemories: number; staleDay
     await table.delete(`id IN (${escapedList})`);
     log.info({ count: toDelete.size, totalWas: count, cap: config.maxMemories }, 'pruned low-value/stale memories');
   }
+
+  return ok(undefined);
 }
 
 export async function deduplicateMemories(similarityThreshold = 0.92): Promise<number> {
@@ -428,23 +446,23 @@ function computeMemoryValue(r: Record<string, unknown>): number {
   );
 }
 
-export async function getMemoryStats(): Promise<any> {
+export async function getMemoryStats(): Promise<ServiceResult<MemoryStats>> {
   const embedder = await getEmbedder();
   const table = await getSemanticTable(embedder.dimensions);
   
   const rows = await table.query().toArray();
-  const stats = {
+  const stats: MemoryStats = {
     total: rows.length,
     pinned: 0,
     stale: 0,
-    byCategory: {} as Record<string, number>,
-    byConfidence: {} as Record<string, number>,
+    byCategory: {},
+    byConfidence: {},
     avgAccessCount: 0,
-    oldestCreatedAt: null as string | null,
-    newestCreatedAt: null as string | null,
+    oldestCreatedAt: null,
+    newestCreatedAt: null,
   };
   
-  if (rows.length === 0) return stats;
+  if (rows.length === 0) return ok(stats);
   
   let totalAccesses = 0;
   let oldest = Number.MAX_VALUE;
@@ -475,5 +493,5 @@ export async function getMemoryStats(): Promise<any> {
   stats.oldestCreatedAt = oldest !== Number.MAX_VALUE ? new Date(oldest).toISOString() : null;
   stats.newestCreatedAt = newest !== 0 ? new Date(newest).toISOString() : null;
   
-  return stats;
+  return ok(stats);
 }

--- a/packages/server/src/memory/types.ts
+++ b/packages/server/src/memory/types.ts
@@ -8,4 +8,4 @@ export type {
   ExtractedFact,
 } from '@stitch/shared/memory/types';
 
-export { MEMORY_CATEGORIES, MEMORY_CONFIDENCES } from '@stitch/shared/memory/types';
+export { MEMORY_CATEGORIES, MEMORY_CONFIDENCES, MEMORY_SOURCES } from '@stitch/shared/memory/types';

--- a/packages/server/src/routes/memory.ts
+++ b/packages/server/src/routes/memory.ts
@@ -16,8 +16,17 @@ import {
   pruneStaleMemories,
 } from '@/memory/service.js';
 import { dropSemanticTable } from '@/memory/store/tables.js';
-import { MEMORY_CATEGORIES, MEMORY_CONFIDENCES } from '@/memory/types.js';
+import { MEMORY_CATEGORIES, MEMORY_CONFIDENCES, MEMORY_SOURCES } from '@/memory/types.js';
+import { unwrapResult } from '@/lib/route-helpers.js';
 import type { Context } from 'hono';
+
+const semanticQuerySchema = z.object({
+  source: z.enum(MEMORY_SOURCES).optional(),
+  category: z.enum(MEMORY_CATEGORIES).optional(),
+  q: z.string().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).default(20),
+});
 
 const patchSchema = z.object({
   content: z.string().min(1).optional(),
@@ -50,24 +59,8 @@ async function ensureMemoryActive(c: Context): Promise<Response | null> {
   );
 }
 
-function parsePagination(query: Record<string, string | undefined>) {
-  const pageRaw = Number.parseInt(query.page ?? '1', 10);
-  const pageSizeRaw = Number.parseInt(query.pageSize ?? '20', 10);
-
-  const page = Number.isFinite(pageRaw) && pageRaw > 0 ? pageRaw : 1;
-  const pageSize = Number.isFinite(pageSizeRaw) ? Math.min(Math.max(pageSizeRaw, 1), 100) : 20;
-
-  return { page, pageSize };
-}
-
-memoryRouter.get('/semantic', async (c) => {
-  const source = c.req.query('source');
-  const category = c.req.query('category');
-  const q = c.req.query('q');
-  const { page, pageSize } = parsePagination({
-    page: c.req.query('page'),
-    pageSize: c.req.query('pageSize'),
-  });
+memoryRouter.get('/semantic', zValidator('query', semanticQuerySchema), async (c) => {
+  const { source, category, q, page, pageSize } = c.req.valid('query');
 
   const config = await getMemoryConfig();
   if (!isMemoryActive(config)) {
@@ -75,44 +68,32 @@ memoryRouter.get('/semantic', async (c) => {
   }
 
   if (q) {
-    const results = await searchSemanticMemories({
-      query: q,
-      page,
-      pageSize,
-      sourceFilter: source as 'chat' | 'automation' | undefined,
-      categoryFilter: category as (typeof MEMORY_CATEGORIES)[number] | undefined,
-    });
-    return c.json(results);
+    const result = await searchSemanticMemories({ query: q, page, pageSize, sourceFilter: source, categoryFilter: category });
+    return unwrapResult(c, result);
   }
 
-  const memories = await getAllSemanticMemories({
-    page,
-    pageSize,
-    sourceFilter: source as 'chat' | 'automation' | undefined,
-    categoryFilter: category as (typeof MEMORY_CATEGORIES)[number] | undefined,
-  });
-  return c.json(memories);
+  const result = await getAllSemanticMemories({ page, pageSize, sourceFilter: source, categoryFilter: category });
+  return unwrapResult(c, result);
 });
 
 memoryRouter.get('/stats', async (c) => {
   const inactiveResponse = await ensureMemoryActive(c);
   if (inactiveResponse) return inactiveResponse;
-  
-  const stats = await getMemoryStats();
-  return c.json(stats);
+
+  const result = await getMemoryStats();
+  return unwrapResult(c, result);
 });
 
 memoryRouter.post('/prune', async (c) => {
   const inactiveResponse = await ensureMemoryActive(c);
   if (inactiveResponse) return inactiveResponse;
-  
+
   const config = await getMemoryConfig();
-  await pruneStaleMemories({
+  const result = await pruneStaleMemories({
     maxMemories: config.maxMemories,
     staleDays: config.staleDays,
   });
-  
-  return c.body(null, 204);
+  return unwrapResult(c, result, 204);
 });
 
 memoryRouter.patch('/semantic/:id/pin', zValidator('json', pinSchema), async (c) => {
@@ -122,8 +103,8 @@ memoryRouter.patch('/semantic/:id/pin', zValidator('json', pinSchema), async (c)
   const id = c.req.param('id');
   const { pinned } = c.req.valid('json');
 
-  await pinSemanticMemory(id, pinned);
-  return c.body(null, 204);
+  const result = await pinSemanticMemory(id, pinned);
+  return unwrapResult(c, result, 204);
 });
 
 memoryRouter.patch('/semantic/:id', zValidator('json', patchSchema), async (c) => {
@@ -137,8 +118,8 @@ memoryRouter.patch('/semantic/:id', zValidator('json', patchSchema), async (c) =
     return c.json({ error: 'No updates provided' }, 400);
   }
 
-  await updateSemanticMemory(id, updates);
-  return c.body(null, 204);
+  const result = await updateSemanticMemory(id, updates);
+  return unwrapResult(c, result, 204);
 });
 
 memoryRouter.delete('/semantic/:id', async (c) => {
@@ -146,8 +127,8 @@ memoryRouter.delete('/semantic/:id', async (c) => {
   if (inactiveResponse) return inactiveResponse;
 
   const id = c.req.param('id');
-  await deleteSemanticMemory(id);
-  return c.body(null, 204);
+  const result = await deleteSemanticMemory(id);
+  return unwrapResult(c, result, 204);
 });
 
 memoryRouter.delete('/semantic', zValidator('json', bulkDeleteSchema), async (c) => {
@@ -155,8 +136,8 @@ memoryRouter.delete('/semantic', zValidator('json', bulkDeleteSchema), async (c)
   if (inactiveResponse) return inactiveResponse;
 
   const { ids } = c.req.valid('json');
-  await deleteSemanticMemories(ids);
-  return c.body(null, 204);
+  const result = await deleteSemanticMemories(ids);
+  return unwrapResult(c, result, 204);
 });
 
 memoryRouter.post('/maintenance', async (c) => {

--- a/packages/server/src/routes/usage.ts
+++ b/packages/server/src/routes/usage.ts
@@ -1,33 +1,25 @@
+import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
+import { z } from 'zod';
 
-import { USAGE_DATE_RANGES, type UsageDateRange } from '@stitch/shared/usage/types';
+import { USAGE_DATE_RANGES } from '@stitch/shared/usage/types';
 
 import { getUsageDashboard } from '@/usage/service.js';
+import { unwrapResult } from '@/lib/route-helpers.js';
+
+const usageQuerySchema = z.object({
+  providerId: z.string().optional(),
+  modelId: z.string().optional(),
+  range: z.enum(USAGE_DATE_RANGES).optional(),
+  from: z.coerce.number().positive().optional(),
+  to: z.coerce.number().positive().optional(),
+});
 
 export const usageRouter = new Hono();
 
-usageRouter.get('/', async (c) => {
-  const providerId = c.req.query('providerId') ?? undefined;
-  const modelId = c.req.query('modelId') ?? undefined;
-  const from = c.req.query('from');
-  const to = c.req.query('to');
-  const rangeRaw = c.req.query('range');
+usageRouter.get('/', zValidator('query', usageQuerySchema), async (c) => {
+  const { providerId, modelId, range, from, to } = c.req.valid('query');
 
-  const range =
-    rangeRaw && (USAGE_DATE_RANGES as readonly string[]).includes(rangeRaw)
-      ? (rangeRaw as UsageDateRange)
-      : undefined;
-
-  const parsedFrom = from ? Number(from) : undefined;
-  const parsedTo = to ? Number(to) : undefined;
-
-  const usage = await getUsageDashboard({
-    providerId,
-    modelId,
-    range,
-    from: Number.isFinite(parsedFrom) ? parsedFrom : undefined,
-    to: Number.isFinite(parsedTo) ? parsedTo : undefined,
-  });
-
-  return c.json(usage);
+  const result = await getUsageDashboard({ providerId, modelId, range, from, to });
+  return unwrapResult(c, result);
 });

--- a/packages/server/src/tools/core/memory.ts
+++ b/packages/server/src/tools/core/memory.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 
 import { getMemoryConfig } from '@/memory/config.js';
+import { isServiceError } from '@/lib/service-result.js';
 import {
   addSemanticMemory,
   deleteSemanticMemory,
@@ -73,12 +74,16 @@ function createMemoryTool(context: ToolContext) {
             return { output: 'Please provide a search query.' };
           }
 
-          const result = await searchSemanticMemories({
+          const searchResult = await searchSemanticMemories({
             query: input.content,
             page: 1,
             pageSize: 10,
             sourceFilter: 'chat',
           });
+          if (isServiceError(searchResult)) {
+            return { output: 'Failed to search memories.' };
+          }
+          const result = searchResult.data;
           if (result.memories.length === 0) {
             return { output: 'No relevant memories found.' };
           }
@@ -101,11 +106,15 @@ function createMemoryTool(context: ToolContext) {
         }
 
         case 'list': {
-          const all = await getAllSemanticMemories({
+          const listResult = await getAllSemanticMemories({
             page: 1,
             pageSize: 1000,
             sourceFilter: 'chat',
           });
+          if (isServiceError(listResult)) {
+            return { output: 'Failed to list memories.' };
+          }
+          const all = listResult.data;
           if (all.memories.length === 0) {
             return { output: 'No memories stored yet.' };
           }

--- a/packages/server/src/usage/service.ts
+++ b/packages/server/src/usage/service.ts
@@ -11,6 +11,8 @@ import {
 
 import { getDb } from '@/db/client.js';
 import { llmUsageEvents, sessions } from '@/db/schema.js';
+import { ok } from '@/lib/service-result.js';
+import type { ServiceResult } from '@/lib/service-result.js';
 import type { LanguageModelUsage } from 'ai';
 
 type GetUsageDashboardInput = {
@@ -302,7 +304,7 @@ function normalizeEventSource(
 
 export async function getUsageDashboard(
   input: GetUsageDashboardInput,
-): Promise<UsageDashboardResponse> {
+): Promise<ServiceResult<UsageDashboardResponse>> {
   const db = getDb();
   const window = await resolveWindow(input);
   const granularity = inferGranularity(window);
@@ -438,7 +440,7 @@ export async function getUsageDashboard(
     { costUsd: 0, tokenMetrics: cloneEmptyTokenMetrics() },
   );
 
-  return {
+  return ok({
     range: {
       from: window.from,
       to: window.to,
@@ -468,7 +470,7 @@ export async function getUsageDashboard(
       bySource: totalsBySource,
     },
     buckets,
-  };
+  });
 }
 
 export const usageServiceInternals = {


### PR DESCRIPTION
## Change Summary

Normalizes the memory and usage service/route layer to use consistent ServiceResult contracts, and improves the UX of the memory and agenda detail sheets with auto-save.

### New Features
- **Auto-save in Agenda Item Detail Sheet**: Text fields debounce 600ms; status, priority, and due date save immediately on change. Pending saves are flushed on close. Save/Cancel buttons removed.
- **Auto-save in Memory Detail Sheet**: Content debounces 600ms; category and confidence save immediately. Same flush-on-close behaviour. Save/Cancel buttons removed.

### Improvements & Refactors
- **Memory service**: getMemoryStats, updateSemanticMemory, deleteSemanticMemory, deleteSemanticMemories, pinSemanticMemory, pruneStaleMemories, searchSemanticMemories, and getAllSemanticMemories now return ServiceResult instead of bare values or void. Exported typed MemoryStats replacing the previous any return type.
- **Usage service**: getUsageDashboard now returns ServiceResult.
- **Memory route**: Replaced manual parsePagination() with a Zod semanticQuerySchema via zValidator. All handlers use unwrapResult.
- **Usage route**: Replaced manual query string parsing with a Zod usageQuerySchema. Handler uses unwrapResult.
- **Callers updated**: maintenance.ts, retriever.ts, processor.ts, and tools/core/memory.ts all unwrap ServiceResult before accessing data.
- **Confidence dropdown**: Removed badge styling from confidence select items in the memory detail sheet.