### PR TITLE
improvement(toolsets): add keyword search to list_toolsets for catalog scalability

### DIFF
--- a/packages/server/__test__/tools/toolset-management.test.ts
+++ b/packages/server/__test__/tools/toolset-management.test.ts
@@ -201,4 +201,108 @@ describe('toolset management tools', () => {
     expect(result.warning).toBeUndefined();
     expect(result.collisions).toBeUndefined();
   });
+
+  describe('list_toolsets query filtering', () => {
+    beforeEach(() => {
+      clearToolsets();
+      registerToolset({
+        id: 'browser-toolset',
+        name: 'Browser',
+        description: 'Control a headless browser',
+        tools: () => [],
+        activate: async () => ({}),
+      } satisfies Toolset);
+      registerToolset({
+        id: 'database-toolset',
+        name: 'Database',
+        description: 'Query and manage SQL databases',
+        tools: () => [],
+        activate: async () => ({}),
+      } satisfies Toolset);
+      registerToolset({
+        id: 'email-sender',
+        name: 'Email',
+        description: 'Send and receive messages',
+        tools: () => [],
+        activate: async () => ({}),
+      } satisfies Toolset);
+    });
+
+    test('filters by name match', async () => {
+      const manager = createManager();
+      const tools = createToolsetTools(manager);
+      const result = (await tools.list_toolsets.execute?.({ query: 'browser' }, {} as never)) as {
+        toolsets: { id: string }[];
+        totalAvailable: number;
+      };
+
+      expect(result.toolsets).toHaveLength(1);
+      expect(result.toolsets[0].id).toBe('browser-toolset');
+      expect(result.totalAvailable).toBe(3);
+    });
+
+    test('filters by description match', async () => {
+      const manager = createManager();
+      const tools = createToolsetTools(manager);
+      const result = (await tools.list_toolsets.execute?.({ query: 'sql' }, {} as never)) as {
+        toolsets: { id: string }[];
+        totalAvailable: number;
+      };
+
+      expect(result.toolsets).toHaveLength(1);
+      expect(result.toolsets[0].id).toBe('database-toolset');
+      expect(result.totalAvailable).toBe(3);
+    });
+
+    test('filters by id match', async () => {
+      const manager = createManager();
+      const tools = createToolsetTools(manager);
+      const result = (await tools.list_toolsets.execute?.({ query: 'email-sender' }, {} as never)) as {
+        toolsets: { id: string }[];
+        totalAvailable: number;
+      };
+
+      expect(result.toolsets).toHaveLength(1);
+      expect(result.toolsets[0].id).toBe('email-sender');
+      expect(result.totalAvailable).toBe(3);
+    });
+
+    test('returns empty array with totalAvailable when no match', async () => {
+      const manager = createManager();
+      const tools = createToolsetTools(manager);
+      const result = (await tools.list_toolsets.execute?.(
+        { query: 'xyz_nomatch' },
+        {} as never,
+      )) as {
+        toolsets: unknown[];
+        totalAvailable: number;
+      };
+
+      expect(result.toolsets).toHaveLength(0);
+      expect(result.totalAvailable).toBe(3);
+    });
+
+    test('returns full catalog without totalAvailable when no query provided', async () => {
+      const manager = createManager();
+      const tools = createToolsetTools(manager);
+      const result = (await tools.list_toolsets.execute?.({}, {} as never)) as {
+        toolsets: { id: string }[];
+        totalAvailable?: number;
+      };
+
+      expect(result.toolsets).toHaveLength(3);
+      expect(result.totalAvailable).toBeUndefined();
+    });
+
+    test('toolsetId takes precedence over query when both provided', async () => {
+      const manager = createManager();
+      const tools = createToolsetTools(manager);
+      const result = (await tools.list_toolsets.execute?.(
+        { toolsetId: 'browser-toolset', query: 'database' },
+        {} as never,
+      )) as { toolsetId: string };
+
+      expect(result.toolsetId).toBe('browser-toolset');
+    });
+  });
 });

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -17,18 +17,34 @@ export function createToolsetTools(manager: ToolsetManager) {
       .join(' ');
 
   const list_toolsets = tool({
-    description: `List toolsets and inspect toolset contents. Call with no arguments for a compact catalog, or pass a toolset ID for detailed tools and prompts.`,
+    description: `List toolsets and inspect toolset contents. Call with no arguments for the full catalog, pass a query string to filter by keyword (e.g. "database"), or pass a toolsetId to inspect a specific toolset's tools and prompts in detail.`,
     inputSchema: z.object({
       toolsetId: z
         .string()
         .optional()
         .describe('Optional toolset ID to inspect in detail (e.g. "browser")'),
+      query: z
+        .string()
+        .optional()
+        .describe('Keyword to filter the catalog (e.g. "database", "browser", "email")'),
     }),
-    execute: async ({ toolsetId }) => {
+    execute: async ({ toolsetId, query }) => {
       if (!toolsetId) {
-        return {
-          toolsets: manager.getCatalogWithState(),
-        };
+        const fullCatalog = manager.getCatalogWithState();
+
+        if (!query) {
+          return { toolsets: fullCatalog };
+        }
+
+        const q = query.toLowerCase();
+        const filtered = fullCatalog.filter(
+          (ts) =>
+            ts.name.toLowerCase().includes(q) ||
+            ts.description.toLowerCase().includes(q) ||
+            ts.id.toLowerCase().includes(q),
+        );
+
+        return { toolsets: filtered, totalAvailable: fullCatalog.length };
       }
 
       const toolset = getToolset(toolsetId);


### PR DESCRIPTION
## 🚀 Change Summary

Adds a `query` parameter to the `list_toolsets` meta-tool so the LLM can filter the toolset catalog by keyword instead of scanning the full list on every discovery call. This unblocks the Tool Search / Lazy Loading pattern as the MCP server catalog grows.

### ✨ New Features
- **Keyword search for `list_toolsets`**: Pass `query: "browser"` to get back only toolsets matching the keyword in their `id`, `name`, or `description` (case-insensitive). Filtered responses include `totalAvailable` so the LLM knows more toolsets exist and can refine its search terms.
- **`toolsetId` precedence**: When both `toolsetId` and `query` are supplied, `toolsetId` takes precedence and the detailed-inspect path runs as before — no regression.

### 🛠 Improvements & Refactors
- Updated `list_toolsets` tool description to document the new `query` parameter alongside the existing no-args and `toolsetId` modes.

Closes #128