### PR TITLE
improvement(server): ServiceResult consistency and Zod param schemas for provider/model routes

### DIFF
--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -11,7 +11,7 @@ import { getDb } from '@/db/client.js';
 import { messages, providerConfig, sessions } from '@/db/schema.js';
 import * as AbortRegistry from '@/lib/abort-registry.js';
 import * as Log from '@/lib/log.js';
-import { err, ok } from '@/lib/service-result.js';
+import { err, isServiceError, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { broadcast } from '@/lib/sse.js';
 import { buildCompactedHistory, compact } from '@/llm/compaction.js';
@@ -604,7 +604,8 @@ export async function getSessionStats(
   // Resolve provider/model labels and context limit
   const latestMessage =
     sessionMessages.length > 0 ? sessionMessages[sessionMessages.length - 1] : null;
-  const [providers, modelCatalog] = await Promise.all([listProviders(), Models.get()]);
+  const [providersResult, modelCatalog] = await Promise.all([listProviders(), Models.get()]);
+  const providers = isServiceError(providersResult) ? [] : providersResult.data;
 
   let providerLabel = '-';
   let modelLabel = '-';

--- a/packages/server/src/llm/provider/model-visibility.ts
+++ b/packages/server/src/llm/provider/model-visibility.ts
@@ -11,9 +11,9 @@ type VisibilityOverride = {
   visibility: 'show' | 'hide';
 };
 
-export async function listVisibilityOverrides(): Promise<VisibilityOverride[]> {
+export async function listVisibilityOverrides(): Promise<ServiceResult<VisibilityOverride[]>> {
   const db = getDb();
-  return db.select().from(modelVisibility);
+  return ok(await db.select().from(modelVisibility));
 }
 
 export async function upsertVisibility(

--- a/packages/server/src/llm/provider/service.ts
+++ b/packages/server/src/llm/provider/service.ts
@@ -69,15 +69,15 @@ async function resolveProvider(providerId: string): Promise<ServiceResult<Models
   return ok(provider);
 }
 
-export async function listProviders(): Promise<ProviderSummary[]> {
+export async function listProviders(): Promise<ServiceResult<ProviderSummary[]>> {
   const db = getDb();
   const [providers, configs] = await Promise.all([
     Models.get(),
     db.select({ providerId: providerConfig.providerId }).from(providerConfig),
   ]);
   const enabledIds = new Set(configs.map((row) => row.providerId));
-  return Object.values(providers).map((provider) =>
-    toProviderSummary(provider, enabledIds.has(provider.id)),
+  return ok(
+    Object.values(providers).map((provider) => toProviderSummary(provider, enabledIds.has(provider.id))),
   );
 }
 
@@ -107,7 +107,7 @@ export async function listProviderModels(
   return ok(Object.values(providerResult.data.models).map(toModelSummary));
 }
 
-export async function listEnabledProviderAudioModels(): Promise<ProviderModelsSummary[]> {
+export async function listEnabledProviderAudioModels(): Promise<ServiceResult<ProviderModelsSummary[]>> {
   const db = getDb();
   const [providers, configs] = await Promise.all([
     Models.getAudioModels(),
@@ -115,16 +115,18 @@ export async function listEnabledProviderAudioModels(): Promise<ProviderModelsSu
   ]);
   const enabledIds = new Set(configs.map((row) => row.providerId));
 
-  return Object.values(providers)
-    .filter((provider) => enabledIds.has(provider.id))
-    .map((provider) => ({
-      providerId: provider.id,
-      providerName: provider.name,
-      models: Object.values(provider.models).map(toModelSummary),
-    }));
+  return ok(
+    Object.values(providers)
+      .filter((provider) => enabledIds.has(provider.id))
+      .map((provider) => ({
+        providerId: provider.id,
+        providerName: provider.name,
+        models: Object.values(provider.models).map(toModelSummary),
+      })),
+  );
 }
 
-export async function listEnabledProviderEmbeddingModels(): Promise<ProviderModelsSummary[]> {
+export async function listEnabledProviderEmbeddingModels(): Promise<ServiceResult<ProviderModelsSummary[]>> {
   const db = getDb();
   const [providers, configs] = await Promise.all([
     Models.getEmbeddingModels(),
@@ -132,13 +134,15 @@ export async function listEnabledProviderEmbeddingModels(): Promise<ProviderMode
   ]);
   const enabledIds = new Set(configs.map((row) => row.providerId));
 
-  return Object.values(providers)
-    .filter((provider) => enabledIds.has(provider.id))
-    .map((provider) => ({
-      providerId: provider.id,
-      providerName: provider.name,
-      models: Object.values(provider.models).map(toModelSummary),
-    }));
+  return ok(
+    Object.values(providers)
+      .filter((provider) => enabledIds.has(provider.id))
+      .map((provider) => ({
+        providerId: provider.id,
+        providerName: provider.name,
+        models: Object.values(provider.models).map(toModelSummary),
+      })),
+  );
 }
 
 export async function getEmbeddingModelDimensions(

--- a/packages/server/src/recordings/analysis-service.ts
+++ b/packages/server/src/recordings/analysis-service.ts
@@ -265,7 +265,8 @@ export async function startRecordingAnalysis(
     return ok({ analysis: toResponse(existing, recordingId) });
   }
 
-  const audioProviders = await listEnabledProviderAudioModels();
+  const audioProvidersResult = await listEnabledProviderAudioModels();
+  const audioProviders = isServiceError(audioProvidersResult) ? [] : audioProvidersResult.data;
   const fallbackProvider = audioProviders[0];
   const fallbackModel = fallbackProvider?.models[0];
 

--- a/packages/server/src/routes/llm-models.ts
+++ b/packages/server/src/routes/llm-models.ts
@@ -3,46 +3,51 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 
 import { unwrapResult } from '@/lib/route-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
 import {
   deleteVisibility,
   listVisibilityOverrides,
   upsertVisibility,
 } from '@/llm/provider/model-visibility.js';
+import { PROVIDER_IDS } from '@stitch/shared/providers/types';
 
 export const modelsRouter = new Hono();
 
 const visibilityRouter = new Hono();
+
+const providerIdSchema = z.enum(PROVIDER_IDS);
+const modelIdSchema = z.string().min(1);
 
 const upsertVisibilitySchema = z.object({
   visibility: z.enum(['show', 'hide']),
 });
 
 visibilityRouter.get('/', async (c) => {
-  const overrides = await listVisibilityOverrides();
-  return c.json(overrides);
+  const result = await listVisibilityOverrides();
+  return unwrapResult(c, result);
 });
 
 visibilityRouter.put(
   '/:providerId/:modelId',
+  zValidator('param', z.object({ providerId: providerIdSchema, modelId: modelIdSchema })),
   zValidator('json', upsertVisibilitySchema),
   async (c) => {
-    const providerId = c.req.param('providerId');
-    const modelId = c.req.param('modelId');
+    const { providerId, modelId } = c.req.valid('param');
     const { visibility } = c.req.valid('json');
 
     const result = await upsertVisibility(providerId, modelId, visibility);
-    if (isServiceError(result)) return unwrapResult(c, result);
     return unwrapResult(c, result, 204);
   },
 );
 
-visibilityRouter.delete('/:providerId/:modelId', async (c) => {
-  const providerId = c.req.param('providerId');
-  const modelId = c.req.param('modelId');
+visibilityRouter.delete(
+  '/:providerId/:modelId',
+  zValidator('param', z.object({ providerId: providerIdSchema, modelId: modelIdSchema })),
+  async (c) => {
+    const { providerId, modelId } = c.req.valid('param');
 
-  const result = await deleteVisibility(providerId, modelId);
-  return unwrapResult(c, result, 204);
-});
+    const result = await deleteVisibility(providerId, modelId);
+    return unwrapResult(c, result, 204);
+  },
+);
 
 modelsRouter.route('/visibility', visibilityRouter);

--- a/packages/server/src/routes/llm-provider.ts
+++ b/packages/server/src/routes/llm-provider.ts
@@ -17,61 +17,58 @@ import {
   listProviders,
   upsertProviderCredentials,
 } from '@/llm/provider/service.js';
+import { PROVIDER_IDS } from '@stitch/shared/providers/types';
 
 const log = Log.create({ service: 'provider-routes' });
 
+const providerIdSchema = z.enum(PROVIDER_IDS);
+const modelIdSchema = z.string().min(1);
 const providerConfigSchema = z.record(z.string(), z.unknown());
 
 export const providerRouter = new Hono();
 
 providerRouter.get('/', async (c) => {
-  const providers = await listProviders();
-  return c.json(providers);
+  const result = await listProviders();
+  return unwrapResult(c, result);
 });
 
 providerRouter.get('/audio-models', async (c) => {
-  const providers = await listEnabledProviderAudioModels();
-  return c.json(providers);
+  const result = await listEnabledProviderAudioModels();
+  return unwrapResult(c, result);
 });
 
 providerRouter.get('/embedding-models', async (c) => {
-  const providers = await listEnabledProviderEmbeddingModels();
-  return c.json(providers);
+  const result = await listEnabledProviderEmbeddingModels();
+  return unwrapResult(c, result);
 });
 
-providerRouter.get('/:providerId', async (c) => {
-  const providerId = c.req.param('providerId');
+providerRouter.get('/:providerId', zValidator('param', z.object({ providerId: providerIdSchema })), async (c) => {
+  const { providerId } = c.req.valid('param');
   const result = await getProvider(providerId);
-  if (isServiceError(result)) {
-    log.warn({ providerId }, 'blocked access to provider');
-    return unwrapResult(c, result);
-  }
+  if (isServiceError(result)) log.warn({ providerId }, 'blocked access to provider');
   return unwrapResult(c, result);
 });
 
-providerRouter.get('/:providerId/models', async (c) => {
-  const providerId = c.req.param('providerId');
+providerRouter.get('/:providerId/models', zValidator('param', z.object({ providerId: providerIdSchema })), async (c) => {
+  const { providerId } = c.req.valid('param');
   const result = await listProviderModels(providerId);
-  if (isServiceError(result)) {
-    log.warn({ providerId }, 'blocked access to provider models');
-    return unwrapResult(c, result);
-  }
+  if (isServiceError(result)) log.warn({ providerId }, 'blocked access to provider models');
   return unwrapResult(c, result);
 });
 
-providerRouter.get('/:providerId/models/:modelId', async (c) => {
-  const providerId = c.req.param('providerId');
-  const modelId = c.req.param('modelId');
-  const result = await getProviderModel(providerId, modelId);
-  if (isServiceError(result)) {
-    log.warn({ providerId, modelId }, 'blocked access to provider model');
+providerRouter.get(
+  '/:providerId/models/:modelId',
+  zValidator('param', z.object({ providerId: providerIdSchema, modelId: modelIdSchema })),
+  async (c) => {
+    const { providerId, modelId } = c.req.valid('param');
+    const result = await getProviderModel(providerId, modelId);
+    if (isServiceError(result)) log.warn({ providerId, modelId }, 'blocked access to provider model');
     return unwrapResult(c, result);
-  }
-  return unwrapResult(c, result);
-});
+  },
+);
 
-providerRouter.get('/:providerId/logo', async (c) => {
-  const providerId = c.req.param('providerId');
+providerRouter.get('/:providerId/logo', zValidator('param', z.object({ providerId: providerIdSchema })), async (c) => {
+  const { providerId } = c.req.valid('param');
   const result = await getProviderLogo(providerId);
   if (isServiceError(result)) {
     log.warn({ providerId }, 'provider logo request failed');
@@ -83,35 +80,33 @@ providerRouter.get('/:providerId/logo', async (c) => {
   return c.body(result.data, 200);
 });
 
-providerRouter.get('/:providerId/config', async (c) => {
-  const providerId = c.req.param('providerId');
+providerRouter.get('/:providerId/config', zValidator('param', z.object({ providerId: providerIdSchema })), async (c) => {
+  const { providerId } = c.req.valid('param');
   const result = await getProviderCredentials(providerId);
-  if (isServiceError(result)) {
-    log.warn({ providerId }, 'provider config request failed');
-    return unwrapResult(c, result);
-  }
+  if (isServiceError(result)) log.warn({ providerId }, 'provider config request failed');
   return unwrapResult(c, result);
 });
 
-providerRouter.put('/:providerId/config', zValidator('json', providerConfigSchema), async (c) => {
-  const providerId = c.req.param('providerId');
-  const body = c.req.valid('json');
-  const result = await upsertProviderCredentials(providerId, body);
-  if (isServiceError(result)) {
-    log.warn({ providerId }, 'provider config update failed');
-    return unwrapResult(c, result);
-  }
+providerRouter.put(
+  '/:providerId/config',
+  zValidator('param', z.object({ providerId: providerIdSchema })),
+  zValidator('json', providerConfigSchema),
+  async (c) => {
+    const { providerId } = c.req.valid('param');
+    const body = c.req.valid('json');
+    const result = await upsertProviderCredentials(providerId, body);
+    if (isServiceError(result)) log.warn({ providerId }, 'provider config update failed');
+    return unwrapResult(c, result, 204);
+  },
+);
 
-  return unwrapResult(c, result, 204);
-});
-
-providerRouter.delete('/:providerId/config', async (c) => {
-  const providerId = c.req.param('providerId');
-  const result = await deleteProviderCredentials(providerId);
-  if (isServiceError(result)) {
-    log.warn({ providerId }, 'provider config delete failed');
-    return unwrapResult(c, result);
-  }
-
-  return unwrapResult(c, result, 204);
-});
+providerRouter.delete(
+  '/:providerId/config',
+  zValidator('param', z.object({ providerId: providerIdSchema })),
+  async (c) => {
+    const { providerId } = c.req.valid('param');
+    const result = await deleteProviderCredentials(providerId);
+    if (isServiceError(result)) log.warn({ providerId }, 'provider config delete failed');
+    return unwrapResult(c, result, 204);
+  },
+);

--- a/packages/server/src/routes/settings.ts
+++ b/packages/server/src/routes/settings.ts
@@ -36,7 +36,8 @@ settingsRouter.put('/:key', zValidator('json', settingValueSchema), async (c) =>
       );
     }
 
-    const providerModels = await listEnabledProviderEmbeddingModels();
+    const providerModelsResult = await listEnabledProviderEmbeddingModels();
+    const providerModels = isServiceError(providerModelsResult) ? [] : providerModelsResult.data;
     const hasConfiguredModel = providerModels.some(
       (provider) =>
         provider.providerId === memoryConfig.embeddingProviderId &&

--- a/packages/server/src/tools/runtime/registry.ts
+++ b/packages/server/src/tools/runtime/registry.ts
@@ -2,6 +2,7 @@ import type { PrefixedString } from '@stitch/shared/id';
 import type { ToolType } from '@stitch/shared/tools/types';
 
 import { isDbInitialized } from '@/db/client.js';
+import { isServiceError } from '@/lib/service-result.js';
 import { listEnabledProviderEmbeddingModels } from '@/llm/provider/service.js';
 import { getMemoryConfig, hasConfiguredEmbeddingModel } from '@/memory/config.js';
 import {
@@ -105,7 +106,10 @@ export async function createTools(context: {
   if (isDbInitialized()) {
     const memoryConfig = await getMemoryConfig();
     if (hasConfiguredEmbeddingModel(memoryConfig)) {
-      const embeddingProviders = await listEnabledProviderEmbeddingModels();
+      const embeddingProvidersResult = await listEnabledProviderEmbeddingModels();
+      const embeddingProviders = isServiceError(embeddingProvidersResult)
+        ? []
+        : embeddingProvidersResult.data;
       shouldEnableMemoryTool = embeddingProviders.some(
         (provider) =>
           provider.providerId === memoryConfig.embeddingProviderId &&


### PR DESCRIPTION
## 🚀 Change Summary

Closes #77. Brings `ServiceResult` consistency to all LLM provider and model-visibility service methods, and adds Zod param validation to provider/model routes so invalid IDs are rejected at the boundary before reaching service logic.

### ✨ New Features
- **Zod param schemas on provider/model routes**: `/:providerId` params now validate against the `PROVIDER_IDS` enum; `/:modelId` params validate as non-empty strings — invalid IDs return a structured 422 before hitting the service layer

### 🛠 Improvements & Refactors
- **`listProviders`, `listEnabledProviderAudioModels`, `listEnabledProviderEmbeddingModels`** now return `ServiceResult<T>` instead of plain arrays, matching all other service methods
- **`listVisibilityOverrides`** similarly converted to `ServiceResult<VisibilityOverride[]>`
- **`llm-provider.ts` route handlers** simplified: removed the redundant `if (isServiceError) return unwrapResult` + `return unwrapResult` double pattern — error logging is kept where needed, then `unwrapResult` is called unconditionally
- **Call sites** in `chat/service.ts`, `recordings/analysis-service.ts`, `routes/settings.ts`, and `tools/runtime/registry.ts` updated to unwrap the new `ServiceResult` returns with `isServiceError` guards (falling back to empty arrays on failure)