### PR TITLE
fix: skip killStaleServers in dev mode to avoid killing prod server

### DIFF
--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -87,7 +87,10 @@ function killStaleServers(): Promise<void> {
             .split('\n')
             .map((line) => parseInt(line.split(',')[1]?.replace(/"/g, '') ?? '', 10))
             .filter(Number.isFinite)
-        : output.split('\n').map((s) => parseInt(s, 10)).filter(Number.isFinite);
+        : output
+            .split('\n')
+            .map((s) => parseInt(s, 10))
+            .filter(Number.isFinite);
 
     for (const pid of pids) {
       try {
@@ -108,7 +111,9 @@ function killStaleServers(): Promise<void> {
 }
 
 export async function spawnServer(port: number): Promise<string> {
-  await killStaleServers();
+  if (app.isPackaged) {
+    await killStaleServers();
+  }
 
   const { cmd, args, cwd } = getSidecarCommand(port);
   const url = `http://${HOSTNAME}:${port}`;


### PR DESCRIPTION
## Change Summary

When launching the app in dev mode on a machine with a production installation running, the dev instance's startup routine was terminating the production server process.

## Bug Fixes
- **Dev mode no longer kills production server on startup**: `killStaleServers()` scans for and kills any process named `stitch-server` system-wide. In dev mode the server runs as `bun` (not `stitch-server.exe`), so there are no stale dev servers to clean up -- but the scan was still killing the production binary. The fix guards the call behind `app.isPackaged`, so stale server cleanup only runs in production builds.