### PR TITLE
improvement(server): unify ServiceResult contracts and strengthen route validation for automations

### DIFF
--- a/packages/server/src/automations/scheduler.ts
+++ b/packages/server/src/automations/scheduler.ts
@@ -4,6 +4,7 @@ import type { Automation, AutomationSchedule } from '@stitch/shared/automations/
 import { listAutomations, runAutomation } from './service.js';
 
 import { registerSchedulerJob, unregisterSchedulerJob } from '@/scheduler/runtime.js';
+import { isServiceError } from '@/lib/service-result.js';
 
 const AUTOMATION_JOB_KEY_PREFIX = 'automation:';
 
@@ -27,7 +28,7 @@ async function registerAutomationJob(automation: Automation): Promise<void> {
     schedule: toSchedulerSchedule(automation.schedule),
     callback: async () => {
       const result = await runAutomation(automation.id);
-      if ('error' in result) {
+      if (isServiceError(result)) {
         throw new Error(result.error);
       }
     },
@@ -51,19 +52,21 @@ export async function unregisterAutomationSchedule(automationId: string): Promis
 
 export async function syncAllAutomationSchedules(): Promise<void> {
   const pageSize = 100;
-  const automations: Automation[] = [];
+  const automationList: Automation[] = [];
   let page = 1;
 
   while (true) {
     const result = await listAutomations({ page, pageSize });
-    automations.push(...result.automations);
+    if (isServiceError(result)) break;
 
-    if (result.totalPages === 0 || page >= result.totalPages) {
+    automationList.push(...result.data.automations);
+
+    if (result.data.totalPages === 0 || page >= result.data.totalPages) {
       break;
     }
 
     page += 1;
   }
 
-  await Promise.all(automations.map((automation) => syncAutomationSchedule(automation)));
+  await Promise.all(automationList.map((automation) => syncAutomationSchedule(automation)));
 }

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -71,7 +71,7 @@ import { paginatedQuery } from '@/lib/paginated-query.js';
 export async function listAutomations(input: {
   page: number;
   pageSize: number;
-}): Promise<ListAutomationsResponse> {
+}): Promise<ServiceResult<ListAutomationsResponse>> {
   const db = getDb();
 
   const result = await paginatedQuery({
@@ -82,7 +82,7 @@ export async function listAutomations(input: {
     transform: toAutomationRow,
   });
 
-  return { automations: result.items, ...result };
+  return ok({ automations: result.items, ...result });
 }
 
 export async function createAutomation(

--- a/packages/server/src/routes/automations.ts
+++ b/packages/server/src/routes/automations.ts
@@ -17,7 +17,7 @@ import {
   updateAutomation,
 } from '@/automations/service.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
-import { paginationQuerySchema } from '@/lib/route-schemas.js';
+import { paginationQuerySchema, routeSchemas } from '@/lib/route-schemas.js';
 import { isServiceError } from '@/lib/service-result.js';
 
 const scheduleSchema = z
@@ -41,6 +41,8 @@ const updateAutomationSchema = createAutomationSchema
     message: 'At least one field must be provided',
   });
 
+const automationIdParamSchema = z.object({ id: routeSchemas.automationId });
+
 export const automationsRouter = new Hono();
 
 automationsRouter.get(
@@ -49,7 +51,7 @@ automationsRouter.get(
   async (c) => {
     const { page, pageSize } = c.req.valid('query');
     const result = await listAutomations({ page, pageSize });
-    return c.json(result);
+    return unwrapResult(c, result);
   },
 );
 
@@ -68,40 +70,57 @@ automationsRouter.post('/', zValidator('json', createAutomationSchema), async (c
   return unwrapResult(c, result, 201);
 });
 
-automationsRouter.patch('/:id', zValidator('json', updateAutomationSchema), async (c) => {
-  const id = c.req.param('id');
-  const body = c.req.valid('json') as UpdateAutomationInput;
-  const result = await updateAutomation(id, body);
-  if (isServiceError(result)) return unwrapResult(c, result);
+automationsRouter.patch(
+  '/:id',
+  zValidator('param', automationIdParamSchema),
+  zValidator('json', updateAutomationSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const body = c.req.valid('json') as UpdateAutomationInput;
+    const result = await updateAutomation(id, body);
+    if (isServiceError(result)) return unwrapResult(c, result);
 
-  try {
-    await syncAutomationSchedule(result.data);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to schedule automation';
-    return c.json({ error: message }, 500);
-  }
+    try {
+      await syncAutomationSchedule(result.data);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to schedule automation';
+      return c.json({ error: message }, 500);
+    }
 
-  return unwrapResult(c, result);
-});
+    return unwrapResult(c, result);
+  },
+);
 
-automationsRouter.delete('/:id', async (c) => {
-  const id = c.req.param('id');
-  const result = await deleteAutomation(id);
-  if (isServiceError(result)) return unwrapResult(c, result);
+automationsRouter.delete(
+  '/:id',
+  zValidator('param', automationIdParamSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const result = await deleteAutomation(id);
+    if (isServiceError(result)) return unwrapResult(c, result);
 
-  await unregisterAutomationSchedule(id).catch(() => {});
+    await unregisterAutomationSchedule(id).catch(() => {});
 
-  return unwrapResult(c, result, 204);
-});
+    return unwrapResult(c, result, 204);
+  },
+);
 
-automationsRouter.get('/:id/sessions', async (c) => {
-  const id = c.req.param('id');
-  const result = await listAutomationSessions(id);
-  return unwrapResult(c, result);
-});
+automationsRouter.get(
+  '/:id/sessions',
+  zValidator('param', automationIdParamSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const result = await listAutomationSessions(id);
+    return unwrapResult(c, result);
+  },
+);
 
-automationsRouter.post('/:id/run', async (c) => {
-  const id = c.req.param('id');
-  const result = await runAutomation(id);
-  return unwrapResult(c, result, 201);
-});
+automationsRouter.post(
+  '/:id/run',
+  zValidator('param', automationIdParamSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const result = await runAutomation(id);
+    return unwrapResult(c, result, 201);
+  },
+);


### PR DESCRIPTION
## Change Summary

Aligns the automations module with the established ServiceResult + route validation patterns used across the rest of the server codebase.

### New Features
- **Param validation**: All `/:id` routes now use `zValidator('param', automationIdParamSchema)` with `routeSchemas.automationId` for typed, validated ID extraction

### Improvements & Refactors
- **`listAutomations`** service now returns `ServiceResult<ListAutomationsResponse>` — consistent with all other service methods
- **`GET /`** route now uses `unwrapResult` instead of `c.json(result)` directly
- **`syncAllAutomationSchedules`** in scheduler updated to handle the new `ServiceResult` return from `listAutomations` using `isServiceError`
- Replaced all raw `'error' in result` checks in scheduler with `isServiceError`

Closes #74