### PR TITLE
improvement(settings): overhaul tool and toolset configuration UX

### DIFF
--- a/apps/web/__test__/tools-filtering.test.ts
+++ b/apps/web/__test__/tools-filtering.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  filterCoreTools,
+  filterToolsetsByQuery,
+  type KnownToolSummary,
+  type KnownToolsetSummary,
+} from '../src/components/settings/permissions/filtering.js';
+
+describe('tools settings filtering', () => {
+  test('core tools filter matches by displayName and toolName', () => {
+    const tools: KnownToolSummary[] = [
+      { toolType: 'stitch', toolName: 'bash', displayName: 'Bash' },
+      { toolType: 'stitch', toolName: 'webfetch', displayName: 'Web Fetch' },
+      { toolType: 'mcp', toolName: 'mcp_server_search', displayName: 'Search' },
+    ];
+
+    expect(filterCoreTools(tools, 'bash').map((tool) => tool.toolName)).toEqual(['bash']);
+    expect(filterCoreTools(tools, 'web fetch').map((tool) => tool.toolName)).toEqual(['webfetch']);
+    expect(filterCoreTools(tools, 'search')).toEqual([]);
+  });
+
+  test('toolset filter matches toolset metadata and individual tools', () => {
+    const toolsets: KnownToolsetSummary[] = [
+      {
+        id: 'agenda',
+        name: 'Agenda',
+        description: 'Manage tasks and lists',
+        tools: [
+          { toolName: 'agenda_add_item', displayName: 'Agenda Add Item' },
+          { toolName: 'agenda_list_items', displayName: 'Agenda List Items' },
+        ],
+      },
+      {
+        id: 'google-calendar',
+        name: 'Google Calendar',
+        description: 'Manage calendar events',
+        tools: [{ toolName: 'calendar_update', displayName: 'Calendar Update' }],
+      },
+    ];
+
+    expect(filterToolsetsByQuery(toolsets, 'agenda').map((toolset) => toolset.id)).toEqual([
+      'agenda',
+    ]);
+    expect(filterToolsetsByQuery(toolsets, 'events').map((toolset) => toolset.id)).toEqual([
+      'google-calendar',
+    ]);
+    expect(filterToolsetsByQuery(toolsets, 'calendar_update').map((toolset) => toolset.id)).toEqual(
+      ['google-calendar'],
+    );
+    expect(filterToolsetsByQuery(toolsets, 'add item').map((toolset) => toolset.id)).toEqual([
+      'agenda',
+    ]);
+  });
+});

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -5,6 +5,7 @@ import {
   NetworkIcon,
   ServerIcon,
   PaletteIcon,
+  WrenchIcon,
   FolderOpenIcon,
   MonitorIcon,
   CpuIcon,
@@ -19,7 +20,7 @@ import { KeyLocationsSettings } from '@/components/settings/key-locations';
 import { McpServersSettings } from '@/components/settings/mcp-servers';
 import { MemorySettings } from '@/components/settings/memory';
 import { ModelsSettings } from '@/components/settings/models';
-import { PermissionsSettings } from '@/components/settings/permissions';
+import { ToolsSettings } from '@/components/settings/permissions';
 import { ProvidersSettings } from '@/components/settings/providers';
 import { RecordingsSettings } from '@/components/settings/recordings';
 import { ShortcutsSettings } from '@/components/settings/shortcuts';
@@ -63,7 +64,7 @@ const SECTIONS: SettingsSection[] = [
       { id: 'providers', label: 'Providers', icon: <ServerIcon className="size-4" /> },
       { id: 'models', label: 'Models', icon: <CpuIcon className="size-4" /> },
       { id: 'memory', label: 'Memory', icon: <BrainIcon className="size-4" /> },
-      { id: 'permissions', label: 'Permissions', icon: <ServerIcon className="size-4" /> },
+      { id: 'tools', label: 'Tools', icon: <WrenchIcon className="size-4" /> },
       { id: 'mcp-servers', label: 'MCP Servers', icon: <NetworkIcon className="size-4" /> },
     ],
   },
@@ -140,8 +141,8 @@ function SettingsContent({ activeItem }: { activeItem: string }) {
       return <ModelsSettings />;
     case 'memory':
       return <MemorySettings />;
-    case 'permissions':
-      return <PermissionsSettings />;
+    case 'tools':
+      return <ToolsSettings />;
     case 'mcp-servers':
       return <McpServersSettings />;
     default:

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -7,6 +7,10 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { PermissionPolicyEditor } from './permissions/permission-policy-editor';
 
 import { ConnectorIcon } from '@/components/connectors/connector-icon';
+import {
+  filterCoreTools,
+  filterToolsetsByQuery,
+} from '@/components/settings/permissions/filtering';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
@@ -221,24 +225,9 @@ function ToolsContent() {
   );
 
   const query = search.trim().toLowerCase();
-  const stitchTools = knownTools
-    .filter((tool) => tool.toolType === 'stitch')
-    .filter((tool) => {
-      if (!query) return true;
-      return (
-        tool.displayName.toLowerCase().includes(query) ||
-        tool.toolName.toLowerCase().includes(query)
-      );
-    });
+  const stitchTools = filterCoreTools(knownTools, query);
 
-  const filteredToolsets = knownToolsets.filter((toolset) => {
-    if (!query) return true;
-    return (
-      toolset.name.toLowerCase().includes(query) ||
-      toolset.id.toLowerCase().includes(query) ||
-      toolset.description.toLowerCase().includes(query)
-    );
-  });
+  const filteredToolsets = filterToolsetsByQuery(knownToolsets, query);
 
   const nativeToolsets = filteredToolsets.filter((toolset) => toolset.source === 'native');
   const connectorToolsets = filteredToolsets.filter((toolset) => toolset.source === 'connector');

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -1,53 +1,148 @@
-import { SearchIcon, Settings2Icon } from 'lucide-react';
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  SearchIcon,
+  ServerIcon,
+  Settings2Icon,
+  WrenchIcon,
+} from 'lucide-react';
 import * as React from 'react';
 import { toast } from 'sonner';
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 
-import type { ToolPermissionValue } from '@stitch/shared/permissions/types';
-
-import {
-  PATTERN_POLICY_TOOLS,
-  PermissionPolicyEditor,
-} from './permissions/permission-policy-editor';
-import { PermissionSelect } from './permissions/permission-select';
+import { PermissionPolicyEditor } from './permissions/permission-policy-editor';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import {
   knownMcpToolsQueryOptions,
   knownToolsQueryOptions,
-  toolPermissionsQueryOptions,
-  useUpsertToolPermission,
+  toolEnabledStatesQueryOptions,
+  useSetToolEnabledState,
 } from '@/lib/queries/tools';
+import { cn } from '@/lib/utils';
 
