### PR TITLE
feat(google-docs): add docs_edit tool for targeted text replacement

### DIFF
--- a/connectors/google/src/__test__/docs-tools.test.ts
+++ b/connectors/google/src/__test__/docs-tools.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createDocsTools } from '../docs/tools.js';
+
+import type { GoogleClient } from '../client.js';
+
+const { readDocumentMock, updateDocumentMock } = vi.hoisted(() => ({
+  readDocumentMock: vi.fn(),
+  updateDocumentMock: vi.fn(),
+}));
+
+vi.mock('../docs/api.js', () => ({
+  readDocument: readDocumentMock,
+  updateDocument: updateDocumentMock,
+}));
+
+type ExecutableTool = {
+  execute: (input: unknown) => Promise<unknown>;
+};
+
+function getToolExecutor(tools: Record<string, unknown>, name: string): ExecutableTool {
+  const candidate = tools[name];
+  if (!candidate || typeof candidate !== 'object' || !('execute' in candidate)) {
+    throw new Error(`Missing execute for tool: ${name}`);
+  }
+
+  return candidate as ExecutableTool;
+}
+
+describe('createDocsTools docs_edit', () => {
+  const client = { request: vi.fn() } as unknown as GoogleClient;
+
+  const resolveClient: Parameters<typeof createDocsTools>[0] = async () => ({
+    client,
+    usedAccount: 'personal@gmail.com',
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('edits the first matching string by default', async () => {
+    readDocumentMock.mockResolvedValue({
+      id: 'doc-1',
+      title: 'Roadmap',
+      text: 'alpha beta alpha',
+      webViewLink: 'https://docs.google.com/document/d/doc-1/edit',
+    });
+    updateDocumentMock.mockResolvedValue({
+      id: 'doc-1',
+      title: 'Roadmap',
+      webViewLink: 'https://docs.google.com/document/d/doc-1/edit',
+    });
+
+    const tools = createDocsTools(resolveClient, true);
+    const docsEdit = getToolExecutor(tools, 'docs_edit');
+    const result = await docsEdit.execute({
+      documentId: 'doc-1',
+      oldString: 'beta',
+      newString: 'gamma',
+    });
+
+    expect(readDocumentMock).toHaveBeenCalledWith(client, 'doc-1');
+    expect(updateDocumentMock).toHaveBeenCalledWith(client, 'doc-1', 'alpha gamma alpha', 'replace');
+    expect(result).toEqual({
+      id: 'doc-1',
+      title: 'Roadmap',
+      webViewLink: 'https://docs.google.com/document/d/doc-1/edit',
+      usedAccount: 'personal@gmail.com',
+    });
+  });
+
+  it('throws when oldString does not exist in the document', async () => {
+    readDocumentMock.mockResolvedValue({
+      id: 'doc-2',
+      title: 'Notes',
+      text: 'hello world',
+      webViewLink: 'https://docs.google.com/document/d/doc-2/edit',
+    });
+
+    const tools = createDocsTools(resolveClient, true);
+    const docsEdit = getToolExecutor(tools, 'docs_edit');
+
+    await expect(
+      docsEdit.execute({
+        documentId: 'doc-2',
+        oldString: 'missing',
+        newString: 'found',
+      }),
+    ).rejects.toThrow('oldString not found in content');
+    expect(updateDocumentMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when oldString has multiple matches and replaceAll is false', async () => {
+    readDocumentMock.mockResolvedValue({
+      id: 'doc-3',
+      title: 'Draft',
+      text: 'repeat this repeat this',
+      webViewLink: 'https://docs.google.com/document/d/doc-3/edit',
+    });
+
+    const tools = createDocsTools(resolveClient, true);
+    const docsEdit = getToolExecutor(tools, 'docs_edit');
+
+    await expect(
+      docsEdit.execute({
+        documentId: 'doc-3',
+        oldString: 'repeat',
+        newString: 'replace',
+      }),
+    ).rejects.toThrow('Found multiple matches for oldString');
+    expect(updateDocumentMock).not.toHaveBeenCalled();
+  });
+
+  it('replaces all matches when replaceAll is true', async () => {
+    readDocumentMock.mockResolvedValue({
+      id: 'doc-4',
+      title: 'Checklist',
+      text: 'task task done',
+      webViewLink: 'https://docs.google.com/document/d/doc-4/edit',
+    });
+    updateDocumentMock.mockResolvedValue({
+      id: 'doc-4',
+      title: 'Checklist',
+      webViewLink: 'https://docs.google.com/document/d/doc-4/edit',
+    });
+
+    const tools = createDocsTools(resolveClient, true);
+    const docsEdit = getToolExecutor(tools, 'docs_edit');
+
+    await docsEdit.execute({
+      documentId: 'doc-4',
+      oldString: 'task',
+      newString: 'item',
+      replaceAll: true,
+    });
+
+    expect(updateDocumentMock).toHaveBeenCalledWith(client, 'doc-4', 'item item done', 'replace');
+  });
+});

--- a/connectors/google/src/__test__/toolsets.test.ts
+++ b/connectors/google/src/__test__/toolsets.test.ts
@@ -82,6 +82,7 @@ describe('buildGoogleToolsets', () => {
       'docs_read',
       'docs_create',
       'docs_update',
+      'docs_edit',
     ]);
   });
 

--- a/connectors/google/src/docs/tools.ts
+++ b/connectors/google/src/docs/tools.ts
@@ -51,6 +51,44 @@ const docsUpdateSchema = z.object({
     .describe('Use "replace" to overwrite content or "append" to add at the end'),
 });
 
+const docsEditSchema = z
+  .object({
+    account: z
+      .string()
+      .optional()
+      .describe('Optional account email or label when multiple Google accounts are connected'),
+    documentId: z.string().describe('The Google Docs document ID'),
+    oldString: z.string().min(1).describe('The text to replace'),
+    newString: z
+      .string()
+      .describe('The text to replace it with (must be different from oldString)'),
+    replaceAll: z
+      .boolean()
+      .optional()
+      .describe('Replace all occurrences of oldString (default false)'),
+  })
+  .refine((value) => value.newString !== value.oldString, {
+    message: 'newString must be different from oldString',
+    path: ['newString'],
+  });
+
+const MULTIPLE_MATCHES_ERROR =
+  'Found multiple matches for oldString. Provide more surrounding lines in oldString to identify the correct match.';
+
+function countOccurrences(content: string, oldString: string): number {
+  let count = 0;
+  let startIndex = 0;
+
+  while (true) {
+    const index = content.indexOf(oldString, startIndex);
+    if (index === -1) {
+      return count;
+    }
+    count += 1;
+    startIndex = index + oldString.length;
+  }
+}
+
 export function createDocsTools(
   resolveClient: (
     account?: string,
@@ -110,6 +148,37 @@ export function createDocsTools(
         return { ...result, usedAccount };
       },
     });
+
+    tools['docs_edit'] = tool({
+      description:
+        'Edit a Google Docs document by replacing exact text. Replaces one match by default, or all matches when replaceAll is true.',
+      inputSchema: docsEditSchema,
+      execute: async (input: z.infer<typeof docsEditSchema>) => {
+        const { client, usedAccount } = await resolveClient(input.account);
+        const document = await DocsApi.readDocument(client, input.documentId);
+        const matchCount = countOccurrences(document.text, input.oldString);
+
+        if (matchCount === 0) {
+          throw new Error('oldString not found in content');
+        }
+
+        if (!input.replaceAll && matchCount > 1) {
+          throw new Error(MULTIPLE_MATCHES_ERROR);
+        }
+
+        const nextContent = input.replaceAll
+          ? document.text.replaceAll(input.oldString, input.newString)
+          : document.text.replace(input.oldString, input.newString);
+
+        const result = await DocsApi.updateDocument(
+          client,
+          input.documentId,
+          nextContent,
+          'replace',
+        );
+        return { ...result, usedAccount };
+      },
+    });
   }
 
   return tools;
