### PR TITLE
feat(google-calendar): add update and delete event tools

### DIFF
--- a/connectors/google/src/__test__/toolsets.test.ts
+++ b/connectors/google/src/__test__/toolsets.test.ts
@@ -84,4 +84,25 @@ describe('buildGoogleToolsets', () => {
       'docs_update',
     ]);
   });
+
+  it('only exposes calendar write tools when calendar write access exists', () => {
+    const readOnly = buildGoogleToolsets({
+      scopes: ['https://www.googleapis.com/auth/calendar.readonly'],
+      capabilities: ['google.calendar.read', 'google.calendar.write'],
+    }).find((toolset) => toolset.id === 'google-calendar');
+
+    const writable = buildGoogleToolsets({
+      scopes: ['https://www.googleapis.com/auth/calendar.events'],
+      capabilities: ['google.calendar.read', 'google.calendar.write'],
+    }).find((toolset) => toolset.id === 'google-calendar');
+
+    expect(readOnly?.tools().map((tool) => tool.name)).toEqual(['calendar_list', 'calendar_get']);
+    expect(writable?.tools().map((tool) => tool.name)).toEqual([
+      'calendar_list',
+      'calendar_get',
+      'calendar_create',
+      'calendar_update',
+      'calendar_delete',
+    ]);
+  });
 });

--- a/connectors/google/src/calendar/api.ts
+++ b/connectors/google/src/calendar/api.ts
@@ -164,3 +164,59 @@ export async function createEvent(
 
   return mapEvent(raw);
 }
+
+export async function updateEvent(
+  client: GoogleClient,
+  eventId: string,
+  patch: {
+    summary?: string;
+    description?: string;
+    location?: string;
+    start?: { dateTime: string; timeZone?: string };
+    end?: { dateTime: string; timeZone?: string };
+    attendees?: string[];
+    addMeet?: boolean;
+  },
+  calendarId = 'primary',
+  sendUpdates: 'all' | 'externalOnly' | 'none' = 'all',
+): Promise<CalendarEvent> {
+  const url = new URL(
+    `${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${eventId}`,
+  );
+  url.searchParams.set('sendUpdates', sendUpdates);
+  if (patch.addMeet) url.searchParams.set('conferenceDataVersion', '1');
+
+  const body: Record<string, unknown> = {};
+  if (patch.summary !== undefined) body['summary'] = patch.summary;
+  if (patch.description !== undefined) body['description'] = patch.description;
+  if (patch.location !== undefined) body['location'] = patch.location;
+  if (patch.start !== undefined) body['start'] = patch.start;
+  if (patch.end !== undefined) body['end'] = patch.end;
+  if (patch.attendees !== undefined) body['attendees'] = patch.attendees.map((email) => ({ email }));
+  if (patch.addMeet) {
+    body['conferenceData'] = {
+      createRequest: { requestId: `meet-${Date.now()}` },
+    };
+  }
+
+  const raw = await client.request<CalendarEventRaw>(url.toString(), {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+
+  return mapEvent(raw);
+}
+
+export async function deleteEvent(
+  client: GoogleClient,
+  eventId: string,
+  calendarId = 'primary',
+  sendUpdates: 'all' | 'externalOnly' | 'none' = 'all',
+): Promise<void> {
+  const url = new URL(
+    `${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events/${eventId}`,
+  );
+  url.searchParams.set('sendUpdates', sendUpdates);
+
+  await client.request<void>(url.toString(), { method: 'DELETE' });
+}

--- a/connectors/google/src/calendar/tools.ts
+++ b/connectors/google/src/calendar/tools.ts
@@ -56,6 +56,45 @@ const calendarCreateSchema = z.object({
   calendarId: z.string().optional().describe('Calendar ID (defaults to primary)'),
 });
 
+const sendUpdatesEnum = z
+  .enum(['all', 'externalOnly', 'none'])
+  .optional()
+  .default('all')
+  .describe(
+    'Who to notify about the change: "all" (default), "externalOnly", or "none"',
+  );
+
+const calendarUpdateSchema = z.object({
+  account: z
+    .string()
+    .optional()
+    .describe('Optional account email or label when multiple Google accounts are connected'),
+  eventId: z.string().describe('The calendar event ID to update'),
+  summary: z.string().optional().describe('New event title'),
+  description: z.string().optional().describe('New event description'),
+  location: z.string().optional().describe('New event location'),
+  startDateTime: z.string().optional().describe('New start time (ISO 8601)'),
+  endDateTime: z.string().optional().describe('New end time (ISO 8601)'),
+  timeZone: z.string().optional().describe('Time zone for start/end times (e.g. "America/Chicago")'),
+  attendees: z.array(z.string()).optional().describe('Replacement list of attendee email addresses'),
+  addMeet: z
+    .boolean()
+    .optional()
+    .describe('Set to true to attach a Google Meet link if not already present'),
+  calendarId: z.string().optional().describe('Calendar ID (defaults to primary)'),
+  sendUpdates: sendUpdatesEnum,
+});
+
+const calendarDeleteSchema = z.object({
+  account: z
+    .string()
+    .optional()
+    .describe('Optional account email or label when multiple Google accounts are connected'),
+  eventId: z.string().describe('The calendar event ID to delete'),
+  calendarId: z.string().optional().describe('Calendar ID (defaults to primary)'),
+  sendUpdates: sendUpdatesEnum,
+});
+
 export function createCalendarTools(
   resolveClient: (
     account?: string,
@@ -113,6 +152,54 @@ export function createCalendarTools(
         return { ...result, usedAccount };
       },
     });
+
+    tools['calendar_update'] = tool({
+      description:
+        'Update an existing Google Calendar event. Only supply the fields you want to change.',
+      inputSchema: calendarUpdateSchema,
+      execute: async (input: z.infer<typeof calendarUpdateSchema>) => {
+        const { client, usedAccount } = await resolveClient(input.account);
+        const start =
+          input.startDateTime !== undefined
+            ? { dateTime: input.startDateTime, timeZone: input.timeZone }
+            : undefined;
+        const end =
+          input.endDateTime !== undefined
+            ? { dateTime: input.endDateTime, timeZone: input.timeZone }
+            : undefined;
+        const result = await CalendarApi.updateEvent(
+          client,
+          input.eventId,
+          {
+            summary: input.summary,
+            description: input.description,
+            location: input.location,
+            start,
+            end,
+            attendees: input.attendees,
+            addMeet: input.addMeet,
+          },
+          input.calendarId,
+          input.sendUpdates,
+        );
+        return { ...result, usedAccount };
+      },
+    });
+
+    tools['calendar_delete'] = tool({
+      description: 'Delete a Google Calendar event by its ID.',
+      inputSchema: calendarDeleteSchema,
+      execute: async (input: z.infer<typeof calendarDeleteSchema>) => {
+        const { client, usedAccount } = await resolveClient(input.account);
+        await CalendarApi.deleteEvent(
+          client,
+          input.eventId,
+          input.calendarId,
+          input.sendUpdates,
+        );
+        return { deleted: true, eventId: input.eventId, usedAccount };
+      },
+    });
   }
 
   return tools;
@@ -125,4 +212,9 @@ export const CALENDAR_TOOL_SUMMARIES = [
   },
   { name: 'calendar_get', description: 'Get full details for a specific calendar event' },
   { name: 'calendar_create', description: 'Create a new calendar event (requires write access)' },
+  {
+    name: 'calendar_update',
+    description: 'Update an existing calendar event (requires write access)',
+  },
+  { name: 'calendar_delete', description: 'Delete a calendar event (requires write access)' },
 ];