-function PermissionsContent() {
+type EditingTarget =
+  | {
+      type: 'tool';
+      toolName: string;
+      displayName: string;
+      enabledScope: 'tool' | 'toolset' | 'mcp_tool';
+    }
+  | {
+      type: 'toolset';
+      toolsetId: string;
+      displayName: string;
+      mcpTools: { toolName: string; displayName: string }[];
+    };
+
+type ScopeFilter = 'all' | 'stitch' | 'providers' | 'mcp';
+
+type ToolRowProps = {
+  name: string;
+  subtitle?: string;
+  iconPath?: string;
+  technicalName?: string;
+  enabled: boolean;
+  onConfigure: () => void;
+  onToggleEnabled: (enabled: boolean) => void;
+  isMutating: boolean;
+  reserveMiddleSlot?: boolean;
+  isNested?: boolean;
+};
+
+function ToolRow({
+  name,
+  iconPath,
+  enabled,
+  onConfigure,
+  onToggleEnabled,
+  isMutating,
+  reserveMiddleSlot = false,
+  isNested = false,
+}: ToolRowProps) {
+  return (
+    <div
+      className={cn(
+        'grid items-center gap-3 px-3 py-2.5 sm:px-4',
+        reserveMiddleSlot
+          ? 'grid-cols-[minmax(0,1fr)_5rem_5rem_2.5rem]'
+          : 'grid-cols-[minmax(0,1fr)_5rem_2.5rem]',
+        isNested && 'pl-10 sm:pl-12 bg-muted/10',
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2.5">
+        {iconPath && (
+          <img src={iconPath} alt="" className="size-4 shrink-0 rounded-sm" loading="lazy" />
+        )}
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{name}</p>
+        </div>
+      </div>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={onConfigure}
+        className="h-7 w-full justify-start px-2 text-muted-foreground hover:text-foreground"
+      >
+        <Settings2Icon className="size-3.5" />
+        Settings
+      </Button>
+      {reserveMiddleSlot && <div className="h-7 w-full" aria-hidden="true" />}
+      <div className="flex w-10 justify-end">
+        <Switch checked={enabled} onCheckedChange={onToggleEnabled} disabled={isMutating} />
+      </div>
+    </div>
+  );
+}
+
+function SectionCard({
+  title,
+  description,
+  count,
+  children,
+}: {
+  title: string;
+  description: string;
+  count: number;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="overflow-hidden rounded-xl border border-border/60 bg-card/40">
+      <div className="flex items-start justify-between gap-3 border-b border-border/50 px-4 py-3">
+        <div>
+          <p className="text-sm font-semibold">{title}</p>
+          <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+        <p className="rounded-md border border-border/60 bg-muted/20 px-2 py-0.5 text-xs text-muted-foreground">
+          {count}
+        </p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function ToolsContent() {
   const { data: knownTools } = useSuspenseQuery(knownToolsQueryOptions);
   const { data: knownMcpTools } = useSuspenseQuery(knownMcpToolsQueryOptions);
-  const { data: permissions } = useSuspenseQuery(toolPermissionsQueryOptions);
-  const upsertPermission = useUpsertToolPermission();
+  const { data: enabledStates } = useSuspenseQuery(toolEnabledStatesQueryOptions);
+  const setToolEnabledState = useSetToolEnabledState();
 
   const [search, setSearch] = React.useState('');
-  const [scope, setScope] = React.useState('all');
-  const [editingTool, setEditingTool] = React.useState<string | null>(null);
-  const mcpServerNames = Array.from(new Set(knownMcpTools.map((tool) => tool.serverName))).sort();
+  const [scope, setScope] = React.useState<ScopeFilter>('all');
+  const [editingTarget, setEditingTarget] = React.useState<EditingTarget | null>(null);
+  const [expandedServers, setExpandedServers] = React.useState<Record<string, boolean>>({});
 
-  const mcpServerNameByTool = React.useMemo(() => {
-    return new Map(knownMcpTools.map((tool) => [tool.name, tool.serverName]));
-  }, [knownMcpTools]);
-
-  const mcpToolMetaByTool = React.useMemo(() => {
+  const mcpToolMetaByName = React.useMemo(() => {
     return new Map(
       knownMcpTools.map((tool) => [
         tool.name,
         {
+          serverId: tool.serverId,
+          serverName: tool.serverName,
           serverIconPath: tool.serverIconPath,
           toolIconPath: tool.toolIconPath,
         },
@@ -55,256 +150,399 @@ function PermissionsContent() {
     );
   }, [knownMcpTools]);
 
-  const getGlobalPermission = (toolName: string): ToolPermissionValue => {
-    const rule = permissions.find((permission) => {
-      return permission.toolName === toolName && permission.pattern === null;
+  const enabledMap = React.useMemo(() => {
+    return new Map(
+      enabledStates.map((state) => [`${state.scope}:${state.identifier}`, state.enabled]),
+    );
+  }, [enabledStates]);
+
+  const getEnabled = React.useCallback(
+    (kind: 'tool' | 'toolset' | 'mcp_tool', identifier: string) => {
+      return enabledMap.get(`${kind}:${identifier}`) ?? true;
+    },
+    [enabledMap],
+  );
+
+  const updateEnabled = React.useCallback(
+    (kind: 'tool' | 'toolset' | 'mcp_tool', identifier: string, enabled: boolean) => {
+      void setToolEnabledState
+        .mutateAsync({ scope: kind, identifier, enabled })
+        .catch((error: unknown) => {
+          toast.error(error instanceof Error ? error.message : 'Failed to update tool state');
+        });
+    },
+    [setToolEnabledState],
+  );
+
+  const query = search.trim().toLowerCase();
+  const stitchTools = knownTools
+    .filter((tool) => tool.toolType === 'stitch')
+    .filter((tool) => {
+      if (!query) return true;
+      return (
+        tool.displayName.toLowerCase().includes(query) ||
+        tool.toolName.toLowerCase().includes(query)
+      );
     });
-    return rule?.permission ?? 'ask';
-  };
 
-  const handlePermissionChange = (toolName: string, permission: ToolPermissionValue) => {
-    void upsertPermission
-      .mutateAsync({ toolName, pattern: null, permission })
-      .catch((error: unknown) => {
-        toast.error(error instanceof Error ? error.message : 'Failed to update permission');
+  const pluginTools = knownTools
+    .filter((tool) => tool.toolType === 'plugin')
+    .filter((tool) => {
+      if (!query) return true;
+      return (
+        tool.displayName.toLowerCase().includes(query) ||
+        tool.toolName.toLowerCase().includes(query)
+      );
+    });
+
+  const mcpToolsetGroups = React.useMemo(() => {
+    const groups = new Map<
+      string,
+      {
+        serverId: string;
+        serverName: string;
+        serverIconPath?: string;
+        tools: { toolName: string; displayName: string; iconPath?: string }[];
+      }
+    >();
+
+    for (const tool of knownTools) {
+      if (tool.toolType !== 'mcp') continue;
+      const meta = mcpToolMetaByName.get(tool.toolName);
+      if (!meta) continue;
+
+      const current = groups.get(meta.serverId) ?? {
+        serverId: meta.serverId,
+        serverName: meta.serverName,
+        serverIconPath: meta.serverIconPath,
+        tools: [],
+      };
+
+      current.tools.push({
+        toolName: tool.toolName,
+        displayName: tool.displayName,
+        iconPath: meta.toolIconPath ?? meta.serverIconPath,
       });
-  };
+      groups.set(meta.serverId, current);
+    }
 
-  if (editingTool) {
-    const tool = knownTools.find((item) => item.toolName === editingTool);
+    return Array.from(groups.values())
+      .map((group) => ({
+        ...group,
+        tools: group.tools.sort((a, b) => a.displayName.localeCompare(b.displayName)),
+      }))
+      .sort((a, b) => a.serverName.localeCompare(b.serverName));
+  }, [knownTools, mcpToolMetaByName]);
+
+  if (editingTarget) {
     return (
       <React.Suspense fallback={<div className="text-xs text-muted-foreground">Loading...</div>}>
         <PermissionPolicyEditor
-          toolName={editingTool}
-          displayName={tool?.displayName ?? editingTool}
-          onBack={() => setEditingTool(null)}
+          target={editingTarget}
+          onBack={() => setEditingTarget(null)}
+          getEnabled={getEnabled}
+          onToggleEnabled={updateEnabled}
         />
       </React.Suspense>
     );
   }
 
-  const query = search.trim().toLowerCase();
-  const searchFilteredTools = knownTools.filter((tool) => {
-    if (query === '') return true;
-    const serverName = mcpServerNameByTool.get(tool.toolName)?.toLowerCase() ?? '';
-    return (
-      tool.displayName.toLowerCase().includes(query) ||
-      tool.toolName.toLowerCase().includes(query) ||
-      serverName.includes(query)
-    );
-  });
+  const filteredMcpGroups = mcpToolsetGroups
+    .map((group) => {
+      if (!query) return group;
+      const serverMatch = group.serverName.toLowerCase().includes(query);
+      if (serverMatch) return group;
 
-  const selectedServerName = scope.startsWith('mcp:') ? scope.slice(4) : null;
-  const filteredTools = searchFilteredTools.filter((tool) => {
-    if (scope === 'all') return true;
-    if (scope === 'stitch') return tool.toolType === 'stitch';
-    if (scope === 'providers') return tool.toolType === 'plugin';
-    if (selectedServerName) {
-      return (
-        tool.toolType === 'mcp' && mcpServerNameByTool.get(tool.toolName) === selectedServerName
+      const matchingTools = group.tools.filter(
+        (tool) =>
+          tool.displayName.toLowerCase().includes(query) ||
+          tool.toolName.toLowerCase().includes(query),
       );
-    }
-    return true;
-  });
 
-  const stitchTools = filteredTools.filter((tool) => tool.toolType === 'stitch');
-  const pluginTools = filteredTools.filter((tool) => tool.toolType === 'plugin');
-  const mcpTools = filteredTools.filter((tool) => tool.toolType === 'mcp');
+      return { ...group, tools: matchingTools };
+    })
+    .filter((group) => group.tools.length > 0);
 
-  const mcpToolsByServer = new Map<string, typeof mcpTools>();
-  for (const tool of mcpTools) {
-    const serverName = mcpServerNameByTool.get(tool.toolName) ?? 'MCP';
-    const group = mcpToolsByServer.get(serverName) ?? [];
-    group.push(tool);
-    mcpToolsByServer.set(serverName, group);
-  }
+  const visibleStitch = scope === 'all' || scope === 'stitch';
+  const visibleProviders = scope === 'all' || scope === 'providers';
+  const visibleMcp = scope === 'all' || scope === 'mcp';
 
-  const isMutating = upsertPermission.isPending;
+  const enabledCount =
+    (visibleStitch ? stitchTools.filter((tool) => getEnabled('tool', tool.toolName)).length : 0) +
+    (visibleProviders
+      ? pluginTools.filter((tool) => getEnabled('toolset', tool.toolName)).length
+      : 0) +
+    (visibleMcp
+      ? filteredMcpGroups.reduce((count, group) => {
+          const serverEnabled = getEnabled('toolset', `mcp:${group.serverId}`) ? 1 : 0;
+          const toolsEnabled = group.tools.filter((tool) =>
+            getEnabled('mcp_tool', tool.toolName),
+          ).length;
+          return count + serverEnabled + toolsEnabled;
+        }, 0)
+      : 0);
+
+  const totalCount =
+    (visibleStitch ? stitchTools.length : 0) +
+    (visibleProviders ? pluginTools.length : 0) +
+    (visibleMcp
+      ? filteredMcpGroups.reduce((count, group) => count + 1 + group.tools.length, 0)
+      : 0);
+
+  const isMutating = setToolEnabledState.isPending;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-5">
       <div>
-        <h2 className="text-base font-bold">Permissions</h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Configure default approval behavior for built-in, MCP, and provider tools
+        <h2 className="text-base font-bold">Tools</h2>
+        <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+          Keep only the tools you need enabled, then open settings for permission behavior.
         </p>
       </div>
 
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <div className="rounded-xl border border-border/60 bg-muted/15 px-4 py-3">
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <div className="rounded-md border border-border/60 bg-background px-2 py-1">
+            <span className="text-muted-foreground">Enabled </span>
+            <span className="font-semibold text-foreground">{enabledCount}</span>
+          </div>
+          <div className="rounded-md border border-border/60 bg-background px-2 py-1">
+            <span className="text-muted-foreground">Disabled </span>
+            <span className="font-semibold text-foreground">
+              {Math.max(totalCount - enabledCount, 0)}
+            </span>
+          </div>
+          <div className="rounded-md border border-border/60 bg-background px-2 py-1 text-muted-foreground">
+            Disabled tools are removed from agent availability
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-3">
         <div className="relative flex-1">
           <SearchIcon className="absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
             className="pl-8"
-            placeholder="Search tools..."
+            placeholder="Search by tool or MCP server..."
             value={search}
             onChange={(event) => setSearch(event.target.value)}
           />
         </div>
-        <Select value={scope} onValueChange={(value) => setScope(value ?? 'all')}>
-          <SelectTrigger className="w-full sm:w-64">
-            <SelectValue>
-              {scope === 'all' ? (
-                'All'
-              ) : scope === 'stitch' ? (
-                <span className="flex w-full items-center justify-between gap-2">
-                  <span>Stitch tools</span>
-                  <span className="rounded border border-border/60 bg-muted/20 px-1.5 py-0.5 text-[10px] leading-none font-medium text-muted-foreground">
-                    Stitch
-                  </span>
-                </span>
-              ) : scope === 'providers' ? (
-                'Provider tools'
-              ) : (
-                <span className="flex w-full items-center justify-between gap-2">
-                  <span className="truncate">{selectedServerName ?? 'MCP server'}</span>
-                  <span className="rounded border border-border/60 bg-muted/20 px-1.5 py-0.5 text-[10px] leading-none font-medium text-muted-foreground">
-                    MCP
-                  </span>
-                </span>
-              )}
-            </SelectValue>
-          </SelectTrigger>
-          <SelectContent align="end">
-            <SelectItem value="all">All</SelectItem>
-            <SelectItem value="stitch">
-              <span className="flex w-full items-center justify-between gap-2">
-                <span>Stitch tools</span>
-                <span className="rounded border border-border/60 bg-muted/20 px-1.5 py-0.5 text-[10px] leading-none font-medium text-muted-foreground">
-                  Stitch
-                </span>
-              </span>
-            </SelectItem>
-            <SelectItem value="providers">Provider tools</SelectItem>
-            {mcpServerNames.map((serverName) => (
-              <SelectItem key={serverName} value={`mcp:${serverName}`}>
-                <span className="flex w-full items-center justify-between gap-2">
-                  <span className="truncate">{serverName}</span>
-                  <span className="rounded border border-border/60 bg-muted/20 px-1.5 py-0.5 text-[10px] leading-none font-medium text-muted-foreground">
-                    MCP
-                  </span>
-                </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+
+        <div className="flex flex-wrap gap-1.5">
+          {(
+            [
+              { id: 'all', label: 'All tools' },
+              { id: 'stitch', label: 'Core tools' },
+              { id: 'providers', label: 'Provider tools' },
+              { id: 'mcp', label: 'MCP servers' },
+            ] as const
+          ).map((option) => (
+            <Button
+              key={option.id}
+              size="sm"
+              variant={scope === option.id ? 'secondary' : 'outline'}
+              className={cn(scope === option.id ? 'border-border/70' : 'text-muted-foreground')}
+              onClick={() => setScope(option.id)}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
       </div>
 
-      {stitchTools.length > 0 && (
-        <div className="space-y-1.5">
-          <p className="text-xs font-medium text-muted-foreground">Stitch</p>
-          <div className="overflow-hidden rounded-md border border-border/50">
-            {stitchTools.map((tool) => {
-              const hasPatternEditor = PATTERN_POLICY_TOOLS.has(tool.toolName);
-              const permission = getGlobalPermission(tool.toolName);
+      {visibleStitch && stitchTools.length > 0 && (
+        <SectionCard
+          title="Core tools"
+          description="Built-in tools provided by Stitch"
+          count={stitchTools.length}
+        >
+          <div className="divide-y divide-border/40">
+            {stitchTools.map((tool) => (
+              <ToolRow
+                key={tool.toolName}
+                name={tool.displayName}
+                technicalName={tool.toolName}
+                enabled={getEnabled('tool', tool.toolName)}
+                onConfigure={() =>
+                  setEditingTarget({
+                    type: 'tool',
+                    toolName: tool.toolName,
+                    displayName: tool.displayName,
+                    enabledScope: 'tool',
+                  })
+                }
+                onToggleEnabled={(checked) => updateEnabled('tool', tool.toolName, checked)}
+                isMutating={isMutating}
+              />
+            ))}
+          </div>
+        </SectionCard>
+      )}
+
+      {visibleProviders && pluginTools.length > 0 && (
+        <SectionCard
+          title="Provider tools"
+          description="Tool integrations shipped by model providers"
+          count={pluginTools.length}
+        >
+          <div className="divide-y divide-border/40">
+            {pluginTools.map((tool) => (
+              <ToolRow
+                key={tool.toolName}
+                name={tool.displayName}
+                subtitle="Provider toolset"
+                technicalName={tool.toolName}
+                enabled={getEnabled('toolset', tool.toolName)}
+                onConfigure={() =>
+                  setEditingTarget({
+                    type: 'tool',
+                    toolName: tool.toolName,
+                    displayName: tool.displayName,
+                    enabledScope: 'toolset',
+                  })
+                }
+                onToggleEnabled={(checked) => updateEnabled('toolset', tool.toolName, checked)}
+                isMutating={isMutating}
+              />
+            ))}
+          </div>
+        </SectionCard>
+      )}
+
+      {visibleMcp && filteredMcpGroups.length > 0 && (
+        <SectionCard
+          title="MCP servers"
+          description="Enable entire servers or fine-tune individual MCP tools"
+          count={filteredMcpGroups.length}
+        >
+          <div className="divide-y divide-border/40">
+            {filteredMcpGroups.map((group) => {
+              const isExpanded = query.length > 0 || expandedServers[group.serverId] === true;
 
               return (
-                <div
-                  key={tool.toolName}
-                  className="flex items-center gap-3 border-b border-border/40 px-3 py-2.5 last:border-b-0"
-                >
-                  <p className="flex-1 text-sm">{tool.displayName}</p>
-                  {hasPatternEditor ? (
-                    <div className="flex size-7 items-center justify-center">
-                      <Button
-                        size="icon-sm"
-                        variant="ghost"
-                        onClick={() => setEditingTool(tool.toolName)}
-                        aria-label={`Configure ${tool.toolName} permissions`}
-                        className="size-7 text-muted-foreground/60 hover:text-foreground"
-                      >
-                        <Settings2Icon className="size-3.5" />
-                      </Button>
+                <div key={group.serverId} className="flex flex-col">
+                  <div className="grid grid-cols-[minmax(0,1fr)_5rem_5rem_2.5rem] items-center gap-3 px-3 py-2.5 sm:px-4">
+                    <div className="flex min-w-0 items-center gap-2.5">
+                      {group.serverIconPath ? (
+                        <img
+                          src={group.serverIconPath}
+                          alt=""
+                          className="size-4 shrink-0 rounded-sm"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <ServerIcon className="size-4 shrink-0 text-muted-foreground" />
+                      )}
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">{group.serverName}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {group.tools.length} tool{group.tools.length === 1 ? '' : 's'}
+                        </p>
+                      </div>
                     </div>
-                  ) : (
-                    <div className="size-7" />
-                  )}
-                  <PermissionSelect
-                    value={permission}
-                    onChange={(value) => handlePermissionChange(tool.toolName, value)}
-                    includeDeny
-                    disabled={isMutating}
-                  />
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
-      {Array.from(mcpToolsByServer.entries()).map(([serverName, tools]) => (
-        <div key={serverName} className="space-y-1.5">
-          <p className="text-xs font-medium text-muted-foreground">{serverName}</p>
-          <div className="overflow-hidden rounded-md border border-border/50">
-            {tools.map((tool) => {
-              const permission = getGlobalPermission(tool.toolName);
-              return (
-                <div
-                  key={tool.toolName}
-                  className="flex items-center gap-3 border-b border-border/40 px-3 py-2.5 last:border-b-0"
-                >
-                  {(() => {
-                    const icon = mcpToolMetaByTool.get(tool.toolName);
-                    const iconPath = icon?.toolIconPath ?? icon?.serverIconPath;
-                    if (!iconPath) return null;
-                    return (
-                      <img
-                        src={iconPath}
-                        alt=""
-                        className="size-4 shrink-0 rounded-sm"
-                        loading="lazy"
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 w-full justify-start px-2 text-muted-foreground hover:text-foreground"
+                      onClick={() =>
+                        setEditingTarget({
+                          type: 'toolset',
+                          toolsetId: `mcp:${group.serverId}`,
+                          displayName: group.serverName,
+                          mcpTools: group.tools.map((tool) => ({
+                            toolName: tool.toolName,
+                            displayName: tool.displayName,
+                          })),
+                        })
+                      }
+                    >
+                      <Settings2Icon className="size-3.5" />
+                      Settings
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 w-full justify-start px-2 text-muted-foreground hover:text-foreground"
+                      onClick={() =>
+                        setExpandedServers((current) => ({
+                          ...current,
+                          [group.serverId]: !isExpanded,
+                        }))
+                      }
+                    >
+                      {isExpanded ? (
+                        <ChevronDownIcon className="size-3.5" />
+                      ) : (
+                        <ChevronRightIcon className="size-3.5" />
+                      )}
+                      {isExpanded ? 'Hide' : 'Show'}
+                    </Button>
+                    <div className="flex w-10 justify-end">
+                      <Switch
+                        checked={getEnabled('toolset', `mcp:${group.serverId}`)}
+                        onCheckedChange={(checked) =>
+                          updateEnabled('toolset', `mcp:${group.serverId}`, checked)
+                        }
+                        disabled={isMutating}
                       />
-                    );
-                  })()}
-                  <p className="flex-1 font-mono text-sm">{tool.displayName}</p>
-                  <PermissionSelect
-                    value={permission}
-                    onChange={(value) => handlePermissionChange(tool.toolName, value)}
-                    includeDeny
-                    disabled={isMutating}
-                  />
+                    </div>
+                  </div>
+
+                  {isExpanded && (
+                    <div className="divide-y divide-border/40 border-t border-border/40">
+                      {group.tools.map((tool) => (
+                        <ToolRow
+                          key={tool.toolName}
+                          name={tool.displayName}
+                          iconPath={tool.iconPath}
+                          enabled={getEnabled('mcp_tool', tool.toolName)}
+                          reserveMiddleSlot
+                          isNested
+                          onConfigure={() =>
+                            setEditingTarget({
+                              type: 'tool',
+                              toolName: tool.toolName,
+                              displayName: tool.displayName,
+                              enabledScope: 'mcp_tool',
+                            })
+                          }
+                          onToggleEnabled={(checked) =>
+                            updateEnabled('mcp_tool', tool.toolName, checked)
+                          }
+                          isMutating={isMutating}
+                        />
+                      ))}
+                    </div>
+                  )}
                 </div>
               );
             })}
           </div>
-        </div>
-      ))}
+        </SectionCard>
+      )}
 
-      {pluginTools.length > 0 && (
-        <div className="space-y-1.5">
-          <p className="text-xs font-medium text-muted-foreground">Providers</p>
-          <div className="overflow-hidden rounded-md border border-border/50">
-            {pluginTools.map((tool) => {
-              const permission = getGlobalPermission(tool.toolName);
-              return (
-                <div
-                  key={tool.toolName}
-                  className="flex items-center gap-3 border-b border-border/40 px-3 py-2.5 last:border-b-0"
-                >
-                  <p className="flex-1 text-sm">{tool.displayName}</p>
-                  <PermissionSelect
-                    value={permission}
-                    onChange={(value) => handlePermissionChange(tool.toolName, value)}
-                    includeDeny
-                    disabled={isMutating}
-                  />
-                </div>
-              );
-            })}
+      {((visibleStitch && stitchTools.length === 0) || !visibleStitch) &&
+        ((visibleProviders && pluginTools.length === 0) || !visibleProviders) &&
+        ((visibleMcp && filteredMcpGroups.length === 0) || !visibleMcp) && (
+          <div className="rounded-lg border border-dashed border-border/70 px-4 py-8 text-center">
+            <WrenchIcon className="mx-auto mb-2 size-4 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">No tools match your current filters.</p>
           </div>
-        </div>
-      )}
+        )}
 
-      {filteredTools.length === 0 && (
-        <p className="text-sm text-muted-foreground">No tools match &ldquo;{search}&rdquo;.</p>
-      )}
+      <p className="text-xs text-muted-foreground">
+        Tip: use <span className="font-medium text-foreground">Settings</span> to configure ask,
+        allow, deny, and path/command rules.
+      </p>
     </div>
   );
 }
 
-export function PermissionsSettings() {
+export function ToolsSettings() {
   return (
     <React.Suspense fallback={<div className="text-sm text-muted-foreground">Loading...</div>}>
-      <PermissionsContent />
+      <ToolsContent />
     </React.Suspense>
   );
 }

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -1,11 +1,4 @@
-import {
-  ChevronDownIcon,
-  ChevronRightIcon,
-  SearchIcon,
-  ServerIcon,
-  Settings2Icon,
-  WrenchIcon,
-} from 'lucide-react';
+import { SearchIcon, ServerIcon, Settings2Icon, WrenchIcon } from 'lucide-react';
 import * as React from 'react';
 import { toast } from 'sonner';
 
@@ -13,11 +6,13 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { PermissionPolicyEditor } from './permissions/permission-policy-editor';
 
+import { ConnectorIcon } from '@/components/connectors/connector-icon';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import {
   knownMcpToolsQueryOptions,
+  knownToolsetsQueryOptions,
   knownToolsQueryOptions,
   toolEnabledStatesQueryOptions,
   useSetToolEnabledState,
@@ -35,10 +30,12 @@ type EditingTarget =
       type: 'toolset';
       toolsetId: string;
       displayName: string;
-      mcpTools: { toolName: string; displayName: string }[];
+      subtitle: string;
+      tools: { toolName: string; displayName: string }[];
+      perToolEnabledScope?: 'tool' | 'mcp_tool';
     };
 
-type ScopeFilter = 'all' | 'stitch' | 'providers' | 'mcp';
+type ScopeFilter = 'stitch' | 'native' | 'connectors' | 'mcp';
 
 type ToolRowProps = {
   name: string;
@@ -51,6 +48,17 @@ type ToolRowProps = {
   isMutating: boolean;
   reserveMiddleSlot?: boolean;
   isNested?: boolean;
+};
+
+type ToolsetRowProps = {
+  name: string;
+  description: string;
+  icon?: React.ReactNode;
+  enabled: boolean;
+  onConfigure: () => void;
+  onToggleEnabled: (enabled: boolean) => void;
+  isMutating: boolean;
+  settingsAlign?: 'start' | 'end';
 };
 
 function ToolRow({
@@ -98,6 +106,44 @@ function ToolRow({
   );
 }
 
+function ToolsetRow({
+  name,
+  description,
+  icon,
+  enabled,
+  onConfigure,
+  onToggleEnabled,
+  isMutating,
+  settingsAlign = 'start',
+}: ToolsetRowProps) {
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_5rem_2.5rem] items-center gap-3 px-3 py-2.5 sm:px-4">
+      <div className="flex min-w-0 items-center gap-2.5">
+        {icon ?? <ServerIcon className="size-4 shrink-0 text-muted-foreground" />}
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{name}</p>
+          <p className="truncate text-xs text-muted-foreground">{description}</p>
+        </div>
+      </div>
+      <Button
+        size="sm"
+        variant="ghost"
+        onClick={onConfigure}
+        className={cn(
+          'h-7 w-full px-2 text-muted-foreground hover:text-foreground',
+          settingsAlign === 'end' ? 'justify-end' : 'justify-start',
+        )}
+      >
+        <Settings2Icon className="size-3.5" />
+        Settings
+      </Button>
+      <div className="flex w-10 justify-end">
+        <Switch checked={enabled} onCheckedChange={onToggleEnabled} disabled={isMutating} />
+      </div>
+    </div>
+  );
+}
+
 function SectionCard({
   title,
   description,
@@ -128,13 +174,13 @@ function SectionCard({
 function ToolsContent() {
   const { data: knownTools } = useSuspenseQuery(knownToolsQueryOptions);
   const { data: knownMcpTools } = useSuspenseQuery(knownMcpToolsQueryOptions);
+  const { data: knownToolsets } = useSuspenseQuery(knownToolsetsQueryOptions);
   const { data: enabledStates } = useSuspenseQuery(toolEnabledStatesQueryOptions);
   const setToolEnabledState = useSetToolEnabledState();
 
   const [search, setSearch] = React.useState('');
-  const [scope, setScope] = React.useState<ScopeFilter>('all');
+  const [scope, setScope] = React.useState<ScopeFilter>('stitch');
   const [editingTarget, setEditingTarget] = React.useState<EditingTarget | null>(null);
-  const [expandedServers, setExpandedServers] = React.useState<Record<string, boolean>>({});
 
   const mcpToolMetaByName = React.useMemo(() => {
     return new Map(
@@ -185,15 +231,17 @@ function ToolsContent() {
       );
     });
 
-  const pluginTools = knownTools
-    .filter((tool) => tool.toolType === 'plugin')
-    .filter((tool) => {
-      if (!query) return true;
-      return (
-        tool.displayName.toLowerCase().includes(query) ||
-        tool.toolName.toLowerCase().includes(query)
-      );
-    });
+  const filteredToolsets = knownToolsets.filter((toolset) => {
+    if (!query) return true;
+    return (
+      toolset.name.toLowerCase().includes(query) ||
+      toolset.id.toLowerCase().includes(query) ||
+      toolset.description.toLowerCase().includes(query)
+    );
+  });
+
+  const nativeToolsets = filteredToolsets.filter((toolset) => toolset.source === 'native');
+  const connectorToolsets = filteredToolsets.filter((toolset) => toolset.source === 'connector');
 
   const mcpToolsetGroups = React.useMemo(() => {
     const groups = new Map<
@@ -263,14 +311,18 @@ function ToolsContent() {
     })
     .filter((group) => group.tools.length > 0);
 
-  const visibleStitch = scope === 'all' || scope === 'stitch';
-  const visibleProviders = scope === 'all' || scope === 'providers';
-  const visibleMcp = scope === 'all' || scope === 'mcp';
+  const visibleStitch = scope === 'stitch';
+  const visibleNative = scope === 'native';
+  const visibleConnectors = scope === 'connectors';
+  const visibleMcp = scope === 'mcp';
 
   const enabledCount =
     (visibleStitch ? stitchTools.filter((tool) => getEnabled('tool', tool.toolName)).length : 0) +
-    (visibleProviders
-      ? pluginTools.filter((tool) => getEnabled('toolset', tool.toolName)).length
+    (visibleNative
+      ? nativeToolsets.filter((toolset) => getEnabled('toolset', toolset.id)).length
+      : 0) +
+    (visibleConnectors
+      ? connectorToolsets.filter((toolset) => getEnabled('toolset', toolset.id)).length
       : 0) +
     (visibleMcp
       ? filteredMcpGroups.reduce((count, group) => {
@@ -284,7 +336,8 @@ function ToolsContent() {
 
   const totalCount =
     (visibleStitch ? stitchTools.length : 0) +
-    (visibleProviders ? pluginTools.length : 0) +
+    (visibleNative ? nativeToolsets.length : 0) +
+    (visibleConnectors ? connectorToolsets.length : 0) +
     (visibleMcp
       ? filteredMcpGroups.reduce((count, group) => count + 1 + group.tools.length, 0)
       : 0);
@@ -323,7 +376,7 @@ function ToolsContent() {
           <SearchIcon className="absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
             className="pl-8"
-            placeholder="Search by tool or MCP server..."
+            placeholder="Search by tool, toolset, or MCP server..."
             value={search}
             onChange={(event) => setSearch(event.target.value)}
           />
@@ -332,9 +385,9 @@ function ToolsContent() {
         <div className="flex flex-wrap gap-1.5">
           {(
             [
-              { id: 'all', label: 'All tools' },
               { id: 'stitch', label: 'Core tools' },
-              { id: 'providers', label: 'Provider tools' },
+              { id: 'native', label: 'Native toolsets' },
+              { id: 'connectors', label: 'Connector tools' },
               { id: 'mcp', label: 'MCP servers' },
             ] as const
           ).map((option) => (
@@ -380,29 +433,69 @@ function ToolsContent() {
         </SectionCard>
       )}
 
-      {visibleProviders && pluginTools.length > 0 && (
+      {visibleNative && nativeToolsets.length > 0 && (
         <SectionCard
-          title="Provider tools"
-          description="Tool integrations shipped by model providers"
-          count={pluginTools.length}
+          title="Native toolsets"
+          description="Built-in toolsets available in Stitch"
+          count={nativeToolsets.length}
         >
           <div className="divide-y divide-border/40">
-            {pluginTools.map((tool) => (
-              <ToolRow
-                key={tool.toolName}
-                name={tool.displayName}
-                subtitle="Provider toolset"
-                technicalName={tool.toolName}
-                enabled={getEnabled('toolset', tool.toolName)}
+            {nativeToolsets.map((toolset) => (
+              <ToolsetRow
+                key={toolset.id}
+                name={toolset.name}
+                description={toolset.description}
+                enabled={getEnabled('toolset', toolset.id)}
+                settingsAlign="end"
                 onConfigure={() =>
                   setEditingTarget({
-                    type: 'tool',
-                    toolName: tool.toolName,
-                    displayName: tool.displayName,
-                    enabledScope: 'toolset',
+                    type: 'toolset',
+                    toolsetId: toolset.id,
+                    displayName: toolset.name,
+                    subtitle: 'Native toolset',
+                    tools: toolset.tools,
                   })
                 }
-                onToggleEnabled={(checked) => updateEnabled('toolset', tool.toolName, checked)}
+                onToggleEnabled={(checked) => updateEnabled('toolset', toolset.id, checked)}
+                isMutating={isMutating}
+              />
+            ))}
+          </div>
+        </SectionCard>
+      )}
+
+      {visibleConnectors && connectorToolsets.length > 0 && (
+        <SectionCard
+          title="Connector tools"
+          description="Toolsets from connected apps like Google Workspace"
+          count={connectorToolsets.length}
+        >
+          <div className="divide-y divide-border/40">
+            {connectorToolsets.map((toolset) => (
+              <ToolsetRow
+                key={toolset.id}
+                name={toolset.name}
+                description={toolset.description}
+                icon={
+                  toolset.icon ? (
+                    <ConnectorIcon
+                      icon={toolset.icon}
+                      className="size-4 shrink-0 text-muted-foreground"
+                    />
+                  ) : undefined
+                }
+                enabled={getEnabled('toolset', toolset.id)}
+                settingsAlign="end"
+                onConfigure={() =>
+                  setEditingTarget({
+                    type: 'toolset',
+                    toolsetId: toolset.id,
+                    displayName: toolset.name,
+                    subtitle: 'Connector toolset',
+                    tools: toolset.tools,
+                  })
+                }
+                onToggleEnabled={(checked) => updateEnabled('toolset', toolset.id, checked)}
                 isMutating={isMutating}
               />
             ))}
@@ -413,16 +506,14 @@ function ToolsContent() {
       {visibleMcp && filteredMcpGroups.length > 0 && (
         <SectionCard
           title="MCP servers"
-          description="Enable entire servers or fine-tune individual MCP tools"
+          description="Enable entire servers and open settings to manage server tools"
           count={filteredMcpGroups.length}
         >
           <div className="divide-y divide-border/40">
             {filteredMcpGroups.map((group) => {
-              const isExpanded = query.length > 0 || expandedServers[group.serverId] === true;
-
               return (
                 <div key={group.serverId} className="flex flex-col">
-                  <div className="grid grid-cols-[minmax(0,1fr)_5rem_5rem_2.5rem] items-center gap-3 px-3 py-2.5 sm:px-4">
+                  <div className="grid grid-cols-[minmax(0,1fr)_5rem_2.5rem] items-center gap-3 px-3 py-2.5 sm:px-4">
                     <div className="flex min-w-0 items-center gap-2.5">
                       {group.serverIconPath ? (
                         <img
@@ -450,7 +541,9 @@ function ToolsContent() {
                           type: 'toolset',
                           toolsetId: `mcp:${group.serverId}`,
                           displayName: group.serverName,
-                          mcpTools: group.tools.map((tool) => ({
+                          subtitle: 'MCP server',
+                          perToolEnabledScope: 'mcp_tool',
+                          tools: group.tools.map((tool) => ({
                             toolName: tool.toolName,
                             displayName: tool.displayName,
                           })),
@@ -459,24 +552,6 @@ function ToolsContent() {
                     >
                       <Settings2Icon className="size-3.5" />
                       Settings
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="h-7 w-full justify-start px-2 text-muted-foreground hover:text-foreground"
-                      onClick={() =>
-                        setExpandedServers((current) => ({
-                          ...current,
-                          [group.serverId]: !isExpanded,
-                        }))
-                      }
-                    >
-                      {isExpanded ? (
-                        <ChevronDownIcon className="size-3.5" />
-                      ) : (
-                        <ChevronRightIcon className="size-3.5" />
-                      )}
-                      {isExpanded ? 'Hide' : 'Show'}
                     </Button>
                     <div className="flex w-10 justify-end">
                       <Switch
@@ -488,33 +563,6 @@ function ToolsContent() {
                       />
                     </div>
                   </div>
-
-                  {isExpanded && (
-                    <div className="divide-y divide-border/40 border-t border-border/40">
-                      {group.tools.map((tool) => (
-                        <ToolRow
-                          key={tool.toolName}
-                          name={tool.displayName}
-                          iconPath={tool.iconPath}
-                          enabled={getEnabled('mcp_tool', tool.toolName)}
-                          reserveMiddleSlot
-                          isNested
-                          onConfigure={() =>
-                            setEditingTarget({
-                              type: 'tool',
-                              toolName: tool.toolName,
-                              displayName: tool.displayName,
-                              enabledScope: 'mcp_tool',
-                            })
-                          }
-                          onToggleEnabled={(checked) =>
-                            updateEnabled('mcp_tool', tool.toolName, checked)
-                          }
-                          isMutating={isMutating}
-                        />
-                      ))}
-                    </div>
-                  )}
                 </div>
               );
             })}
@@ -523,7 +571,8 @@ function ToolsContent() {
       )}
 
       {((visibleStitch && stitchTools.length === 0) || !visibleStitch) &&
-        ((visibleProviders && pluginTools.length === 0) || !visibleProviders) &&
+        ((visibleNative && nativeToolsets.length === 0) || !visibleNative) &&
+        ((visibleConnectors && connectorToolsets.length === 0) || !visibleConnectors) &&
         ((visibleMcp && filteredMcpGroups.length === 0) || !visibleMcp) && (
           <div className="rounded-lg border border-dashed border-border/70 px-4 py-8 text-center">
             <WrenchIcon className="mx-auto mb-2 size-4 text-muted-foreground" />

--- a/apps/web/src/components/settings/permissions/filtering.ts
+++ b/apps/web/src/components/settings/permissions/filtering.ts
@@ -1,0 +1,47 @@
+export type KnownToolSummary = {
+  toolType: 'stitch' | 'mcp' | 'plugin';
+  toolName: string;
+  displayName: string;
+};
+
+export type KnownToolsetSummary = {
+  id: string;
+  name: string;
+  description: string;
+  tools: { toolName: string; displayName: string }[];
+};
+
+function includesQuery(value: string, query: string): boolean {
+  return value.toLowerCase().includes(query);
+}
+
+export function filterCoreTools(tools: KnownToolSummary[], query: string): KnownToolSummary[] {
+  return tools
+    .filter((tool) => tool.toolType === 'stitch')
+    .filter((tool) => {
+      if (!query) return true;
+      return includesQuery(tool.displayName, query) || includesQuery(tool.toolName, query);
+    });
+}
+
+export function filterToolsetsByQuery<T extends KnownToolsetSummary>(
+  toolsets: T[],
+  query: string,
+): T[] {
+  return toolsets.filter((toolset) => {
+    if (!query) return true;
+
+    const matchesToolset =
+      includesQuery(toolset.name, query) ||
+      includesQuery(toolset.id, query) ||
+      includesQuery(toolset.description, query);
+
+    if (matchesToolset) {
+      return true;
+    }
+
+    return toolset.tools.some(
+      (tool) => includesQuery(tool.displayName, query) || includesQuery(tool.toolName, query),
+    );
+  });
+}

--- a/apps/web/src/components/settings/permissions/permission-policy-editor.tsx
+++ b/apps/web/src/components/settings/permissions/permission-policy-editor.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon, FolderOpenIcon, Trash2Icon } from 'lucide-react';
+import { ArrowLeftIcon, FolderOpenIcon, Settings2Icon, Trash2Icon } from 'lucide-react';
 import * as React from 'react';
 import { toast } from 'sonner';
 
@@ -12,6 +12,7 @@ import { PermissionSelect } from './permission-select';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import {
   toolPermissionsQueryOptions,
   useDeleteToolPermission,
@@ -20,19 +21,108 @@ import {
 
 const FILE_PATTERN_TOOLS = new Set(['read', 'edit', 'write', 'glob', 'grep']);
 const COMMAND_PATTERN_TOOLS = new Set(['bash']);
-export const PATTERN_POLICY_TOOLS = new Set([...FILE_PATTERN_TOOLS, ...COMMAND_PATTERN_TOOLS]);
+const PATTERN_POLICY_TOOLS = new Set([...FILE_PATTERN_TOOLS, ...COMMAND_PATTERN_TOOLS]);
+
+type PermissionTarget =
+  | {
+      type: 'tool';
+      toolName: string;
+      displayName: string;
+      enabledScope: 'tool' | 'toolset' | 'mcp_tool';
+    }
+  | {
+      type: 'toolset';
+      toolsetId: string;
+      displayName: string;
+      mcpTools: { toolName: string; displayName: string }[];
+    };
 
 type PermissionPolicyEditorProps = {
-  toolName: string;
-  displayName: string;
+  target: PermissionTarget;
   onBack: () => void;
+  getEnabled: (scope: 'tool' | 'toolset' | 'mcp_tool', identifier: string) => boolean;
+  onToggleEnabled: (
+    scope: 'tool' | 'toolset' | 'mcp_tool',
+    identifier: string,
+    enabled: boolean,
+  ) => void;
 };
 
-export function PermissionPolicyEditor({
+function EditorHeader({
+  title,
+  subtitle,
+  enabled,
+  onBack,
+  onToggle,
+}: {
+  title: string;
+  subtitle: string;
+  enabled: boolean;
+  onBack: () => void;
+  onToggle: (enabled: boolean) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <Button variant="ghost" size="sm" onClick={onBack} className="h-7 w-fit px-2">
+        <ArrowLeftIcon className="size-3.5" />
+        Back to tools
+      </Button>
+
+      <div className="rounded-xl border border-border/60 bg-card/40 px-4 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold">{title}</p>
+            <p className="text-xs text-muted-foreground">{subtitle}</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">Enabled</span>
+            <Switch checked={enabled} onCheckedChange={onToggle} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-2">
+      <div>
+        <p className="text-sm font-semibold">{title}</p>
+        <p className="text-xs text-muted-foreground">{description}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function ToolPermissionEditor({
   toolName,
   displayName,
   onBack,
-}: PermissionPolicyEditorProps) {
+  enabledScope,
+  getEnabled,
+  onToggleEnabled,
+}: {
+  toolName: string;
+  displayName: string;
+  onBack: () => void;
+  enabledScope: 'tool' | 'toolset' | 'mcp_tool';
+  getEnabled: (scope: 'tool' | 'toolset' | 'mcp_tool', identifier: string) => boolean;
+  onToggleEnabled: (
+    scope: 'tool' | 'toolset' | 'mcp_tool',
+    identifier: string,
+    enabled: boolean,
+  ) => void;
+}) {
   const { data: permissions } = useSuspenseQuery(toolPermissionsQueryOptions);
   const upsertPermission = useUpsertToolPermission();
   const deletePermission = useDeleteToolPermission();
@@ -46,6 +136,7 @@ export function PermissionPolicyEditor({
   const globalPermission: ToolPermissionValue = globalRule?.permission ?? 'ask';
 
   const isFileTool = FILE_PATTERN_TOOLS.has(toolName);
+  const isPatternTool = PATTERN_POLICY_TOOLS.has(toolName);
   const isMutating = upsertPermission.isPending || deletePermission.isPending;
 
   const handleGlobalChange = (permission: ToolPermissionValue) => {
@@ -97,72 +188,78 @@ export function PermissionPolicyEditor({
   };
 
   return (
-    <div className="space-y-5">
-      <div className="flex items-center gap-2">
-        <Button variant="ghost" size="icon-sm" onClick={onBack} aria-label="Back to permissions">
-          <ArrowLeftIcon className="size-4" />
-        </Button>
-        <div>
-          <p className="text-sm font-semibold">{displayName} permissions</p>
-          <p className="text-xs text-muted-foreground">
-            Configure when this tool requires approval
-          </p>
-        </div>
-      </div>
+    <div className="space-y-6">
+      <EditorHeader
+        title={displayName}
+        subtitle={`Tool id: ${toolName}`}
+        enabled={getEnabled(enabledScope, toolName)}
+        onBack={onBack}
+        onToggle={(checked) => onToggleEnabled(enabledScope, toolName, checked)}
+      />
 
-      <div className="space-y-1.5">
-        <p className="text-xs font-medium text-muted-foreground">Default behavior</p>
-        <div className="flex items-center justify-between rounded-md border border-border/50 px-3 py-2">
-          <div>
-            <p className="text-sm">All uses</p>
-            <p className="text-xs text-muted-foreground">Applied when no specific rule matches</p>
+      <Section
+        title="Default behavior"
+        description="This permission is used when no path or command rule matches."
+      >
+        <div className="rounded-lg border border-border/60 bg-card/30 px-3 py-2.5">
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+            <div>
+              <p className="text-sm font-medium">All uses</p>
+              <p className="text-xs text-muted-foreground">
+                Choose allow, ask, or deny by default.
+              </p>
+            </div>
+            <PermissionSelect
+              value={globalPermission}
+              onChange={handleGlobalChange}
+              includeDeny
+              disabled={isMutating}
+            />
           </div>
-          <PermissionSelect
-            value={globalPermission}
-            onChange={handleGlobalChange}
-            includeDeny
-            disabled={isMutating}
-          />
         </div>
-      </div>
+      </Section>
 
-      {patternRules.length > 0 && (
-        <div className="space-y-1.5">
-          <p className="text-xs font-medium text-muted-foreground">Specific rules</p>
-          <div className="overflow-hidden rounded-md border border-border/50">
-            {patternRules.map((rule) => (
-              <div
-                key={rule.id}
-                className="flex items-center gap-3 border-b border-border/40 px-3 py-2.5 last:border-b-0"
-              >
-                <p className="flex-1 truncate font-mono text-xs text-muted-foreground">
-                  {rule.pattern}
-                </p>
-                <PermissionSelect
-                  value={rule.permission}
-                  onChange={(value) => handlePatternPermissionChange(rule, value)}
-                  includeDeny
-                  disabled={isMutating}
-                />
-                <Button
-                  size="icon-sm"
-                  variant="ghost"
-                  onClick={() => handleDeleteRule(rule)}
-                  disabled={isMutating}
-                  aria-label="Delete rule"
-                  className="shrink-0 text-muted-foreground/60 hover:text-destructive"
+      {isPatternTool && patternRules.length > 0 && (
+        <Section
+          title="Specific rules"
+          description="More specific patterns override the default behavior."
+        >
+          <div className="overflow-hidden rounded-lg border border-border/60">
+            <div className="divide-y divide-border/40">
+              {patternRules.map((rule) => (
+                <div
+                  key={rule.id}
+                  className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 px-3 py-2.5"
                 >
-                  <Trash2Icon className="size-3.5" />
-                </Button>
-              </div>
-            ))}
+                  <p className="truncate font-mono text-xs text-muted-foreground">{rule.pattern}</p>
+                  <PermissionSelect
+                    value={rule.permission}
+                    onChange={(value) => handlePatternPermissionChange(rule, value)}
+                    includeDeny
+                    disabled={isMutating}
+                  />
+                  <Button
+                    size="icon-sm"
+                    variant="ghost"
+                    onClick={() => handleDeleteRule(rule)}
+                    disabled={isMutating}
+                    aria-label="Delete rule"
+                    className="text-muted-foreground/70 hover:text-destructive"
+                  >
+                    <Trash2Icon className="size-3.5" />
+                  </Button>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
+        </Section>
       )}
 
-      {toolName === 'bash' && (
-        <div className="space-y-1.5">
-          <p className="text-xs font-medium text-muted-foreground">Common commands</p>
+      {isPatternTool && toolName === 'bash' && (
+        <Section
+          title="Common command presets"
+          description="Quickly allow common safe command patterns."
+        >
           <div className="flex flex-wrap gap-1.5">
             {BASH_COMMON_PRESETS.map((preset: BashPreset) => {
               const existing = patternRules.find((rule) => rule.pattern === preset.pattern);
@@ -201,49 +298,149 @@ export function PermissionPolicyEditor({
               );
             })}
           </div>
-        </div>
+        </Section>
       )}
 
-      <div className="space-y-1.5">
-        <p className="text-xs font-medium text-muted-foreground">
-          {isFileTool ? 'Add path rule' : 'Add command rule'}
-        </p>
-        <div className="flex gap-2">
-          <div className="relative flex-1">
-            <Input
-              value={newPattern}
-              onChange={(event) => setNewPattern(event.target.value)}
-              placeholder={isFileTool ? '/path/to/dir/*' : 'git *'}
-              className={isFileTool ? 'pr-8 font-mono text-xs' : 'font-mono text-xs'}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter') handleAddRule();
-              }}
-            />
-            {isFileTool && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                className="absolute top-1/2 right-1 -translate-y-1/2 text-muted-foreground"
-                onClick={handleBrowse}
-                aria-label="Browse for path"
-                tabIndex={-1}
-              >
-                <FolderOpenIcon className="size-3.5" />
-              </Button>
-            )}
+      {isPatternTool && (
+        <Section
+          title={isFileTool ? 'Add path rule' : 'Add command rule'}
+          description={
+            isFileTool
+              ? 'Add file and directory patterns that should use a specific permission.'
+              : 'Add command patterns that should use a specific permission.'
+          }
+        >
+          <div className="rounded-lg border border-border/60 bg-card/30 p-3">
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <div className="relative min-w-0 flex-1">
+                <Input
+                  value={newPattern}
+                  onChange={(event) => setNewPattern(event.target.value)}
+                  placeholder={isFileTool ? '/path/to/dir/*' : 'git *'}
+                  className={isFileTool ? 'pr-8 font-mono text-xs' : 'font-mono text-xs'}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') handleAddRule();
+                  }}
+                />
+                {isFileTool && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    className="absolute top-1/2 right-1 -translate-y-1/2 text-muted-foreground"
+                    onClick={handleBrowse}
+                    aria-label="Browse for path"
+                    tabIndex={-1}
+                  >
+                    <FolderOpenIcon className="size-3.5" />
+                  </Button>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <PermissionSelect
+                  value={newPermission}
+                  onChange={setNewPermission}
+                  includeDeny
+                  disabled={isMutating}
+                />
+                <Button
+                  size="sm"
+                  onClick={handleAddRule}
+                  disabled={!newPattern.trim() || isMutating}
+                >
+                  Add rule
+                </Button>
+              </div>
+            </div>
           </div>
-          <PermissionSelect
-            value={newPermission}
-            onChange={setNewPermission}
-            includeDeny
-            disabled={isMutating}
-          />
-          <Button size="sm" onClick={handleAddRule} disabled={!newPattern.trim() || isMutating}>
-            Add
-          </Button>
+        </Section>
+      )}
+    </div>
+  );
+}
+
+export function PermissionPolicyEditor({
+  target,
+  onBack,
+  getEnabled,
+  onToggleEnabled,
+}: PermissionPolicyEditorProps) {
+  const [editingMcpTool, setEditingMcpTool] = React.useState<{
+    toolName: string;
+    displayName: string;
+  } | null>(null);
+
+  if (editingMcpTool) {
+    return (
+      <ToolPermissionEditor
+        toolName={editingMcpTool.toolName}
+        displayName={editingMcpTool.displayName}
+        onBack={() => setEditingMcpTool(null)}
+        enabledScope="mcp_tool"
+        getEnabled={getEnabled}
+        onToggleEnabled={onToggleEnabled}
+      />
+    );
+  }
+
+  if (target.type === 'tool') {
+    return (
+      <ToolPermissionEditor
+        toolName={target.toolName}
+        displayName={target.displayName}
+        onBack={onBack}
+        enabledScope={target.enabledScope}
+        getEnabled={getEnabled}
+        onToggleEnabled={onToggleEnabled}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <EditorHeader
+        title={target.displayName}
+        subtitle="MCP server"
+        enabled={getEnabled('toolset', target.toolsetId)}
+        onBack={onBack}
+        onToggle={(checked) => onToggleEnabled('toolset', target.toolsetId, checked)}
+      />
+
+      <Section
+        title="Server tools"
+        description="Enable specific MCP tools and open settings for per-tool permission behavior."
+      >
+        <div className="overflow-hidden rounded-lg border border-border/60">
+          <div className="divide-y divide-border/40">
+            {target.mcpTools.map((tool) => (
+              <div
+                key={tool.toolName}
+                className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 px-3 py-2.5"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">{tool.displayName}</p>
+                  <p className="truncate font-mono text-xs text-muted-foreground">
+                    {tool.toolName}
+                  </p>
+                </div>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setEditingMcpTool(tool)}
+                  className="h-7 w-20 justify-center text-muted-foreground hover:text-foreground"
+                >
+                  <Settings2Icon className="size-3.5" />
+                  Settings
+                </Button>
+                <Switch
+                  checked={getEnabled('mcp_tool', tool.toolName)}
+                  onCheckedChange={(checked) => onToggleEnabled('mcp_tool', tool.toolName, checked)}
+                />
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      </Section>
     </div>
   );
 }

--- a/apps/web/src/components/settings/permissions/permission-policy-editor.tsx
+++ b/apps/web/src/components/settings/permissions/permission-policy-editor.tsx
@@ -34,7 +34,9 @@ type PermissionTarget =
       type: 'toolset';
       toolsetId: string;
       displayName: string;
-      mcpTools: { toolName: string; displayName: string }[];
+      subtitle: string;
+      tools: { toolName: string; displayName: string }[];
+      perToolEnabledScope?: 'tool' | 'mcp_tool';
     };
 
 type PermissionPolicyEditorProps = {
@@ -396,32 +398,32 @@ export function PermissionPolicyEditor({
     );
   }
 
+  const hasPerToolToggle = !!target.perToolEnabledScope;
+
   return (
     <div className="space-y-6">
       <EditorHeader
         title={target.displayName}
-        subtitle="MCP server"
+        subtitle={target.subtitle}
         enabled={getEnabled('toolset', target.toolsetId)}
         onBack={onBack}
         onToggle={(checked) => onToggleEnabled('toolset', target.toolsetId, checked)}
       />
 
-      <Section
-        title="Server tools"
-        description="Enable specific MCP tools and open settings for per-tool permission behavior."
-      >
+      <Section title="Toolset tools" description="Open settings for per-tool permission behavior.">
         <div className="overflow-hidden rounded-lg border border-border/60">
           <div className="divide-y divide-border/40">
-            {target.mcpTools.map((tool) => (
+            {target.tools.map((tool) => (
               <div
                 key={tool.toolName}
-                className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 px-3 py-2.5"
+                className={
+                  hasPerToolToggle
+                    ? 'grid grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 px-3 py-2.5'
+                    : 'grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 px-3 py-2.5'
+                }
               >
                 <div className="min-w-0">
                   <p className="truncate text-sm font-medium">{tool.displayName}</p>
-                  <p className="truncate font-mono text-xs text-muted-foreground">
-                    {tool.toolName}
-                  </p>
                 </div>
                 <Button
                   size="sm"
@@ -432,10 +434,19 @@ export function PermissionPolicyEditor({
                   <Settings2Icon className="size-3.5" />
                   Settings
                 </Button>
-                <Switch
-                  checked={getEnabled('mcp_tool', tool.toolName)}
-                  onCheckedChange={(checked) => onToggleEnabled('mcp_tool', tool.toolName, checked)}
-                />
+                {target.perToolEnabledScope
+                  ? (() => {
+                      const perToolEnabledScope = target.perToolEnabledScope;
+                      return (
+                        <Switch
+                          checked={getEnabled(perToolEnabledScope, tool.toolName)}
+                          onCheckedChange={(checked) =>
+                            onToggleEnabled(perToolEnabledScope, tool.toolName, checked)
+                          }
+                        />
+                      );
+                    })()
+                  : null}
               </div>
             ))}
           </div>

--- a/apps/web/src/lib/queries/tools.ts
+++ b/apps/web/src/lib/queries/tools.ts
@@ -1,7 +1,7 @@
 import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { ToolPermission, ToolPermissionValue } from '@stitch/shared/permissions/types';
-import type { ToolType } from '@stitch/shared/tools/types';
+import type { ToolEnabledScope, ToolEnabledState, ToolType } from '@stitch/shared/tools/types';
 
 import { serverFetch } from '@/lib/api';
 
@@ -25,6 +25,7 @@ export const toolKeys = {
   knownTools: () => [...toolKeys.all, 'known-tools'] as const,
   knownMcpTools: () => [...toolKeys.all, 'known-mcp-tools'] as const,
   permissions: () => [...toolKeys.all, 'permissions'] as const,
+  enabledStates: () => [...toolKeys.all, 'enabled-states'] as const,
 };
 
 export const knownToolsQueryOptions = queryOptions({
@@ -56,6 +57,17 @@ export const toolPermissionsQueryOptions = queryOptions({
     const res = await serverFetch('/config/permissions');
     if (!res.ok) throw new Error('Failed to fetch permissions');
     return res.json() as Promise<ToolPermission[]>;
+  },
+});
+
+export const toolEnabledStatesQueryOptions = queryOptions({
+  queryKey: toolKeys.enabledStates(),
+  staleTime: Infinity,
+  queryFn: async (): Promise<ToolEnabledState[]> => {
+    const res = await serverFetch('/config/tools/enabled');
+    if (!res.ok) throw new Error('Failed to fetch tool enabled states');
+    const data = (await res.json()) as { states: ToolEnabledState[] };
+    return data.states;
   },
 });
 
@@ -97,6 +109,34 @@ export function useDeleteToolPermission() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: toolKeys.permissions() });
+    },
+  });
+}
+
+export function useSetToolEnabledState() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: {
+      scope: ToolEnabledScope;
+      identifier: string;
+      enabled: boolean;
+    }) => {
+      const res = await serverFetch('/config/tools/enabled', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(err.error ?? 'Failed to update tool state');
+      }
+    },
+    onSuccess: () => {
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: toolKeys.enabledStates() }),
+        queryClient.invalidateQueries({ queryKey: toolKeys.knownTools() }),
+        queryClient.invalidateQueries({ queryKey: toolKeys.knownMcpTools() }),
+      ]);
     },
   });
 }

--- a/apps/web/src/lib/queries/tools.ts
+++ b/apps/web/src/lib/queries/tools.ts
@@ -1,5 +1,6 @@
 import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
 
+import type { ConnectorIconSource } from '@stitch/shared/connectors/types';
 import type { ToolPermission, ToolPermissionValue } from '@stitch/shared/permissions/types';
 import type { ToolEnabledScope, ToolEnabledState, ToolType } from '@stitch/shared/tools/types';
 
@@ -20,10 +21,23 @@ type KnownMcpTool = {
   toolIconPath?: string;
 };
 
+type KnownToolset = {
+  id: string;
+  name: string;
+  description: string;
+  icon: ConnectorIconSource | null;
+  source: 'native' | 'provider' | 'connector' | 'mcp';
+  toolCount: number;
+  hasInstructions: boolean;
+  promptCount: number;
+  tools: { toolName: string; displayName: string }[];
+};
+
 export const toolKeys = {
   all: ['tools-config'] as const,
   knownTools: () => [...toolKeys.all, 'known-tools'] as const,
   knownMcpTools: () => [...toolKeys.all, 'known-mcp-tools'] as const,
+  knownToolsets: () => [...toolKeys.all, 'known-toolsets'] as const,
   permissions: () => [...toolKeys.all, 'permissions'] as const,
   enabledStates: () => [...toolKeys.all, 'enabled-states'] as const,
 };
@@ -47,6 +61,17 @@ export const knownMcpToolsQueryOptions = queryOptions({
     if (!res.ok) throw new Error('Failed to fetch MCP tools');
     const data = (await res.json()) as { tools: KnownMcpTool[] };
     return data.tools;
+  },
+});
+
+export const knownToolsetsQueryOptions = queryOptions({
+  queryKey: toolKeys.knownToolsets(),
+  staleTime: Infinity,
+  queryFn: async (): Promise<KnownToolset[]> => {
+    const res = await serverFetch('/config/toolsets');
+    if (!res.ok) throw new Error('Failed to fetch toolsets');
+    const data = (await res.json()) as { toolsets: KnownToolset[] };
+    return data.toolsets;
   },
 });
 
@@ -136,6 +161,7 @@ export function useSetToolEnabledState() {
         queryClient.invalidateQueries({ queryKey: toolKeys.enabledStates() }),
         queryClient.invalidateQueries({ queryKey: toolKeys.knownTools() }),
         queryClient.invalidateQueries({ queryKey: toolKeys.knownMcpTools() }),
+        queryClient.invalidateQueries({ queryKey: toolKeys.knownToolsets() }),
       ]);
     },
   });

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -46,7 +46,7 @@ const settingsSearchSchema = z.object({
       'key-locations',
       'providers',
       'models',
-      'permissions',
+      'tools',
       'mcp-servers',
       'memory',
     ])

--- a/packages/server/__test__/tools/runtime-filtering.test.ts
+++ b/packages/server/__test__/tools/runtime-filtering.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { createTools } from '@/tools/runtime/registry.js';
+import { ToolsetManager } from '@/tools/toolsets/manager.js';
+import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
+import type { Toolset } from '@/tools/toolsets/types.js';
+import type { ToolEnabledScope } from '@stitch/shared/tools/types';
+import type { Tool } from 'ai';
+
+const mockIsToolEnabled = vi.fn<(opts: { scope: ToolEnabledScope; identifier: string }) => Promise<boolean>>(
+  async () => true,
+);
+const mockGetDisabledToolIdentifiers = vi.fn<(scope: ToolEnabledScope) => Promise<Set<string>>>(
+  async () => new Set<string>(),
+);
+
+vi.mock('@/db/client.js', () => ({
+  isDbInitialized: () => false,
+}));
+
+vi.mock('@/tools/enabled-service.js', () => ({
+  isToolEnabled: (opts: { scope: ToolEnabledScope; identifier: string }) => mockIsToolEnabled(opts),
+  getDisabledToolIdentifiers: (scope: ToolEnabledScope) => mockGetDisabledToolIdentifiers(scope),
+}));
+
+function clearToolsets(): void {
+  for (const id of listToolsetIds()) {
+    unregisterToolset(id);
+  }
+}
+
+function makeTool(description: string): Tool {
+  return { description, parameters: { type: 'object', properties: {} } } as unknown as Tool;
+}
+
+describe('runtime tool filtering', () => {
+  beforeEach(() => {
+    clearToolsets();
+    mockIsToolEnabled.mockReset();
+    mockGetDisabledToolIdentifiers.mockReset();
+    mockIsToolEnabled.mockResolvedValue(true);
+    mockGetDisabledToolIdentifiers.mockResolvedValue(new Set<string>());
+  });
+
+  test('filters disabled core tools when building runtime tool map', async () => {
+    mockGetDisabledToolIdentifiers.mockImplementation(async (scope: ToolEnabledScope) =>
+      scope === 'tool' ? new Set(['bash']) : new Set<string>(),
+    );
+
+    const tools = await createTools({
+      sessionId: 'ses_test' as never,
+      messageId: 'msg_test' as never,
+      streamRunId: 'run_test',
+    });
+
+    expect(Object.keys(tools)).not.toContain('bash');
+    expect(Object.keys(tools)).toContain('read');
+  });
+
+  test('blocks activation for disabled toolsets', async () => {
+    registerToolset({
+      id: 'toolset-disabled',
+      name: 'Disabled Toolset',
+      description: 'Should not activate',
+      tools: () => [{ name: 'disabled_tool', description: 'disabled' }],
+      activate: async () => ({ disabled_tool: makeTool('disabled') }),
+    } satisfies Toolset);
+
+    mockIsToolEnabled.mockResolvedValue(false);
+
+    const manager = new ToolsetManager({
+      sessionId: 'ses_test' as never,
+      messageId: 'msg_test' as never,
+      streamRunId: 'run_test',
+    });
+
+    const result = await manager.activate('toolset-disabled');
+
+    expect(result).toBeNull();
+    expect(manager.getActiveTools()).toEqual({});
+  });
+
+  test('filters disabled mcp tools when activating mcp toolsets', async () => {
+    registerToolset({
+      id: 'mcp:test-server',
+      name: 'Test MCP',
+      description: 'MCP test toolset',
+      tools: () => [
+        { name: 'mcp_alpha', description: 'alpha' },
+        { name: 'mcp_beta', description: 'beta' },
+      ],
+      activate: async () => ({
+        mcp_alpha: makeTool('alpha'),
+        mcp_beta: makeTool('beta'),
+      }),
+    } satisfies Toolset);
+
+    mockGetDisabledToolIdentifiers.mockImplementation(async (scope: ToolEnabledScope) =>
+      scope === 'mcp_tool' ? new Set(['mcp_alpha']) : new Set<string>(),
+    );
+
+    const manager = new ToolsetManager({
+      sessionId: 'ses_test' as never,
+      messageId: 'msg_test' as never,
+      streamRunId: 'run_test',
+    });
+
+    const result = await manager.activate('mcp:test-server');
+    const activeTools = manager.getActiveTools();
+
+    expect(result?.toolNames).toEqual(['mcp_beta']);
+    expect(Object.keys(activeTools)).toEqual(['mcp_beta']);
+  });
+});

--- a/packages/server/drizzle/0018_sparkling_firebrand.sql
+++ b/packages/server/drizzle/0018_sparkling_firebrand.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `tool_enabled` (
+	`scope` text NOT NULL,
+	`identifier` text NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `tool_enabled_scope_identifier_uidx` ON `tool_enabled` (`scope`,`identifier`);

--- a/packages/server/drizzle/meta/0018_snapshot.json
+++ b/packages/server/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,2403 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2fe8af0b-b1fc-4a62-a02f-6dbacac519fb",
+  "prevId": "747c191b-92a6-48bb-a408-a6c170d1d969",
+  "tables": {
+    "agenda_item_events": {
+      "name": "agenda_item_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_item_events_item_id_idx": {
+          "name": "agenda_item_events_item_id_idx",
+          "columns": ["item_id"],
+          "isUnique": false
+        },
+        "agenda_item_events_created_at_idx": {
+          "name": "agenda_item_events_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_item_events_item_id_agenda_items_id_fk": {
+          "name": "agenda_item_events_item_id_agenda_items_id_fk",
+          "tableFrom": "agenda_item_events",
+          "tableTo": "agenda_items",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_item_events_type_check": {
+          "name": "agenda_item_events_type_check",
+          "value": "\"agenda_item_events\".\"type\" in ('created', 'status_change', 'updated', 'comment')"
+        }
+      }
+    },
+    "agenda_items": {
+      "name": "agenda_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'todo'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_items_list_id_idx": {
+          "name": "agenda_items_list_id_idx",
+          "columns": ["list_id"],
+          "isUnique": false
+        },
+        "agenda_items_status_idx": {
+          "name": "agenda_items_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "agenda_items_due_at_idx": {
+          "name": "agenda_items_due_at_idx",
+          "columns": ["due_at"],
+          "isUnique": false
+        },
+        "agenda_items_created_at_idx": {
+          "name": "agenda_items_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_items_list_id_agenda_lists_id_fk": {
+          "name": "agenda_items_list_id_agenda_lists_id_fk",
+          "tableFrom": "agenda_items",
+          "tableTo": "agenda_lists",
+          "columnsFrom": ["list_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_items_type_check": {
+          "name": "agenda_items_type_check",
+          "value": "\"agenda_items\".\"type\" in ('todo', 'reminder', 'checkup')"
+        },
+        "agenda_items_status_check": {
+          "name": "agenda_items_status_check",
+          "value": "\"agenda_items\".\"status\" in ('open', 'in_progress', 'done', 'cancelled')"
+        },
+        "agenda_items_priority_check": {
+          "name": "agenda_items_priority_check",
+          "value": "\"agenda_items\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      }
+    },
+    "agenda_lists": {
+      "name": "agenda_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_lists_name_uidx": {
+          "name": "agenda_lists_name_uidx",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "agenda_lists_created_at_idx": {
+          "name": "agenda_lists_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": ["connector_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lance_migrations": {
+      "name": "lance_migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "prev_id": {
+          "name": "prev_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'applied'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "is_attributable": {
+          "name": "is_attributable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_index": {
+          "name": "attempt_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_run_id_idx": {
+          "name": "llm_usage_events_run_id_idx",
+          "columns": ["run_id"],
+          "isUnique": false
+        },
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ollama_models": {
+      "name": "ollama_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_limit": {
+          "name": "input_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_limit": {
+          "name": "output_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_cost_per_million": {
+          "name": "input_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_cost_per_million": {
+          "name": "output_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_cost_per_million": {
+          "name": "cache_read_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_per_million": {
+          "name": "cache_write_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_tool_calls": {
+          "name": "supports_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_vision": {
+          "name": "supports_vision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_reasoning": {
+          "name": "supports_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permission_responses": {
+      "name": "permission_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_reminder": {
+          "name": "system_reminder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_responses_session_id_sessions_id_fk": {
+          "name": "permission_responses_session_id_sessions_id_fk",
+          "tableFrom": "permission_responses",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_messages": {
+      "name": "queued_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "queued_messages_session_id_sessions_id_fk": {
+          "name": "queued_messages_session_id_sessions_id_fk",
+          "tableFrom": "queued_messages",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_analyses": {
+      "name": "recording_analyses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_sections": {
+          "name": "topic_sections",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockers": {
+          "name": "blockers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_provider_id": {
+          "name": "transcription_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_model_id": {
+          "name": "transcription_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_provider_id": {
+          "name": "analysis_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_model_id": {
+          "name": "analysis_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recording_analyses_recording_id_uidx": {
+          "name": "recording_analyses_recording_id_uidx",
+          "columns": ["recording_id"],
+          "isUnique": true
+        },
+        "recording_analyses_status_idx": {
+          "name": "recording_analyses_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recording_analyses_recording_id_recordings_id_fk": {
+          "name": "recording_analyses_recording_id_recordings_id_fk",
+          "tableFrom": "recording_analyses",
+          "tableTo": "recordings",
+          "columnsFrom": ["recording_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recording_analyses_status_check": {
+          "name": "recording_analyses_status_check",
+          "value": "\"recording_analyses\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "recordings": {
+      "name": "recordings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'recording'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'audio/ogg'"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recordings_created_at_idx": {
+          "name": "recordings_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "recordings_status_idx": {
+          "name": "recordings_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recordings_status_check": {
+          "name": "recordings_status_check",
+          "value": "\"recordings\".\"status\" in ('recording', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": ["job_id"],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": ["key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "queue_enabled": {
+          "name": "queue_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": ["key"],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": ["next_run_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_automation_id_automations_id_fk": {
+          "name": "sessions_automation_id_automations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "automations",
+          "columnsFrom": ["automation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": ["parent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_enabled": {
+      "name": "tool_enabled",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_enabled_scope_identifier_uidx": {
+          "name": "tool_enabled_scope_identifier_uidx",
+          "columns": ["scope", "identifier"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": ["tool_name", "pattern"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1776305872769,
       "tag": "0017_grey_doctor_spectrum",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1776372719576,
+      "tag": "0018_sparkling_firebrand",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -28,6 +28,7 @@ import type {
   PermissionSuggestion,
 } from '@stitch/shared/permissions/types';
 import type { QuestionInfo, QuestionRequestStatus } from '@stitch/shared/questions/types';
+import type { ToolEnabledScope } from '@stitch/shared/tools/types';
 
 /** @deprecated Type field is no longer used but kept for DB compatibility */
 type AgendaItemType = 'todo' | 'reminder' | 'checkup';
@@ -284,6 +285,22 @@ export const toolPermissions = sqliteTable(
       .$defaultFn(() => Date.now()),
   },
   (table) => [uniqueIndex('tool_permissions_tool_pattern_idx').on(table.toolName, table.pattern)],
+);
+
+export const toolEnabled = sqliteTable(
+  'tool_enabled',
+  {
+    scope: text('scope').$type<ToolEnabledScope>().notNull(),
+    identifier: text('identifier').notNull(),
+    enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+    createdAt: integer('created_at', { mode: 'number' })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+    updatedAt: integer('updated_at', { mode: 'number' })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (table) => [uniqueIndex('tool_enabled_scope_identifier_uidx').on(table.scope, table.identifier)],
 );
 
 export const mcpServers = sqliteTable('mcp_servers', {

--- a/packages/server/src/mcp/service.ts
+++ b/packages/server/src/mcp/service.ts
@@ -1,11 +1,11 @@
-import { asc, eq } from 'drizzle-orm';
+import { and, asc, eq, like, or } from 'drizzle-orm';
 
 import { createMcpServerId } from '@stitch/shared/id';
 import type { PrefixedString } from '@stitch/shared/id';
 import type { McpAuthConfig, McpTool, McpTransport } from '@stitch/shared/mcp/types';
 
 import { getDb } from '@/db/client.js';
-import { mcpServers } from '@/db/schema.js';
+import { mcpServers, toolEnabled, toolPermissions } from '@/db/schema.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { withMcpClient } from '@/mcp/client.js';
@@ -38,6 +38,9 @@ export async function createMcpServer(input: {
 
 export async function deleteMcpServer(serverId: string): Promise<ServiceResult<null>> {
   const db = getDb();
+  const toolsetId = `mcp:${serverId}`;
+  const mcpToolPrefix = `${serverId}_%`;
+
   const [existing] = await db
     .select()
     .from(mcpServers)
@@ -45,7 +48,18 @@ export async function deleteMcpServer(serverId: string): Promise<ServiceResult<n
   if (!existing) {
     return err('MCP server not found', 404);
   }
+
   await db.delete(mcpServers).where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  await db
+    .delete(toolEnabled)
+    .where(
+      or(
+        and(eq(toolEnabled.scope, 'toolset'), eq(toolEnabled.identifier, toolsetId)),
+        and(eq(toolEnabled.scope, 'mcp_tool'), like(toolEnabled.identifier, mcpToolPrefix)),
+      ),
+    );
+  await db.delete(toolPermissions).where(like(toolPermissions.toolName, mcpToolPrefix));
+
   return ok(null);
 }
 

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -4,10 +4,12 @@ import { z } from 'zod';
 
 import type { PrefixedString } from '@stitch/shared/id';
 import { formatMcpToolName } from '@stitch/shared/mcp/types';
+import { TOOL_ENABLED_SCOPES } from '@stitch/shared/tools/types';
 
 import { getMcpServersWithCachedTools } from '@/mcp/service.js';
 import { getMcpServerPresentation } from '@/mcp/tool-executor.js';
 import { deletePerm, getPerms, upsertPerm } from '@/permission/service.js';
+import { getToolEnabledStates, setToolEnabledState } from '@/tools/enabled-service.js';
 import { getGlobalProviderKnownTools } from '@/tools/providers/index.js';
 import { STITCH_KNOWN_TOOLS } from '@/tools/runtime/registry.js';
 
@@ -15,6 +17,12 @@ const upsertPermissionSchema = z.object({
   toolName: z.string().min(1),
   pattern: z.string().nullable().optional(),
   permission: z.enum(['allow', 'deny', 'ask']),
+});
+
+const upsertToolEnabledSchema = z.object({
+  scope: z.enum(TOOL_ENABLED_SCOPES),
+  identifier: z.string().min(1),
+  enabled: z.boolean(),
 });
 
 export const configRouter = new Hono();
@@ -57,6 +65,21 @@ configRouter.get('/mcp-tools', async (c) => {
   });
 
   return c.json({ tools });
+});
+
+configRouter.get('/tools/enabled', async (c) => {
+  const states = await getToolEnabledStates();
+  return c.json({ states });
+});
+
+configRouter.put('/tools/enabled', zValidator('json', upsertToolEnabledSchema), async (c) => {
+  const body = c.req.valid('json');
+  await setToolEnabledState({
+    scope: body.scope,
+    identifier: body.identifier,
+    enabled: body.enabled,
+  });
+  return c.body(null, 204);
 });
 
 configRouter.get('/permissions', async (c) => {

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -6,12 +6,14 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { formatMcpToolName } from '@stitch/shared/mcp/types';
 import { TOOL_ENABLED_SCOPES } from '@stitch/shared/tools/types';
 
+import { listConnectorDefinitions } from '@/connectors/registry.js';
 import { getMcpServersWithCachedTools } from '@/mcp/service.js';
 import { getMcpServerPresentation } from '@/mcp/tool-executor.js';
 import { deletePerm, getPerms, upsertPerm } from '@/permission/service.js';
 import { getToolEnabledStates, setToolEnabledState } from '@/tools/enabled-service.js';
 import { getGlobalProviderKnownTools } from '@/tools/providers/index.js';
 import { STITCH_KNOWN_TOOLS } from '@/tools/runtime/registry.js';
+import { listToolsets } from '@/tools/toolsets/registry.js';
 
 const upsertPermissionSchema = z.object({
   toolName: z.string().min(1),
@@ -26,6 +28,30 @@ const upsertToolEnabledSchema = z.object({
 });
 
 export const configRouter = new Hono();
+
+type ToolsetSource = 'native' | 'provider' | 'connector' | 'mcp';
+
+const NATIVE_TOOLSET_IDS = new Set(['browser', 'agenda']);
+
+function getToolsetSource(toolsetId: string): ToolsetSource {
+  if (toolsetId.startsWith('mcp:')) return 'mcp';
+  if (NATIVE_TOOLSET_IDS.has(toolsetId)) return 'native';
+
+  const connectorDefs = listConnectorDefinitions();
+  if (connectorDefs.some((definition) => toolsetId.startsWith(`${definition.id}-`))) {
+    return 'connector';
+  }
+
+  return 'provider';
+}
+
+function humanizeToolName(name: string): string {
+  return name
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
 
 configRouter.get('/tools', async (c) => {
   const mcpServersWithTools = await getMcpServersWithCachedTools();
@@ -65,6 +91,27 @@ configRouter.get('/mcp-tools', async (c) => {
   });
 
   return c.json({ tools });
+});
+
+configRouter.get('/toolsets', async (c) => {
+  const toolsets = listToolsets()
+    .map((toolset) => ({
+      id: toolset.id,
+      name: toolset.name,
+      description: toolset.description,
+      icon: toolset.icon ?? null,
+      source: getToolsetSource(toolset.id),
+      toolCount: toolset.tools().length,
+      hasInstructions: !!toolset.instructions,
+      promptCount: toolset.prompts?.length ?? 0,
+      tools: toolset.tools().map((tool) => ({
+        toolName: tool.name,
+        displayName: humanizeToolName(tool.name),
+      })),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return c.json({ toolsets });
 });
 
 configRouter.get('/tools/enabled', async (c) => {

--- a/packages/server/src/tools/enabled-service.ts
+++ b/packages/server/src/tools/enabled-service.ts
@@ -1,0 +1,76 @@
+import { and, eq } from 'drizzle-orm';
+
+import type { ToolEnabledScope, ToolEnabledState } from '@stitch/shared/tools/types';
+
+import { getDb, isDbInitialized } from '@/db/client.js';
+import { toolEnabled } from '@/db/schema.js';
+
+export async function getToolEnabledStates(): Promise<ToolEnabledState[]> {
+  if (!isDbInitialized()) {
+    return [];
+  }
+
+  const db = getDb();
+  return db.select().from(toolEnabled);
+}
+
+export async function setToolEnabledState(opts: {
+  scope: ToolEnabledScope;
+  identifier: string;
+  enabled: boolean;
+}): Promise<void> {
+  if (!isDbInitialized()) {
+    return;
+  }
+
+  const db = getDb();
+  const now = Date.now();
+
+  await db
+    .insert(toolEnabled)
+    .values({
+      scope: opts.scope,
+      identifier: opts.identifier,
+      enabled: opts.enabled,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [toolEnabled.scope, toolEnabled.identifier],
+      set: {
+        enabled: opts.enabled,
+        updatedAt: now,
+      },
+    });
+}
+
+export async function isToolEnabled(opts: {
+  scope: ToolEnabledScope;
+  identifier: string;
+}): Promise<boolean> {
+  if (!isDbInitialized()) {
+    return true;
+  }
+
+  const db = getDb();
+  const [row] = await db
+    .select({ enabled: toolEnabled.enabled })
+    .from(toolEnabled)
+    .where(and(eq(toolEnabled.scope, opts.scope), eq(toolEnabled.identifier, opts.identifier)));
+
+  return row?.enabled ?? true;
+}
+
+export async function getDisabledToolIdentifiers(scope: ToolEnabledScope): Promise<Set<string>> {
+  if (!isDbInitialized()) {
+    return new Set();
+  }
+
+  const db = getDb();
+  const rows = await db
+    .select({ identifier: toolEnabled.identifier })
+    .from(toolEnabled)
+    .where(and(eq(toolEnabled.scope, scope), eq(toolEnabled.enabled, false)));
+
+  return new Set(rows.map((row) => row.identifier));
+}

--- a/packages/server/src/tools/providers/browser-provider.ts
+++ b/packages/server/src/tools/providers/browser-provider.ts
@@ -15,7 +15,7 @@ const browserInstructions = readFileSync(
 
 export const browserToolProvider: ToolProvider = {
   name: 'browser',
-  knownTools: () => [{ toolType: 'stitch', toolName: 'browser', displayName: 'Browser' }],
+  knownTools: () => [{ toolType: 'plugin', toolName: 'browser', displayName: 'Browser' }],
   createTools: (context) => ({
     browser: createRegisteredTool(context),
   }),

--- a/packages/server/src/tools/runtime/registry.ts
+++ b/packages/server/src/tools/runtime/registry.ts
@@ -41,6 +41,7 @@ import {
   createRegisteredTool as createWriteRegisteredTool,
   DISPLAY_NAME as WRITE_DISPLAY_NAME,
 } from '@/tools/core/write.js';
+import { getDisabledToolIdentifiers } from '@/tools/enabled-service.js';
 import { withToolResultHandlingRecord } from '@/tools/runtime/wrappers.js';
 
 export const MAX_STEPS = 25;
@@ -123,7 +124,12 @@ export async function createTools(context: {
     return shouldEnableMemoryTool;
   });
 
+  const disabledTools = await getDisabledToolIdentifiers('tool');
+  const enabledToolEntries = toolEntries.filter(([name]) => !disabledTools.has(name));
+
   return withToolResultHandlingRecord(
-    Object.fromEntries(toolEntries.map(([name, mod]) => [name, mod.createRegisteredTool(context)])),
+    Object.fromEntries(
+      enabledToolEntries.map(([name, mod]) => [name, mod.createRegisteredTool(context)]),
+    ),
   );
 }

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -1,6 +1,7 @@
 import type { ConnectorIconSource } from '@stitch/shared/connectors/types';
 
 import * as Log from '@/lib/log.js';
+import { getDisabledToolIdentifiers, isToolEnabled } from '@/tools/enabled-service.js';
 import { withToolResultHandlingRecord } from '@/tools/runtime/wrappers.js';
 import type { ToolContext } from '@/tools/runtime/wrappers.js';
 import { getToolset, listToolsets } from '@/tools/toolsets/registry.js';
@@ -30,9 +31,7 @@ export class ToolsetManager {
    * Activate a toolset by ID.
    * Returns the newly available tool names and any collision warnings, or null if not found.
    */
-  async activate(
-    toolsetId: string,
-  ): Promise<{ toolNames: string[]; collisions: string[] } | null> {
+  async activate(toolsetId: string): Promise<{ toolNames: string[]; collisions: string[] } | null> {
     if (this.activeIds.has(toolsetId)) {
       return { toolNames: Object.keys(this.activeToolCache.get(toolsetId) ?? {}), collisions: [] };
     }
@@ -46,7 +45,25 @@ export class ToolsetManager {
       return null;
     }
 
-    const tools = withToolResultHandlingRecord(await toolset.activate(this.context));
+    const toolsetEnabled = await isToolEnabled({ scope: 'toolset', identifier: toolsetId });
+    if (!toolsetEnabled) {
+      log.info(
+        { event: 'toolset.activate.disabled', toolsetId },
+        'attempted to activate disabled toolset',
+      );
+      return null;
+    }
+
+    const allTools = withToolResultHandlingRecord(await toolset.activate(this.context));
+    const disabledMcpTools = toolsetId.startsWith('mcp:')
+      ? await getDisabledToolIdentifiers('mcp_tool')
+      : new Set<string>();
+    const tools =
+      disabledMcpTools.size === 0
+        ? allTools
+        : Object.fromEntries(
+            Object.entries(allTools).filter(([toolName]) => !disabledMcpTools.has(toolName)),
+          );
     const currentToolNames = new Set(Object.keys(this.getActiveTools()));
     const collisions = Object.keys(tools).filter((name) => currentToolNames.has(name));
 

--- a/packages/shared/src/tools/types.ts
+++ b/packages/shared/src/tools/types.ts
@@ -2,6 +2,18 @@ export const TOOL_TYPES = ['stitch', 'mcp', 'plugin'] as const;
 
 export type ToolType = (typeof TOOL_TYPES)[number];
 
+export const TOOL_ENABLED_SCOPES = ['tool', 'toolset', 'mcp_tool'] as const;
+
+export type ToolEnabledScope = (typeof TOOL_ENABLED_SCOPES)[number];
+
+export type ToolEnabledState = {
+  scope: ToolEnabledScope;
+  identifier: string;
+  enabled: boolean;
+  createdAt: number;
+  updatedAt: number;
+};
+
 type ToolDataResult<T = unknown> = {
   data: T;
   error?: never;


### PR DESCRIPTION
## 🚀 Change Summary
This PR overhauls Tools settings to center on configurable toolsets, adds a new backend toolset catalog endpoint, and tightens runtime filtering so disabled tools/toolsets are excluded consistently during agent streaming.

### ✨ New Features
- Added a new /config/toolsets endpoint that exposes toolset metadata (source, icon, tool inventory, instructions/prompts counts) for settings UX and discovery
- Added native and connector toolset configuration flows in Tools settings, including per-tool settings navigation from each toolset
- Added query filtering that matches core tools, toolsets, and individual tools inside each toolset for better discoverability

### 🛠 Improvements & Refactors
- Simplified MCP server list UX by removing inline expand/show and routing detailed management through Settings
- Updated Tools tabs to focus on concrete categories (Core/Native/Connector/MCP) with Core as default and removed ambiguous Provider/All tabs
- Aligned toolset row actions in settings and cleaned detail views to reduce visual noise (removed inline tool IDs where not needed)

### 🐛 Bug Fixes
- Fixed provider tool classification for browser integration so it is represented as a plugin toolset in configuration surfaces
- Ensured runtime activation honors disabled states for tool scope, toolset scope, and MCP tool scope consistently

### 📚 Documentation
- Added targeted tests that document expected filtering behavior across tools, toolsets, and nested tool entries