### PR TITLE
feat(server): consolidate model resolution into shared primitive

### DIFF
--- a/packages/server/__test__/llm/resolve-model.test.ts
+++ b/packages/server/__test__/llm/resolve-model.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { resolveModel } from '@/llm/resolve-model.js';
+import * as Models from '@/llm/provider/models.js';
+import { getDb } from '@/db/client.js';
+
+vi.mock('@/db/client.js', () => ({
+  getDb: vi.fn(),
+}));
+
+vi.mock('@/llm/provider/models.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof Models>();
+  return {
+    ...actual,
+    get: vi.fn(),
+    isAllowedProvider: vi.fn(),
+  };
+});
+
+describe('resolveModel', () => {
+  let mockDbSelect: any;
+  let mockDbFrom: any;
+  let mockDbWhere: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDbWhere = vi.fn().mockResolvedValue([]);
+    mockDbFrom = vi.fn().mockReturnValue({ where: mockDbWhere });
+    mockDbSelect = vi.fn().mockReturnValue({ from: mockDbFrom });
+
+    // For the providerConfig select which doesn't have where
+    mockDbFrom.mockResolvedValue([]);
+
+    const mockDb = { select: mockDbSelect };
+    vi.mocked(getDb).mockReturnValue(mockDb as any);
+
+    vi.mocked(Models.isAllowedProvider).mockReturnValue(true);
+    vi.mocked(Models.get).mockResolvedValue({
+      'test-provider': {
+        id: 'test-provider',
+        name: 'Test Provider',
+        api: 'test',
+        env: [],
+        models: {
+          'test-model': {
+            id: 'test-model',
+            name: 'Test Model',
+            cost: { input: 0, output: 0 },
+            limit: { context: 1000, output: 1000 },
+            release_date: '2024',
+            attachment: false,
+            reasoning: false,
+            temperature: false,
+            tool_call: false,
+            options: {},
+          },
+          'audio-model': {
+            id: 'audio-model',
+            name: 'Audio Model',
+            cost: { input: 0, output: 0 },
+            limit: { context: 1000, output: 1000 },
+            release_date: '2024',
+            attachment: false,
+            reasoning: false,
+            temperature: false,
+            tool_call: false,
+            options: {},
+            modalities: { input: ['audio', 'text'], output: ['text'] },
+          },
+        },
+      },
+    });
+  });
+
+  function mockDbResponses(settings: { key: string; value: string }[], configs: any[]) {
+    // The query first calls db.select() for settings, then db.select() for configs
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(settings),
+      }),
+    });
+    mockDbSelect.mockReturnValueOnce({
+      from: vi.fn().mockResolvedValue(configs),
+    });
+  }
+
+  test('resolves using settings when present', async () => {
+    mockDbResponses(
+      [
+        { key: 'pref.provider', value: 'test-provider' },
+        { key: 'pref.model', value: 'test-model' },
+      ],
+      [{ providerId: 'test-provider', credentials: { apiKey: 'secret' } }],
+    );
+
+    const result = await resolveModel({
+      providerIdKey: 'pref.provider' as any,
+      modelIdKey: 'pref.model' as any,
+    });
+
+    expect('error' in result).toBe(false);
+    expect((result as any).data).toEqual({
+      providerId: 'test-provider',
+      modelId: 'test-model',
+      credentials: { apiKey: 'secret' },
+    });
+  });
+
+  test('resolves using priorityModelIds when settings are missing', async () => {
+    mockDbResponses(
+      [],
+      [
+        { providerId: 'other-provider', credentials: { apiKey: 'secret2' } },
+        { providerId: 'test-provider', credentials: { apiKey: 'secret' } },
+      ],
+    );
+
+    const result = await resolveModel({
+      providerIdKey: 'pref.provider' as any,
+      modelIdKey: 'pref.model' as any,
+      priorityModelIds: ['missing-model', 'audio-model'], // test-provider has audio-model
+    });
+
+    expect('error' in result).toBe(false);
+    expect((result as any).data).toEqual({
+      providerId: 'test-provider',
+      modelId: 'audio-model',
+      credentials: { apiKey: 'secret' },
+    });
+  });
+
+  test('falls back to fallback keys when priorityModelIds yields no match', async () => {
+    mockDbResponses(
+      [],
+      [{ providerId: 'test-provider', credentials: { apiKey: 'secret' } }],
+    );
+
+    const result = await resolveModel({
+      providerIdKey: 'pref.provider' as any,
+      modelIdKey: 'pref.model' as any,
+      priorityModelIds: ['missing-model1', 'missing-model2'],
+      fallbackProviderId: 'test-provider',
+      fallbackModelId: 'test-model',
+    });
+
+    expect('error' in result).toBe(false);
+    expect((result as any).data).toEqual({
+      providerId: 'test-provider',
+      modelId: 'test-model',
+      credentials: { apiKey: 'secret' },
+    });
+  });
+
+  test('returns error when settings missing without fallback', async () => {
+    mockDbResponses([], [{ providerId: 'test-provider', credentials: { apiKey: 'secret' } }]);
+
+    const result = await resolveModel({
+      providerIdKey: 'pref.provider' as any,
+      modelIdKey: 'pref.model' as any,
+    });
+
+    expect('error' in result).toBe(true);
+    expect((result as any).error).toBe('No model configured and no fallback available');
+    expect((result as any).status).toBe(400);
+  });
+
+  test('returns error for invalid provider', async () => {
+    vi.mocked(Models.isAllowedProvider).mockReturnValue(false);
+    mockDbResponses(
+      [
+        { key: 'pref.provider', value: 'invalid-provider' },
+        { key: 'pref.model', value: 'test-model' },
+      ],
+      [],
+    );
+
+    const result = await resolveModel({
+      providerIdKey: 'pref.provider' as any,
+      modelIdKey: 'pref.model' as any,
+    });
+
+    expect('error' in result).toBe(true);
+    expect((result as any).error).toBe('Provider not found');
+    expect((result as any).status).toBe(404);
+  });
+
+  test('returns error for invalid model', async () => {
+    mockDbResponses(
+      [
+        { key: 'pref.provider', value: 'test-provider' },
+        { key: 'pref.model', value: 'invalid-model' },
+      ],
+      [{ providerId: 'test-provider', credentials: { apiKey: 'secret' } }],
+    );
+
+    const result = await resolveModel({
+      providerIdKey: 'pref.provider' as any,
+      modelIdKey: 'pref.model' as any,
+    });
+
+    expect('error' in result).toBe(true);
+    expect((result as any).error).toBe('Model not found for provider');
+    expect((result as any).status).toBe(400);
+  });
+
+  test('returns error when model filter rejects', async () => {
+    mockDbResponses(
+      [
+        { key: 'pref.provider', value: 'test-provider' },
+        { key: 'pref.model', value: 'test-model' }, // Note: test-model does not have audio modality
+      ],
+      [{ providerId: 'test-provider', credentials: { apiKey: 'secret' } }],
+    );
+
+    const result = await resolveModel({
+      providerIdKey: 'pref.provider' as any,
+      modelIdKey: 'pref.model' as any,
+      modelFilter: (m: any) => m.modalities?.input?.includes('audio') ?? false,
+    });
+
+    expect('error' in result).toBe(true);
+    expect((result as any).error).toBe('Model does not meet required capabilities');
+    expect((result as any).status).toBe(400);
+  });
+
+  test('succeeds when model filter passes', async () => {
+    mockDbResponses(
+      [
+        { key: 'pref.provider', value: 'test-provider' },
+        { key: 'pref.model', value: 'audio-model' }, // audio-model has audio modality
+      ],
+      [{ providerId: 'test-provider', credentials: { apiKey: 'secret' } }],
+    );
+
+    const result = await resolveModel({
+      providerIdKey: 'pref.provider' as any,
+      modelIdKey: 'pref.model' as any,
+      modelFilter: (m: any) => m.modalities?.input?.includes('audio') ?? false,
+    });
+
+    expect('error' in result).toBe(false);
+    expect((result as any).data).toEqual({
+      providerId: 'test-provider',
+      modelId: 'audio-model',
+      credentials: { apiKey: 'secret' },
+    });
+  });
+
+  test('returns error when provider is not configured', async () => {
+    mockDbResponses(
+      [
+        { key: 'pref.provider', value: 'test-provider' },
+        { key: 'pref.model', value: 'test-model' },
+      ],
+      [], // No configs
+    );
+
+    const result = await resolveModel({
+      providerIdKey: 'pref.provider' as any,
+      modelIdKey: 'pref.model' as any,
+    });
+
+    expect('error' in result).toBe(true);
+    expect((result as any).error).toBe('Provider is not configured');
+    expect((result as any).status).toBe(400);
+  });
+});

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -16,44 +16,13 @@ import type { PrefixedString } from '@stitch/shared/id';
 
 import { createSession, sendMessage } from '@/chat/service.js';
 import { getDb } from '@/db/client.js';
