### PR TITLE
fix(recordings): fix macOS audio permission detection, stale TCC handling, and improve permission UX

### DIFF
--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -82,6 +82,8 @@ const config: Configuration = {
     artifactName: '${productName}-macos-${arch}.${ext}',
     icon: 'resources/icon.icns',
     category: 'public.app-category.developer-tools',
+    entitlements: 'resources/entitlements.mac.plist',
+    entitlementsInherit: 'resources/entitlements.mac.inherit.plist',
     binaries: [
       'Contents/Resources/stitch-server',
       'Contents/Resources/audio-capture/stitch-audio-capture',

--- a/apps/desktop/resources/entitlements.mac.inherit.plist
+++ b/apps/desktop/resources/entitlements.mac.inherit.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/resources/entitlements.mac.plist
+++ b/apps/desktop/resources/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,14 @@
-import { app, BrowserWindow, dialog, ipcMain, nativeImage, shell } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  nativeImage,
+  shell,
+  systemPreferences,
+} from 'electron';
 import { randomUUID } from 'node:crypto';
-import { writeFile, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -15,6 +23,42 @@ const DEV_SERVER_POLL_MS = 200;
 const DEV_SERVER_TIMEOUT_MS = 30_000;
 const DEV_APP_NAME = 'stitch-dev';
 const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1_000;
+
+/**
+ * With adhoc code signing, macOS ties TCC permissions to the exact code signature hash.
+ * After an app update the hash changes but old TCC entries remain, causing permissions
+ * to appear granted in System Settings while being silently rejected at runtime.
+ * This detects version changes and resets TCC so macOS will re-prompt.
+ */
+async function resetTccPermissionsIfVersionChanged(): Promise<boolean> {
+  if (process.platform !== 'darwin' || !app.isPackaged) return false;
+
+  const versionFile = join(app.getPath('userData'), '.last-tcc-version');
+  const currentVersion = app.getVersion();
+
+  try {
+    const lastVersion = (await readFile(versionFile, 'utf-8')).trim();
+    if (lastVersion === currentVersion) return false;
+  } catch {
+    // File doesn't exist — first run or upgrade from before this logic
+  }
+
+  const { execSync } = await import('node:child_process');
+  const bundleId = 'com.stitch.desktop';
+
+  for (const service of ['Microphone', 'ScreenCapture']) {
+    try {
+      execSync(`tccutil reset ${service} ${bundleId}`, { timeout: 5_000 });
+    } catch {
+      // tccutil may fail if no entry exists
+    }
+  }
+
+  await mkdir(join(app.getPath('userData')), { recursive: true });
+  await writeFile(versionFile, currentVersion, 'utf-8');
+
+  return true;
+}
 
 function configureAppIdentityForEnvironment(): void {
   if (app.isPackaged) {
@@ -220,6 +264,24 @@ ipcMain.handle('dialog:openPath', async () => {
   return result.canceled ? [] : result.filePaths;
 });
 
+ipcMain.handle('permissions:requestMicrophone', async () => {
+  if (process.platform !== 'darwin') return true;
+  return systemPreferences.askForMediaAccess('microphone');
+});
+
+ipcMain.handle('permissions:getScreenCaptureStatus', () => {
+  if (process.platform !== 'darwin') return 'granted';
+  return systemPreferences.getMediaAccessStatus('screen');
+});
+
+ipcMain.handle('permissions:openScreenCaptureSettings', () => {
+  if (process.platform === 'darwin') {
+    void shell.openExternal(
+      'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
+    );
+  }
+});
+
 ipcMain.handle('updater:check', () => {
   return updater.checkForUpdates();
 });
@@ -251,7 +313,20 @@ void app.whenReady().then(async () => {
     const port = await findAvailablePort();
     serverUrl = await spawnServer(port);
 
+    const permissionsWereReset = await resetTccPermissionsIfVersionChanged();
+
     await createWindow();
+
+    if (permissionsWereReset && mainWindow) {
+      void dialog.showMessageBox(mainWindow, {
+        type: 'info',
+        title: 'Permissions Required',
+        message: 'Stitch was updated and needs audio permissions re-granted.',
+        detail:
+          'When you start a recording, you will be prompted to grant microphone access. You may also need to enable Stitch under "System Audio Recording Only" in System Settings > Privacy & Security.',
+        buttons: ['OK'],
+      });
+    }
 
     if (process.platform !== 'darwin') {
       updater.init();

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -53,4 +53,12 @@ contextBridge.exposeInMainWorld('api', {
     replaceMisspelling: (word: string) => ipcRenderer.invoke('spellcheck:replaceMisspelling', word),
     addToDictionary: (word: string) => ipcRenderer.invoke('spellcheck:addToDictionary', word),
   },
+  permissions: {
+    requestMicrophone: () =>
+      ipcRenderer.invoke('permissions:requestMicrophone') as Promise<boolean>,
+    getScreenCaptureStatus: () =>
+      ipcRenderer.invoke('permissions:getScreenCaptureStatus') as Promise<string>,
+    openScreenCaptureSettings: () =>
+      ipcRenderer.invoke('permissions:openScreenCaptureSettings') as Promise<void>,
+  },
 });

--- a/apps/web/src/components/settings/recordings.tsx
+++ b/apps/web/src/components/settings/recordings.tsx
@@ -155,36 +155,52 @@ function ModelSelect({
 }
 
 function PermissionStatus() {
-  const { data: permissions } = useQuery(audioPermissionsQueryOptions);
+  const { data: permissions, refetch } = useQuery(audioPermissionsQueryOptions);
+  const [requesting, setRequesting] = React.useState(false);
 
   if (!permissions) return null;
 
   const micDenied = permissions.microphone === 'denied';
-  const screenDenied = permissions.screenCapture === 'denied';
+  const screenDenied = permissions.screenCapture !== 'granted';
 
   if (!micDenied && !screenDenied) return null;
 
+  const handleGrantPermissions = async () => {
+    setRequesting(true);
+    try {
+      if (micDenied && window.api?.permissions?.requestMicrophone) {
+        await window.api.permissions.requestMicrophone();
+      }
+      if (screenDenied && window.api?.permissions?.openScreenCaptureSettings) {
+        await window.api.permissions.openScreenCaptureSettings();
+      }
+      setTimeout(() => void refetch(), 2000);
+    } finally {
+      setRequesting(false);
+    }
+  };
+
   return (
     <div className="rounded-lg border border-warning/30 bg-warning/5 p-3">
-      <p className="text-sm font-medium text-warning">Missing Permissions</p>
-      <ul className="mt-1 space-y-1 text-xs text-muted-foreground">
-        {micDenied ? (
-          <li>
-            Microphone access is denied. Go to{' '}
-            <strong>System Settings &gt; Privacy &amp; Security &gt; Microphone</strong> and grant
-            access.
-          </li>
-        ) : null}
-        {screenDenied ? (
-          <li>
-            Screen recording access is denied. Go to{' '}
-            <strong>
-              System Settings &gt; Privacy &amp; Security &gt; Screen &amp; System Audio Recording
-            </strong>{' '}
-            and grant access.
-          </li>
-        ) : null}
-      </ul>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-warning">Missing Permissions</p>
+          <ul className="mt-1 space-y-1 text-xs text-muted-foreground">
+            {micDenied ? <li>Microphone access is required to capture audio.</li> : null}
+            {screenDenied ? (
+              <li>System audio recording access is required to capture system audio.</li>
+            ) : null}
+          </ul>
+        </div>
+        <button
+          type="button"
+          className="shrink-0 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          disabled={requesting}
+          onClick={() => void handleGrantPermissions()}
+        >
+          {requesting ? 'Requesting...' : 'Grant Permissions'}
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -65,6 +65,11 @@ declare global {
         replaceMisspelling: (word: string) => Promise<void>;
         addToDictionary: (word: string) => Promise<void>;
       };
+      permissions?: {
+        requestMicrophone: () => Promise<boolean>;
+        getScreenCaptureStatus: () => Promise<string>;
+        openScreenCaptureSettings: () => Promise<void>;
+      };
     };
   }
 }

--- a/apps/web/src/lib/queries/recordings.ts
+++ b/apps/web/src/lib/queries/recordings.ts
@@ -70,20 +70,47 @@ export const audioPermissionsQueryOptions = queryOptions({
 
 async function preflightPermissionCheck(): Promise<void> {
   try {
+    // Request microphone permission via Electron (triggers native macOS prompt)
+    if (window.api?.permissions?.requestMicrophone) {
+      await window.api.permissions.requestMicrophone();
+    }
+
+    // Check screen capture permission from the Electron main process.
+    // This is more reliable than the native binary's TCC check because it
+    // queries from the actual app process (correct code signing identity).
+    if (window.api?.permissions?.getScreenCaptureStatus) {
+      const status = await window.api.permissions.getScreenCaptureStatus();
+      if (status !== 'granted') {
+        if (window.api?.permissions?.openScreenCaptureSettings) {
+          void window.api.permissions.openScreenCaptureSettings();
+        }
+        throw new Error(
+          'Audio capture permission is needed. In the System Settings window, toggle on Stitch under "Screen & System Audio Recording", then click Start Recording again.',
+        );
+      }
+      return;
+    }
+
+    // Fallback for non-Electron (dev server): use the native binary check
     const res = await serverFetch('/recordings/permissions');
     if (!res.ok) return;
 
     const permissions = (await res.json()) as AudioPermissionsStatus;
+
+    if (permissions.microphone === 'granted' && permissions.screenCapture === 'granted') {
+      return;
+    }
+
     const issues: string[] = [];
 
-    if (permissions.microphone === 'denied') {
+    if (permissions.microphone !== 'granted') {
       issues.push(
         'Microphone access is denied. Grant microphone permission in System Settings > Privacy & Security > Microphone.',
       );
     }
-    if (permissions.screenCapture === 'denied') {
+    if (permissions.screenCapture !== 'granted') {
       issues.push(
-        'Screen recording access is denied. Grant screen recording permission in System Settings > Privacy & Security > Screen & System Audio Recording.',
+        'Audio capture permission is needed. Toggle on Stitch under "Screen & System Audio Recording" in System Settings > Privacy & Security.',
       );
     }
 
@@ -91,6 +118,9 @@ async function preflightPermissionCheck(): Promise<void> {
       throw new Error(issues.join('\n'));
     }
   } catch (error) {
+    if (error instanceof Error && error.message.includes('permission is needed')) {
+      throw error;
+    }
     if (error instanceof Error && error.message.includes('access is denied')) {
       throw error;
     }

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -43,7 +43,7 @@ checksum = "f93ebbf82d06013f4c41fe71303feb980cddd78496d904d06be627972de51a24"
 name = "audio-meeting-detect"
 version = "0.1.0"
 dependencies = [
- "cidre",
+ "cidre 0.14.2",
  "serde",
  "serde_json",
  "sysinfo",
@@ -56,7 +56,7 @@ name = "audio-recording"
 version = "0.1.0"
 dependencies = [
  "audio-core 0.1.0",
- "cidre",
+ "cidre 0.15.0",
  "cpal",
  "ogg",
  "opus-rs",
@@ -137,6 +137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +164,19 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c49de1cb1a7d9d19697c53a00fccde65f29b6757f4474055d0af0a0465c8ff0d"
 dependencies = [
+ "cidre-macros",
+ "half",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "cidre"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c903ff1729987d29e07295d2c5841993db25ff86cca43bee04505878d3ec1a7"
+dependencies = [
+ "cc",
  "cidre-macros",
  "half",
  "parking_lot",
@@ -257,6 +280,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "futures-core"
@@ -824,6 +853,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,7 +897,9 @@ dependencies = [
  "audio-core 0.1.0",
  "audio-meeting-detect",
  "audio-recording",
+ "cidre 0.15.0",
  "cpal",
+ "libc",
  "serde_json",
 ]
 

--- a/native/crates/audio-cli/Cargo.toml
+++ b/native/crates/audio-cli/Cargo.toml
@@ -13,3 +13,7 @@ audio-meeting-detect = { path = "../audio-meeting-detect" }
 audio-recording = { path = "../audio-recording" }
 serde_json = "1"
 cpal = "0.17"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+cidre = { version = "0.15", features = ["av", "sc"] }
+libc = "0.2"

--- a/native/crates/audio-cli/src/main.rs
+++ b/native/crates/audio-cli/src/main.rs
@@ -60,15 +60,51 @@ fn check_microphone_permission() -> &'static str {
   }
 }
 
+/// Query the TCC (Transparency, Consent, and Control) database for a permission.
+/// Returns 0 for granted, other values for denied/restricted.
+#[cfg(target_os = "macos")]
+fn tcc_preflight(service: &str) -> i32 {
+  use std::ffi::CStr;
+
+  type TCCPreflightFn =
+    unsafe extern "C" fn(service: *const std::ffi::c_void, options: *const std::ffi::c_void) -> i32;
+
+  unsafe {
+    let path = CStr::from_bytes_with_nul_unchecked(
+      b"/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC\0",
+    );
+    let handle = libc::dlopen(path.as_ptr(), libc::RTLD_NOW);
+    if handle.is_null() {
+      return -1;
+    }
+
+    let sym_name = CStr::from_bytes_with_nul_unchecked(b"TCCAccessPreflight\0");
+    let sym = libc::dlsym(handle, sym_name.as_ptr());
+    if sym.is_null() {
+      libc::dlclose(handle);
+      return -1;
+    }
+
+    let preflight: TCCPreflightFn = std::mem::transmute(sym);
+    let service_str = cidre::ns::String::with_str(service);
+    let result = preflight(
+      service_str.as_ref() as *const cidre::ns::String as *const std::ffi::c_void,
+      std::ptr::null(),
+    );
+
+    libc::dlclose(handle);
+    result
+  }
+}
+
 fn check_screen_capture_permission() -> &'static str {
   #[cfg(target_os = "macos")]
   {
-    // On macOS, CGPreflightScreenCaptureAccess checks if the app has screen recording permission.
-    // This is available on macOS 10.15+. We use the foreign function interface to call it.
-    unsafe extern "C" {
-      fn CGPreflightScreenCaptureAccess() -> bool;
-    }
-    if unsafe { CGPreflightScreenCaptureAccess() } {
+    // Speaker capture uses two paths in parallel: process taps (need kTCCServiceAudioCapture)
+    // and ScreenCaptureKit (needs kTCCServiceScreenCapture). Either one is sufficient.
+    let audio_capture = tcc_preflight("kTCCServiceAudioCapture");
+    let screen_capture = tcc_preflight("kTCCServiceScreenCapture");
+    if audio_capture == 0 || screen_capture == 0 {
       return "granted";
     }
     return "denied";

--- a/native/crates/audio-recording/Cargo.toml
+++ b/native/crates/audio-recording/Cargo.toml
@@ -15,5 +15,5 @@ wasapi = "0.23"
 windows = { version = "0.61", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cidre = { version = "0.14", features = ["av", "sc", "blocks", "async"] }
+cidre = { version = "0.15", features = ["av", "sc", "blocks", "async"] }
 tokio = { version = "1", features = ["rt", "macros", "time"] }

--- a/native/crates/audio-recording/src/speaker.rs
+++ b/native/crates/audio-recording/src/speaker.rs
@@ -317,13 +317,18 @@ fn spawn_macos_speaker_source(
 
         let use_tap = std::sync::atomic::AtomicBool::new(true);
         let decided = std::sync::atomic::AtomicBool::new(false);
+        let mut decision_ticks: u32 = 0;
+        // Allow ~2 seconds (200 ticks at 10ms) for audio to start flowing
+        const DECISION_GRACE_TICKS: u32 = 200;
 
         while !stop_flag.load(Ordering::Relaxed) {
           tokio::time::sleep(Duration::from_millis(10)).await;
 
-          let mut got_tap = false;
+          let mut tap_has_signal = false;
           while let Ok(chunk) = tap_rx.try_recv() {
-            got_tap = true;
+            if !tap_has_signal {
+              tap_has_signal = chunk.iter().any(|&s| s.abs() > 1e-6);
+            }
             if use_tap.load(Ordering::Relaxed) {
               for c in chunk.chunks(960) {
                 let _ = tx.try_send(c.to_vec());
@@ -331,18 +336,35 @@ fn spawn_macos_speaker_source(
             }
           }
 
+          let mut got_sck = false;
           while let Ok(chunk) = sck_rx.try_recv() {
+            got_sck = true;
             if !use_tap.load(Ordering::Relaxed) {
               let _ = tx.try_send(chunk);
             }
           }
 
-          if !decided.load(Ordering::Relaxed) && sck_ok.is_some() {
-            if got_tap {
+          if !decided.load(Ordering::Relaxed) {
+            decision_ticks += 1;
+
+            if tap_has_signal {
+              // Tap is producing real audio — use it
               use_tap.store(true, Ordering::Relaxed);
               decided.store(true, Ordering::Relaxed);
-            } else {
+            } else if got_sck && decision_ticks >= DECISION_GRACE_TICKS {
+              // Tap silent after grace period, SCK has data — switch to SCK
               use_tap.store(false, Ordering::Relaxed);
+              decided.store(true, Ordering::Relaxed);
+            } else if sck_ok.is_some() && got_sck {
+              // SCK started and is producing data, but still in grace period — buffer SCK
+              // data by not deciding yet (tap may still start producing signal)
+            } else if decision_ticks >= DECISION_GRACE_TICKS {
+              // Grace period elapsed, tap silent, SCK either failed or has no data.
+              // If SCK started, use it even without data yet. Otherwise stick with tap.
+              if sck_ok.is_some() {
+                use_tap.store(false, Ordering::Relaxed);
+              }
+              decided.store(true, Ordering::Relaxed);
             }
           }
         }


### PR DESCRIPTION
## 🚀 Change Summary

Fixes multiple issues with macOS audio recording permissions that caused recordings to fail silently in the packaged app, even when permissions appeared granted in System Settings. Adds a proper permission request flow so users are prompted natively instead of being told to manually find settings.

### 🐛 Bug Fixes

- **Permission check used wrong macOS API**: `CGPreflightScreenCaptureAccess()` only checks `kTCCServiceScreenCapture` for the calling binary. For the `stitch-audio-capture` helper bundled inside the Electron app, this always returned false. Replaced with `TCCAccessPreflight` via the private TCC framework, which queries the TCC database directly and checks both `kTCCServiceAudioCapture` (process taps) and `kTCCServiceScreenCapture` (ScreenCaptureKit).

- **Silent process tap starved ScreenCaptureKit**: The speaker capture runs process taps and ScreenCaptureKit in parallel, picking whichever produces audio first. The process tap can initialize without error but deliver only silent zero-filled frames when permissions are stale. The old decision logic saw "frames arrived" and permanently locked to the tap, so SCK was never used. Fixed the decision to check for actual audio signal (amplitude > 1e-6) with a 2-second grace period before falling back to SCK.

- **Recording started before permissions were granted**: The preflight used the native binary's TCC check which returned stale results with adhoc signing. Now checks screen capture from the Electron main process via `systemPreferences.getMediaAccessStatus('screen')` and blocks recording until permissions are confirmed.

- **Permissions silently broke after app updates**: With adhoc code signing, macOS ties TCC permissions to the exact code signature hash. Every new build invalidates old TCC entries, causing permissions to appear granted in System Settings while being silently rejected at runtime. Added version-change detection on every app launch that resets TCC entries via `tccutil` and shows a dialog prompting the user to re-grant.

- **Missing audio-input entitlement**: The packaged app had no `com.apple.security.device.audio-input` entitlement, preventing the Electron process and child processes from properly accessing audio input. Added entitlements for the main app and inherited by all child processes.

### ✨ New Features

- **Native microphone permission prompt**: Clicking "Start Recording" triggers macOS's native Allow/Deny dialog via `systemPreferences.askForMediaAccess('microphone')` instead of requiring users to manually navigate to System Settings.

- **Auto-open System Settings for screen capture**: When screen capture permission is missing, System Settings opens directly to the "Screen & System Audio Recording" page with a clear error message explaining what to toggle.

- **Grant Permissions button in Settings**: Replaced passive "go to System Settings" text on the Settings > Recordings page with an actionable "Grant Permissions" button that triggers the mic prompt and opens System Settings, with auto-refresh of permission status afterward.

### 🛠 Improvements & Refactors

- Upgraded `cidre` from 0.14 to 0.15 for improved macOS compatibility.