### PR TITLE
chore(google): connector improvements - caching, reliability, and cleanup

### DIFF
--- a/connectors/google/src/__test__/toolsets.test.ts
+++ b/connectors/google/src/__test__/toolsets.test.ts
@@ -12,8 +12,8 @@ describe('buildGoogleToolsets', () => {
     expect(gmail?.tools().map((tool) => tool.name)).toEqual([
       'gmail_search',
       'gmail_read',
-      'listLabels',
-      'getLabels',
+      'gmail_list_labels',
+      'gmail_get_label',
     ]);
   });
 
@@ -32,18 +32,18 @@ describe('buildGoogleToolsets', () => {
       'gmail_search',
       'gmail_read',
       'gmail_send',
-      'listLabels',
-      'getLabels',
+      'gmail_list_labels',
+      'gmail_get_label',
     ]);
 
     expect(modify?.tools().map((tool) => tool.name)).toEqual([
       'gmail_search',
       'gmail_read',
       'gmail_send',
-      'listLabels',
-      'getLabels',
-      'modifyLabels',
-      'modifyMessages',
+      'gmail_list_labels',
+      'gmail_get_label',
+      'gmail_modify_labels',
+      'gmail_modify_messages',
     ]);
   });
 

--- a/connectors/google/src/client.ts
+++ b/connectors/google/src/client.ts
@@ -11,6 +11,7 @@ import {
   GoogleRateLimitCoordinator,
   type GoogleRateLimitConfig,
 } from './rate-limit.js';
+import { sleep } from './utils.js';
 
 type GoogleClientConfig = {
   /** Callback that returns a fresh access token (post-refresh if needed). */
@@ -189,54 +190,23 @@ type ParsedApiError = {
 function mergeRateLimitConfig(
   overrides: Partial<GoogleRateLimitConfig> | undefined,
 ): GoogleRateLimitConfig {
-  if (!overrides) {
-    return DEFAULT_GOOGLE_RATE_LIMIT_CONFIG;
+  if (!overrides) return DEFAULT_GOOGLE_RATE_LIMIT_CONFIG;
+  
+  const services = { ...DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services };
+  if (overrides.services) {
+    for (const key of Object.keys(services) as (keyof typeof services)[]) {
+      if (overrides.services[key]) {
+        services[key] = {
+          project: overrides.services[key]?.project ?? services[key].project,
+          account: overrides.services[key]?.account ?? services[key].account,
+        };
+      }
+    }
   }
 
   return {
     maxQueueWaitMs: overrides.maxQueueWaitMs ?? DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.maxQueueWaitMs,
-    services: {
-      gmail: {
-        project:
-          overrides.services?.gmail?.project ??
-          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.gmail.project,
-        account:
-          overrides.services?.gmail?.account ??
-          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.gmail.account,
-      },
-      drive: {
-        project:
-          overrides.services?.drive?.project ??
-          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.drive.project,
-        account:
-          overrides.services?.drive?.account ??
-          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.drive.account,
-      },
-      docsRead: {
-        project:
-          overrides.services?.docsRead?.project ??
-          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.docsRead.project,
-        account:
-          overrides.services?.docsRead?.account ??
-          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.docsRead.account,
-      },
-      docsWrite: {
-        project:
-          overrides.services?.docsWrite?.project ??
-          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.docsWrite.project,
-        account:
-          overrides.services?.docsWrite?.account ??
-          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.docsWrite.account,
-      },
-      calendar: {
-        project:
-          overrides.services?.calendar?.project ??
-          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.calendar.project,
-        account:
-          overrides.services?.calendar?.account ??
-          DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services.calendar.account,
-      },
-    },
+    services,
   };
 }
 
@@ -334,29 +304,4 @@ function isRetryableRateLimit(
   }
 
   return /rate.?limit|too many requests|quota/i.test(message);
-}
-
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (ms <= 0) {
-      resolve();
-      return;
-    }
-
-    const onAbort = () => {
-      clearTimeout(timeout);
-      reject(new DOMException('Aborted', 'AbortError'));
-    };
-
-    const timeout = setTimeout(() => {
-      if (signal) {
-        signal.removeEventListener('abort', onAbort);
-      }
-      resolve();
-    }, ms);
-
-    if (signal) {
-      signal.addEventListener('abort', onAbort, { once: true });
-    }
-  });
 }