--- a/connectors/google/src/toolsets.ts
+++ b/connectors/google/src/toolsets.ts
@@ -135,7 +135,12 @@ function createCalendarToolset(scopes: string[], capabilities: string[]): Google
     hasCapability(capabilities, GOOGLE_CAPABILITY_CALENDAR_WRITE);
   const summaries = canWrite
     ? CALENDAR_TOOL_SUMMARIES
-    : CALENDAR_TOOL_SUMMARIES.filter((t) => t.name !== 'calendar_create');
+    : CALENDAR_TOOL_SUMMARIES.filter(
+        (t) =>
+          t.name !== 'calendar_create' &&
+          t.name !== 'calendar_update' &&
+          t.name !== 'calendar_delete',
+      );
 
   return {
     id: 'google-calendar',
@@ -149,8 +154,8 @@ function createCalendarToolset(scopes: string[], capabilities: string[]): Google
       'Always pass the user\'s local IANA timezone (e.g. "America/New_York") so that "today" and time ranges are anchored to their local time, not UTC.',
       'The calendar_list tool defaults to showing upcoming events from now.',
       canWrite
-        ? 'You have write access. Use calendar_create to schedule new events. Pass addMeet: true to automatically attach a Google Meet link.'
-        : 'You have read-only access. Creating events is not available.',
+        ? 'You have write access. Use calendar_create to schedule new events, calendar_update to modify existing events, and calendar_delete to remove them. Pass addMeet: true to automatically attach a Google Meet link.'
+        : 'You have read-only access. Creating, updating, and deleting events is not available.',
     ].join('\n'),
     tools: () => summaries,
     activate: (resolveClient) => createCalendarTools(resolveClient, canWrite),


### PR DESCRIPTION
## 🚀 Change Summary

Completes the Google Calendar connector with `calendar_update` and `calendar_delete` tools, giving the agent full CRUD coverage for calendar events. Both tools are write-gated and respect attendee notification preferences via the `sendUpdates` parameter.

### ✨ New Features
- **`calendar_update`**: PATCH an existing calendar event with any subset of fields (summary, description, location, start/end times, attendees, Meet link)
- **`calendar_delete`**: DELETE a calendar event by ID, with optional `sendUpdates` control

### 🛠 Improvements & Refactors
- Updated `CALENDAR_TOOL_SUMMARIES` and the toolset `instructions` string to reflect write access correctly
- Write-only tools are filtered from summaries when `canWrite` is false, consistent with existing patterns

Closes #136