### PR TITLE
fix: shell-aware prompt rules and bash failure status in UI

### DIFF
--- a/apps/web/src/components/chat/message-bubble/assistant-message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble/assistant-message-bubble.tsx
@@ -68,7 +68,8 @@ export function AssistantMessageBubble({
                   output !== null &&
                   output !== undefined &&
                   typeof output === 'object' &&
-                  'error' in (output as object);
+                  ('error' in (output as object) ||
+                    (output as { failed?: unknown }).failed === true);
                 const missingResult = !result;
                 const status = missingResult || isError ? 'error' : 'completed';
 

--- a/apps/web/src/components/chat/message-bubble/tool-call-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-block.tsx
@@ -85,7 +85,15 @@ export function ToolCallBlock({
   }
 
   if (toolName === 'bash' && hasArgs) {
-    return <BashToolBlock toolName={toolName} status={status} args={args} onAbort={onAbort} />;
+    return (
+      <BashToolBlock
+        toolName={toolName}
+        status={status}
+        args={args}
+        result={result}
+        onAbort={onAbort}
+      />
+    );
   }
 
   if (toolName === 'execute_typescript' && hasArgs) {

--- a/apps/web/src/components/chat/message-bubble/tool-call/bash-tool-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/bash-tool-block.tsx
@@ -3,10 +3,17 @@ import * as React from 'react';
 
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
 
-import { ToolCard, getToolCardState, truncateText, useStitchToolDisplayName } from './card-primitives';
+import {
+  ToolCard,
+  getToolCardState,
+  truncateText,
+  useStitchToolDisplayName,
+} from './card-primitives';
 
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+
+const MAX_OUTPUT_PREVIEW = 400;
 
 function getBashArgs(args: unknown): {
   action: string | null;
@@ -23,22 +30,37 @@ function getBashArgs(args: unknown): {
   return { action, command };
 }
 
+function getBashResult(result: unknown): { exitCode: number | null; output: string | null } {
+  if (!result || typeof result !== 'object') return { exitCode: null, output: null };
+  const r = result as { metadata?: { exit?: unknown }; output?: unknown };
+  const exitCode = typeof r.metadata?.exit === 'number' ? r.metadata.exit : null;
+  const output =
+    typeof r.output === 'string' && r.output.trim().length > 0 ? r.output.trim() : null;
+  return { exitCode, output };
+}
+
 type BashToolBlockProps = {
   toolName: string;
   status: ToolCallStatus;
   args: unknown;
+  result?: unknown;
   onAbort?: () => void;
 };
 
-export function BashToolBlock({ toolName, status, args, onAbort }: BashToolBlockProps) {
-  const { isActive } = getToolCardState(status);
+export function BashToolBlock({ toolName, status, args, result, onAbort }: BashToolBlockProps) {
+  const { isActive, hasError } = getToolCardState(status);
   const { action, command } = getBashArgs(args);
+  const { exitCode, output } = getBashResult(result);
   const displayName = useStitchToolDisplayName(toolName);
   const [open, setOpen] = React.useState(false);
   const [showFullCommand, setShowFullCommand] = React.useState(false);
   const actionLabel = action ?? 'Run a shell command';
   const commandPreview = command ? truncateText(command, 180) : 'Waiting for command...';
   const canExpandCommand = Boolean(command && command.length > 180);
+
+  const outputPreview = output ? truncateText(output, MAX_OUTPUT_PREVIEW) : null;
+  const canExpandOutput = Boolean(output && output.length > MAX_OUTPUT_PREVIEW);
+  const [showFullOutput, setShowFullOutput] = React.useState(false);
 
   return (
     <ToolCard.Root status={status}>
@@ -69,21 +91,47 @@ export function BashToolBlock({ toolName, status, args, onAbort }: BashToolBlock
       </ToolCard.Header>
 
       <ToolCard.Content open={open}>
-        <div className="space-y-1.5">
-          <div className="font-medium text-foreground">Command</div>
-          <div className="font-mono text-xs break-all whitespace-pre-wrap text-muted-foreground">
-            {showFullCommand ? (command ?? commandPreview) : commandPreview}
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <div className="font-medium text-foreground">Command</div>
+            <div className="font-mono text-xs break-all whitespace-pre-wrap text-muted-foreground">
+              {showFullCommand ? (command ?? commandPreview) : commandPreview}
+            </div>
+            {canExpandCommand ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                onClick={() => setShowFullCommand((current) => !current)}
+                className="h-6 px-2 text-xs"
+              >
+                {showFullCommand ? 'Show less' : 'Show full command'}
+              </Button>
+            ) : null}
           </div>
-          {canExpandCommand ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="xs"
-              onClick={() => setShowFullCommand((current) => !current)}
-              className="h-6 px-2 text-xs"
-            >
-              {showFullCommand ? 'Show less' : 'Show full command'}
-            </Button>
+
+          {hasError && exitCode !== null ? (
+            <div className="space-y-1.5">
+              <div className="font-medium text-destructive">Exit code: {exitCode}</div>
+              {outputPreview ? (
+                <>
+                  <div className="font-mono text-xs break-all whitespace-pre-wrap text-muted-foreground">
+                    {showFullOutput ? output : outputPreview}
+                  </div>
+                  {canExpandOutput ? (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="xs"
+                      onClick={() => setShowFullOutput((current) => !current)}
+                      className="h-6 px-2 text-xs"
+                    >
+                      {showFullOutput ? 'Show less' : 'Show full output'}
+                    </Button>
+                  ) : null}
+                </>
+              ) : null}
+            </div>
           ) : null}
         </div>
       </ToolCard.Content>

--- a/packages/server/src/llm/prompt/env.ts
+++ b/packages/server/src/llm/prompt/env.ts
@@ -3,6 +3,29 @@ import path from 'node:path';
 
 import { resolvePreferredShell } from '@/lib/shell.js';
 
+const SHELL_RULES_REUSE_CONTEXT = `- Do not re-query information already present in prior tool results in the same conversation.`;
+
+const SHELL_RULES_PWSH = `Shell usage rules:
+- All bash tool calls run in PowerShell — write PowerShell syntax exclusively.
+- Never use cmd.exe idioms: dir /b, del, findstr, type, etc.
+- In Where-Object blocks always use the $_ sigil (e.g. $_.Extension, not .Extension).
+- Pass multiple paths to Remove-Item with -Path @("a","b") not space-separated args.
+- Never wrap commands in \`powershell -Command "..."\` — they already run in PowerShell.
+${SHELL_RULES_REUSE_CONTEXT}`;
+
+const SHELL_RULES_CMD = `Shell usage rules:
+- All bash tool calls run in cmd.exe — use cmd.exe syntax exclusively.
+- Never use PowerShell-specific syntax.
+${SHELL_RULES_REUSE_CONTEXT}`;
+
+const SHELL_RULES_MACOS = (shell: string) => `Shell usage rules:
+- All bash tool calls run in ${shell} — use POSIX/bash/zsh syntax.
+${SHELL_RULES_REUSE_CONTEXT}`;
+
+const SHELL_RULES_LINUX = (shell: string) => `Shell usage rules:
+- All bash tool calls run in ${shell} — use POSIX/bash/sh syntax.
+${SHELL_RULES_REUSE_CONTEXT}`;
+
 export function buildPromptEnvironment(input?: { userTimezone?: string | null }): string {
   const currentDate = new Date().toISOString().slice(0, 10);
   const preferredShell = resolvePreferredShell().shell;
@@ -23,11 +46,13 @@ export function buildPromptEnvironment(input?: { userTimezone?: string | null })
     const windowsLocalAppData = process.env.LOCALAPPDATA ?? path.join(homeDir, 'AppData', 'Local');
     const windowsLocalLow = path.join(homeDir, 'AppData', 'LocalLow');
     const windowsProgramData = process.env.PROGRAMDATA ?? 'C:\\ProgramData';
+    const isPwsh = preferredShell.startsWith('pwsh') || preferredShell.startsWith('powershell');
     lines.push('Common app data locations:');
     lines.push(
       `Windows (user): APPDATA=${windowsAppData}; LOCALAPPDATA=${windowsLocalAppData}; LocalLow=${windowsLocalLow}`,
     );
     lines.push(`Windows (machine): PROGRAMDATA=${windowsProgramData}`);
+    lines.push(isPwsh ? SHELL_RULES_PWSH : SHELL_RULES_CMD);
   }
 
   if (process.platform === 'darwin') {
@@ -37,6 +62,7 @@ export function buildPromptEnvironment(input?: { userTimezone?: string | null })
       `macOS (user): Application Support=${path.join(macosLibrary, 'Application Support')}; Preferences=${path.join(macosLibrary, 'Preferences')}; Caches=${path.join(macosLibrary, 'Caches')}; Logs=${path.join(macosLibrary, 'Logs')}`,
     );
     lines.push('macOS (machine): Application Support=/Library/Application Support');
+    lines.push(SHELL_RULES_MACOS(preferredShell));
   }
 
   if (process.platform === 'linux') {
@@ -48,6 +74,7 @@ export function buildPromptEnvironment(input?: { userTimezone?: string | null })
     lines.push(
       `Linux/XDG (user): XDG_DATA_HOME=${xdgDataHome}; XDG_CONFIG_HOME=${xdgConfigHome}; XDG_CACHE_HOME=${xdgCacheHome}; XDG_STATE_HOME=${xdgStateHome}`,
     );
+    lines.push(SHELL_RULES_LINUX(preferredShell));
   }
 
   lines.push('</env>');

--- a/packages/server/src/llm/stream/stream-accumulator.ts
+++ b/packages/server/src/llm/stream/stream-accumulator.ts
@@ -254,13 +254,19 @@ export class StreamAccumulator {
         const fallbackError = isToolErrorResult(sanitizedOutput)
           ? sanitizedOutput.error
           : undefined;
+        const isBashFailure =
+          !fallbackError &&
+          sanitizedOutput !== null &&
+          typeof sanitizedOutput === 'object' &&
+          (sanitizedOutput as { failed?: unknown }).failed === true;
+        const isError = Boolean(fallbackError) || isBashFailure;
 
         await this.broadcast('stream-tool-state', {
           sessionId: this.sessionId,
           messageId: this.messageId,
           toolCallId: part.toolCallId,
           toolName: part.toolName,
-          status: fallbackError ? 'error' : 'completed',
+          status: isError ? 'error' : 'completed',
           input: part.input,
           ...(fallbackError ? { error: fallbackError } : { output: sanitizedOutput }),
         });

--- a/packages/server/src/tools/core/bash.ts
+++ b/packages/server/src/tools/core/bash.ts
@@ -164,13 +164,16 @@ Usage:
       }
 
       const cleanedOutput = stripAnsi(output);
+      const exitCode = proc.exitCode ?? 0;
+      const failed = exitCode !== 0 && !timedOut && !aborted;
 
       return {
         title: input.description,
         output: cleanedOutput,
+        failed,
         metadata: {
           description: input.description,
-          exit: proc.exitCode,
+          exit: exitCode,
           output:
             cleanedOutput.length > MAX_METADATA_LENGTH
               ? `${cleanedOutput.slice(0, MAX_METADATA_LENGTH)}\n\n...`


### PR DESCRIPTION
## Change Summary

Two fixes identified from session replay of a multi-tool-call failure where the agent kept retrying broken cmd.exe commands in a PowerShell shell, and every failed bash call showed green in the UI.

### Bug Fixes

- **Shell-aware prompt rules**: The env block already included Preferred shell but had no behavioral instructions. Per-platform shell usage rules are now injected alongside the env data — PowerShell users get rules covering syntax exclusivity, dollar-underscore sigil usage, Remove-Item array syntax, and no powershell -Command wrapping; cmd users get cmd-only rules; macOS/Linux get POSIX rules. Rules are defined as named multiline consts at the top of env.ts for readability.

- **Bash exit failures shown as success**: The bash tool always returned a success-shaped result even on non-zero exit codes, so the UI rendered a green checkmark regardless of whether the command failed. A failed flag is now set on the result when exit code is non-zero (and the command was not aborted/timed out). Both the streaming path (stream-accumulator.ts) and stored message path (assistant-message-bubble.tsx) check this flag to correctly render the error state.

- **Exit code visible in UI**: BashToolBlock now shows the exit code and a truncated output snippet in its expanded panel when the status is error, with expand/collapse for long output.