--- a/connectors/google/src/connector.ts
+++ b/connectors/google/src/connector.ts
@@ -160,7 +160,7 @@ export const googleConnectorModule: ConnectorModule = {
     ],
   },
   hooks: {
-    onAuthorized: async ({ accessToken }) => {
+    onAuthorized: async ({ accessToken, logger }) => {
       try {
         const res = await fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
           headers: { Authorization: `Bearer ${accessToken}` },
@@ -174,8 +174,7 @@ export const googleConnectorModule: ConnectorModule = {
           accountInfo: info as Record<string, unknown>,
         };
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.warn('Google onAuthorized hook profile fetch failed:', error);
+        logger.warn({ error }, 'Google onAuthorized hook profile fetch failed');
         return { accountEmail: null, accountInfo: null };
       }
     },

--- a/connectors/google/src/connector.ts
+++ b/connectors/google/src/connector.ts
@@ -173,7 +173,9 @@ export const googleConnectorModule: ConnectorModule = {
           accountEmail: info.email ?? null,
           accountInfo: info as Record<string, unknown>,
         };
-      } catch {
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.warn('Google onAuthorized hook profile fetch failed:', error);
         return { accountEmail: null, accountInfo: null };
       }
     },
@@ -193,19 +195,10 @@ export const googleConnectorModule: ConnectorModule = {
         }
       }
     },
-    onDeleted: async () => {
-      return;
-    },
   },
   lifecycle: {
-    register: async () => {
-      return;
-    },
     init: async ({ refreshToolsets }) => {
       await refreshToolsets();
-    },
-    shutdown: async () => {
-      return;
     },
   },
 };

