### PR TITLE
fix(server): warn on tool name collision when activating overlapping toolsets

### DIFF
--- a/packages/server/__test__/tools/toolset-management.test.ts
+++ b/packages/server/__test__/tools/toolset-management.test.ts
@@ -4,6 +4,7 @@ import { createToolsetTools } from '@/tools/core/toolset-management.js';
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
 import type { Toolset } from '@/tools/toolsets/types.js';
+import type { Tool } from 'ai';
 
 function clearToolsets(): void {
   for (const id of listToolsetIds()) {
@@ -17,6 +18,10 @@ function createManager(): ToolsetManager {
     messageId: 'msg_test' as never,
     streamRunId: 'run_test',
   });
+}
+
+function makeTool(description: string): Tool {
+  return { description, parameters: { type: 'object', properties: {} } } as unknown as Tool;
 }
 
 function registerTestToolset(overrides: Partial<Toolset> = {}): Toolset {
@@ -131,5 +136,69 @@ describe('toolset management tools', () => {
     await expect(
       tools.activate_toolset.execute?.({ toolsetId: 'missing-toolset' }, {} as never),
     ).rejects.toThrow('Unknown toolset');
+  });
+
+  test('activate_toolset includes warning and collisions when tool names overlap', async () => {
+    registerToolset({
+      id: 'first-toolset',
+      name: 'First',
+      description: 'First toolset',
+      tools: () => [{ name: 'search', description: 'search' }],
+      activate: async () => ({ search: makeTool('search from first') }),
+    } satisfies Toolset);
+
+    registerToolset({
+      id: 'second-toolset',
+      name: 'Second',
+      description: 'Second toolset',
+      tools: () => [
+        { name: 'search', description: 'search' },
+        { name: 'list', description: 'list' },
+      ],
+      activate: async () => ({
+        search: makeTool('search from second'),
+        list: makeTool('list from second'),
+      }),
+    } satisfies Toolset);
+
+    const manager = createManager();
+    const tools = createToolsetTools(manager);
+    await tools.activate_toolset.execute?.({ toolsetId: 'first-toolset' }, {} as never);
+    const result = (await tools.activate_toolset.execute?.(
+      { toolsetId: 'second-toolset' },
+      {} as never,
+    )) as { warning?: string; collisions?: string[] };
+
+    expect(result.warning).toContain('search');
+    expect(result.collisions).toEqual(['search']);
+  });
+
+  test('activate_toolset omits warning and collisions when no overlap exists', async () => {
+    registerToolset({
+      id: 'no-overlap-a',
+      name: 'A',
+      description: 'A',
+      tools: () => [{ name: 'tool_a', description: 'a' }],
+      activate: async () => ({ tool_a: makeTool('a') }),
+    } satisfies Toolset);
+
+    registerToolset({
+      id: 'no-overlap-b',
+      name: 'B',
+      description: 'B',
+      tools: () => [{ name: 'tool_b', description: 'b' }],
+      activate: async () => ({ tool_b: makeTool('b') }),
+    } satisfies Toolset);
+
+    const manager = createManager();
+    const tools = createToolsetTools(manager);
+    await tools.activate_toolset.execute?.({ toolsetId: 'no-overlap-a' }, {} as never);
+    const result = (await tools.activate_toolset.execute?.(
+      { toolsetId: 'no-overlap-b' },
+      {} as never,
+    )) as { warning?: string; collisions?: string[] };
+
+    expect(result.warning).toBeUndefined();
+    expect(result.collisions).toBeUndefined();
   });
 });

--- a/packages/server/__test__/tools/toolset-manager-ordering.test.ts
+++ b/packages/server/__test__/tools/toolset-manager-ordering.test.ts
@@ -23,6 +23,97 @@ function makeTool(description: string): Tool {
   return { description, parameters: { type: 'object', properties: {} } } as unknown as Tool;
 }
 
