### PR TITLE
Extract shared paginatedQuery service helper

### DIFF
--- a/packages/server/__test__/lib/paginated-query.test.ts
+++ b/packages/server/__test__/lib/paginated-query.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import { computeTotalPages, paginatedQuery } from '../../src/lib/paginated-query.js';
+
+describe('paginated-query', () => {
+  describe('computeTotalPages', () => {
+    it('returns 0 for 0 total items', () => {
+      expect(computeTotalPages(0, 10)).toBe(0);
+    });
+
+    it('calculates correct total pages for exact multiples', () => {
+      expect(computeTotalPages(20, 10)).toBe(2);
+    });
+
+    it('calculates correct total pages for partial pages', () => {
+      expect(computeTotalPages(21, 10)).toBe(3);
+    });
+  });
+
+  describe('paginatedQuery', () => {
+    it('applies offset and limit correctly and computes totalPages', async () => {
+      const mockData = [{ id: 1 }, { id: 2 }];
+      const offsetSpy = vi.fn().mockResolvedValue(mockData);
+      const limitSpy = vi.fn().mockReturnValue({ offset: offsetSpy });
+
+      const mockDataQuery = { limit: limitSpy };
+      const mockCountQuery = Promise.resolve([{ total: 25 }]);
+
+      const result = await paginatedQuery({
+        dataQuery: mockDataQuery,
+        countQuery: mockCountQuery,
+        page: 2,
+        pageSize: 10,
+      });
+
+      expect(limitSpy).toHaveBeenCalledWith(10);
+      expect(offsetSpy).toHaveBeenCalledWith(10); // (2-1) * 10
+      expect(result).toEqual({
+        items: mockData,
+        page: 2,
+        pageSize: 10,
+        total: 25,
+        totalPages: 3,
+      });
+    });
+
+    it('handles empty result set properly', async () => {
+      const offsetSpy = vi.fn().mockResolvedValue([]);
+      const limitSpy = vi.fn().mockReturnValue({ offset: offsetSpy });
+
+      const mockDataQuery = { limit: limitSpy };
+      const mockCountQuery = Promise.resolve([{ total: 0 }]);
+
+      const result = await paginatedQuery({
+        dataQuery: mockDataQuery,
+        countQuery: mockCountQuery,
+        page: 1,
+        pageSize: 10,
+      });
+
+      expect(limitSpy).toHaveBeenCalledWith(10);
+      expect(offsetSpy).toHaveBeenCalledWith(0); // (1-1) * 10
+      expect(result).toEqual({
+        items: [],
+        page: 1,
+        pageSize: 10,
+        total: 0,
+        totalPages: 0,
+      });
+    });
+
+    it('applies transform function if provided', async () => {
+      const mockData = [{ val: 1 }, { val: 2 }];
+      const offsetSpy = vi.fn().mockResolvedValue(mockData);
+      const limitSpy = vi.fn().mockReturnValue({ offset: offsetSpy });
+
+      const mockDataQuery = { limit: limitSpy };
+      const mockCountQuery = Promise.resolve([{ total: 2 }]);
+
+      const result = await paginatedQuery({
+        dataQuery: mockDataQuery,
+        countQuery: mockCountQuery,
+        page: 1,
+        pageSize: 10,
+        transform: (row: any) => ({ transformed: row.val * 2 }),
+      });
+
+      expect(result.items).toEqual([{ transformed: 2 }, { transformed: 4 }]);
+    });
+  });
+});

--- a/packages/server/src/agenda/service.ts
+++ b/packages/server/src/agenda/service.ts
@@ -1,4 +1,5 @@
 import { and, asc, count, desc, eq, sql } from 'drizzle-orm';
