### PR TITLE
improvement: use server-defined display names in chat tool cards

### DIFF
--- a/apps/web/src/components/chat/message-bubble/tool-call/bash-tool-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/bash-tool-block.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
 
-import { ToolCard, getToolCardState, truncateText } from './card-primitives';
+import { ToolCard, getToolCardState, truncateText, useStitchToolDisplayName } from './card-primitives';
 
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -33,6 +33,7 @@ type BashToolBlockProps = {
 export function BashToolBlock({ toolName, status, args, onAbort }: BashToolBlockProps) {
   const { isActive } = getToolCardState(status);
   const { action, command } = getBashArgs(args);
+  const displayName = useStitchToolDisplayName(toolName);
   const [open, setOpen] = React.useState(false);
   const [showFullCommand, setShowFullCommand] = React.useState(false);
   const actionLabel = action ?? 'Run a shell command';
@@ -50,7 +51,7 @@ export function BashToolBlock({ toolName, status, args, onAbort }: BashToolBlock
         >
           <ToolCard.StatusIndicator status={status} />
           <span className="min-w-0 flex-1 text-left">
-            <ToolCard.Title>{toolName}</ToolCard.Title>
+            <ToolCard.Title>{displayName}</ToolCard.Title>
             <ToolCard.TitleContent truncate className="mt-1 block">
               {actionLabel}
             </ToolCard.TitleContent>

--- a/apps/web/src/components/chat/message-bubble/tool-call/card-primitives.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/card-primitives.tsx
@@ -1,10 +1,23 @@
 import { AlertCircleIcon, CheckIcon, CopyIcon, LoaderIcon, SquareIcon } from 'lucide-react';
 import * as React from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
+
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
 
 import { Button } from '@/components/ui/button';
+import { toolKeys } from '@/lib/queries/tools';
 import { cn } from '@/lib/utils';
+
+type KnownTool = { toolName: string; displayName: string };
+
+export function useStitchToolDisplayName(toolName: string): string {
+  const queryClient = useQueryClient();
+  return React.useMemo(() => {
+    const knownTools = queryClient.getQueryData<KnownTool[]>(toolKeys.knownTools());
+    return knownTools?.find((t) => t.toolName === toolName)?.displayName ?? formatToolDisplayName(toolName);
+  }, [queryClient, toolName]);
+}
 
 type ToolCardState = {
   hasError: boolean;

--- a/apps/web/src/components/chat/message-bubble/tool-call/file-tool-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/file-tool-block.tsx
@@ -1,6 +1,6 @@
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
 
-import { ToolCard, getToolLabel, truncateText } from './card-primitives';
+import { ToolCard, getToolLabel, truncateText, useStitchToolDisplayName } from './card-primitives';
 
 function getFilePathFromArgs(args: unknown): string | null {
   const value = (args as { filePath?: unknown })?.filePath;
@@ -18,6 +18,7 @@ type FileToolBlockProps = {
 
 export function FileToolBlock({ toolName, status, args, error }: FileToolBlockProps) {
   const label = getToolLabel(status, error);
+  const displayName = useStitchToolDisplayName(toolName);
   const filePath = getFilePathFromArgs(args);
   const displayPath = filePath ? truncateText(filePath) : 'Waiting for path...';
 
@@ -26,7 +27,7 @@ export function FileToolBlock({ toolName, status, args, error }: FileToolBlockPr
       <ToolCard.Header>
         <ToolCard.StatusIndicator status={status} />
         <div className="min-w-0 flex-1 space-y-1">
-          <ToolCard.Title>{toolName}</ToolCard.Title>
+          <ToolCard.Title>{displayName}</ToolCard.Title>
           <ToolCard.TitleContent truncate mono className="block">
             {label ? `${displayPath} - ${label}` : displayPath}
           </ToolCard.TitleContent>

--- a/apps/web/src/components/chat/message-bubble/tool-call/generic-tool-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/generic-tool-block.tsx
@@ -1,6 +1,6 @@
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
 
-import { ToolCard, formatToolDisplayName, getToolLabel } from './card-primitives';
+import { ToolCard, getToolLabel, useStitchToolDisplayName } from './card-primitives';
 
 type GenericToolBlockProps = {
   toolName: string;
@@ -26,6 +26,7 @@ function getUsedAccount(args: unknown, result: unknown): string | null {
 
 export function GenericToolBlock({ toolName, status, args, result, error }: GenericToolBlockProps) {
   const label = getToolLabel(status, error);
+  const displayName = useStitchToolDisplayName(toolName) ?? toolName;
   const usedAccount = getUsedAccount(args, result);
 
   return (
@@ -34,7 +35,7 @@ export function GenericToolBlock({ toolName, status, args, result, error }: Gene
         <ToolCard.StatusIndicator status={status} />
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex items-center gap-2">
-            <ToolCard.Title>{formatToolDisplayName(toolName)}</ToolCard.Title>
+            <ToolCard.Title>{displayName}</ToolCard.Title>
             {usedAccount ? (
               <span className="rounded-sm border border-border/50 bg-muted/40 px-1.5 py-0.5 text-[10px] text-muted-foreground">
                 {usedAccount}

--- a/apps/web/src/components/chat/message-bubble/tool-call/webfetch-tool-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/webfetch-tool-block.tsx
@@ -1,6 +1,6 @@
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
 
-import { ToolCard, getToolCardState, getToolLabel, truncateText } from './card-primitives';
+import { ToolCard, getToolCardState, getToolLabel, truncateText, useStitchToolDisplayName } from './card-primitives';
 
 function getWebfetchUrl(args: unknown): string | null {
   const value = (args as { url?: unknown })?.url;
@@ -26,6 +26,7 @@ export function WebfetchToolBlock({
 }: WebfetchToolBlockProps) {
   const { isActive } = getToolCardState(status);
   const label = getToolLabel(status, error);
+  const displayName = useStitchToolDisplayName(toolName);
   const url = getWebfetchUrl(args);
   const displayUrl = url ? truncateText(url) : 'Waiting for URL...';
 
@@ -34,7 +35,7 @@ export function WebfetchToolBlock({
       <ToolCard.Header>
         <ToolCard.StatusIndicator status={status} />
         <div className="min-w-0 flex-1 space-y-1">
-          <ToolCard.Title>{toolName}</ToolCard.Title>
+          <ToolCard.Title>{displayName}</ToolCard.Title>
           <ToolCard.TitleContent truncate mono className="block">
             {label ? `${displayUrl} - ${label}` : displayUrl}
           </ToolCard.TitleContent>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -28,6 +28,7 @@ import { useActions } from '@/lib/actions';
 import { providersQueryOptions } from '@/lib/queries/providers';
 import { settingsQueryOptions } from '@/lib/queries/settings';
 import { shortcutsQueryOptions } from '@/lib/queries/shortcuts';
+import { knownToolsQueryOptions } from '@/lib/queries/tools';
 import { useGlobalHotkeys } from '@/lib/use-global-hotkeys';
 
 interface RouterContext {
@@ -62,6 +63,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       context.queryClient.ensureQueryData(shortcutsQueryOptions),
       context.queryClient.ensureQueryData(providersQueryOptions),
       context.queryClient.ensureQueryData(settingsQueryOptions),
+      context.queryClient.ensureQueryData(knownToolsQueryOptions),
     ]),
 });
 

--- a/packages/server/__test__/llm/compaction.test.ts
+++ b/packages/server/__test__/llm/compaction.test.ts
@@ -1,9 +1,11 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, beforeEach } from 'vitest';
 
 import type { StoredPart } from '@stitch/shared/chat/messages';
 
-import { isOverflow } from '@/llm/compaction.js';
+import { isOverflow, buildActiveToolsetInstructionsBlock } from '@/llm/compaction.js';
 import { buildHistoryMessages } from '@/llm/history-messages.js';
+import { setSessionActiveToolsetIds } from '@/llm/stream/session-toolsets.js';
+import { registerToolset, unregisterToolset, listToolsetIds } from '@/tools/toolsets/registry.js';
 
 describe('isOverflow', () => {
   const defaultLimits = { context: 200_000, output: 8_192 };
@@ -477,5 +479,101 @@ describe('buildHistoryMessages', () => {
     const firstContent = userMessages[0].content as Array<{ type: string }>;
     const realImages = firstContent.filter((p) => p.type === 'image');
     expect(realImages).toHaveLength(1);
+  });
+});
+
+describe('buildActiveToolsetInstructionsBlock', () => {
+  const sessionId = 'ses_test_compaction' as never;
+
+  beforeEach(() => {
+    for (const id of listToolsetIds()) {
+      unregisterToolset(id);
+    }
+    setSessionActiveToolsetIds(sessionId, []);
+  });
+
+  test('returns empty string when no toolsets are active', () => {
+    const result = buildActiveToolsetInstructionsBlock(sessionId);
+    expect(result).toBe('');
+  });
+
+  test('returns empty string when active toolsets have no instructions', () => {
+    registerToolset({
+      id: 'no-instructions',
+      name: 'No Instructions',
+      description: 'Toolset without instructions',
+      tools: () => [],
+      activate: async () => ({}),
+    });
+    setSessionActiveToolsetIds(sessionId, ['no-instructions']);
+
+    const result = buildActiveToolsetInstructionsBlock(sessionId);
+    expect(result).toBe('');
+  });
+
+  test('includes instructions for active toolsets that have them', () => {
+    registerToolset({
+      id: 'browser',
+      name: 'Browser',
+      description: 'Browser toolset',
+      instructions: 'Use browser_navigate to open pages.',
+      tools: () => [],
+      activate: async () => ({}),
+    });
+    setSessionActiveToolsetIds(sessionId, ['browser']);
+
+    const result = buildActiveToolsetInstructionsBlock(sessionId);
+    expect(result).toContain('## Active Toolset Instructions');
+    expect(result).toContain('### Browser Toolset Instructions');
+    expect(result).toContain('Use browser_navigate to open pages.');
+  });
+
+  test('omits toolsets that have no instructions even when mixed with ones that do', () => {
+    registerToolset({
+      id: 'with-instructions',
+      name: 'With Instructions',
+      description: 'Has instructions',
+      instructions: 'Do something specific.',
+      tools: () => [],
+      activate: async () => ({}),
+    });
+    registerToolset({
+      id: 'without-instructions',
+      name: 'Without Instructions',
+      description: 'No instructions',
+      tools: () => [],
+      activate: async () => ({}),
+    });
+    setSessionActiveToolsetIds(sessionId, ['with-instructions', 'without-instructions']);
+
+    const result = buildActiveToolsetInstructionsBlock(sessionId);
+    expect(result).toContain('### With Instructions Toolset Instructions');
+    expect(result).not.toContain('### Without Instructions Toolset Instructions');
+  });
+
+  test('includes multiple toolset instruction blocks', () => {
+    registerToolset({
+      id: 'ts-alpha',
+      name: 'Alpha',
+      description: 'Alpha',
+      instructions: 'Alpha instructions.',
+      tools: () => [],
+      activate: async () => ({}),
+    });
+    registerToolset({
+      id: 'ts-beta',
+      name: 'Beta',
+      description: 'Beta',
+      instructions: 'Beta instructions.',
+      tools: () => [],
+      activate: async () => ({}),
+    });
+    setSessionActiveToolsetIds(sessionId, ['ts-alpha', 'ts-beta']);
+
+    const result = buildActiveToolsetInstructionsBlock(sessionId);
+    expect(result).toContain('### Alpha Toolset Instructions');
+    expect(result).toContain('Alpha instructions.');
+    expect(result).toContain('### Beta Toolset Instructions');
+    expect(result).toContain('Beta instructions.');
   });
 });

--- a/packages/server/__test__/tools/toolset-management.test.ts
+++ b/packages/server/__test__/tools/toolset-management.test.ts
@@ -76,6 +76,23 @@ describe('toolset management tools', () => {
       instructions: null,
       prompts: null,
     });
+    expect((result as { message: string }).message).toContain(
+      'Call deactivate_toolset("test-toolset") when you no longer need it',
+    );
+  });
+
+  test('activate_toolset already_active response does not include deactivation nudge', async () => {
+    registerTestToolset();
+    const manager = createManager();
+    const tools = createToolsetTools(manager);
+    await tools.activate_toolset.execute?.({ toolsetId: 'test-toolset' }, {} as never);
+    const result = await tools.activate_toolset.execute?.(
+      { toolsetId: 'test-toolset' },
+      {} as never,
+    );
+
+    expect((result as { status: string }).status).toBe('already_active');
+    expect((result as { message: string }).message).not.toContain('deactivate_toolset');
   });
 
   test('activate_toolset includes details when verbose=true', async () => {

--- a/packages/server/src/llm/compaction.ts
+++ b/packages/server/src/llm/compaction.ts
@@ -17,7 +17,9 @@ import { createProvider } from '@/llm/provider/provider.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
 import { mapAIError, toStreamErrorDetails } from '@/llm/stream/ai-error-mapper.js';
+import { getSessionActiveToolsetIds } from '@/llm/stream/session-toolsets.js';
 import { retrieveMemoryContext } from '@/memory/retriever.js';
+import { getToolset } from '@/tools/toolsets/registry.js';
 import { recordUsageEvent } from '@/usage/ledger.js';
 import { calculateMessageCostUsd } from '@/utils/cost.js';
 import { estimate } from '@/utils/token.js';
@@ -549,7 +551,7 @@ export async function buildCompactedHistory(
     }
   }
 
-  return buildHistoryMessages(msgs.slice(startIndex), {
+  const historyMessages = buildHistoryMessages(msgs.slice(startIndex), {
     useBasePrompt: promptConfig?.useBasePrompt ?? true,
     systemPrompt: promptConfig?.systemPrompt ?? null,
     userName: promptUserContext.userName,
@@ -557,6 +559,26 @@ export async function buildCompactedHistory(
     memoryContext,
     codeModePrompt: promptConfig?.codeModePrompt ?? null,
   });
+
+  const instructionsBlock = buildActiveToolsetInstructionsBlock(sessionId);
+  if (instructionsBlock && historyMessages.length > 0 && historyMessages[0]?.role === 'system') {
+    const sysMsg = historyMessages[0];
+    const existing = typeof sysMsg.content === 'string' ? sysMsg.content : '';
+    historyMessages[0] = { role: 'system', content: `${existing}${instructionsBlock}` };
+  }
+
+  return historyMessages;
+}
+
+export function buildActiveToolsetInstructionsBlock(sessionId: PrefixedString<'ses'>): string {
+  const activeIds = getSessionActiveToolsetIds(sessionId);
+  const instructionBlocks = activeIds
+    .map((id) => getToolset(id))
+    .filter((ts): ts is NonNullable<ReturnType<typeof getToolset>> => !!ts?.instructions)
+    .map((ts) => `### ${ts.name} Toolset Instructions\n${ts.instructions}`)
+    .join('\n\n');
+
+  return instructionBlocks ? `\n\n## Active Toolset Instructions\n\n${instructionBlocks}` : '';
 }
 
 /**

--- a/packages/server/src/llm/prompt/base-system-prompt.txt
+++ b/packages/server/src/llm/prompt/base-system-prompt.txt
@@ -24,7 +24,7 @@ You are assisting users on their local machine.
 
 ## Tool Management
 
-You have a set of core tools always available: bash, read, write, edit, glob, grep, question, webfetch, agenda.
+You have a set of core tools always available: bash, read, write, edit, glob, grep, question, webfetch.
 
 Additional capabilities are organized into **toolsets** — groups of related tools that you can discover and load on demand.
 
@@ -36,7 +36,7 @@ Additional capabilities are organized into **toolsets** — groups of related to
 
 **Guidelines:**
 - Only activate toolsets you need for the current task.
-- Deactivate toolsets once you are done with them.
+- After completing a task that required a toolset, deactivate it immediately with deactivate_toolset.
 - Do not activate all toolsets at once — this wastes context space.
 - If unsure whether a toolset has what you need, use `list_toolsets` first to check.
 

--- a/packages/server/src/tools/core/glob.ts
+++ b/packages/server/src/tools/core/glob.ts
@@ -100,7 +100,7 @@ function getSuggestion() {
 
 const shouldTruncate = true;
 
-export const DISPLAY_NAME = 'Glob';
+export const DISPLAY_NAME = 'File Search';
 
 export function createRegisteredTool(context: ToolContext) {
   const baseTool = createGlobTool();

--- a/packages/server/src/tools/core/grep.ts
+++ b/packages/server/src/tools/core/grep.ts
@@ -203,7 +203,7 @@ function getSuggestion() {
 
 const shouldTruncate = true;
 
-export const DISPLAY_NAME = 'Grep';
+export const DISPLAY_NAME = 'Text Search';
 
 export function createRegisteredTool(context: ToolContext) {
   const baseTool = createGrepTool();

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -97,7 +97,7 @@ export function createToolsetTools(manager: ToolsetManager) {
         tools: toolNames,
         toolDisplayNames: toolNames.map(humanizeToolName),
         icon: toolset?.icon ?? null,
-        message: `Toolset "${toolsetId}" activated. ${toolNames.length} tool(s) now available: ${toolNames.map(humanizeToolName).join(', ')}`,
+        message: `Toolset "${toolsetId}" activated. ${toolNames.length} tool(s) now available: ${toolNames.map(humanizeToolName).join(', ')}. Call deactivate_toolset("${toolsetId}") when you no longer need it to keep context clean.`,
         hasInstructions: !!toolset?.instructions,
         promptCount: toolset?.prompts?.length ?? 0,
         instructions: shouldIncludeVerbose ? (toolset?.instructions ?? null) : null,


### PR DESCRIPTION
## Change Summary

Tool cards in the chat view now use the display names defined on the server (via each tool's `DISPLAY_NAME` export) instead of deriving names client-side from the raw tool key string. This ensures naming is consistent across the app and controlled from a single source of truth.

### New Features
- **Server-authoritative tool display names**: Chat tool cards (bash, file, webfetch, generic) now resolve their title from the `/config/tools` response via a new `useStitchToolDisplayName` hook in `card-primitives.tsx`, falling back to the existing `formatToolDisplayName` formatter if the cache is unpopulated
- **Eager config prefetch**: `knownToolsQueryOptions` is now fetched in the root route loader alongside other startup queries, guaranteeing the cache is warm before any tool card renders

### Improvements & Refactors
- Renamed `glob` display name to `'File Search'` and `grep` to `'Text Search'` for clarity
- Toolsets system enhancements: active toolset instructions are now injected into the system prompt during compaction, and the activate response nudges the model to deactivate when done