--- a/connectors/google/src/drive/api.ts
+++ b/connectors/google/src/drive/api.ts
@@ -100,10 +100,18 @@ const EXPORT_MIME_MAP: Record<string, string> = {
 export async function getFileContent(
   client: GoogleClient,
   fileId: string,
+  mimeType?: string,
 ): Promise<DriveFileContent> {
-  const meta = await getFileMetadata(client, fileId);
+  let fileMimeType = mimeType;
+  let fileName = fileId;
 
-  const exportMime = EXPORT_MIME_MAP[meta.mimeType];
+  if (!fileMimeType) {
+    const meta = await getFileMetadata(client, fileId);
+    fileMimeType = meta.mimeType;
+    fileName = meta.name;
+  }
+
+  const exportMime = EXPORT_MIME_MAP[fileMimeType];
 
   let content: string;
   if (exportMime) {
@@ -117,9 +125,9 @@ export async function getFileContent(
   }
 
   return {
-    id: meta.id,
-    name: meta.name,
-    mimeType: meta.mimeType,
+    id: fileId,
+    name: fileName,
+    mimeType: fileMimeType,
     content,
   };
 }

--- a/connectors/google/src/drive/tools.ts
+++ b/connectors/google/src/drive/tools.ts
@@ -21,6 +21,10 @@ const driveFileSchema = z.object({
     .optional()
     .describe('Optional account email or label when multiple Google accounts are connected'),
   fileId: z.string().describe('The Google Drive file ID'),
+  mimeType: z
+    .string()
+    .optional()
+    .describe('Optional MIME type of the file. Providing this skips an extra metadata lookup if known from a previous search.'),
 });
 
 const driveWriteSchema = z.object({
@@ -71,7 +75,7 @@ export function createDriveTools(
       inputSchema: driveFileSchema,
       execute: async (input: z.infer<typeof driveFileSchema>) => {
         const { client, usedAccount } = await resolveClient(input.account);
-        const result = await DriveApi.getFileContent(client, input.fileId);
+        const result = await DriveApi.getFileContent(client, input.fileId, input.mimeType);
         return { ...result, usedAccount };
       },
     }),

--- a/connectors/google/src/gmail/api.ts
+++ b/connectors/google/src/gmail/api.ts
@@ -224,22 +224,28 @@ export async function searchMessages(
     return { messages: [], nextPageToken: undefined, totalEstimate: 0 };
   }
 
-  // Fetch metadata for each message (batch-friendly: only headers)
-  const summaries = await Promise.all(
-    list.messages.map(async (msg) => {
-      const full = await client.request<GmailMessageRaw>(
-        `${GMAIL_API}/messages/${msg.id}?format=METADATA&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date`,
-      );
-      return {
-        id: full.id,
-        threadId: full.threadId,
-        snippet: full.snippet,
-        from: extractHeader(full.payload?.headers, 'From'),
-        subject: extractHeader(full.payload?.headers, 'Subject'),
-        date: extractHeader(full.payload?.headers, 'Date'),
-      };
-    }),
-  );
+  // Fetch metadata for each message in chunks to avoid overwhelming the network
+  const summaries: GmailSearchResult['messages'] = [];
+  const chunkSize = 5;
+  for (let i = 0; i < list.messages.length; i += chunkSize) {
+    const chunk = list.messages.slice(i, i + chunkSize);
+    const results = await Promise.all(
+      chunk.map(async (msg) => {
+        const full = await client.request<GmailMessageRaw>(
+          `${GMAIL_API}/messages/${msg.id}?format=METADATA&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date`,
+        );
+        return {
+          id: full.id,
+          threadId: full.threadId,
+          snippet: full.snippet,
+          from: extractHeader(full.payload?.headers, 'From'),
+          subject: extractHeader(full.payload?.headers, 'Subject'),
+          date: extractHeader(full.payload?.headers, 'Date'),
+        };
+      }),
+    );
+    summaries.push(...results);
+  }
 
   return {
     messages: summaries,

--- a/connectors/google/src/gmail/tools.ts
+++ b/connectors/google/src/gmail/tools.ts
@@ -169,7 +169,7 @@ export function createGmailTools(
         return { ...result, usedAccount };
       },
     }),
-    listLabels: tool({
+    gmail_list_labels: tool({
       description: 'List Gmail labels with visibility and message/thread counts.',
       inputSchema: gmailListLabelsSchema,
       execute: async (input: z.infer<typeof gmailListLabelsSchema>) => {
@@ -178,7 +178,7 @@ export function createGmailTools(
         return { ...result, usedAccount };
       },
     }),
-    getLabels: tool({
+    gmail_get_label: tool({
       description: 'Get details for one Gmail label by label ID.',
       inputSchema: gmailGetLabelsSchema,
       execute: async (input: z.infer<typeof gmailGetLabelsSchema>) => {
@@ -209,7 +209,7 @@ export function createGmailTools(
   }
 
   if (canModify) {
-    tools['modifyLabels'] = tool({
+    tools['gmail_modify_labels'] = tool({
       description:
         'Create, update, or delete Gmail labels using operation enum values: create, update, delete.',
       inputSchema: gmailModifyLabelsSchema,
@@ -220,7 +220,7 @@ export function createGmailTools(
       },
     });
 
-    tools['modifyMessages'] = tool({
+    tools['gmail_modify_messages'] = tool({
       description: 'Add/remove Gmail labels on messages, or on threads when modifyThreads=true.',
       inputSchema: gmailModifyMessagesSchema,
       execute: async (input: z.infer<typeof gmailModifyMessagesSchema>) => {
@@ -243,14 +243,14 @@ export const GMAIL_TOOL_SUMMARIES = [
   { name: 'gmail_search', description: 'Search Gmail messages using Gmail search syntax' },
   { name: 'gmail_read', description: 'Read the full content of a Gmail message by ID' },
   { name: 'gmail_send', description: 'Send an email or reply to a thread (requires write access)' },
-  { name: 'listLabels', description: 'List Gmail labels with metadata and visibility settings' },
-  { name: 'getLabels', description: 'Get details for a single Gmail label by ID' },
+  { name: 'gmail_list_labels', description: 'List Gmail labels with metadata and visibility settings' },
+  { name: 'gmail_get_label', description: 'Get details for a single Gmail label by ID' },
   {
-    name: 'modifyLabels',
+    name: 'gmail_modify_labels',
     description: 'Create, update, or delete Gmail labels using an operation enum',
   },
   {
-    name: 'modifyMessages',
+    name: 'gmail_modify_messages',
     description: 'Add or remove labels on messages (or threads with modifyThreads=true)',
   },
 ];

--- a/connectors/google/src/rate-limit.ts
+++ b/connectors/google/src/rate-limit.ts
@@ -1,3 +1,5 @@
+import { sleep } from './utils.js';
+
 type RateLimitBucket = {
   capacity: number;
   windowMs: number;
@@ -154,36 +156,12 @@ type AcquireOptions = {
   maxWaitMs: number;
 };
 
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (ms <= 0) {
-      resolve();
-      return;
-    }
-
-    const onAbort = () => {
-      clearTimeout(timeout);
-      reject(new DOMException('Aborted', 'AbortError'));
-    };
-
-    const timeout = setTimeout(() => {
-      if (signal) {
-        signal.removeEventListener('abort', onAbort);
-      }
-      resolve();
-    }, ms);
-
-    if (signal) {
-      signal.addEventListener('abort', onAbort, { once: true });
-    }
-  });
-}
-
 class SlidingWindowLimiter {
   private readonly capacity: number;
   private readonly windowMs: number;
   private readonly events: { timestamp: number; weight: number }[] = [];
   private pending: Promise<void> = Promise.resolve();
+  private usedWeight: number = 0;
 
   constructor(config: RateLimitBucket) {
     this.capacity = config.capacity;
@@ -206,13 +184,23 @@ class SlidingWindowLimiter {
   }
 
   private pruneExpired(now: number): void {
-    while (this.events.length > 0 && now - this.events[0].timestamp >= this.windowMs) {
-      this.events.shift();
+    const expiredCount = this.events.findIndex((event) => now - event.timestamp < this.windowMs);
+    
+    if (expiredCount === -1 && this.events.length > 0) {
+      // All events are expired
+      this.usedWeight = 0;
+      this.events.length = 0;
+    } else if (expiredCount > 0) {
+      // Some events are expired
+      const expired = this.events.splice(0, expiredCount);
+      for (const event of expired) {
+        this.usedWeight -= event.weight;
+      }
     }
   }
 
   private used(): number {
-    return this.events.reduce((total, event) => total + event.weight, 0);
+    return this.usedWeight;
   }
 
   private async acquireInternal(weight: number, options: AcquireOptions): Promise<number> {
@@ -224,6 +212,7 @@ class SlidingWindowLimiter {
 
       if (this.used() + weight <= this.capacity) {
         this.events.push({ timestamp: now, weight });
+        this.usedWeight += weight;
         return waitedMs;
       }
 
@@ -288,14 +277,16 @@ export class GoogleRateLimitCoordinator {
       serviceConfig.account,
     );
 
-    const projectWait = await projectLimiter.acquire(operation.quotaCost, {
-      maxWaitMs: this.config.maxQueueWaitMs,
-      signal,
-    });
-    const accountWait = await accountLimiter.acquire(operation.quotaCost, {
-      maxWaitMs: this.config.maxQueueWaitMs,
-      signal,
-    });
+    const [projectWait, accountWait] = await Promise.all([
+      projectLimiter.acquire(operation.quotaCost, {
+        maxWaitMs: this.config.maxQueueWaitMs,
+        signal,
+      }),
+      accountLimiter.acquire(operation.quotaCost, {
+        maxWaitMs: this.config.maxQueueWaitMs,
+        signal,
+      }),
+    ]);
 
     return projectWait + accountWait;
   }

--- a/connectors/google/src/toolsets.ts
+++ b/connectors/google/src/toolsets.ts
@@ -70,13 +70,42 @@ function hasCapability(capabilities: string[], capability: string): boolean {
   return capabilities.includes(capability);
 }
 
+export function canActivateToolset(
+  toolsetId: string,
+  scopes: string[],
+  capabilities: string[],
+): boolean {
+  if (toolsetId === 'google-gmail') {
+    return (
+      hasServiceAccess(scopes, 'gmail') && hasCapability(capabilities, GOOGLE_CAPABILITY_GMAIL_READ)
+    );
+  }
+  if (toolsetId === 'google-drive') {
+    return (
+      hasServiceAccess(scopes, 'drive') && hasCapability(capabilities, GOOGLE_CAPABILITY_DRIVE_READ)
+    );
+  }
+  if (toolsetId === 'google-calendar') {
+    return (
+      hasServiceAccess(scopes, 'calendar') &&
+      hasCapability(capabilities, GOOGLE_CAPABILITY_CALENDAR_READ)
+    );
+  }
+  if (toolsetId === 'google-docs') {
+    return (
+      hasServiceAccess(scopes, 'docs') && hasCapability(capabilities, GOOGLE_CAPABILITY_DOCS_READ)
+    );
+  }
+  return false;
+}
+
 function createGmailToolset(scopes: string[], capabilities: string[]): GoogleToolsetDefinition {
   const canWriteCapability = hasCapability(capabilities, GOOGLE_CAPABILITY_GMAIL_WRITE);
   const canSend = hasGmailSendAccess(scopes) && canWriteCapability;
   const canModify = hasGmailModifyAccess(scopes) && canWriteCapability;
   const summaries = GMAIL_TOOL_SUMMARIES.filter((t) => {
     if (t.name === 'gmail_send') return canSend;
-    if (t.name === 'modifyLabels' || t.name === 'modifyMessages') return canModify;
+    if (t.name === 'gmail_modify_labels' || t.name === 'gmail_modify_messages') return canModify;
     return true;
   });
 
@@ -94,8 +123,8 @@ function createGmailToolset(scopes: string[], capabilities: string[]): GoogleToo
         ? 'You have send access. Use gmail_send to compose or reply to emails.'
         : 'You do not have send access. Sending emails is not available.',
       canModify
-        ? 'You have label modify access. Use modifyLabels and modifyMessages to manage labels and archive messages.'
-        : 'You have read-only label access. Use listLabels and getLabels to inspect labels.',
+        ? 'You have label modify access. Use gmail_modify_labels and gmail_modify_messages to manage labels and archive messages.'
+        : 'You have read-only label access. Use gmail_list_labels and gmail_get_label to inspect labels.',
     ].join('\n'),
     tools: () => summaries,
     activate: (resolveClient) => createGmailTools(resolveClient, { canSend, canModify }),

--- a/connectors/google/src/utils.ts
+++ b/connectors/google/src/utils.ts
@@ -1,0 +1,24 @@
+export function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ms <= 0) {
+      resolve();
+      return;
+    }
+
+    const onAbort = () => {
+      clearTimeout(timeout);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+
+    const timeout = setTimeout(() => {
+      if (signal) {
+        signal.removeEventListener('abort', onAbort);
+      }
+      resolve();
+    }, ms);
+
+    if (signal) {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}

--- a/connectors/sdk/src/types.ts
+++ b/connectors/sdk/src/types.ts
@@ -7,6 +7,7 @@ import type {
   ConnectorVersion,
   OAuthConfig,
 } from '@stitch/shared/connectors/types';
+import type { StitchLogger } from '@stitch/shared/logger';
 
 export type ConnectorIconSource =
   | { type: 'svgString'; svgString: string }
@@ -49,15 +50,17 @@ export type ConnectorInstanceRecord = {
 export type ConnectorLifecycleContext = {
   listInstances: (connectorId: string) => Promise<ConnectorInstanceRecord[]>;
   refreshToolsets: () => Promise<void>;
+  logger: StitchLogger;
 };
 
 export type ConnectorServiceHooks = {
   onAuthorized?: (input: {
     instance: ConnectorInstanceRecord;
     accessToken: string;
+    logger: StitchLogger;
   }) => Promise<{ accountEmail: string | null; accountInfo: Record<string, unknown> | null }>;
-  onDeleted?: (input: { instance: ConnectorInstanceRecord }) => Promise<void>;
-  testConnection?: (input: { instance: ConnectorInstanceRecord }) => Promise<void>;
+  onDeleted?: (input: { instance: ConnectorInstanceRecord; logger: StitchLogger }) => Promise<void>;
+  testConnection?: (input: { instance: ConnectorInstanceRecord; logger: StitchLogger }) => Promise<void>;
 };
 
 export type ConnectorModule = {

--- a/packages/server/src/connectors/google-toolsets.ts
+++ b/packages/server/src/connectors/google-toolsets.ts
@@ -30,6 +30,9 @@ import type { Tool } from 'ai';
 const log = Log.create({ service: 'google-toolsets' });
 const REFRESH_BUFFER_MS = 60_000;
 
+/** Deduplicates concurrent refresh attempts for the same account. */
+const refreshInFlight = new Map<string, Promise<string>>();
+
 /** Convert a @stitch-connectors/google toolset definition into the server Toolset type. */
 function toServerToolset(def: GoogleToolsetDefinition): Toolset {
   return {
@@ -141,28 +144,56 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
               if (definition?.authType === 'oauth2') {
                 const creds = await resolveOAuthCredentials(latest);
                 if (creds && latest.refreshToken) {
+                  const inFlight = refreshInFlight.get(chosen.id);
+                  if (inFlight) {
+                    cachedToken = await inFlight;
+                    return cachedToken;
+                  }
+
                   const config = definition.authConfig as OAuthConfig;
-                  const refreshed = await refreshAccessToken(
+                  const refreshPromise = refreshAccessToken(
                     config.tokenUrl,
                     creds.clientId,
                     creds.clientSecret,
                     latest.refreshToken,
                   );
+                  refreshInFlight.set(chosen.id, refreshPromise.then((r) => r.accessToken));
 
-                  await db
-                    .update(connectorInstances)
-                    .set({
-                      accessToken: refreshed.accessToken,
-                      refreshToken: refreshed.refreshToken ?? latest.refreshToken,
-                      tokenExpiresAt: refreshed.expiresIn ? now + refreshed.expiresIn * 1000 : null,
-                      status: 'connected',
-                      updatedAt: now,
-                    })
-                    .where(eq(connectorInstances.id, chosen.id));
+                  try {
+                    const refreshed = await refreshPromise;
 
-                  cachedToken = refreshed.accessToken;
-                  cachedTokenExpiresAt = refreshed.expiresIn ? now + refreshed.expiresIn * 1000 : null;
-                  return cachedToken;
+                    await db
+                      .update(connectorInstances)
+                      .set({
+                        accessToken: refreshed.accessToken,
+                        refreshToken: refreshed.refreshToken ?? latest.refreshToken,
+                        tokenExpiresAt: refreshed.expiresIn
+                          ? now + refreshed.expiresIn * 1000
+                          : null,
+                        status: 'connected',
+                        updatedAt: now,
+                      })
+                      .where(eq(connectorInstances.id, chosen.id));
+
+                    cachedToken = refreshed.accessToken;
+                    cachedTokenExpiresAt = refreshed.expiresIn
+                      ? now + refreshed.expiresIn * 1000
+                      : null;
+                    return cachedToken;
+                  } catch (error) {
+                    const message = error instanceof Error ? error.message : String(error);
+                    log.error(
+                      { event: 'google.token.refresh.failed', instanceId: chosen.id, error: message },
+                      'Google token refresh failed — marking instance as error',
+                    );
+                    await db
+                      .update(connectorInstances)
+                      .set({ status: 'error', updatedAt: Date.now() })
+                      .where(eq(connectorInstances.id, chosen.id));
+                    throw error;
+                  } finally {
+                    refreshInFlight.delete(chosen.id);
+                  }
                 }
               }
             }

--- a/packages/server/src/connectors/google-toolsets.ts
+++ b/packages/server/src/connectors/google-toolsets.ts
@@ -7,15 +7,12 @@
 import { eq } from 'drizzle-orm';
 
 import { GoogleClient } from '@stitch-connectors/google/client';
-import { hasServiceAccess } from '@stitch-connectors/google/scopes';
+
 import {
-  GOOGLE_CAPABILITY_CALENDAR_READ,
-  GOOGLE_CAPABILITY_DOCS_READ,
-  GOOGLE_CAPABILITY_DRIVE_READ,
-  GOOGLE_CAPABILITY_GMAIL_READ,
   GOOGLE_TOOLSET_IDS,
   type GoogleToolsetDefinition,
   buildGoogleToolsets,
+  canActivateToolset,
 } from '@stitch-connectors/google/toolsets';
 
 import type { OAuthConfig } from '@stitch/shared/connectors/types';
@@ -33,42 +30,6 @@ import type { Tool } from 'ai';
 const log = Log.create({ service: 'google-toolsets' });
 const REFRESH_BUFFER_MS = 60_000;
 
-function hasCapability(capabilities: string[] | null | undefined, capability: string): boolean {
-  return (capabilities ?? []).includes(capability);
-}
-
-function accountSupportsToolset(
-  toolsetId: string,
-  account: { scopes: string[] | null; capabilities: string[] | null },
-): boolean {
-  const scopes = account.scopes ?? [];
-  if (toolsetId === 'google-gmail') {
-    return (
-      hasServiceAccess(scopes, 'gmail') &&
-      hasCapability(account.capabilities, GOOGLE_CAPABILITY_GMAIL_READ)
-    );
-  }
-  if (toolsetId === 'google-drive') {
-    return (
-      hasServiceAccess(scopes, 'drive') &&
-      hasCapability(account.capabilities, GOOGLE_CAPABILITY_DRIVE_READ)
-    );
-  }
-  if (toolsetId === 'google-calendar') {
-    return (
-      hasServiceAccess(scopes, 'calendar') &&
-      hasCapability(account.capabilities, GOOGLE_CAPABILITY_CALENDAR_READ)
-    );
-  }
-  if (toolsetId === 'google-docs') {
-    return (
-      hasServiceAccess(scopes, 'docs') &&
-      hasCapability(account.capabilities, GOOGLE_CAPABILITY_DOCS_READ)
-    );
-  }
-  return false;
-}
-
 /** Convert a @stitch-connectors/google toolset definition into the server Toolset type. */
 function toServerToolset(def: GoogleToolsetDefinition): Toolset {
   return {
@@ -79,7 +40,15 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
     instructions: def.instructions,
     tools: () => def.tools(),
     activate: async () => {
+      const clientCache = new Map<string, { client: GoogleClient; usedAccount: string }>();
+
       return def.activate(async (account) => {
+        const cacheKey = account?.trim().toLowerCase() || 'default';
+        const cached = clientCache.get(cacheKey);
+        if (cached) {
+          return cached;
+        }
+
         const db = getDb();
         const rows = await db
           .select({
@@ -123,14 +92,25 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
           throw new Error(`Unknown Google account "${account}". Available accounts: ${available}`);
         }
 
-        if (!accountSupportsToolset(def.id, chosen)) {
+        if (!canActivateToolset(def.id, (chosen.scopes as string[]) ?? [], (chosen.capabilities) ?? [])) {
           throw new Error(
             `Google account ${chosen.accountEmail ?? chosen.label} does not have the permissions required for ${def.name}. Re-authorize this account with the required scopes.`,
           );
         }
 
+        let cachedToken: string | null = null;
+        let cachedTokenExpiresAt: number | null = null;
+
         const client = new GoogleClient({
           getAccessToken: async () => {
+            const now = Date.now();
+            if (
+              cachedToken &&
+              (!cachedTokenExpiresAt || cachedTokenExpiresAt > now + REFRESH_BUFFER_MS)
+            ) {
+              return cachedToken;
+            }
+
             const [latest] = await db
               .select({
                 id: connectorInstances.id,
@@ -150,7 +130,6 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
               );
             }
 
-            const now = Date.now();
             const shouldRefresh =
               Boolean(latest.refreshToken) &&
               (latest.accessToken === null ||
@@ -181,7 +160,9 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
                     })
                     .where(eq(connectorInstances.id, chosen.id));
 
-                  return refreshed.accessToken;
+                  cachedToken = refreshed.accessToken;
+                  cachedTokenExpiresAt = refreshed.expiresIn ? now + refreshed.expiresIn * 1000 : null;
+                  return cachedToken;
                 }
               }
             }
@@ -192,16 +173,20 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
               );
             }
 
-            return latest.accessToken;
+            cachedToken = latest.accessToken;
+            cachedTokenExpiresAt = latest.tokenExpiresAt;
+            return cachedToken;
           },
           logger: log,
           quotaAccountKey: chosen.id,
         });
 
-        return {
+        const result = {
           client,
           usedAccount: chosen.accountEmail ?? chosen.label,
         };
+        clientCache.set(cacheKey, result);
+        return result;
       }) as Record<string, Tool>;
     },
   };
@@ -220,7 +205,14 @@ export async function registerGoogleToolsets(): Promise<void> {
   const db = getDb();
 
   const instances = await db
-    .select()
+    .select({
+      id: connectorInstances.id,
+      status: connectorInstances.status,
+      accessToken: connectorInstances.accessToken,
+      scopes: connectorInstances.scopes,
+      capabilities: connectorInstances.capabilities,
+      appliedVersion: connectorInstances.appliedVersion,
+    })
     .from(connectorInstances)
     .where(eq(connectorInstances.connectorId, 'google'));
 

--- a/packages/server/src/connectors/runtime.ts
+++ b/packages/server/src/connectors/runtime.ts
@@ -31,6 +31,7 @@ function getLifecycleContext(connectorId: string) {
       return rows.filter((row) => row.connectorId === id);
     },
     refreshToolsets: async () => refreshConnectorToolsets(connectorId),
+    logger: log,
   };
 }
 

--- a/packages/server/src/connectors/service.ts
+++ b/packages/server/src/connectors/service.ts
@@ -13,7 +13,7 @@ import { createConnectorInstanceId } from '@stitch/shared/id';
 import type { PrefixedString } from '@stitch/shared/id';
 
 import { resolveOAuthCredentials } from '@/connectors/auth/oauth-credentials.js';
-import { startOAuthFlow } from '@/connectors/auth/oauth2.js';
+import { refreshAccessToken, startOAuthFlow } from '@/connectors/auth/oauth2.js';
 import { getConnectorDefinition } from '@/connectors/registry.js';
 import { getConnectorModule, refreshConnectorToolsetsFor } from '@/connectors/runtime.js';
 import { getDb } from '@/db/client.js';
@@ -23,6 +23,7 @@ import { err, ok, isServiceError } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 
 const log = Log.create({ service: 'connectors' });
+const REFRESH_BUFFER_MS = 60_000;
 
 function toSafe(
   instance: ConnectorInstance,
@@ -451,13 +452,52 @@ export async function testConnectorInstance(instanceId: string): Promise<Service
   if (!definition) return err('Unknown connector type', 400);
 
   try {
+    // Proactively refresh an expiring/expired OAuth token before testing so the
+    // hook receives a usable access token even if the stored one has lapsed.
+    let testedInstance = instance;
+    if (
+      definition.authType === 'oauth2' &&
+      instance.refreshToken &&
+      (instance.accessToken === null ||
+        (instance.tokenExpiresAt !== null &&
+          instance.tokenExpiresAt <= Date.now() + REFRESH_BUFFER_MS))
+    ) {
+      const creds = await resolveOAuthCredentials(instance);
+      if (creds) {
+        const config = definition.authConfig as OAuthConfig;
+        const now = Date.now();
+        const refreshed = await refreshAccessToken(
+          config.tokenUrl,
+          creds.clientId,
+          creds.clientSecret,
+          instance.refreshToken,
+        );
+        await db
+          .update(connectorInstances)
+          .set({
+            accessToken: refreshed.accessToken,
+            refreshToken: refreshed.refreshToken ?? instance.refreshToken,
+            tokenExpiresAt: refreshed.expiresIn ? now + refreshed.expiresIn * 1000 : null,
+            status: 'connected' as ConnectorStatus,
+            updatedAt: now,
+          })
+          .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+        testedInstance = {
+          ...instance,
+          accessToken: refreshed.accessToken,
+          refreshToken: refreshed.refreshToken ?? instance.refreshToken,
+          tokenExpiresAt: refreshed.expiresIn ? now + refreshed.expiresIn * 1000 : null,
+        };
+      }
+    }
+
     const module = getConnectorModule(instance.connectorId);
     if (module?.hooks?.testConnection) {
-      await module.hooks.testConnection({ instance, logger: log });
+      await module.hooks.testConnection({ instance: testedInstance, logger: log });
       return ok(true);
     }
 
-    if (definition.authType === 'oauth2' && instance.accessToken) {
+    if (definition.authType === 'oauth2' && testedInstance.accessToken) {
       return ok(true);
     } else if (definition.authType === 'api_key' && instance.apiKey) {
       return err('Connector test is not supported for this connector type', 400);

--- a/packages/server/src/connectors/service.ts
+++ b/packages/server/src/connectors/service.ts
@@ -223,6 +223,7 @@ export async function authorizeOAuthInstance(
         const hookResult = await module.hooks.onAuthorized({
           instance,
           accessToken: tokens.accessToken,
+          logger: log,
         });
         accountEmail = hookResult.accountEmail;
         accountInfo = hookResult.accountInfo;
@@ -425,7 +426,7 @@ export async function deleteConnectorInstance(instanceId: string): Promise<Servi
 
   const module = getConnectorModule(existing.connectorId);
   if (module?.hooks?.onDeleted) {
-    await module.hooks.onDeleted({ instance: existing });
+    await module.hooks.onDeleted({ instance: existing, logger: log });
   }
   await refreshConnectorToolsetsFor(existing.connectorId);
 
@@ -452,7 +453,7 @@ export async function testConnectorInstance(instanceId: string): Promise<Service
   try {
     const module = getConnectorModule(instance.connectorId);
     if (module?.hooks?.testConnection) {
-      await module.hooks.testConnection({ instance });
+      await module.hooks.testConnection({ instance, logger: log });
       return ok(true);
     }
 


### PR DESCRIPTION
## Change Summary

A batch of targeted improvements to the Google connector focused on performance, reliability, and consistency. This includes in-memory caching for token resolution and toolset activation, smarter Gmail metadata fetching, Drive optimization, deduplication of concurrent token refreshes, and a round of cleanup across the connector surface.

### New Features
- **In-memory client & token caching**: Resolving a Google account within a single toolset activation now reuses the same `GoogleClient` instance and caches the access token in-memory, avoiding redundant DB lookups and token refreshes per tool call
- **Deduplication of concurrent token refreshes**: A `refreshInFlight` map ensures only one refresh runs at a time per account, with concurrent callers waiting on the same promise rather than racing

### Improvements & Refactors
- **Gmail metadata chunked fetching**: Message metadata fetches are now batched in chunks of 5 instead of firing all in parallel, preventing network overwhelm on large result sets
- **Drive `mimeType` shortcut**: `getFileContent` now accepts an optional `mimeType` parameter; if provided, the redundant metadata prefetch is skipped entirely
- **Standardised Gmail tool names**: Renamed `listLabels`, `getLabels`, `modifyLabels`, `modifyMessages` to `gmail_list_labels`, `gmail_get_label`, `gmail_modify_labels`, `gmail_modify_messages` for consistent `service_verb_noun` naming
- **`canActivateToolset` extracted to connector package**: Toolset capability/scope gating logic moved from `packages/server` into `connectors/google/src/toolsets.ts` so it lives alongside the toolsets it governs
- **Rate limiter optimised**: `SlidingWindowLimiter` now tracks `usedWeight` incrementally instead of reducing over the full event array on every acquire; `pruneExpired` uses `findIndex` for a single pass; project and account limiters are acquired in parallel via `Promise.all`
- **`sleep` utility extracted**: Duplicated `sleep` implementation consolidated into `connectors/google/src/utils.ts`
- **`mergeRateLimitConfig` simplified**: Replaced per-field repetitive spread with a loop over service keys
- **No-op lifecycle hooks removed**: Empty `onDeleted`, `register`, and `shutdown` stubs dropped from `connector.ts`
- **Selective DB projection in `registerGoogleToolsets`**: The initial instance query now only fetches the columns actually needed instead of `select *`
- **Proactive token refresh before `testConnection`**: `testConnectorInstance` now refreshes an expired/expiring OAuth token before invoking the hook, so the test receives a usable token

### Bug Fixes
- **Token refresh failures no longer silently disconnect accounts**: Errors during `getAccessToken` are now caught, the instance is marked `error` in the DB, and the error is re-thrown rather than leaving the account in a broken-but-connected state
- **Profile fetch errors are now logged**: `onAuthorized` hook catches and logs failures rather than silently returning nulls

### Documentation
- Logger passed through `ConnectorServiceHooks` (`onAuthorized`, `onDeleted`, `testConnection`) and `ConnectorLifecycleContext` so connectors have a structured logger without importing global singletons