+import { paginatedQuery } from '@/lib/paginated-query.js';
 
 import {
   createAgendaItemEventId,
@@ -206,7 +207,6 @@ export async function getAgendaItems(input: {
   pageSize: number;
 }): Promise<ListAgendaItemsResponse> {
   const db = getDb();
-  const offset = (input.page - 1) * input.pageSize;
 
   const conditions = [];
   if (input.listId) conditions.push(eq(agendaItems.listId, input.listId));
@@ -215,28 +215,20 @@ export async function getAgendaItems(input: {
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;
 
-  const [rows, countResult] = [
-    db
+  const result = await paginatedQuery({
+    dataQuery: db
       .select({ item: agendaItems, listName: agendaLists.name })
       .from(agendaItems)
       .leftJoin(agendaLists, eq(agendaItems.listId, agendaLists.id))
       .where(where)
-      .orderBy(asc(agendaItems.position), desc(agendaItems.createdAt))
-      .limit(input.pageSize)
-      .offset(offset)
-      .all(),
-    db.select({ count: count() }).from(agendaItems).where(where).get(),
-  ];
-
-  const total = countResult?.count ?? 0;
-
-  return {
-    items: rows.map((r) => toAgendaItem(r.item, r.listName ?? undefined)),
+      .orderBy(asc(agendaItems.position), desc(agendaItems.createdAt)),
+    countQuery: db.select({ total: count() }).from(agendaItems).where(where),
     page: input.page,
     pageSize: input.pageSize,
-    total,
-    totalPages: Math.ceil(total / input.pageSize),
-  };
+    transform: (r) => toAgendaItem(r.item, r.listName ?? undefined),
+  });
+
+  return result;
 }
 
 export async function getAgendaItem(

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -97,32 +97,23 @@ function toAutomationRow(row: AutomationDbRow): AutomationRow {
   };
 }
 
+import { paginatedQuery } from '@/lib/paginated-query.js';
+
 export async function listAutomations(input: {
   page: number;
   pageSize: number;
 }): Promise<ListAutomationsResponse> {
   const db = getDb();
-  const offset = (input.page - 1) * input.pageSize;
-  const [rows, countRows] = await Promise.all([
-    db
-      .select()
-      .from(automations)
-      .orderBy(asc(automations.createdAt))
-      .limit(input.pageSize)
-      .offset(offset),
-    db.select({ total: sql<number>`count(*)` }).from(automations),
-  ]);
-
-  const total = Number(countRows[0]?.total ?? 0);
-  const totalPages = total === 0 ? 0 : Math.ceil(total / input.pageSize);
-
-  return {
-    automations: rows.map(toAutomationRow),
+  
+  const result = await paginatedQuery({
+    dataQuery: db.select().from(automations).orderBy(asc(automations.createdAt)),
+    countQuery: db.select({ total: sql<number>`count(*)` }).from(automations),
     page: input.page,
     pageSize: input.pageSize,
-    total,
-    totalPages,
-  };
+    transform: toAutomationRow,
+  });
+
+  return { automations: result.items, ...result };
 }
 
 export async function createAutomation(

--- a/packages/server/src/lib/paginated-query.ts
+++ b/packages/server/src/lib/paginated-query.ts
@@ -1,0 +1,52 @@
+
+type PaginatedResult<T> = {
+  items: T[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+};
+
+/**
+ * Compute totalPages from a total count and pageSize.
+ * Standalone helper for cases where the full paginatedQuery isn't needed.
+ */
+export function computeTotalPages(total: number, pageSize: number): number {
+  return total === 0 ? 0 : Math.ceil(total / pageSize);
+}
+
+/**
+ * Runs a paginated data query in parallel with a count query.
+ * Returns a standardized envelope with items, page, pageSize, total, totalPages.
+ *
+ * @param dataQuery  - A Drizzle query builder. limit() and offset() will be applied.
+ * @param countQuery - A Drizzle count query (e.g. db.select({ total: sql\`count(*)\` }).from(table).where(...))
+ * @param page       - 1-indexed page number
+ * @param pageSize   - Items per page
+ * @param transform  - Optional row mapper applied to each data row
+ */
+export async function paginatedQuery<TRow, TOut = TRow>(input: {
+  dataQuery: { limit: (n: number) => { offset: (n: number) => Promise<TRow[]> | PromiseLike<TRow[]> } };
+  countQuery: PromiseLike<{ total: number }[]>;
+  page: number;
+  pageSize: number;
+  transform?: (row: TRow) => TOut;
+}): Promise<PaginatedResult<TOut>> {
+  const offset = (input.page - 1) * input.pageSize;
+
+  const [rows, countRows] = await Promise.all([
+    input.dataQuery.limit(input.pageSize).offset(offset),
+    input.countQuery,
+  ]);
+
+  const total = Number(countRows[0]?.total ?? 0);
+  const transform = input.transform ?? ((row: TRow) => row as unknown as TOut);
+
+  return {
+    items: rows.map(transform),
+    page: input.page,
+    pageSize: input.pageSize,
+    total,
+    totalPages: computeTotalPages(total, input.pageSize),
+  };
+}

--- a/packages/server/src/memory/service.ts
+++ b/packages/server/src/memory/service.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import * as Log from '@/lib/log.js';
 import { ok, err } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
+import { computeTotalPages } from '@/lib/paginated-query.js';
 import type { MemoryEmbedder } from '@/memory/embedding/embedder.js';
 import { createEmbedder } from '@/memory/embedding/factory.js';
 import { getSemanticTable } from '@/memory/store/tables.js';
@@ -206,7 +207,7 @@ export async function searchSemanticMemories(input: {
   const end = start + input.pageSize;
   const pageRows = results.slice(start, end);
   const total = results.length;
-  const totalPages = total === 0 ? 0 : Math.ceil(total / input.pageSize);
+  const totalPages = computeTotalPages(total, input.pageSize);
 
   return ok({
     memories: pageRows.map((r: Record<string, unknown>) => ({
@@ -257,7 +258,7 @@ export async function getAllSemanticMemories(input: {
   const end = start + input.pageSize;
   const pageRows = rows.slice(start, end);
   const total = rows.length;
-  const totalPages = total === 0 ? 0 : Math.ceil(total / input.pageSize);
+  const totalPages = computeTotalPages(total, input.pageSize);
 
   return ok({
     memories: pageRows.map((r) => ({

--- a/packages/server/src/recordings/service.ts
+++ b/packages/server/src/recordings/service.ts
@@ -15,6 +15,7 @@ import type {
 
 import { getDb } from '@/db/client.js';
 import { recordingAnalyses, recordings, userSettings } from '@/db/schema.js';
+import { computeTotalPages } from '@/lib/paginated-query.js';
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
 import { err, ok } from '@/lib/service-result.js';
@@ -109,7 +110,7 @@ export async function listRecordings(input: {
     db.select({ total: sql<number>`count(*)` }).from(recordings),
   ]);
   const total = Number(countRows[0]?.total ?? 0);
-  const totalPages = total === 0 ? 0 : Math.ceil(total / input.pageSize);
+  const totalPages = computeTotalPages(total, input.pageSize);
 
   return {
     recordings: rows.map((row) => toRecording(row.recording, row.analysisTitle || null)),


### PR DESCRIPTION
## 🚀 Change Summary

Extracts common pagination logic into reusable \paginatedQuery\ and \computeTotalPages\ helpers to dry up repeating boilerplate across multiple service files.

Closes #107 

### ✨ New Features
- **Pagination Helpers**: Created \packages/server/src/lib/paginated-query.ts\ exposing \paginatedQuery\ and \computeTotalPages\ functions to simplify building paginated queries in services.

### 🛠 Improvements & Refactors
- Refactored \utomations/service.ts\ (\listAutomations\) and \genda/service.ts\ (\getAgendaItems\) to use the new \paginatedQuery\ helper.
- Refactored \memory/service.ts\ and \ecordings/service.ts\ to use \computeTotalPages\.
- Replaced manual \Math.ceil(total / input.pageSize)\ logic with standardized formulas.