### PR TITLE
improvement(server): move settings side-effects into service and standardize to ServiceResult

### DIFF
--- a/packages/server/src/lib/browser/browser-manager.ts
+++ b/packages/server/src/lib/browser/browser-manager.ts
@@ -18,6 +18,7 @@ import { SessionHealthWatchdog } from '@/lib/browser/watchdogs/session-health-wa
 import { StorageStateManager } from '@/lib/browser/watchdogs/storage-state-manager.js';
 import * as Log from '@/lib/log.js';
 import { getBrowserProfilePath } from '@/lib/paths.js';
+import { isServiceError } from '@/lib/service-result.js';
 import { listSettings } from '@/settings/service.js';
 import type { ChildProcess } from 'node:child_process';
 
@@ -37,8 +38,9 @@ async function resolveActiveProfileDir(): Promise<string> {
   // Profile importing is not supported on Windows; always use the default clean profile.
   if (process.platform === 'win32') return DEFAULT_BROWSER_PROFILE_DIR;
 
-  const settings = await listSettings();
-  const activeProfile = settings['browser.activeProfile'];
+  const settingsResult = await listSettings();
+  if (isServiceError(settingsResult)) return DEFAULT_BROWSER_PROFILE_DIR;
+  const activeProfile = settingsResult.data['browser.activeProfile'];
   if (!activeProfile) return DEFAULT_BROWSER_PROFILE_DIR;
 
   const parts = activeProfile.split('/');
@@ -419,9 +421,8 @@ class BrowserManager {
       return;
     }
 
-    const [userDataDir, settings] = await Promise.all([resolveActiveProfileDir(), listSettings()]);
-
-    const headless = options.headless ?? settings['browser.headless'] !== 'false';
+    const [userDataDir, settingsResult] = await Promise.all([resolveActiveProfileDir(), listSettings()]);
+    const headless = options.headless ?? (!isServiceError(settingsResult) && settingsResult.data['browser.headless'] !== 'false');
 
     const instance = await launchChrome({
       userDataDir,

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -2,93 +2,33 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { z } from 'zod';
 
-import { syncAllAutomationSchedules } from '@/automations/scheduler.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
-import { listEnabledProviderEmbeddingModels } from '@/llm/provider/service.js';
-import { getMemoryConfig, hasConfiguredEmbeddingModel } from '@/memory/config.js';
-import { resetEmbedder } from '@/memory/embedding/factory.js';
 import { deleteSetting, listSettings, saveSetting } from '@/settings/service.js';
 
 const settingValueSchema = z.object({ value: z.string() });
+const settingKeySchema = z.object({ key: z.string().min(1) });
 
 export const settingsRouter = new Hono();
 
 settingsRouter.get('/', async (c) => {
   const result = await listSettings();
-  return c.json(result);
+  return unwrapResult(c, result);
 });
 
-settingsRouter.put('/:key', zValidator('json', settingValueSchema), async (c) => {
-  const key = c.req.param('key');
-  const { value } = c.req.valid('json');
+settingsRouter.put(
+  '/:key',
+  zValidator('param', settingKeySchema),
+  zValidator('json', settingValueSchema),
+  async (c) => {
+    const { key } = c.req.valid('param');
+    const { value } = c.req.valid('json');
+    const result = await saveSetting(key, value);
+    return unwrapResult(c, result, 204);
+  },
+);
 
-  if (key === 'memory.enabled' && value === 'true') {
-    const memoryConfig = await getMemoryConfig();
-    const canEnableMemory = hasConfiguredEmbeddingModel(memoryConfig);
-    if (!canEnableMemory) {
-      return c.json(
-        {
-          error:
-            'Cannot enable memory without an embedding model. Configure memory.embedding.providerId and memory.embedding.modelId first.',
-        },
-        400,
-      );
-    }
-
-    const providerModels = await listEnabledProviderEmbeddingModels();
-    const hasConfiguredModel = providerModels.some(
-      (provider) =>
-        provider.providerId === memoryConfig.embeddingProviderId &&
-        provider.models.some((model) => model.id === memoryConfig.embeddingModelId),
-    );
-    if (!hasConfiguredModel) {
-      return c.json(
-        {
-          error:
-            'Cannot enable memory without a configured embedding model from an enabled provider.',
-        },
-        400,
-      );
-    }
-  }
-
-  const result = await saveSetting(key, value);
-  if (isServiceError(result)) return unwrapResult(c, result);
-
-  if (key === 'profile.timezone') {
-    try {
-      await syncAllAutomationSchedules();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to reschedule automations';
-      return c.json({ error: message }, 500);
-    }
-  }
-
-  if (key === 'memory.embedding.providerId' || key === 'memory.embedding.modelId') {
-    resetEmbedder();
-  }
-
-  return c.body(null, 204);
-});
-
-settingsRouter.delete('/:key', async (c) => {
-  const key = c.req.param('key');
+settingsRouter.delete('/:key', zValidator('param', settingKeySchema), async (c) => {
+  const { key } = c.req.valid('param');
   const result = await deleteSetting(key);
-  if (isServiceError(result)) return unwrapResult(c, result);
-
-  if (key === 'profile.timezone') {
-    try {
-      await syncAllAutomationSchedules();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to reschedule automations';
-      return c.json({ error: message }, 500);
-    }
-  }
-
-  if (key === 'memory.embedding.providerId' || key === 'memory.embedding.modelId') {
-    resetEmbedder();
-  }
-
-  return c.body(null, 204);
+  return unwrapResult(c, result, 204);
 });

--- a/packages/server/src/settings/service.ts
+++ b/packages/server/src/settings/service.ts
@@ -3,19 +3,56 @@ import { eq } from 'drizzle-orm';
 import { SETTINGS_SCHEMAS } from '@stitch/shared/settings/types';
 import type { SettingsKey } from '@stitch/shared/settings/types';
 
+import { syncAllAutomationSchedules } from '@/automations/scheduler.js';
 import { getDb } from '@/db/client.js';
 import { userSettings } from '@/db/schema.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
+import { listEnabledProviderEmbeddingModels } from '@/llm/provider/service.js';
+import { getMemoryConfig, hasConfiguredEmbeddingModel } from '@/memory/config.js';
+import { resetEmbedder } from '@/memory/embedding/factory.js';
 
-export async function listSettings(): Promise<Record<string, string>> {
+export async function listSettings(): Promise<ServiceResult<Record<string, string>>> {
   const db = getDb();
   const rows = await db.select().from(userSettings);
   const result: Record<string, string> = {};
   for (const row of rows) {
     result[row.key] = row.value;
   }
-  return result;
+  return ok(result);
+}
+
+async function checkMemoryEnablePrerequisites(): Promise<ServiceResult<null>> {
+  const memoryConfig = await getMemoryConfig();
+  if (!hasConfiguredEmbeddingModel(memoryConfig)) {
+    return err(
+      'Cannot enable memory without an embedding model. Configure memory.embedding.providerId and memory.embedding.modelId first.',
+      400,
+    );
+  }
+
+  const providerModels = await listEnabledProviderEmbeddingModels();
+  const hasConfiguredModel = providerModels.some(
+    (provider) =>
+      provider.providerId === memoryConfig.embeddingProviderId &&
+      provider.models.some((model) => model.id === memoryConfig.embeddingModelId),
+  );
+  if (!hasConfiguredModel) {
+    return err(
+      'Cannot enable memory without a configured embedding model from an enabled provider.',
+      400,
+    );
+  }
+
+  return ok(null);
+}
+
+function isTimezoneKey(key: string): boolean {
+  return key === 'profile.timezone';
+}
+
+function isEmbeddingKey(key: string): boolean {
+  return key === 'memory.embedding.providerId' || key === 'memory.embedding.modelId';
 }
 
 export async function saveSetting(key: string, value: string): Promise<ServiceResult<null>> {
@@ -24,10 +61,15 @@ export async function saveSetting(key: string, value: string): Promise<ServiceRe
     return err('Invalid setting key', 400);
   }
 
-  const result = schema.safeParse(value);
-  if (!result.success) {
-    const issue = result.error.issues[0];
+  const parseResult = schema.safeParse(value);
+  if (!parseResult.success) {
+    const issue = parseResult.error.issues[0];
     return err(`Invalid value: ${issue.message}`, 400);
+  }
+
+  if (key === 'memory.enabled' && value === 'true') {
+    const prereqResult = await checkMemoryEnablePrerequisites();
+    if ('error' in prereqResult) return prereqResult;
   }
 
   const db = getDb();
@@ -38,6 +80,14 @@ export async function saveSetting(key: string, value: string): Promise<ServiceRe
       target: userSettings.key,
       set: { value, updatedAt: Date.now() },
     });
+
+  if (isTimezoneKey(key)) {
+    await syncAllAutomationSchedules();
+  }
+
+  if (isEmbeddingKey(key)) {
+    resetEmbedder();
+  }
 
   return ok(null);
 }
@@ -54,6 +104,14 @@ export async function deleteSetting(key: string): Promise<ServiceResult<null>> {
     .returning({ key: userSettings.key });
   if (result.length === 0) {
     return err('Setting not found', 404);
+  }
+
+  if (isTimezoneKey(key)) {
+    await syncAllAutomationSchedules();
+  }
+
+  if (isEmbeddingKey(key)) {
+    resetEmbedder();
   }
 
   return ok(null);

--- a/packages/server/src/tools/core/agenda.ts
+++ b/packages/server/src/tools/core/agenda.ts
@@ -13,6 +13,7 @@ import {
   updateAgendaItem,
 } from '@/agenda/service.js';
 import { listSettings } from '@/settings/service.js';
+import { isServiceError } from '@/lib/service-result.js';
 import type { ToolContext } from '@/tools/runtime/wrappers.js';
 import type { Toolset } from '@/tools/toolsets/types.js';
 import type { Tool } from 'ai';
@@ -58,8 +59,9 @@ function parseDueDate(dateStr: string, timeZone: string): number | null {
 }
 
 async function getUserTimezone(): Promise<string> {
-  const settings = await listSettings();
-  return settings['profile.timezone'] || 'UTC';
+  const settingsResult = await listSettings();
+  if (isServiceError(settingsResult)) return 'UTC';
+  return settingsResult.data['profile.timezone'] || 'UTC';
 }
 
 const TOOL_SUMMARIES = [

--- a/packages/server/src/tools/core/browser.ts
+++ b/packages/server/src/tools/core/browser.ts
@@ -8,6 +8,7 @@ import type { ScrollDirection } from '@/lib/browser/types.js';
 import * as Log from '@/lib/log.js';
 import { askQuestion } from '@/question/service.js';
 import { listSettings, saveSetting } from '@/settings/service.js';
+import { isServiceError } from '@/lib/service-result.js';
 import type { ToolContext } from '@/tools/runtime/wrappers.js';
 import { withTruncation } from '@/tools/runtime/wrappers.js';
 
@@ -451,8 +452,8 @@ async function maybePromptProfileImport(
 ): Promise<void> {
   if (hasPromptedImport) return;
 
-  const settings = await listSettings();
-  const imported = settings['browser.profileImported'];
+  const settingsResult = await listSettings();
+  const imported = !isServiceError(settingsResult) && settingsResult.data['browser.profileImported'];
   if (imported) {
     hasPromptedImport = true;
     return;


### PR DESCRIPTION
## Change Summary

Implements #73. Moves all route-level side effects out of the settings route handlers and into the settings service, and standardizes all settings service APIs to return ServiceResult consistently.

### New Features
- **Settings service orchestration**: saveSetting and deleteSetting now own all side effects — memory prerequisite checks, timezone/scheduler sync, and embedder reset — so callers get a single clean ServiceResult back with no extra wiring required

### Improvements and Refactors
- listSettings now returns ServiceResult<Record<string, string>> consistently with all other service APIs
- Settings route reduced from 94 to 33 lines — all manual isServiceError checks and side-effect blocks removed, replaced with unwrapResult and zValidator param validation
- Internal callers (browser-manager, agenda, browser tool) updated to narrow ServiceResult with isServiceError before use