-import { automations, providerConfig, sessions } from '@/db/schema.js';
+import { automations, sessions } from '@/db/schema.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
-import { isAllowedProvider } from '@/llm/provider/models.js';
-import * as Models from '@/llm/provider/models.js';
+import { validateProviderModel } from '@/llm/resolve-model.js';
 
 type AutomationDbRow = typeof automations.$inferSelect;
 type AutomationRow = Automation;
-
-async function validateProviderModel(
-  providerId: string,
-  modelId: string,
-): Promise<ServiceResult<null>> {
-  if (!isAllowedProvider(providerId)) {
-    return err('Provider not found', 404);
-  }
-
-  const providers = await Models.get();
-  const provider = providers[providerId];
-  if (!provider) {
-    return err('Provider not found', 404);
-  }
-
-  if (!provider.models[modelId]) {
-    return err('Model not found for provider', 400);
-  }
-
-  const db = getDb();
-  const [configuredProvider] = await db
-    .select({ providerId: providerConfig.providerId })
-    .from(providerConfig)
-    .where(eq(providerConfig.providerId, providerId));
-  if (!configuredProvider) {
-    return err('Provider is not configured', 400);
-  }
-
-  return ok(null);
-}
 
 function normalizeText(value: string): string {
   return value.trim();

--- a/packages/server/src/llm/resolve-cheap-model.ts
+++ b/packages/server/src/llm/resolve-cheap-model.ts
@@ -1,11 +1,5 @@
-import { inArray } from 'drizzle-orm';
-
 import type { SettingsKey } from '@stitch/shared/settings/types';
-
-import { getDb } from '@/db/client.js';
-import { userSettings, providerConfig } from '@/db/schema.js';
-import * as Models from '@/llm/provider/models.js';
-import type { ProviderCredentials } from '@/llm/provider/provider.js';
+import { resolveModel, type ResolvedModel } from '@/llm/resolve-model.js';
 
 const CHEAP_MODEL_PRIORITY = [
   'claude-haiku-4-5',
@@ -14,12 +8,6 @@ const CHEAP_MODEL_PRIORITY = [
   'gemini-2.5-flash',
   'gpt-5-nano',
 ] as const;
-
-type ResolvedModel = {
-  providerId: string;
-  modelId: string;
-  credentials: ProviderCredentials;
-};
 
 /**
  * Resolve a cheap/fast model for auxiliary LLM tasks (title generation,
@@ -30,6 +18,9 @@ type ResolvedModel = {
  * 3. Fallback to the caller-provided model (usually the active chat model)
  *
  * Returns `null` only when no configured provider is found at all.
+ * 
+ * Note: This acts as a wrapper around `resolveModel`, passing the cheap model
+ * priority list, and swallowing errors to return `null` instead for forgiving tasks.
  */
 export async function resolveCheapModel(input: {
   providerIdKey: SettingsKey;
@@ -37,53 +28,17 @@ export async function resolveCheapModel(input: {
   fallbackProviderId: string;
   fallbackModelId: string;
 }): Promise<ResolvedModel | null> {
-  const db = getDb();
+  const result = await resolveModel({
+    providerIdKey: input.providerIdKey,
+    modelIdKey: input.modelIdKey,
+    fallbackProviderId: input.fallbackProviderId,
+    fallbackModelId: input.fallbackModelId,
+    priorityModelIds: CHEAP_MODEL_PRIORITY,
+  });
 
-  const [settingRows, enabledConfigs] = await Promise.all([
-    db
-      .select()
-      .from(userSettings)
-      .where(inArray(userSettings.key, [input.providerIdKey, input.modelIdKey])),
-    db.select().from(providerConfig),
-  ]);
-
-  // 1. Check explicit settings
-  const providerIdSetting = settingRows.find((r) => r.key === input.providerIdKey);
-  const modelIdSetting = settingRows.find((r) => r.key === input.modelIdKey);
-  const providerId = providerIdSetting?.value;
-  const modelId = modelIdSetting?.value;
-  if (providerId && modelId) {
-    const config = enabledConfigs.find((c) => c.providerId === providerId);
-    if (config) {
-      return { providerId, modelId, credentials: config.credentials };
-    }
+  if ('error' in result) {
+    return null;
   }
 
-  // 2. Try cheap models from priority list
-  const modelsData = await Models.get();
-  const enabledProviderIds = new Set(enabledConfigs.map((c) => c.providerId));
-
-  for (const modelId of CHEAP_MODEL_PRIORITY) {
-    for (const providerId of enabledProviderIds) {
-      const provider = modelsData[providerId];
-      if (provider?.models[modelId]) {
-        const config = enabledConfigs.find((c) => c.providerId === providerId);
-        if (config) {
-          return { providerId, modelId, credentials: config.credentials };
-        }
-      }
-    }
-  }
-
-  // 3. Fall back to the caller-provided model
-  const fallbackConfig = enabledConfigs.find((c) => c.providerId === input.fallbackProviderId);
-  if (fallbackConfig) {
-    return {
-      providerId: input.fallbackProviderId,
-      modelId: input.fallbackModelId,
-      credentials: fallbackConfig.credentials,
-    };
-  }
-
-  return null;
+  return result.data;
 }

--- a/packages/server/src/llm/resolve-model.ts
+++ b/packages/server/src/llm/resolve-model.ts
@@ -1,0 +1,134 @@
+import { inArray } from 'drizzle-orm';
+import { getDb } from '@/db/client.js';
+import { providerConfig, userSettings } from '@/db/schema.js';
+import { isAllowedProvider } from '@/llm/provider/models.js';
+import * as Models from '@/llm/provider/models.js';
+import type { ProviderCredentials } from '@/llm/provider/provider.js';
+import { err, ok, type ServiceResult } from '@/lib/service-result.js';
+
+import type { SettingsKey } from '@stitch/shared/settings/types';
+
+export type ResolvedModel = {
+  providerId: string;
+  modelId: string;
+  credentials: ProviderCredentials;
+};
+
+type ResolveModelInput = {
+  /** Settings keys to check for user-configured preference */
+  providerIdKey: SettingsKey;
+  modelIdKey: SettingsKey;
+  /** Fallback when settings are missing or invalid */
+  fallbackProviderId?: string;
+  fallbackModelId?: string;
+  /**
+   * Ordered list of model IDs to search for across all enabled providers if settings are missing.
+   * Useful for dynamic discovery of "cheap" or task-specific models.
+   */
+  priorityModelIds?: readonly string[] | string[];
+  /**
+   * Optional filter to restrict which models are acceptable.
+   * E.g., filter for audio-capable models only.
+   */
+  modelFilter?: (model: Models.RawModel) => boolean;
+};
+
+/**
+ * Resolves a model configuration by:
+ * 1. Reading user settings for preferred provider/model
+ * 2. If settings are empty, searching for `priorityModelIds` across all enabled providers
+ * 3. Falling back to provided defaults if nothing else matches
+ * 4. Validating the provider is allowed and the model exists
+ * 5. Optionally filtering by model capabilities
+ * 6. Looking up provider credentials from the database
+ *
+ * Returns a ServiceResult with the resolved provider, model, and credentials.
+ */
+export async function resolveModel(input: ResolveModelInput): Promise<ServiceResult<ResolvedModel>> {
+  const db = getDb();
+
+  const [settingsRows, configs, providers] = await Promise.all([
+    db.select({ key: userSettings.key, value: userSettings.value })
+      .from(userSettings)
+      .where(inArray(userSettings.key, [input.providerIdKey, input.modelIdKey])),
+    db.select().from(providerConfig),
+    Models.get(),
+  ]);
+
+  const configuredProviderId = settingsRows.find((r) => r.key === input.providerIdKey)?.value?.trim();
+  const configuredModelId = settingsRows.find((r) => r.key === input.modelIdKey)?.value?.trim();
+
+  let targetProviderId: string | undefined;
+  let targetModelId: string | undefined;
+
+  // 1. Explicit user settings
+  if (configuredProviderId && configuredModelId) {
+    targetProviderId = configuredProviderId;
+    targetModelId = configuredModelId;
+  }
+  // 2. Priority models search across enabled providers
+  else if (input.priorityModelIds && input.priorityModelIds.length > 0) {
+    const enabledProviderIds = new Set(configs.map((c) => c.providerId));
+    for (const modelId of input.priorityModelIds) {
+      for (const providerId of enabledProviderIds) {
+        if (providers[providerId]?.models[modelId]) {
+          targetProviderId = providerId;
+          targetModelId = modelId;
+          break;
+        }
+      }
+      if (targetProviderId) break;
+    }
+  }
+
+  // 3. Fallbacks
+  if (!targetProviderId || !targetModelId) {
+    targetProviderId = input.fallbackProviderId;
+    targetModelId = input.fallbackModelId;
+  }
+
+  if (!targetProviderId || !targetModelId) {
+    return err('No model configured and no fallback available', 400);
+  }
+
+  if (!isAllowedProvider(targetProviderId)) {
+    return err('Provider not found', 404);
+  }
+
+  const provider = providers[targetProviderId];
+  if (!provider) return err('Provider not found', 404);
+
+  const model = provider.models[targetModelId];
+  if (!model) return err('Model not found for provider', 400);
+
+  if (input.modelFilter && !input.modelFilter(model)) {
+    return err('Model does not meet required capabilities', 400);
+  }
+
+  const config = configs.find((c) => c.providerId === targetProviderId);
+  if (!config) return err('Provider is not configured', 400);
+
+  return ok({
+    providerId: targetProviderId,
+    modelId: targetModelId,
+    credentials: config.credentials,
+  });
+}
+
+/**
+ * Validates that a provider + model combination is configured and available.
+ * Does not return credentials — use when you only need to gate on validity.
+ */
+export async function validateProviderModel(
+  providerId: string,
+  modelId: string,
+): Promise<ServiceResult<null>> {
+  const result = await resolveModel({
+    providerIdKey: '' as SettingsKey,
+    modelIdKey: '' as SettingsKey,
+    fallbackProviderId: providerId,
+    fallbackModelId: modelId,
+  });
+  if ('error' in result) return result;
+  return ok(null);
+}

--- a/packages/server/src/recordings/analysis-service.ts
+++ b/packages/server/src/recordings/analysis-service.ts
@@ -1,5 +1,5 @@
 import { Output, generateText } from 'ai';
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { readFileSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import { z } from 'zod';
@@ -16,7 +16,7 @@ import type {
 } from '@stitch/shared/recordings/types';
 
 import { getDb } from '@/db/client.js';
-import { providerConfig, recordingAnalyses, recordings, userSettings } from '@/db/schema.js';
+import { recordingAnalyses, recordings, userSettings } from '@/db/schema.js';
 import * as Log from '@/lib/log.js';
 import { resolveRuntimeAssetPath } from '@/lib/runtime-assets.js';
 import { err, isServiceError, ok } from '@/lib/service-result.js';
@@ -25,7 +25,7 @@ import * as Sse from '@/lib/sse.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { listEnabledProviderAudioModels } from '@/llm/provider/service.js';
-import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
+import { resolveModel } from '@/llm/resolve-model.js';
 import { recordUsageEvent } from '@/usage/ledger.js';
 import { calculateMessageCostUsd } from '@/utils/cost.js';
 import { addUsage, ZERO_USAGE } from '@/utils/usage.js';
@@ -221,121 +221,6 @@ async function broadcastRecordingAnalysisUpdated(input: {
   });
 }
 
-async function resolveTranscriptionModel(): Promise<
-  ServiceResult<{ providerId: string; modelId: string; credentials: ProviderCredentials }>
-> {
-  const db = getDb();
-  const [settingsRows, configs, audioProviders] = await Promise.all([
-    db
-      .select({ key: userSettings.key, value: userSettings.value })
-      .from(userSettings)
-      .where(
-        inArray(userSettings.key, [
-          'recordings.transcription.providerId',
-          'recordings.transcription.modelId',
-        ]),
-      ),
-    db.select().from(providerConfig),
-    listEnabledProviderAudioModels(),
-  ]);
-
-  const configuredProviderId = settingsRows.find(
-    (row) => row.key === 'recordings.transcription.providerId',
-  )?.value;
-  const configuredModelId = settingsRows.find(
-    (row) => row.key === 'recordings.transcription.modelId',
-  )?.value;
-
-  if (configuredProviderId && configuredModelId) {
-    const hasModel = audioProviders.some(
-      (provider) =>
-        provider.providerId === configuredProviderId &&
-        provider.models.some((model) => model.id === configuredModelId),
-    );
-    const config = configs.find((row) => row.providerId === configuredProviderId);
-    if (hasModel && config) {
-      return ok({
-        providerId: configuredProviderId,
-        modelId: configuredModelId,
-        credentials: config.credentials,
-      });
-    }
-  }
-
-  const fallbackProvider = audioProviders[0];
-  const fallbackModel = fallbackProvider?.models[0];
-  if (!fallbackProvider || !fallbackModel) {
-    return err('No enabled provider with audio-capable models found for transcription', 400);
-  }
-
-  const fallbackConfig = configs.find((row) => row.providerId === fallbackProvider.providerId);
-  if (!fallbackConfig) {
-    return err('No provider credentials found for transcription model', 400);
-  }
-
-  return ok({
-    providerId: fallbackProvider.providerId,
-    modelId: fallbackModel.id,
-    credentials: fallbackConfig.credentials,
-  });
-}
-
-async function resolveAnalysisModel(fallback: {
-  providerId: string;
-  modelId: string;
-}): Promise<
-  ServiceResult<{ providerId: string; modelId: string; credentials: ProviderCredentials }>
-> {
-  const db = getDb();
-  const [settingsRows, configs] = await Promise.all([
-    db
-      .select({ key: userSettings.key, value: userSettings.value })
-      .from(userSettings)
-      .where(
-        inArray(userSettings.key, [
-          'recordings.analysis.providerId',
-          'recordings.analysis.modelId',
-        ]),
-      ),
-    db.select().from(providerConfig),
-  ]);
-
-  const configuredProviderId = settingsRows.find(
-    (row) => row.key === 'recordings.analysis.providerId',
-  )?.value;
-  const configuredModelId = settingsRows.find(
-    (row) => row.key === 'recordings.analysis.modelId',
-  )?.value;
-  if (configuredProviderId && configuredModelId) {
-    const config = configs.find((row) => row.providerId === configuredProviderId);
-    if (!config) {
-      return err('Configured analysis provider is not connected', 400);
-    }
-
-    return ok({
-      providerId: configuredProviderId,
-      modelId: configuredModelId,
-      credentials: config.credentials,
-    });
-  }
-
-  const resolved = await resolveCheapModel({
-    providerIdKey: 'recordings.analysis.providerId',
-    modelIdKey: 'recordings.analysis.modelId',
-    fallbackProviderId: fallback.providerId,
-    fallbackModelId: fallback.modelId,
-  });
-  if (!resolved) {
-    return err('No model available for recording analysis', 400);
-  }
-
-  return ok({
-    providerId: resolved.providerId,
-    modelId: resolved.modelId,
-    credentials: resolved.credentials,
-  });
-}
-
 export async function getRecordingAnalysis(
   recordingId: PrefixedString<'rec'>,
 ): Promise<ServiceResult<RecordingAnalysisResponse>> {
@@ -380,15 +265,29 @@ export async function startRecordingAnalysis(
     return ok({ analysis: toResponse(existing, recordingId) });
   }
 
-  const transcriptionModel = await resolveTranscriptionModel();
+  const audioProviders = await listEnabledProviderAudioModels();
+  const fallbackProvider = audioProviders[0];
+  const fallbackModel = fallbackProvider?.models[0];
+
+  const transcriptionModel = await resolveModel({
+    providerIdKey: 'recordings.transcription.providerId',
+    modelIdKey: 'recordings.transcription.modelId',
+    fallbackProviderId: fallbackProvider?.providerId,
+    fallbackModelId: fallbackModel?.id,
+    modelFilter: (model) => model.modalities?.input?.includes('audio') ?? false,
+  });
+
   if (isServiceError(transcriptionModel)) {
     return transcriptionModel;
   }
 
-  const analysisModel = await resolveAnalysisModel({
-    providerId: transcriptionModel.data.providerId,
-    modelId: transcriptionModel.data.modelId,
+  const analysisModel = await resolveModel({
+    providerIdKey: 'recordings.analysis.providerId',
+    modelIdKey: 'recordings.analysis.modelId',
+    fallbackProviderId: transcriptionModel.data.providerId,
+    fallbackModelId: transcriptionModel.data.modelId,
   });
+
   if (isServiceError(analysisModel)) {
     return analysisModel;
   }


### PR DESCRIPTION
## 🚀 Change Summary

Consolidates model and credentials resolution logic into a single shared `resolveModel` primitive, eliminating duplicate code across `automations`, `recordings`, and auxiliary generation tasks.

Closes #108

### ✨ New Features
- **Shared Model Resolver**: Added `resolveModel` and `validateProviderModel` in `packages/server/src/llm/resolve-model.ts` to provide a standard multi-step resolution pipeline (settings lookup -> priority search -> fallback -> capability validation -> credential extraction).
- **Dynamic Priority Search**: Supports resolving the best available model across providers using `priorityModelIds`, which generalizes the "cheap model" lookup behavior for reuse.

### 🛠 Improvements & Refactors
- Replaced 5 independent and inconsistent resolution implementations in `automations/service.ts`, `recordings/analysis-service.ts`, and `llm/resolve-cheap-model.ts`.
- Refactored `resolveCheapModel` to act as a thin wrapper around the new `resolveModel` primitive.

### 📚 Documentation
- Added detailed unit test coverage for the resolution lifecycle, including fallback handling, provider filtering (e.g. audio capabilities), and missing settings errors.