### PR TITLE
improvement(connectors): update Google connector setup flow

### DIFF
--- a/apps/web/src/components/connectors/setup-wizard.tsx
+++ b/apps/web/src/components/connectors/setup-wizard.tsx
@@ -451,6 +451,26 @@ function ScopesStep({
   return (
     <div className="flex h-full min-h-0 flex-col gap-3">
       <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+        {enableApisUrl && (
+          <div className="rounded-lg border border-primary/30 bg-primary/5 p-3">
+            <p className="mb-1.5 text-xs font-medium text-foreground">
+              Before connecting, enable the APIs for the services you select below:
+            </p>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+              onClick={() => {
+                void (
+                  window.api?.shell?.openExternal(enableApisUrl) ??
+                  window.open(enableApisUrl, '_blank')
+                );
+              }}
+            >
+              <ExternalLinkIcon className="size-3.5" />
+              Enable required Google APIs in Cloud Console
+            </button>
+          </div>
+        )}
         {config.serviceAccessOptions && config.serviceAccessOptions.length > 0 ? (
           <div className="space-y-3">
             {config.serviceAccessOptions.map((option) => {
@@ -465,7 +485,7 @@ function ScopesStep({
                     <Button
                       type="button"
                       size="sm"
-                      variant={value === 'none' ? 'secondary' : 'outline'}
+                      variant={value === 'none' ? 'default' : 'outline'}
                       onClick={() => setServiceAccess({ ...serviceAccess, [option.id]: 'none' })}
                     >
                       Off
@@ -473,7 +493,7 @@ function ScopesStep({
                     <Button
                       type="button"
                       size="sm"
-                      variant={value === 'read' ? 'secondary' : 'outline'}
+                      variant={value === 'read' ? 'default' : 'outline'}
                       onClick={() => setServiceAccess({ ...serviceAccess, [option.id]: 'read' })}
                     >
                       Read
@@ -481,7 +501,7 @@ function ScopesStep({
                     <Button
                       type="button"
                       size="sm"
-                      variant={value === 'write' ? 'secondary' : 'outline'}
+                      variant={value === 'write' ? 'default' : 'outline'}
                       onClick={() => setServiceAccess({ ...serviceAccess, [option.id]: 'write' })}
                     >
                       Read + Write
@@ -512,24 +532,6 @@ function ScopesStep({
               ))}
             </div>
           </ScrollArea>
-        )}
-        {enableApisUrl && (
-          <a
-            href={enableApisUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 rounded-md bg-muted/50 px-3 py-2 text-xs text-primary hover:bg-muted"
-            onClick={(e) => {
-              e.preventDefault();
-              void (
-                window.api?.shell?.openExternal(enableApisUrl) ??
-                window.open(enableApisUrl, '_blank')
-              );
-            }}
-          >
-            <ExternalLinkIcon className="size-3" />
-            Enable required Google APIs in Cloud Console
-          </a>
         )}
       </div>
       <DialogFooter className="shrink-0">

--- a/connectors/google/src/connector.ts
+++ b/connectors/google/src/connector.ts
@@ -153,14 +153,9 @@ export const googleConnectorModule: ConnectorModule = {
       { text: 'Give it a name (for example, Stitch Desktop)' },
       { text: 'Copy the Client ID and Client Secret' },
       {
-        text: 'Enable APIs for services you plan to use (Gmail API, Google Drive API, Google Calendar API, Google Docs API)',
-        href: 'https://console.cloud.google.com/apis/library',
-        hrefLabel: 'Google API Library',
-      },
-      {
         text: 'Add your email as a test user in OAuth consent screen while app is in testing mode',
-        href: 'https://console.cloud.google.com/apis/credentials/consent',
-        hrefLabel: 'OAuth Consent Screen',
+        href: 'https://console.cloud.google.com/auth/audience',
+        hrefLabel: 'OAuth Audience Page',
       },
     ],
   },


### PR DESCRIPTION
## Change Summary

Updates the Google connector setup wizard to streamline the flow, fix a broken link, and resolve a dark mode visibility issue in scope selection.

### New Features
- **Prominent API enable callout**: The `Enable required Google APIs` link is now a highlighted instructional callout at the top of the scope selection step, guiding users to enable APIs before choosing services

### Improvements & Refactors
- **Removed API enable step from initial instructions**: Step 8 (Enable APIs) is removed from the setup instructions page - it now lives contextually on the scope page where users can see exactly which APIs they need based on their selection
- **Updated test user link**: Points to the correct Google Cloud audience page (`/auth/audience`) instead of the old OAuth consent screen credentials URL

### Bug Fixes
- **Dark mode scope select visibility**: Service access buttons (Off / Read / Read + Write) now use `variant="default"` for the active/selected state instead of `variant="secondary"`, ensuring clear contrast and visibility across all themes including dark mode

Closes #100