### PR TITLE
fix: target correct Electron ABI when rebuilding better-sqlite3

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
     "build:sidecar": "bun run --filter @stitch/server build",
     "build:audio-native": "bun ../../scripts/build-audio-native.mjs",
     "build:audio-native:x64": "STITCH_AUDIO_NATIVE_TARGET=x86_64-apple-darwin bun ../../scripts/build-audio-native.mjs",
-    "rebuild:native": "electron-rebuild --module-dir ../../packages/server",
+    "rebuild:native": "electron-rebuild --module-dir ../../packages/server --electron-prebuilt-dir node_modules/electron",
     "package": "bun run build:web && bun run build && bun run build:sidecar && bun run build:audio-native && electron-builder --config electron-builder.config.ts",
     "package:x64": "bun run build:web && bun run build && bun run build:sidecar && bun run build:audio-native:x64 && electron-builder --config electron-builder.config.ts --x64",
     "typecheck": "tsc --noEmit"

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -1,3 +1,6 @@
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { migrate } from 'drizzle-orm/better-sqlite3/migrator';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -83,12 +86,6 @@ export async function initDb(): Promise<void> {
   const dbPath = getDatabasePath();
   const migrationsDir = getMigrationsDir();
   fs.mkdirSync(path.dirname(dbPath), { recursive: true });
-
-  const [{ default: Database }, { drizzle }, { migrate }] = await Promise.all([
-    import('better-sqlite3'),
-    import('drizzle-orm/better-sqlite3'),
-    import('drizzle-orm/better-sqlite3/migrator'),
-  ]);
 
   const sqlite = new Database(dbPath);
   sqlite.exec('PRAGMA journal_mode = WAL');


### PR DESCRIPTION
## Change Summary

Fixes a production crash where the server utility process exited immediately on startup due to a native module ABI mismatch. The `better-sqlite3` addon was being compiled against Node.js 22 (ABI 145) instead of Electron 41 (ABI 137), causing it to fail to load at runtime.

### Bug Fixes
- **Native ABI mismatch**: Added `--electron-prebuilt-dir node_modules/electron` to `rebuild:native` so `electron-rebuild` always reads the target Electron version from the local install rather than falling back to the running Node.js ABI
- **Unnecessary dynamic import**: Replaced dynamic `Promise.all([import('better-sqlite3'), ...])` in `db/client.ts` with static top-level imports — the module is already `external` in esbuild so behaviour is identical, but a load failure now surfaces immediately at process start rather than silently at first DB call