+describe('ToolsetManager.activate collision detection', () => {
+  beforeEach(() => {
+    clearToolsets();
+  });
+
+  test('returns empty collisions when no overlap exists', async () => {
+    registerToolset({
+      id: 'ts-a',
+      name: 'A',
+      description: 'A',
+      tools: () => [{ name: 'tool_a', description: 'a' }],
+      activate: async () => ({ tool_a: makeTool('a') }),
+    } satisfies Toolset);
+
+    registerToolset({
+      id: 'ts-b',
+      name: 'B',
+      description: 'B',
+      tools: () => [{ name: 'tool_b', description: 'b' }],
+      activate: async () => ({ tool_b: makeTool('b') }),
+    } satisfies Toolset);
+
+    const manager = createManager();
+    await manager.activate('ts-a');
+    const result = await manager.activate('ts-b');
+
+    expect(result?.collisions).toEqual([]);
+  });
+
+  test('reports collisions when two toolsets share a tool name', async () => {
+    registerToolset({
+      id: 'ts-x',
+      name: 'X',
+      description: 'X',
+      tools: () => [{ name: 'search', description: 'search' }],
+      activate: async () => ({ search: makeTool('search from X') }),
+    } satisfies Toolset);
+
+    registerToolset({
+      id: 'ts-y',
+      name: 'Y',
+      description: 'Y',
+      tools: () => [
+        { name: 'search', description: 'search' },
+        { name: 'list', description: 'list' },
+      ],
+      activate: async () => ({
+        search: makeTool('search from Y'),
+        list: makeTool('list from Y'),
+      }),
+    } satisfies Toolset);
+
+    const manager = createManager();
+    await manager.activate('ts-x');
+    const result = await manager.activate('ts-y');
+
+    expect(result?.collisions).toEqual(['search']);
+  });
+
+  test('returns no collisions when activating the first toolset', async () => {
+    registerToolset({
+      id: 'ts-only',
+      name: 'Only',
+      description: 'Only',
+      tools: () => [{ name: 'tool_a', description: 'a' }],
+      activate: async () => ({ tool_a: makeTool('a') }),
+    } satisfies Toolset);
+
+    const manager = createManager();
+    const result = await manager.activate('ts-only');
+
+    expect(result?.collisions).toEqual([]);
+  });
+
+  test('already-active toolset returns empty collisions', async () => {
+    registerToolset({
+      id: 'ts-once',
+      name: 'Once',
+      description: 'Once',
+      tools: () => [{ name: 'tool_a', description: 'a' }],
+      activate: async () => ({ tool_a: makeTool('a') }),
+    } satisfies Toolset);
+
+    const manager = createManager();
+    await manager.activate('ts-once');
+    const result = await manager.activate('ts-once');
+
+    expect(result?.collisions).toEqual([]);
+  });
+});
+
 describe('ToolsetManager.getActiveTools ordering', () => {
   beforeEach(() => {
     clearToolsets();

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -81,13 +81,14 @@ export function createToolsetTools(manager: ToolsetManager) {
         };
       }
 
-      const toolNames = await manager.activate(toolsetId);
-      if (toolNames === null) {
+      const result = await manager.activate(toolsetId);
+      if (result === null) {
         throw new Error(
           `Unknown toolset: "${toolsetId}". Use list_toolsets with no arguments to see available IDs.`,
         );
       }
 
+      const { toolNames, collisions } = result;
       const toolset = getToolset(toolsetId);
       const shouldIncludeVerbose = verbose === true;
 
@@ -108,6 +109,10 @@ export function createToolsetTools(manager: ToolsetManager) {
               arguments: p.arguments,
             })) ?? null)
           : null,
+        ...(collisions.length > 0 && {
+          warning: `Tool name collision: ${collisions.join(', ')} already exist in another active toolset. The new definitions have overwritten the previous ones.`,
+          collisions,
+        }),
       };
     },
   });

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -26,10 +26,15 @@ export class ToolsetManager {
     this.context = context;
   }
 
-  /** Activate a toolset by ID. Returns the newly available tool names, or null if not found. */
-  async activate(toolsetId: string): Promise<string[] | null> {
+  /**
+   * Activate a toolset by ID.
+   * Returns the newly available tool names and any collision warnings, or null if not found.
+   */
+  async activate(
+    toolsetId: string,
+  ): Promise<{ toolNames: string[]; collisions: string[] } | null> {
     if (this.activeIds.has(toolsetId)) {
-      return Object.keys(this.activeToolCache.get(toolsetId) ?? {});
+      return { toolNames: Object.keys(this.activeToolCache.get(toolsetId) ?? {}), collisions: [] };
     }
 
     const toolset = getToolset(toolsetId);
@@ -42,6 +47,16 @@ export class ToolsetManager {
     }
 
     const tools = withToolResultHandlingRecord(await toolset.activate(this.context));
+    const currentToolNames = new Set(Object.keys(this.getActiveTools()));
+    const collisions = Object.keys(tools).filter((name) => currentToolNames.has(name));
+
+    if (collisions.length > 0) {
+      log.warn(
+        { event: 'toolset.activate.collision', toolsetId, collisions },
+        'tool name collision detected on activation',
+      );
+    }
+
     this.activeIds.add(toolsetId);
     this.activeToolCache.set(toolsetId, tools);
 
@@ -55,7 +70,7 @@ export class ToolsetManager {
       'toolset activated',
     );
 
-    return Object.keys(tools);
+    return { toolNames: Object.keys(tools), collisions };
   }
 
   /** Deactivate a toolset, removing its tools from the active set. */


### PR DESCRIPTION
## Change Summary

Closes #129.

When two active toolsets expose a tool with the same name, `ToolsetManager.getActiveTools()` silently overwrites the earlier definition via `Object.assign`. This is invisible to the LLM, the developer, and the user -- the wrong tool implementation wins with no indication. This is particularly risky for MCP servers, where generic names like `search`, `list`, and `read_file` appear across unrelated servers.

### Bug Fixes
- **Tool name collision detection**: `ToolsetManager.activate()` now compares incoming tool names against all currently-active tools and collects overlaps before caching
- **Warn-level log event**: Collisions emit a structured `toolset.activate.collision` log entry with the colliding names and toolset ID
- **LLM-visible response fields**: `activate_toolset` includes `warning` and `collisions` fields in its response when overlap is detected; non-colliding activations are unchanged with no extra fields or noise
- **Return type updated**: `activate()` return type changed from `string[] | null` to `{ toolNames: string[]; collisions: string[] } | null`; the single call site in `toolset-management.ts` updated accordingly