@@ -120,4 +189,8 @@ export const DOCS_TOOL_SUMMARIES = [
   { name: 'docs_read', description: 'Read a Google Docs document as plain text' },
   { name: 'docs_create', description: 'Create a Google Docs document (requires write access)' },
   { name: 'docs_update', description: 'Update a Google Docs document (requires write access)' },
+  {
+    name: 'docs_edit',
+    description: 'Edit a Google Docs document by replacing exact text (requires write access)',
+  },
 ];

--- a/connectors/google/src/toolsets.ts
+++ b/connectors/google/src/toolsets.ts
@@ -196,7 +196,9 @@ function createDocsToolset(scopes: string[], capabilities: string[]): GoogleTool
     hasWriteAccess(scopes, 'docs') && hasCapability(capabilities, GOOGLE_CAPABILITY_DOCS_WRITE);
   const summaries = canWrite
     ? DOCS_TOOL_SUMMARIES
-    : DOCS_TOOL_SUMMARIES.filter((t) => t.name !== 'docs_create' && t.name !== 'docs_update');
+    : DOCS_TOOL_SUMMARIES.filter(
+        (t) => t.name !== 'docs_create' && t.name !== 'docs_update' && t.name !== 'docs_edit',
+      );
 
   return {
     id: 'google-docs',
@@ -208,7 +210,7 @@ function createDocsToolset(scopes: string[], capabilities: string[]): GoogleTool
       'Google Docs search accepts optional Drive query filters (for example: "name contains \'Roadmap\'").',
       'docs_read returns flattened plain text extracted from the document body.',
       canWrite
-        ? 'You have write access. Use docs_create to create docs and docs_update to append or replace content.'
+        ? 'You have write access. Use docs_create to create docs, docs_update to append or replace content, and docs_edit for targeted text replacement.'
         : 'You have read-only access. Creating and updating docs is not available.',
     ].join('\n'),
     tools: () => summaries,


### PR DESCRIPTION
## 🚀 Change Summary
Adds a targeted Google Docs editing capability so write-enabled users can replace exact text in-place without rewriting entire documents.

### ✨ New Features
- **docs_edit Google Docs tool**: Introduces exact string replacement with support for single replacement by default or full replacement via eplaceAll.

### 🛠 Improvements & Refactors
- Expands Docs toolset guidance to include targeted edit workflows.
- Updates read-only tool filtering so docs_edit is only exposed when Docs write capability is available.
- Adds focused unit coverage for success and failure paths (missing text, mbiguous matches, and eplaceAll behavior).