### PR TITLE
Extract shared paginationQuerySchema utility

### DIFF
--- a/apps/web/src/lib/queries/automations.ts
+++ b/apps/web/src/lib/queries/automations.ts
@@ -35,10 +35,10 @@ export function automationsPageQueryOptions(input: { page: number; pageSize: num
 }
 
 export const automationsQueryOptions = queryOptions({
-  queryKey: automationKeys.list(1, 1000),
+  queryKey: automationKeys.list(1, 100),
   staleTime: Infinity,
   queryFn: async (): Promise<Automation[]> => {
-    const params = new URLSearchParams({ page: '1', pageSize: '1000' });
+    const params = new URLSearchParams({ page: '1', pageSize: '100' });
     const res = await serverFetch(`/automations?${params.toString()}`);
     if (!res.ok) throw new Error('Failed to fetch automations');
     const data = (await res.json()) as ListAutomationsResponse;

--- a/packages/server/__test__/lib/route-schemas.test.ts
+++ b/packages/server/__test__/lib/route-schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { prefixedId, routeSchemas } from '@/lib/route-schemas.js';
+import { paginationQuerySchema, prefixedId, routeSchemas } from '@/lib/route-schemas.js';
 import { ID_PREFIXES } from '@stitch/shared/id';
 
 describe('Route Schemas', () => {
@@ -47,5 +47,54 @@ describe('Route Schemas', () => {
       expect(routeSchemas.automationId.safeParse('auto_123').success).toBe(true);
       expect(routeSchemas.automationId.safeParse('msg_123').success).toBe(false);
     });
+  });
+});
+
+describe('paginationQuerySchema', () => {
+  const schema = paginationQuerySchema();
+  const schema10 = paginationQuerySchema({ pageSize: 10 });
+
+  it('applies default page=1 and pageSize=20 when params are absent', () => {
+    const result = schema.parse({});
+    expect(result).toEqual({ page: 1, pageSize: 20 });
+  });
+
+  it('applies custom default pageSize', () => {
+    const result = schema10.parse({});
+    expect(result).toEqual({ page: 1, pageSize: 10 });
+  });
+
+  it('parses valid page and pageSize from strings', () => {
+    const result = schema.parse({ page: '3', pageSize: '50' });
+    expect(result).toEqual({ page: 3, pageSize: 50 });
+  });
+
+  it('parses valid page and pageSize from numbers', () => {
+    const result = schema.parse({ page: 2, pageSize: 25 });
+    expect(result).toEqual({ page: 2, pageSize: 25 });
+  });
+
+  it('rejects page < 1', () => {
+    expect(schema.safeParse({ page: '0' }).success).toBe(false);
+    expect(schema.safeParse({ page: '-1' }).success).toBe(false);
+  });
+
+  it('rejects pageSize < 1', () => {
+    expect(schema.safeParse({ pageSize: '0' }).success).toBe(false);
+  });
+
+  it('rejects pageSize > 100', () => {
+    expect(schema.safeParse({ pageSize: '101' }).success).toBe(false);
+    expect(schema.safeParse({ pageSize: '200' }).success).toBe(false);
+  });
+
+  it('accepts boundary values pageSize=1 and pageSize=100', () => {
+    expect(schema.parse({ pageSize: '1' })).toEqual({ page: 1, pageSize: 1 });
+    expect(schema.parse({ pageSize: '100' })).toEqual({ page: 1, pageSize: 100 });
+  });
+
+  it('rejects non-numeric strings', () => {
+    expect(schema.safeParse({ page: 'abc' }).success).toBe(false);
+    expect(schema.safeParse({ pageSize: 'xyz' }).success).toBe(false);
   });
 });

--- a/packages/server/src/lib/route-schemas.ts
+++ b/packages/server/src/lib/route-schemas.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod';
 import { ID_PREFIXES, type IdPrefix, type PrefixedString } from '@stitch/shared/id';
 
+export function paginationQuerySchema(defaults: { pageSize?: number } = {}) {
+  const defaultPageSize = defaults.pageSize ?? 20;
+  return z.object({
+    page: z.coerce.number().int().min(1).default(1),
+    pageSize: z.coerce.number().int().min(1).max(100).default(defaultPageSize),
+  });
+}
+
 export function prefixedId<P extends IdPrefix>(prefix: P) {
   return z.custom<PrefixedString<P>>((val) => {
     return typeof val === 'string' && val.startsWith(`${prefix}_`);

--- a/packages/server/src/routes/agenda.ts
+++ b/packages/server/src/routes/agenda.ts
@@ -25,6 +25,7 @@ import {
   updateAgendaList,
 } from '@/agenda/service.js';
 import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
+import { paginationQuerySchema } from '@/lib/route-schemas.js';
 
 const createListSchema = z.object({
   name: z.string().trim().min(1).max(200),
@@ -66,16 +67,6 @@ const addEventSchema = z.object({
 });
 
 export const agendaRouter = new Hono();
-
-function parsePagination(query: Record<string, string | undefined>) {
-  const pageRaw = Number.parseInt(query.page ?? '1', 10);
-  const pageSizeRaw = Number.parseInt(query.pageSize ?? '20', 10);
-
-  const page = Number.isFinite(pageRaw) && pageRaw > 0 ? pageRaw : 1;
-  const pageSize = Number.isFinite(pageSizeRaw) ? Math.min(Math.max(pageSizeRaw, 1), 100) : 20;
-
-  return { page, pageSize };
-}
 
 // --- Lists ---
 
@@ -140,11 +131,8 @@ agendaRouter.post('/items/reorder', zValidator('json', reorderSchema), async (c)
   return c.json({ success: true });
 });
 
-agendaRouter.get('/items', async (c) => {
-  const { page, pageSize } = parsePagination({
-    page: c.req.query('page'),
-    pageSize: c.req.query('pageSize'),
-  });
+agendaRouter.get('/items', zValidator('query', paginationQuerySchema({ pageSize: 20 })), async (c) => {
+  const { page, pageSize } = c.req.valid('query');
 
   const listId = c.req.query('listId') as PrefixedString<'alist'> | undefined;
   const status = c.req.query('status') as (typeof AGENDA_ITEM_STATUSES)[number] | undefined;

--- a/packages/server/src/routes/automations.ts
+++ b/packages/server/src/routes/automations.ts
@@ -18,6 +18,7 @@ import {
 } from '@/automations/service.js';
 import { isServiceError } from '@/lib/service-result.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
+import { paginationQuerySchema } from '@/lib/route-schemas.js';
 
 const scheduleSchema = z
   .object({
@@ -42,21 +43,8 @@ const updateAutomationSchema = createAutomationSchema
 
 export const automationsRouter = new Hono();
 
-function parsePagination(query: Record<string, string | undefined>) {
-  const pageRaw = Number.parseInt(query.page ?? '1', 10);
-  const pageSizeRaw = Number.parseInt(query.pageSize ?? '10', 10);
-
-  const page = Number.isFinite(pageRaw) && pageRaw > 0 ? pageRaw : 1;
-  const pageSize = Number.isFinite(pageSizeRaw) ? Math.min(Math.max(pageSizeRaw, 1), 100) : 10;
-
-  return { page, pageSize };
-}
-
-automationsRouter.get('/', async (c) => {
-  const { page, pageSize } = parsePagination({
-    page: c.req.query('page'),
-    pageSize: c.req.query('pageSize'),
-  });
+automationsRouter.get('/', zValidator('query', paginationQuerySchema({ pageSize: 10 })), async (c) => {
+  const { page, pageSize } = c.req.valid('query');
   const result = await listAutomations({ page, pageSize });
   return c.json(result);
 });

--- a/packages/server/src/routes/memory.ts
+++ b/packages/server/src/routes/memory.ts
@@ -18,14 +18,13 @@ import {
 import { dropSemanticTable } from '@/memory/store/tables.js';
 import { MEMORY_CATEGORIES, MEMORY_CONFIDENCES, MEMORY_SOURCES } from '@/memory/types.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
+import { paginationQuerySchema } from '@/lib/route-schemas.js';
 import type { Context } from 'hono';
 
-const semanticQuerySchema = z.object({
+const semanticQuerySchema = paginationQuerySchema({ pageSize: 20 }).extend({
   source: z.enum(MEMORY_SOURCES).optional(),
   category: z.enum(MEMORY_CATEGORIES).optional(),
   q: z.string().optional(),
-  page: z.coerce.number().int().min(1).default(1),
-  pageSize: z.coerce.number().int().min(1).max(100).default(20),
 });
 
 const patchSchema = z.object({

--- a/packages/server/src/routes/recordings.ts
+++ b/packages/server/src/routes/recordings.ts
@@ -23,15 +23,11 @@ import {
 } from '@/recordings/service.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
 import { isServiceError } from '@/lib/service-result.js';
+import { paginationQuerySchema } from '@/lib/route-schemas.js';
 
 const startRecordingSchema = z.object({
   title: z.string().trim().min(1).max(200).optional(),
   platform: z.enum(['manual', 'zoom', 'teams', 'slack', 'discord', 'google-meet']).optional(),
-});
-
-const paginationQuerySchema = z.object({
-  page: z.string().transform(Number).refine((n) => Number.isInteger(n) && n > 0).default(1),
-  pageSize: z.string().transform(Number).refine((n) => Number.isInteger(n) && n >= 1 && n <= 100).default(10),
 });
 
 const recordingIdParamSchema = z.object({
@@ -46,7 +42,7 @@ export const recordingsRouter = new Hono();
 
 recordingsRouter.get(
   '/',
-  zValidator('query', paginationQuerySchema),
+  zValidator('query', paginationQuerySchema({ pageSize: 10 })),
   async (c) => {
     const { page, pageSize } = c.req.valid('query');
     const result = await listRecordings({ page, pageSize });


### PR DESCRIPTION
## Change Summary

Replaces 4 copy-pasted `parsePagination` functions across route files with a single shared `paginationQuerySchema` factory in `lib/route-schemas.ts`, using Zod + `zValidator` for consistent, declarative query validation.

### New Features
- **`paginationQuerySchema({ pageSize? })`**: Exported from `@/lib/route-schemas.ts`, returns a Zod schema with `page` (min 1) and `pageSize` (min 1, max 100, configurable default) using `z.coerce.number()`

### Improvements & Refactors
- `routes/automations.ts`, `routes/agenda.ts`, `routes/recordings.ts`: replaced local `parsePagination` functions with `zValidator('query', paginationQuerySchema(...))`
- `routes/memory.ts`: replaced inline pagination fields in `semanticQuerySchema` with `.extend()` on `paginationQuerySchema`
- `lib/pagination.ts` deleted — no longer needed
- FE `automationsQueryOptions` corrected from `pageSize: 1000` to `pageSize: 100` to stay within the schema's validated max
- Unit tests added to `__test__/lib/route-schemas.test.ts` covering defaults, valid inputs, boundary values, out-of-range rejection, and non-numeric strings

Closes #106