### PR TITLE
improvement(browser): add required description field to browser tools and display on tool card

### DIFF
--- a/apps/web/src/components/chat/message-bubble/tool-call-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-block.tsx
@@ -116,7 +116,7 @@ export function ToolCallBlock({
     return <FileToolBlock toolName={toolName} status={status} args={args} error={error} />;
   }
 
-  if (toolName === 'browser' && hasArgs) {
+  if (toolName.startsWith('browser_') && hasArgs) {
     return (
       <BrowserToolBlock
         toolName={toolName}

--- a/apps/web/src/components/chat/message-bubble/tool-call/browser-tool-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/browser-tool-block.tsx
@@ -3,87 +3,23 @@ import * as React from 'react';
 
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
 
-import { ToolCard, truncateText } from './card-primitives';
+import { ToolCard, formatToolDisplayName } from './card-primitives';
 
 import { cn } from '@/lib/utils';
 
 function getBrowserArgs(args: unknown): {
-  action: string | null;
-  url: string | null;
-  ref: string | null;
-  text: string | null;
-  key: string | null;
-  tabId: string | null;
+  description: string | null;
   profile: string | null;
 } {
   const value = args as Record<string, unknown> | null | undefined;
   if (!value) {
-    return {
-      action: null,
-      url: null,
-      ref: null,
-      text: null,
-      key: null,
-      tabId: null,
-      profile: null,
-    };
+    return { description: null, profile: null };
   }
 
   return {
-    action: typeof value.action === 'string' ? value.action : null,
-    url: typeof value.url === 'string' ? value.url : null,
-    ref: typeof value.ref === 'string' ? value.ref : null,
-    text: typeof value.text === 'string' ? value.text : null,
-    key: typeof value.key === 'string' ? value.key : null,
-    tabId: typeof value.tabId === 'string' ? value.tabId : null,
+    description: typeof value.description === 'string' ? value.description : null,
     profile: typeof value.profile === 'string' ? value.profile : null,
   };
-}
-
-function getBrowserActionLabel(args: ReturnType<typeof getBrowserArgs>): string {
-  const { action, url, ref, text, key, tabId } = args;
-  if (!action) return 'Waiting...';
-
-  switch (action) {
-    case 'snapshot':
-      return 'Taking page snapshot';
-    case 'navigate':
-      return url ? `Navigate to ${truncateText(url, 60)}` : 'Navigate';
-    case 'click':
-      return ref ? `Click element ${ref}` : 'Click';
-    case 'type':
-      return ref ? `Type into ${ref}${text ? `: "${truncateText(text, 40)}"` : ''}` : 'Type';
-    case 'press':
-      return key ? `Press ${key}` : 'Press key';
-    case 'hover':
-      return ref ? `Hover over ${ref}` : 'Hover';
-    case 'select':
-      return ref ? `Select option in ${ref}` : 'Select';
-    case 'scroll':
-      return ref ? `Scroll ${ref} into view` : 'Scroll';
-    case 'screenshot':
-      return 'Taking screenshot';
-    case 'go_back':
-      return 'Go back';
-    case 'go_forward':
-      return 'Go forward';
-    case 'tab_new':
-      return url ? `Open new tab: ${truncateText(url, 60)}` : 'Open new tab';
-    case 'tab_list':
-      return 'List tabs';
-    case 'tab_focus':
-      return tabId ? `Switch to ${tabId}` : 'Switch tab';
-    case 'tab_close':
-      return tabId ? `Close ${tabId}` : 'Close tab';
-    case 'evaluate':
-      return 'Run JavaScript';
-    case 'wait':
-      return 'Waiting';
-    case 'resize':
-      return 'Resize viewport';
-    default:
-      return action;
-  }
 }
 
 type BrowserToolBlockProps = {
@@ -97,8 +33,8 @@ type BrowserToolBlockProps = {
 export function BrowserToolBlock({ toolName, status, args, result, error }: BrowserToolBlockProps) {
   const [open, setOpen] = React.useState(false);
   const browserArgs = getBrowserArgs(args);
-  const actionLabel = getBrowserActionLabel(browserArgs);
   const profileBadge = browserArgs.profile === 'user' ? 'User profile' : null;
+  const description = browserArgs.description;
 
   const resultOutput = (result as { output?: string } | undefined)?.output;
   const hasExpandableContent = Boolean(error || resultOutput);
@@ -118,7 +54,7 @@ export function BrowserToolBlock({ toolName, status, args, result, error }: Brow
           <ToolCard.StatusIndicator status={status} />
           <span className="min-w-0 flex-1 text-left">
             <span className="flex items-center gap-2">
-              <ToolCard.Title>{toolName}</ToolCard.Title>
+              <ToolCard.Title>{formatToolDisplayName(toolName)}</ToolCard.Title>
               {profileBadge ? (
                 <span className="inline-flex items-center gap-1 rounded-sm border border-border/50 bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
                   <GlobeIcon className="size-2.5" />
@@ -126,9 +62,11 @@ export function BrowserToolBlock({ toolName, status, args, result, error }: Brow
                 </span>
               ) : null}
             </span>
-            <ToolCard.TitleContent truncate className="mt-1 block">
-              {actionLabel}
-            </ToolCard.TitleContent>
+            {description ? (
+              <ToolCard.TitleContent truncate className="mt-1 block">
+                {description}
+              </ToolCard.TitleContent>
+            ) : null}
           </span>
           {hasExpandableContent ? (
             <ChevronRightIcon

--- a/packages/server/src/lib/browser/browser-manager.ts
+++ b/packages/server/src/lib/browser/browser-manager.ts
@@ -245,8 +245,17 @@ const SNAPSHOT_SCRIPT = `
 
     let ref = null;
     if (assignRef) {
-      refCounter++;
-      ref = 'e' + refCounter;
+      const existingRef = el.getAttribute('data-stitch-ref');
+      if (existingRef && /^e\\d+$/.test(existingRef)) {
+        ref = existingRef;
+        const numericRef = Number(existingRef.slice(1));
+        if (Number.isFinite(numericRef) && numericRef > refCounter) {
+          refCounter = numericRef;
+        }
+      } else {
+        refCounter++;
+        ref = 'e' + refCounter;
+      }
       refMap[ref] = { backendNodeId: null, role, name };
       el.setAttribute('data-stitch-ref', ref);
       newRefs.add(ref);
@@ -327,6 +336,10 @@ function buildRefResolveScript(ref: string): string {
       if (!el) return null;
       const rect = el.getBoundingClientRect();
       return {
+        left: Math.round(rect.left),
+        top: Math.round(rect.top),
+        width: Math.max(1, Math.round(rect.width)),
+        height: Math.max(1, Math.round(rect.height)),
         x: Math.round(rect.x + rect.width / 2),
         y: Math.round(rect.y + rect.height / 2),
         tag: el.tagName.toLowerCase(),
@@ -516,6 +529,29 @@ class BrowserManager {
 
   getCompletedDownloads() {
     return this.downloadWatchdog.getCompletedDownloads();
+  }
+
+  async handleDialog(
+    action: 'accept' | 'dismiss',
+    promptText?: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    this.throwIfAborted(signal);
+    await this.getPageSession();
+    this.popupWatchdog.setAutoDismiss(false);
+    try {
+      await this.popupWatchdog.handleDialog({ action, promptText });
+    } finally {
+      this.popupWatchdog.setAutoDismiss(true);
+    }
+    return action === 'accept' ? 'Dialog accepted' : 'Dialog dismissed';
+  }
+
+  async getExecutionState(signal?: AbortSignal): Promise<string> {
+    this.throwIfAborted(signal);
+    const session = await this.getPageSession();
+    const url = await this.getPageUrl(session);
+    return `${this.activeTargetId ?? ''}|${url}`;
   }
 
   /** Expose storage state management */
@@ -939,19 +975,55 @@ class BrowserManager {
     return lines.join('\n') + truncNote;
   }
 
-  async screenshot(signal?: AbortSignal): Promise<ScreenshotResult> {
+  async screenshot(options?: {
+    signal?: AbortSignal;
+    format?: 'png' | 'jpeg' | 'webp';
+    quality?: number;
+    fullPage?: boolean;
+    ref?: string;
+  }): Promise<ScreenshotResult> {
+    const signal = options?.signal;
     this.throwIfAborted(signal);
     const session = await this.getPageSession();
-    const result = await session.send(
-      'Page.captureScreenshot',
-      {
-        format: 'png',
-        quality: 80,
-      },
-      signal,
-    );
 
-    return { data: result.data as string, format: 'png' };
+    const format = options?.format ?? 'png';
+    const quality =
+      format === 'png'
+        ? undefined
+        : Math.max(0, Math.min(100, Math.round(options?.quality ?? 80)));
+
+    const params: Record<string, unknown> = {
+      format,
+      ...(quality !== undefined ? { quality } : {}),
+    };
+
+    if (options?.ref) {
+      const rect = await this.resolveRef(session, options.ref);
+      if (!rect) throw new Error(`Ref "${options.ref}" not found. Take a new snapshot first.`);
+      params.clip = {
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+        scale: 1,
+      };
+      params.captureBeyondViewport = true;
+    } else if (options?.fullPage) {
+      const metrics = await session.send('Page.getLayoutMetrics', {}, signal);
+      const contentSize = metrics.contentSize as Record<string, number>;
+      params.clip = {
+        x: 0,
+        y: 0,
+        width: Math.max(1, Math.round(contentSize?.width ?? DEFAULT_WIDTH)),
+        height: Math.max(1, Math.round(contentSize?.height ?? DEFAULT_HEIGHT)),
+        scale: 1,
+      };
+      params.captureBeyondViewport = true;
+    }
+
+    const result = await session.send('Page.captureScreenshot', params, signal);
+
+    return { data: result.data as string, format };
   }
 
   async evaluate(expression: string, signal?: AbortSignal): Promise<unknown> {
@@ -1376,11 +1448,27 @@ class BrowserManager {
   private async resolveRef(
     session: CDPClient,
     ref: string,
-  ): Promise<{ x: number; y: number } | null> {
+  ): Promise<{ x: number; y: number; left: number; top: number; width: number; height: number } | null> {
     const result = await this.evalInPage(session, buildRefResolveScript(ref));
     if (!result || typeof result !== 'object') return null;
-    const data = result as { x: number; y: number };
-    if (typeof data.x !== 'number' || typeof data.y !== 'number') return null;
+    const data = result as {
+      x: number;
+      y: number;
+      left: number;
+      top: number;
+      width: number;
+      height: number;
+    };
+    if (
+      typeof data.x !== 'number' ||
+      typeof data.y !== 'number' ||
+      typeof data.left !== 'number' ||
+      typeof data.top !== 'number' ||
+      typeof data.width !== 'number' ||
+      typeof data.height !== 'number'
+    ) {
+      return null;
+    }
     return data;
   }
 

--- a/packages/server/src/lib/browser/browser-manager.ts
+++ b/packages/server/src/lib/browser/browser-manager.ts
@@ -28,6 +28,7 @@ const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 720;
 const SETTLE_MS = 500;
 const LOAD_TIMEOUT_MS = 10_000;
+const NAVIGATION_DETECT_WINDOW_MS = 150;
 const SNAPSHOT_MAX_NODES = 5000;
 const SNAPSHOT_MAX_CHARS = 50_000;
 const SNAPSHOT_MAX_DEPTH = 30;
@@ -571,7 +572,11 @@ class BrowserManager {
     return (await response.json()) as BrowserTab[];
   }
 
-  async newTab(url?: string, signal?: AbortSignal): Promise<BrowserTab> {
+  async newTab(
+    url?: string,
+    options?: { signal?: AbortSignal; timeoutMs?: number },
+  ): Promise<BrowserTab> {
+    const signal = options?.signal;
     this.throwIfAborted(signal);
     this.ensureConnected();
     const result = await this.client!.send(
@@ -584,18 +589,27 @@ class BrowserManager {
     const targetId = result.targetId as string;
     this.activeTargetId = targetId;
     this.refMap.clear();
-    await this.ensurePageSession();
+    const session = await this.ensurePageSession();
+
+    await this.waitForLoad(session, signal, options?.timeoutMs);
+    await this.settle(undefined, signal);
 
     return { id: targetId, title: '', url: url ?? 'about:blank', type: 'page' };
   }
 
-  async focusTab(targetId: string, signal?: AbortSignal): Promise<void> {
+  async focusTab(
+    targetId: string,
+    options?: { signal?: AbortSignal; timeoutMs?: number },
+  ): Promise<void> {
+    const signal = options?.signal;
     this.throwIfAborted(signal);
     this.ensureConnected();
     await this.client!.send('Target.activateTarget', { targetId }, signal);
     this.activeTargetId = targetId;
     this.refMap.clear();
-    await this.ensurePageSession();
+    const session = await this.ensurePageSession();
+    await this.waitForLoad(session, signal, options?.timeoutMs);
+    await this.settle(undefined, signal);
   }
 
   async closeTab(targetId?: string, signal?: AbortSignal): Promise<void> {
@@ -625,13 +639,13 @@ class BrowserManager {
 
   // ── Navigation ──────────────────────────────────────────────
 
-  async navigate(url: string, signal?: AbortSignal): Promise<string> {
+  async navigate(url: string, signal?: AbortSignal, timeoutMs?: number): Promise<string> {
     this.throwIfAborted(signal);
     const session = await this.getPageSession();
     this.refMap.clear();
 
     await session.send('Page.navigate', { url }, signal);
-    await this.waitForLoad(session, signal);
+    await this.waitForLoad(session, signal, timeoutMs);
     await this.settle(undefined, signal);
 
     const [title, pageUrl] = await Promise.all([
@@ -642,7 +656,7 @@ class BrowserManager {
     return `Navigated to ${pageUrl} — "${title}"`;
   }
 
-  async goBack(signal?: AbortSignal): Promise<string> {
+  async goBack(signal?: AbortSignal, timeoutMs?: number): Promise<string> {
     this.throwIfAborted(signal);
     const session = await this.getPageSession();
     const entry = await this.getHistoryEntry(session, -1);
@@ -650,12 +664,12 @@ class BrowserManager {
 
     this.refMap.clear();
     await session.send('Page.navigateToHistoryEntry', { entryId: entry.id }, signal);
-    await this.waitForLoad(session, signal);
+    await this.waitForLoad(session, signal, timeoutMs);
     await this.settle(undefined, signal);
     return `Navigated back to ${entry.url} — "${entry.title}"`;
   }
 
-  async goForward(signal?: AbortSignal): Promise<string> {
+  async goForward(signal?: AbortSignal, timeoutMs?: number): Promise<string> {
     this.throwIfAborted(signal);
     const session = await this.getPageSession();
     const entry = await this.getHistoryEntry(session, 1);
@@ -663,7 +677,7 @@ class BrowserManager {
 
     this.refMap.clear();
     await session.send('Page.navigateToHistoryEntry', { entryId: entry.id }, signal);
-    await this.waitForLoad(session, signal);
+    await this.waitForLoad(session, signal, timeoutMs);
     await this.settle(undefined, signal);
     return `Navigated forward to ${entry.url} — "${entry.title}"`;
   }
@@ -677,6 +691,7 @@ class BrowserManager {
       button?: string;
       modifiers?: string[];
       signal?: AbortSignal;
+      timeoutMs?: number;
     },
   ): Promise<string> {
     const signal = options?.signal;
@@ -689,47 +704,36 @@ class BrowserManager {
     const clickCount = options?.doubleClick ? 2 : 1;
     const modifiers = resolveModifiers(options?.modifiers);
 
-    // Navigate-aware click: listen for frameNavigated during the click
-    let navigated = false;
-    const navHandler = () => {
-      navigated = true;
-    };
-    session.on('Page.frameNavigated', navHandler);
-
-    await session.send(
-      'Input.dispatchMouseEvent',
-      {
-        type: 'mousePressed',
-        x: resolved.x,
-        y: resolved.y,
-        button,
-        clickCount,
-        modifiers,
+    await this.runActionWithPotentialNavigation(
+      session,
+      async () => {
+        await session.send(
+          'Input.dispatchMouseEvent',
+          {
+            type: 'mousePressed',
+            x: resolved.x,
+            y: resolved.y,
+            button,
+            clickCount,
+            modifiers,
+          },
+          signal,
+        );
+        await session.send(
+          'Input.dispatchMouseEvent',
+          {
+            type: 'mouseReleased',
+            x: resolved.x,
+            y: resolved.y,
+            button,
+            clickCount,
+            modifiers,
+          },
+          signal,
+        );
       },
-      signal,
+      { signal, timeoutMs: options?.timeoutMs },
     );
-    await session.send(
-      'Input.dispatchMouseEvent',
-      {
-        type: 'mouseReleased',
-        x: resolved.x,
-        y: resolved.y,
-        button,
-        clickCount,
-        modifiers,
-      },
-      signal,
-    );
-
-    await this.settle(undefined, signal);
-
-    if (navigated) {
-      this.refMap.clear();
-      await this.waitForLoad(session, signal);
-      await this.settle(undefined, signal);
-    }
-
-    session.off('Page.frameNavigated', navHandler);
     return `Clicked ${ref} at (${resolved.x}, ${resolved.y})`;
   }
 
@@ -802,33 +806,23 @@ class BrowserManager {
     return `Typed "${text}" into ${ref}${options?.clear ? ' (cleared first)' : ''}${options?.submit ? ' and submitted' : ''}`;
   }
 
-  async press(key: string, signal?: AbortSignal): Promise<string> {
+  async press(key: string, signal?: AbortSignal, timeoutMs?: number): Promise<string> {
     this.throwIfAborted(signal);
     const session = await this.getPageSession();
     const keyDef = resolveKey(key);
 
-    let navigated = false;
-    const navHandler = () => {
-      navigated = true;
-    };
-
-    // Enter might trigger navigation
-    if (key === 'Enter') {
-      session.on('Page.frameNavigated', navHandler);
-    }
-
-    await session.send('Input.dispatchKeyEvent', { type: 'keyDown', ...keyDef }, signal);
-    await session.send('Input.dispatchKeyEvent', { type: 'keyUp', ...keyDef }, signal);
-
-    if (key === 'Enter') {
-      await this.settle(undefined, signal);
-      if (navigated) {
-        this.refMap.clear();
-        await this.waitForLoad(session, signal);
-        await this.settle(undefined, signal);
-      }
-      session.off('Page.frameNavigated', navHandler);
-    }
+    await this.runActionWithPotentialNavigation(
+      session,
+      async () => {
+        await session.send('Input.dispatchKeyEvent', { type: 'keyDown', ...keyDef }, signal);
+        await session.send('Input.dispatchKeyEvent', { type: 'keyUp', ...keyDef }, signal);
+      },
+      {
+        signal,
+        timeoutMs,
+        detectNavigation: key === 'Enter',
+      },
+    );
 
     return `Pressed "${key}"`;
   }
@@ -1152,7 +1146,12 @@ class BrowserManager {
 
   // ── Web search ──────────────────────────────────────────────
 
-  async search(query: string, engine: string = 'google', signal?: AbortSignal): Promise<string> {
+  async search(
+    query: string,
+    engine: string = 'google',
+    signal?: AbortSignal,
+    timeoutMs?: number,
+  ): Promise<string> {
     this.throwIfAborted(signal);
     const encodedQuery = encodeURIComponent(query);
     const searchUrls: Record<string, string> = {
@@ -1164,7 +1163,7 @@ class BrowserManager {
     if (!url)
       throw new Error(`Unsupported search engine: ${engine}. Use: google, duckduckgo, bing`);
 
-    return this.navigate(url, signal);
+    return this.navigate(url, signal, timeoutMs);
   }
 
   // ── Page content extraction (for extract tool) ─────────────
@@ -1324,7 +1323,11 @@ class BrowserManager {
     this.port = 0;
   }
 
-  private async waitForLoad(session: CDPClient, signal?: AbortSignal): Promise<void> {
+  private async waitForLoad(
+    session: CDPClient,
+    signal?: AbortSignal,
+    timeoutMs?: number,
+  ): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       if (signal?.aborted) {
         reject(new DOMException('Browser action aborted', 'AbortError'));
@@ -1405,7 +1408,7 @@ class BrowserManager {
         }
       };
 
-      const hardTimeout = setTimeout(finish, LOAD_TIMEOUT_MS);
+      const hardTimeout = setTimeout(finish, timeoutMs ?? LOAD_TIMEOUT_MS);
 
       signal?.addEventListener('abort', onAbort, { once: true });
       session.on('Page.domContentEventFired', onDomContentLoaded);
@@ -1418,6 +1421,59 @@ class BrowserManager {
 
   private async settle(ms?: number, signal?: AbortSignal): Promise<void> {
     await this.abortableSleep(ms ?? SETTLE_MS, signal);
+  }
+
+  private async runActionWithPotentialNavigation(
+    session: CDPClient,
+    action: () => Promise<void>,
+    options?: {
+      signal?: AbortSignal;
+      timeoutMs?: number;
+      detectNavigation?: boolean;
+      navigationDetectWindowMs?: number;
+    },
+  ): Promise<void> {
+    const signal = options?.signal;
+    this.throwIfAborted(signal);
+
+    const shouldDetectNavigation = options?.detectNavigation ?? true;
+    if (!shouldDetectNavigation) {
+      await action();
+      await this.settle(undefined, signal);
+      return;
+    }
+
+    let sawNavigation = false;
+    const onFrameNavigated = () => {
+      sawNavigation = true;
+    };
+    const onNavigatedWithinDocument = () => {
+      sawNavigation = true;
+    };
+
+    session.on('Page.frameNavigated', onFrameNavigated);
+    session.on('Page.navigatedWithinDocument', onNavigatedWithinDocument);
+
+    try {
+      await action();
+      await this.settle(undefined, signal);
+
+      if (!sawNavigation) {
+        await this.abortableSleep(
+          options?.navigationDetectWindowMs ?? NAVIGATION_DETECT_WINDOW_MS,
+          signal,
+        );
+      }
+
+      if (sawNavigation) {
+        this.refMap.clear();
+        await this.waitForLoad(session, signal, options?.timeoutMs);
+        await this.settle(undefined, signal);
+      }
+    } finally {
+      session.off('Page.frameNavigated', onFrameNavigated);
+      session.off('Page.navigatedWithinDocument', onNavigatedWithinDocument);
+    }
   }
 
   private async getPageTitle(session: CDPClient): Promise<string> {

--- a/packages/server/src/lib/browser/browser-manager.ts
+++ b/packages/server/src/lib/browser/browser-manager.ts
@@ -66,9 +66,12 @@ type NavigationEntry = {
 const SNAPSHOT_SCRIPT = `
 (() => {
   const prevRefs = window.__stitch_prev_refs || new Set();
+  const prevKeyToRef = window.__stitch_prev_key_to_ref || {};
   let refCounter = window.__stitch_ref_counter || 0;
   const refMap = {};
   const newRefs = new Set();
+  const usedRefs = new Set();
+  const keyToRef = {};
   let nodeCount = 0;
   let charCount = 0;
   const MAX_NODES = ${SNAPSHOT_MAX_NODES};
@@ -196,6 +199,35 @@ const SNAPSHOT_SCRIPT = `
     return attrs;
   }
 
+  function normalizeText(value) {
+    if (!value) return '';
+    return String(value).trim().replace(/s+/g, ' ').slice(0, 120);
+  }
+
+  function makeStableRefKey(el, role, name, depth) {
+    const tag = el.tagName.toLowerCase();
+    const parent = el.parentElement;
+    let siblingIndex = 0;
+    if (parent) {
+      const sameTag = Array.from(parent.children).filter((child) => child.tagName === el.tagName);
+      siblingIndex = sameTag.indexOf(el);
+    }
+    const bits = [
+      tag,
+      role || '',
+      normalizeText(name),
+      normalizeText(el.getAttribute('id')),
+      normalizeText(el.getAttribute('name')),
+      normalizeText(el.getAttribute('type')),
+      normalizeText(el.getAttribute('placeholder')),
+      normalizeText(el.getAttribute('aria-label')),
+      normalizeText(el.getAttribute('href')),
+      String(depth),
+      String(Math.max(0, siblingIndex)),
+    ];
+    return bits.join('|');
+  }
+
   // Compress <select> elements: show selected value + option count instead of full tree
   function compressSelect(el, depth, ref) {
     const indent = '  '.repeat(depth);
@@ -243,19 +275,36 @@ const SNAPSHOT_SCRIPT = `
     const shouldShow = role !== 'generic' || name;
     const interact = isInteractable(el);
     const assignRef = shouldShow && interact;
+    const stableKey = assignRef ? makeStableRefKey(el, role, name, depth) : null;
 
     let ref = null;
     if (assignRef) {
       const existingRef = el.getAttribute('data-stitch-ref');
-      if (existingRef && /^e\\d+$/.test(existingRef)) {
+      if (existingRef && /^e\\d+$/.test(existingRef) && !usedRefs.has(existingRef)) {
         ref = existingRef;
         const numericRef = Number(existingRef.slice(1));
+        if (Number.isFinite(numericRef) && numericRef > refCounter) {
+          refCounter = numericRef;
+        }
+      } else if (
+        stableKey &&
+        typeof prevKeyToRef[stableKey] === 'string' &&
+        /^e\\d+$/.test(prevKeyToRef[stableKey]) &&
+        !usedRefs.has(prevKeyToRef[stableKey])
+      ) {
+        ref = prevKeyToRef[stableKey];
+        const numericRef = Number(ref.slice(1));
         if (Number.isFinite(numericRef) && numericRef > refCounter) {
           refCounter = numericRef;
         }
       } else {
         refCounter++;
         ref = 'e' + refCounter;
+      }
+
+      usedRefs.add(ref);
+      if (stableKey) {
+        keyToRef[stableKey] = ref;
       }
       refMap[ref] = { backendNodeId: null, role, name };
       el.setAttribute('data-stitch-ref', ref);
@@ -311,6 +360,7 @@ const SNAPSHOT_SCRIPT = `
   window.__stitch_ref_counter = refCounter;
   window.__stitch_ref_map = refMap;
   window.__stitch_prev_refs = newRefs;
+  window.__stitch_prev_key_to_ref = keyToRef;
 
   // Scroll info
   const scrollTop = window.scrollY || document.documentElement.scrollTop || 0;
@@ -546,6 +596,18 @@ class BrowserManager {
       this.popupWatchdog.setAutoDismiss(true);
     }
     return action === 'accept' ? 'Dialog accepted' : 'Dialog dismissed';
+  }
+
+  async getDialogState(signal?: AbortSignal): Promise<{ open: boolean; type?: string; message?: string }> {
+    this.throwIfAborted(signal);
+    await this.getPageSession();
+    const pending = this.popupWatchdog.getPendingDialog();
+    if (!pending) return { open: false };
+    return {
+      open: true,
+      type: pending.type,
+      message: pending.message,
+    };
   }
 
   async getExecutionState(signal?: AbortSignal): Promise<string> {
@@ -911,6 +973,12 @@ class BrowserManager {
     lines.push(`### Page`);
     lines.push(`- URL: ${url}`);
     lines.push(`- Title: ${title}`);
+
+    const dialogState = this.popupWatchdog.getPendingDialog();
+    if (dialogState) {
+      const messagePreview = dialogState.message ? `: ${dialogState.message.slice(0, 120)}` : '';
+      lines.push(`- Dialog: open (${dialogState.type})${messagePreview}`);
+    }
 
     // Tabs
     try {

--- a/packages/server/src/lib/browser/instructions/browser.md
+++ b/packages/server/src/lib/browser/instructions/browser.md
@@ -1,79 +1,69 @@
-You are the Browser Agent - a specialized assistant that browses the web on behalf of the user. You control a real Chrome browser to navigate pages, interact with elements, and extract information.
+You are the Browser Agent. You control a real Chrome browser through focused tools.
 
-## Core workflow
+## Tool usage contract
 
-1. Use **snapshot** to get the page state: URL, tabs, scroll position, page stats, and a YAML accessibility tree with element refs (e.g. [ref=e1]).
-2. Use refs to interact: click ref=e3, type into ref=e5, hover ref=e7.
-3. After actions that change the page, take a new **snapshot** to get updated refs.
+1. Start with `browser_snapshot` before interactions.
+2. Use refs from the latest snapshot only.
+3. After page-changing actions, take a fresh `browser_snapshot`.
+4. Prefer deterministic refs/selectors over guesswork.
+5. Use `browser_interact` `evaluate` only as a last resort.
 
-## Multi-action batching (efficiency)
+## Primary workflow
 
-You can batch multiple actions in a single tool call using the `actions` array. This is the preferred way to interact - always batch when possible.
+1. `browser_snapshot` to get URL, tabs, page stats, and element refs.
+2. `browser_interact` for click/type/press/hover/select/scroll.
+3. `browser_wait` when stability is required (selector or explicit timing).
+4. `browser_snapshot` again whenever navigation or DOM churn is likely.
 
-- Safe to chain: type + type + type + click (fill a form then submit), scroll + scroll, click + click (when clicks don't navigate).
-- Page-changing actions (always put last): navigate, search, go_back, go_forward, evaluate - remaining actions after these are automatically skipped.
-- If a click triggers navigation, remaining actions are skipped and you get the new page state.
-- Always have one clear goal per batch. Don't try multiple unrelated paths.
+## Tool responsibilities
 
-## Action hierarchy (prefer actions higher in the list)
+- `browser_snapshot`: Capture current page state and refs.
+- `browser_navigate`: Navigate/search/history/tab operations.
+- `browser_interact`: Element and keyboard/mouse interactions.
+- `browser_wait`: Wait for selector or timed delay.
+- `browser_screenshot`: Viewport, full-page, or element screenshots.
+- `browser_dialog`: Inspect/handle open dialogs.
+- `browser_content`: Extract page content, search visible text, find elements by selector.
+- `browser_batch`: Execute a short sequence (max 5) of browser actions in one call.
 
-1. **snapshot** + ref-based actions (click, type, hover, select) - primary workflow
-2. **search** - direct web search, much faster than manually navigating to a search engine
-3. **extract** - pull structured data from the full page content (not just visible area)
-4. **search_page** / **find_elements** - lightweight, zero-cost lookups (no full snapshot needed)
-5. **evaluate** - last resort for complex DOM manipulation only
+## Batch usage rules
 
-## Actions
+- Use `browser_batch` only for one clear goal (e.g., fill form fields then submit).
+- Put page-changing operations last in a batch.
+- If the batch stops due to page change, take a new `browser_snapshot` and continue from remaining intent.
+- Prefer single-tool calls when page state is uncertain.
 
-- **snapshot**: Get accessibility tree with element refs, current URL, open tabs, scroll position, and page stats. Always do this first.
-- **navigate**: Go to a URL (`url`)
-- **search**: Search the web directly (`query`, optional `engine`)
-- **extract**: Extract content from the full page (`query`, optional `selector`)
-- **click**: Click an element (`ref`, optional `doubleClick`, `button`, `modifiers`)
-- **type**: Type text (`ref`, `text`, optional `submit`, `slowly`, `clear`)
-- **press**: Press a key (`key`)
-- **hover**: Hover over an element (`ref`)
-- **select**: Select option(s) in a select (`ref`, `values`)
-- **scroll**: Scroll the page or an element (`direction`, optional `ref`)
-- **screenshot**: Take a screenshot
-- **go_back** / **go_forward**: Navigate history
-- **tab_new** / **tab_list** / **tab_focus** / **tab_close**: Manage tabs
-- **search_page**: Search visible page text quickly
-- **find_elements**: Query DOM by CSS selector quickly
-- **evaluate**: Run JavaScript in the page (last resort)
-- **wait**: Wait for time or selector
-- **resize**: Resize viewport
+### Batch action categories
 
-## Autocomplete and dropdown handling
+- Page-changing (place last): `navigate`, `search`, `go_back`, `go_forward`, `tab_new`, `tab_focus`, `evaluate`.
+- Potentially page-changing: `click`, `press`.
+- Safe to chain: `type`, `hover`, `select`, `scroll`, `wait`, `search_page`, `find_elements`, `extract`, screenshots, dialog checks.
 
-- After typing into search/autocomplete fields, take a new snapshot before pressing Enter.
-- If suggestions appear, click the right suggestion instead of pressing Enter.
+## Reliability rules
 
-## Modal, popup, and cookie banner handling
+- If an interaction fails with stale/missing ref, run `browser_snapshot` and retry once.
+- If blocked by a dialog, use `browser_dialog` before retrying actions.
+- After navigation-capable actions (`browser_navigate`, `click`, `press`), verify current page with `browser_snapshot`.
+- Do not loop retries on CAPTCHA, rate limits, or auth blocks.
 
-- Dismiss cookie banners, modals, and overlays before interacting with the page.
+## Interaction guidance
 
-## Scroll awareness
-
-- If content is missing, scroll and snapshot again.
-- Prefer `search_page` for finding specific text.
-
-## Failure recovery
-
-- If a ref is not found, snapshot again.
-- If the same action fails repeatedly, change strategy.
-- If blocked by access limits/CAPTCHA/rate limit, do not loop retries.
+- For autocomplete fields: type, snapshot, then choose suggestion or submit.
+- Dismiss overlays/cookie banners before main actions.
+- If target content is not visible, scroll and snapshot again.
+- Use `browser_content` for fast text/DOM checks when full snapshots are unnecessary.
 
 ## Asking the user for help
 
-- Use the `question` tool for manual steps (CAPTCHA, 2FA, manual login) or critical confirmations.
+- Use `question` for CAPTCHA, MFA, manual login, or irreversible user decisions.
 
 ## Verification before completion
 
-- Re-read the original request and verify all requirements.
-- Confirm outcomes with snapshot/search_page.
-- Never fabricate data.
+- Re-check the original request.
+- Confirm outcomes with snapshot/content checks.
+- Never fabricate data or claims.
 
-## Response guidelines
+## Response style
 
-When done, provide a concise summary with key results and URLs.
+- Provide concise, factual results.
+- Include key URLs and what was verified.

--- a/packages/server/src/lib/browser/types.ts
+++ b/packages/server/src/lib/browser/types.ts
@@ -39,7 +39,7 @@ export type BrowserVersionInfo = {
 
 export type ScreenshotResult = {
   data: string;
-  format: 'png' | 'jpeg';
+  format: 'png' | 'jpeg' | 'webp';
 };
 
 export type LaunchOptions = {
@@ -121,4 +121,5 @@ export const BROWSER_ACTIONS = [
   'find_elements',
   'search',
   'extract',
+  'handle_dialog',
 ] as const;

--- a/packages/server/src/lib/browser/types.ts
+++ b/packages/server/src/lib/browser/types.ts
@@ -122,4 +122,5 @@ export const BROWSER_ACTIONS = [
   'search',
   'extract',
   'handle_dialog',
+  'dialog_state',
 ] as const;

--- a/packages/server/src/lib/browser/types.ts
+++ b/packages/server/src/lib/browser/types.ts
@@ -97,30 +97,3 @@ export type PageStats = {
   images: number;
   totalElements: number;
 };
-
-export const BROWSER_ACTIONS = [
-  'snapshot',
-  'navigate',
-  'click',
-  'type',
-  'press',
-  'hover',
-  'select',
-  'scroll',
-  'screenshot',
-  'go_back',
-  'go_forward',
-  'tab_new',
-  'tab_list',
-  'tab_focus',
-  'tab_close',
-  'evaluate',
-  'wait',
-  'resize',
-  'search_page',
-  'find_elements',
-  'search',
-  'extract',
-  'handle_dialog',
-  'dialog_state',
-] as const;

--- a/packages/server/src/lib/browser/watchdogs/popup-watchdog.ts
+++ b/packages/server/src/lib/browser/watchdogs/popup-watchdog.ts
@@ -12,30 +12,69 @@ const log = Log.create({ service: 'browser.watchdog.popup' });
  */
 export class PopupWatchdog {
   private sessions = new Set<CDPClient>();
+  private autoDismiss = true;
+  private pendingDialog: { type: string; message?: string } | null = null;
 
   attach(session: CDPClient): void {
     if (this.sessions.has(session)) return;
     this.sessions.add(session);
-    session.on('Page.javascriptDialogOpening', this.handleDialog);
+    session.on('Page.javascriptDialogOpening', this.onDialogOpening);
     log.debug('Popup watchdog attached to session');
   }
 
   detach(session: CDPClient): void {
     if (!this.sessions.has(session)) return;
-    session.off('Page.javascriptDialogOpening', this.handleDialog);
+    session.off('Page.javascriptDialogOpening', this.onDialogOpening);
     this.sessions.delete(session);
   }
 
   detachAll(): void {
     for (const session of this.sessions) {
-      session.off('Page.javascriptDialogOpening', this.handleDialog);
+      session.off('Page.javascriptDialogOpening', this.onDialogOpening);
     }
     this.sessions.clear();
+    this.pendingDialog = null;
   }
 
-  private handleDialog = (params: Record<string, unknown>): void => {
+  setAutoDismiss(enabled: boolean): void {
+    this.autoDismiss = enabled;
+  }
+
+  hasPendingDialog(): boolean {
+    return this.pendingDialog !== null;
+  }
+
+  async handleDialog(options: { action: 'accept' | 'dismiss'; promptText?: string }): Promise<void> {
+    if (!this.pendingDialog) {
+      throw new Error('No open dialog found');
+    }
+
+    const accept = options.action === 'accept';
+    const tasks: Promise<unknown>[] = [];
+    for (const session of this.sessions) {
+      if (!session.isConnected) continue;
+      tasks.push(
+        session.send('Page.handleJavaScriptDialog', {
+          accept,
+          promptText: options.promptText,
+        }),
+      );
+    }
+
+    await Promise.allSettled(tasks);
+    this.pendingDialog = null;
+  }
+
+  private onDialogOpening = (params: Record<string, unknown>): void => {
     const dialogType = params.type as string;
     const message = params.message as string | undefined;
+
+    this.pendingDialog = { type: dialogType, message };
+
+    if (!this.autoDismiss) {
+      log.info({ dialogType, message: message?.slice(0, 200) }, 'Dialog opened and waiting for explicit handling');
+      return;
+    }
 
     log.info({ dialogType, message: message?.slice(0, 200) }, 'Auto-dismissing JS dialog');
 
@@ -51,5 +90,7 @@ export class PopupWatchdog {
         // Swallow — dialog may already have been handled or session closed
       });
     }
+
+    this.pendingDialog = null;
   };
 }

--- a/packages/server/src/lib/browser/watchdogs/popup-watchdog.ts
+++ b/packages/server/src/lib/browser/watchdogs/popup-watchdog.ts
@@ -44,6 +44,11 @@ export class PopupWatchdog {
     return this.pendingDialog !== null;
   }
 
+  getPendingDialog(): { type: string; message?: string } | null {
+    if (!this.pendingDialog) return null;
+    return { ...this.pendingDialog };
+  }
+
   async handleDialog(options: { action: 'accept' | 'dismiss'; promptText?: string }): Promise<void> {
     if (!this.pendingDialog) {
       throw new Error('No open dialog found');

--- a/packages/server/src/tools/core/browser.ts
+++ b/packages/server/src/tools/core/browser.ts
@@ -3,8 +3,7 @@ import { z } from 'zod';
 
 import { getBrowserManager } from '@/lib/browser/browser-manager.js';
 import { importChromeProfile, listChromeProfiles } from '@/lib/browser/chrome-profile-importer.js';
-import { BROWSER_ACTIONS } from '@/lib/browser/types.js';
-import type { ScrollDirection } from '@/lib/browser/types.js';
+import type { BrowserTab, FindElementsResult, ScrollDirection, SearchPageResult } from '@/lib/browser/types.js';
 import * as Log from '@/lib/log.js';
 import { askQuestion } from '@/question/service.js';
 import { listSettings, saveSetting } from '@/settings/service.js';
@@ -12,490 +11,217 @@ import { isServiceError } from '@/lib/service-result.js';
 import type { ToolContext } from '@/tools/runtime/wrappers.js';
 import { withTruncation } from '@/tools/runtime/wrappers.js';
 
-const browserInputSchema = z.object({
-  action: z.enum(BROWSER_ACTIONS).describe('The browser action to perform.'),
-  actions: z
-    .array(
-      z.object({
-        action: z.enum(BROWSER_ACTIONS).describe('The browser action to perform.'),
-        url: z.string().optional().describe('URL for navigate, tab_new, or search engine URL.'),
-        ref: z.string().optional().describe('Element ref from a snapshot (e.g. "e1").'),
-        text: z.string().optional().describe('Text to type or wait for.'),
-        key: z.string().optional().describe('Key to press (e.g. "Enter", "Tab").'),
-        values: z.array(z.string()).optional().describe('Option values to select.'),
-        submit: z.boolean().optional().describe('Press Enter after typing.'),
-        slowly: z.boolean().optional().describe('Type character by character.'),
-        clear: z.boolean().optional().describe('Clear the field before typing.'),
-        doubleClick: z.boolean().optional().describe('Double-click instead of single click.'),
-        button: z.string().optional().describe('Mouse button: "left", "right", or "middle".'),
-        modifiers: z.array(z.string()).optional().describe('Keyboard modifiers.'),
-        direction: z.enum(['up', 'down', 'left', 'right']).optional().describe('Scroll direction.'),
-        fn: z.string().optional().describe('JavaScript expression to evaluate.'),
-        width: z.number().optional().describe('Viewport width in pixels.'),
-        height: z.number().optional().describe('Viewport height in pixels.'),
-        tabId: z.string().optional().describe('Tab ID.'),
-        timeMs: z.number().optional().describe('Wait time in ms.'),
-        selector: z.string().optional().describe('CSS selector.'),
-        format: z.enum(['png', 'jpeg', 'webp']).optional().describe('Screenshot format.'),
-        quality: z.number().optional().describe('Screenshot quality for jpeg/webp (0-100).'),
-        fullPage: z.boolean().optional().describe('Take a full-page screenshot.'),
-        timeoutMs: z.number().optional().describe('Action timeout in milliseconds.'),
-        dialogAction: z.enum(['accept', 'dismiss']).optional().describe('Dialog action to take.'),
-        promptText: z.string().optional().describe('Prompt text for accepted dialog prompts.'),
-        pattern: z.string().optional().describe('Text pattern to search for.'),
-        regex: z.boolean().optional().describe('Treat pattern as regex.'),
-        caseSensitive: z.boolean().optional().describe('Case-sensitive search.'),
-        contextChars: z.number().optional().describe('Context chars per match.'),
-        cssScope: z.string().optional().describe('CSS selector to scope search within.'),
-        maxResults: z.number().optional().describe('Max results to return.'),
-        attributes: z.array(z.string()).optional().describe('Attributes to extract.'),
-        includeText: z.boolean().optional().describe('Include element text content.'),
-        query: z.string().optional().describe('Search query or extraction query.'),
-        engine: z.string().optional().describe('Search engine: google, duckduckgo, bing.'),
-      }),
-    )
-    .optional()
-    .describe(
-      'Array of actions for multi-action batching. Execute sequentially; stops if a page navigation occurs.',
-    ),
+const headlessField = z
+  .boolean()
+  .optional()
+  .default(true)
+  .describe(
+    'Run the browser without a visible window. Defaults to true. Set to false only when you need to show the browser to the user.',
+  );
+
+const timeoutField = z.number().optional().describe('Action timeout in milliseconds.');
+
+const browserSnapshotInputSchema = z.object({
+  headless: headlessField,
+});
+
+const browserNavigateInputSchema = z.object({
+  action: z
+    .enum(['navigate', 'search', 'go_back', 'go_forward', 'tab_new', 'tab_list', 'tab_focus', 'tab_close'])
+    .describe('Navigation action to perform.'),
   url: z.string().optional().describe('URL for navigate or tab_new actions.'),
+  query: z.string().optional().describe('Search query for search action.'),
+  engine: z.string().optional().describe('Search engine: google, duckduckgo, bing.'),
+  tabId: z.string().optional().describe('Tab ID for tab_focus or tab_close actions.'),
+  timeoutMs: timeoutField,
+  headless: headlessField,
+});
+
+const browserInteractInputSchema = z.object({
+  action: z
+    .enum(['click', 'type', 'press', 'hover', 'select', 'scroll', 'resize', 'evaluate'])
+    .describe('Interaction action to perform.'),
   ref: z
     .string()
     .optional()
-    .describe(
-      'Element ref from a snapshot (e.g. "e1", "e2"). Used by click, type, hover, select, scroll.',
-    ),
-  text: z
-    .string()
-    .optional()
-    .describe('Text to type (type action) or text to wait for (wait action).'),
-  key: z
-    .string()
-    .optional()
-    .describe('Key to press (e.g. "Enter", "Tab", "Escape", "ArrowDown"). For press action.'),
-  values: z.array(z.string()).optional().describe('Option values to select. For select action.'),
+    .describe('Element ref from a snapshot (e.g. "e1", "e2"). Required for click/type/hover/select.'),
+  text: z.string().optional().describe('Text to type. Required for type action.'),
+  key: z.string().optional().describe('Key to press (e.g. Enter, Tab, Escape). Required for press action.'),
+  values: z.array(z.string()).optional().describe('Option values for select action.'),
   submit: z.boolean().optional().describe('Press Enter after typing. For type action.'),
-  slowly: z
-    .boolean()
-    .optional()
-    .describe('Type character by character instead of filling. For type action.'),
+  slowly: z.boolean().optional().describe('Type character by character. For type action.'),
   clear: z.boolean().optional().describe('Clear the field before typing. For type action.'),
-  doubleClick: z
-    .boolean()
-    .optional()
-    .describe('Double-click instead of single click. For click action.'),
-  button: z
-    .string()
-    .optional()
-    .describe('Mouse button: "left", "right", or "middle". For click action.'),
-  modifiers: z
-    .array(z.string())
-    .optional()
-    .describe('Keyboard modifiers: "Alt", "Control", "Meta", "Shift". For click action.'),
+  doubleClick: z.boolean().optional().describe('Double-click instead of single click. For click action.'),
+  button: z.string().optional().describe('Mouse button: left, right, or middle. For click action.'),
+  modifiers: z.array(z.string()).optional().describe('Keyboard modifiers for click action.'),
   direction: z
     .enum(['up', 'down', 'left', 'right'])
     .optional()
-    .describe('Direction to scroll. For scroll action.'),
-  fn: z
-    .string()
-    .optional()
-    .describe('JavaScript expression to evaluate in the browser. For evaluate action.'),
-  width: z.number().optional().describe('Viewport width in pixels. For resize action.'),
-  height: z.number().optional().describe('Viewport height in pixels. For resize action.'),
-  tabId: z.string().optional().describe('Tab ID for tab_focus or tab_close actions.'),
-  timeMs: z.number().optional().describe('Time to wait in milliseconds. For wait action.'),
-  selector: z
-    .string()
-    .optional()
-    .describe(
-      'CSS selector. For wait, find_elements, or extract (scopes extraction to element) actions.',
-    ),
-  format: z
-    .enum(['png', 'jpeg', 'webp'])
-    .optional()
-    .describe('Screenshot format. For screenshot action. Default png.'),
-  quality: z
-    .number()
-    .optional()
-    .describe('Screenshot quality 0-100 for jpeg/webp. For screenshot action.'),
-  fullPage: z.boolean().optional().describe('Capture full page screenshot. For screenshot action.'),
-  timeoutMs: z.number().optional().describe('Action timeout in milliseconds.'),
-  dialogAction: z
-    .enum(['accept', 'dismiss'])
-    .optional()
-    .describe('Whether to accept or dismiss a dialog. For handle_dialog action.'),
-  promptText: z
-    .string()
-    .optional()
-    .describe('Optional prompt text for accepted prompt dialogs. For handle_dialog action.'),
-  pattern: z.string().optional().describe('Text pattern to search for. For search_page action.'),
-  regex: z.boolean().optional().describe('Treat pattern as regex. For search_page action.'),
-  caseSensitive: z.boolean().optional().describe('Case-sensitive search. For search_page action.'),
-  contextChars: z
-    .number()
-    .optional()
-    .describe('Characters of surrounding context per match. For search_page action.'),
-  cssScope: z
-    .string()
-    .optional()
-    .describe('CSS selector to scope search within. For search_page action.'),
-  maxResults: z
-    .number()
-    .optional()
-    .describe('Max results to return. For search_page or find_elements actions.'),
-  attributes: z
-    .array(z.string())
-    .optional()
-    .describe('Specific attributes to extract (e.g. ["href", "src"]). For find_elements action.'),
-  includeText: z
-    .boolean()
-    .optional()
-    .describe('Include element text content. For find_elements action. Default true.'),
-  query: z
-    .string()
-    .optional()
-    .describe('Search query for search action, or extraction query for extract action.'),
-  engine: z
-    .string()
-    .optional()
-    .describe('Search engine: "google" (default), "duckduckgo", "bing". For search action.'),
-  headless: z
+    .describe('Direction to scroll. Required for scroll action.'),
+  width: z.number().optional().describe('Viewport width in pixels. Required for resize action.'),
+  height: z.number().optional().describe('Viewport height in pixels. Required for resize action.'),
+  fn: z.string().optional().describe('JavaScript expression to evaluate. Required for evaluate action.'),
+  timeoutMs: timeoutField,
+  headless: headlessField,
+});
+
+const browserWaitInputSchema = z.object({
+  mode: z
+    .enum(['time', 'selector'])
+    .describe('Wait mode. Use time for timed waits and selector for CSS selector waits.'),
+  timeMs: z.number().optional().describe('Time to wait in milliseconds. Required for time mode.'),
+  selector: z.string().optional().describe('CSS selector to wait for. Required for selector mode.'),
+  timeoutMs: timeoutField,
+  headless: headlessField,
+});
+
+const browserScreenshotInputSchema = z.object({
+  ref: z.string().optional().describe('Element ref for element screenshot.'),
+  format: z.enum(['png', 'jpeg', 'webp']).optional().describe('Screenshot format. Default png.'),
+  quality: z.number().optional().describe('Screenshot quality 0-100 for jpeg/webp.'),
+  fullPage: z.boolean().optional().describe('Capture full page screenshot.'),
+  headless: headlessField,
+});
+
+const browserDialogInputSchema = z.object({
+  action: z.enum(['state', 'handle']).describe('Dialog action to perform.'),
+  dialogAction: z.enum(['accept', 'dismiss']).optional().describe('Whether to accept or dismiss a dialog.'),
+  promptText: z.string().optional().describe('Optional prompt text when accepting prompt dialogs.'),
+  headless: headlessField,
+});
+
+const browserContentInputSchema = z.object({
+  action: z.enum(['extract', 'search_page', 'find_elements']).describe('Content action to perform.'),
+  query: z.string().optional().describe('Extraction query for extract action.'),
+  selector: z.string().optional().describe('CSS selector for extract or find_elements actions.'),
+  pattern: z.string().optional().describe('Text pattern to search for. Required for search_page action.'),
+  regex: z.boolean().optional().describe('Treat pattern as regex for search_page action.'),
+  caseSensitive: z.boolean().optional().describe('Case-sensitive search for search_page action.'),
+  contextChars: z.number().optional().describe('Context characters per match for search_page action.'),
+  cssScope: z.string().optional().describe('CSS selector to scope text search within for search_page action.'),
+  maxResults: z.number().optional().describe('Max results for search_page or find_elements actions.'),
+  attributes: z.array(z.string()).optional().describe('Attributes to extract for find_elements action.'),
+  includeText: z.boolean().optional().describe('Include text content for find_elements action. Default true.'),
+  headless: headlessField,
+});
+
+const browserBatchActionSchema = z.object({
+  tool: z
+    .enum([
+      'snapshot',
+      'navigate',
+      'interact',
+      'wait',
+      'screenshot',
+      'dialog',
+      'content',
+    ])
+    .describe('Tool group to execute for this batch action.'),
+  op: z.string().optional().describe('Operation name within the selected tool group.'),
+  url: z.string().optional().describe('URL for navigate/tab_new operations.'),
+  query: z.string().optional().describe('Query for search or extract operations.'),
+  engine: z.string().optional().describe('Search engine for search operation.'),
+  tabId: z.string().optional().describe('Tab ID for tab_focus/tab_close operations.'),
+  ref: z.string().optional().describe('Element ref from latest snapshot.'),
+  text: z.string().optional().describe('Text for type operation.'),
+  key: z.string().optional().describe('Key for press operation.'),
+  values: z.array(z.string()).optional().describe('Values for select operation.'),
+  submit: z.boolean().optional().describe('Submit after typing.'),
+  slowly: z.boolean().optional().describe('Type character by character.'),
+  clear: z.boolean().optional().describe('Clear field before typing.'),
+  doubleClick: z.boolean().optional().describe('Double-click for click operation.'),
+  button: z.string().optional().describe('Mouse button for click operation.'),
+  modifiers: z.array(z.string()).optional().describe('Modifier keys for click operation.'),
+  direction: z.enum(['up', 'down', 'left', 'right']).optional().describe('Scroll direction.'),
+  width: z.number().optional().describe('Width for resize operation.'),
+  height: z.number().optional().describe('Height for resize operation.'),
+  fn: z.string().optional().describe('Expression for evaluate operation.'),
+  mode: z.enum(['time', 'selector']).optional().describe('Mode for wait tool.'),
+  timeMs: z.number().optional().describe('Duration in ms for wait time mode.'),
+  selector: z.string().optional().describe('CSS selector for wait/find/extract scope.'),
+  timeoutMs: timeoutField,
+  format: z.enum(['png', 'jpeg', 'webp']).optional().describe('Screenshot format.'),
+  quality: z.number().optional().describe('Screenshot quality for jpeg/webp.'),
+  fullPage: z.boolean().optional().describe('Full-page screenshot mode.'),
+  dialogAction: z.enum(['accept', 'dismiss']).optional().describe('Dialog handling action.'),
+  promptText: z.string().optional().describe('Prompt text when accepting prompt dialogs.'),
+  pattern: z.string().optional().describe('Pattern for search_page operation.'),
+  regex: z.boolean().optional().describe('Regex mode for search_page operation.'),
+  caseSensitive: z.boolean().optional().describe('Case-sensitive mode for search_page operation.'),
+  contextChars: z.number().optional().describe('Context chars for search_page operation.'),
+  cssScope: z.string().optional().describe('CSS scope for search_page operation.'),
+  maxResults: z.number().optional().describe('Max results for search_page/find_elements.'),
+  attributes: z.array(z.string()).optional().describe('Attributes to return for find_elements.'),
+  includeText: z.boolean().optional().describe('Whether find_elements should include text content.'),
+});
+
+const browserBatchInputSchema = z.object({
+  actions: z.array(browserBatchActionSchema).min(1).max(5).describe('Sequential actions to execute.'),
+  stopOnPageChange: z
     .boolean()
     .optional()
     .default(true)
-    .describe(
-      'Run the browser without a visible window. Defaults to true. Set to false only when you need to show the browser to the user.',
-    ),
+    .describe('Stop executing remaining actions if page state changes.'),
+  stopOnError: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('Stop executing remaining actions when an action fails.'),
+  headless: headlessField,
 });
 
-type BrowserInput = z.infer<typeof browserInputSchema>;
+const SNAPSHOT_DESCRIPTION = `Capture the current browser state as a fresh snapshot.
 
-const TOOL_DESCRIPTION = `Control a Chrome browser to interact with web pages. The browser launches automatically on first use with a persistent profile.
+Use this before interactions to get current refs. The snapshot includes URL, tabs, scroll metadata, page stats, and a YAML accessibility tree with refs like [ref=e12].`;
 
-## Multi-Action Batching
-Use the \`actions\` array to execute multiple actions in one call. Actions run sequentially and stop automatically if a page navigation occurs. This is the most efficient way to fill forms, click through flows, etc.
-Example: \`{"action": "snapshot", "actions": [{"action": "type", "ref": "e3", "text": "hello", "clear": true}, {"action": "type", "ref": "e5", "text": "world"}, {"action": "click", "ref": "e7"}]}\`
-Note: The top-level \`action\` field is ignored when \`actions\` is provided.
+const NAVIGATE_DESCRIPTION = `Run browser navigation and tab actions.
 
-## Actions
-- **snapshot**: Get accessibility tree with element refs (e.g. [ref=e1]). Includes URL, tabs, scroll position, and page stats. New elements since last snapshot are marked with *[ref=eN]. Always do this first.
-- **navigate**: Go to a URL (set \`url\`)
-- **search**: Search the web directly (set \`query\`, optionally \`engine\`: google/duckduckgo/bing). Faster than manually navigating to a search engine.
-- **extract**: Extract structured content from the current page (set \`query\` with what to extract, optionally \`selector\` with a CSS selector to scope extraction to a specific element). Uses the full page content, not just visible area. Great for pulling data, prices, article text, etc.
-- **click**: Click an element (set \`ref\`)
-- **type**: Type text (set \`ref\` and \`text\`, optionally \`submit\`, \`clear\`)
-- **press**: Press a key (set \`key\`)
-- **hover**: Hover over an element (set \`ref\`)
-- **select**: Select option(s) in a <select> (set \`ref\` and \`values\`)
-- **scroll**: Scroll the page or element (set \`direction\`, optionally \`ref\`)
-- **screenshot**: Take a screenshot (base64 PNG)
-- **go_back** / **go_forward**: Navigate history
-- **tab_new** / **tab_list** / **tab_focus** / **tab_close**: Tab management
-- **search_page**: Search visible text for a pattern (set \`pattern\`). Zero cost, instant.
-- **find_elements**: Query DOM by CSS selector (set \`selector\`). Zero cost, instant.
-- **evaluate**: Run JavaScript in the page (set \`fn\`). Last resort.
-- **wait**: Wait for time or selector
-- **resize**: Resize viewport
-- **handle_dialog**: Accept or dismiss an open browser dialog
-- **dialog_state**: Check whether a browser dialog is currently open`;
+Actions:
+- navigate: go to URL
+- search: run web search directly
+- go_back / go_forward: history navigation
+- tab_new / tab_list / tab_focus / tab_close: tab management
 
-async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): Promise<unknown> {
-  const browser = getBrowserManager();
+Use timeoutMs for navigation-sensitive operations.`;
 
-  // Auto-launch on first use — any action can be the first call
-  await browser.launch({ headless: input.headless });
+const INTERACT_DESCRIPTION = `Interact with page elements and keyboard/mouse controls.
 
-  switch (input.action) {
-    case 'snapshot': {
-      const tree = await browser.snapshot(signal);
-      return { output: tree };
-    }
+Actions:
+- click / type / hover / select / scroll
+- press (keyboard)
+- resize (viewport)
+- evaluate (JavaScript, last resort)
 
-    case 'navigate': {
-      if (!input.url) throw new Error('Missing required field: url');
-      const result = await browser.navigate(input.url, signal, input.timeoutMs);
-      return { output: result };
-    }
+Use refs from the latest snapshot for element-targeted actions.`;
 
-    case 'search': {
-      if (!input.query) throw new Error('Missing required field: query');
-      const result = await browser.search(
-        input.query,
-        input.engine ?? 'google',
-        signal,
-        input.timeoutMs,
-      );
-      return { output: result };
-    }
+const WAIT_DESCRIPTION = `Wait for page conditions.
 
-    case 'extract': {
-      if (!input.query) throw new Error('Missing required field: query');
-      const content = await browser.extractPageContent(signal, input.selector);
-      const selectorNote = input.selector ? `\n**Selector:** ${input.selector}` : '';
-      return {
-        output: `### Extracted Content\n**Query:** ${input.query}${selectorNote}\n\n${content}`,
-      };
-    }
+Modes:
+- time: wait a fixed duration using timeMs
+- selector: wait for a CSS selector using selector
 
-    case 'click': {
-      if (!input.ref) throw new Error('Missing required field: ref');
-      const result = await browser.click(input.ref, {
-        doubleClick: input.doubleClick,
-        button: input.button,
-        modifiers: input.modifiers,
-        signal,
-        timeoutMs: input.timeoutMs,
-      });
-      return { output: result };
-    }
+Use timeoutMs to cap the maximum wait.`;
 
-    case 'type': {
-      if (!input.ref) throw new Error('Missing required field: ref');
-      if (!input.text) throw new Error('Missing required field: text');
-      const result = await browser.type(input.ref, input.text, {
-        slowly: input.slowly,
-        submit: input.submit,
-        clear: input.clear,
-        signal,
-      });
-      return { output: result };
-    }
+const SCREENSHOT_DESCRIPTION = `Take a browser screenshot.
 
-    case 'press': {
-      if (!input.key) throw new Error('Missing required field: key');
-      const result = await browser.press(input.key, signal, input.timeoutMs);
-      return { output: result };
-    }
+Supports viewport, full-page, and element screenshots (via ref). Returns base64 image data and format.`;
 
-    case 'hover': {
-      if (!input.ref) throw new Error('Missing required field: ref');
-      const result = await browser.hover(input.ref, signal);
-      return { output: result };
-    }
+const DIALOG_DESCRIPTION = `Inspect and control browser dialogs (alert/confirm/prompt).
 
-    case 'select': {
-      if (!input.ref) throw new Error('Missing required field: ref');
-      if (!input.values) throw new Error('Missing required field: values');
-      const result = await browser.select(input.ref, input.values, signal);
-      return { output: result };
-    }
+Actions:
+- state: check if a dialog is open
+- handle: accept or dismiss the open dialog`;
 
-    case 'scroll': {
-      if (!input.direction) throw new Error('Missing required field: direction');
-      const result = await browser.scroll(input.ref, input.direction as ScrollDirection, signal);
-      return { output: result };
-    }
+const CONTENT_DESCRIPTION = `Query or extract content from the current page.
 
-    case 'screenshot': {
-      const result = await browser.screenshot({
-        signal,
-        format: input.format,
-        quality: input.quality,
-        fullPage: input.fullPage,
-        ref: input.ref,
-      });
-      return {
-        output: `Screenshot taken (${result.format})`,
-        data: result.data,
-        format: result.format,
-      };
-    }
+Actions:
+- extract: extract page content for a query
+- search_page: fast visible-text pattern search
+- find_elements: query DOM elements by CSS selector`;
 
-    case 'go_back': {
-      const result = await browser.goBack(signal, input.timeoutMs);
-      return { output: result };
-    }
+const BATCH_DESCRIPTION = `Execute up to 5 browser actions in one serialized call.
 
-    case 'go_forward': {
-      const result = await browser.goForward(signal, input.timeoutMs);
-      return { output: result };
-    }
-
-    case 'tab_new': {
-      const tab = await browser.newTab(input.url, { signal, timeoutMs: input.timeoutMs });
-      return { output: `Opened new tab: ${tab.id} (${tab.url})` };
-    }
-
-    case 'tab_list': {
-      const tabs = await browser.listTabs(signal);
-      const tabList = tabs
-        .filter((t) => t.type === 'page')
-        .map((t) => `  ${t.id}: ${t.title || '(untitled)'} — ${t.url}`)
-        .join('\n');
-      return { output: `Open tabs:\n${tabList}` };
-    }
-
-    case 'tab_focus': {
-      if (!input.tabId) throw new Error('Missing required field: tabId');
-      await browser.focusTab(input.tabId, { signal, timeoutMs: input.timeoutMs });
-      return { output: `Focused tab: ${input.tabId}` };
-    }
-
-    case 'tab_close': {
-      await browser.closeTab(input.tabId, signal);
-      return { output: `Closed tab: ${input.tabId ?? 'active'}` };
-    }
-
-    case 'evaluate': {
-      if (!input.fn) throw new Error('Missing required field: fn');
-      const result = await browser.evaluate(input.fn, signal);
-      return {
-        output: typeof result === 'string' ? result : JSON.stringify(result, null, 2),
-      };
-    }
-
-    case 'wait': {
-      const result = await browser.wait(input.timeMs ?? input.timeoutMs, input.selector, signal);
-      return { output: result };
-    }
-
-    case 'resize': {
-      if (!input.width) throw new Error('Missing required field: width');
-      if (!input.height) throw new Error('Missing required field: height');
-      const result = await browser.resize(input.width, input.height, signal);
-      return { output: result };
-    }
-
-    case 'handle_dialog': {
-      if (!input.dialogAction) throw new Error('Missing required field: dialogAction');
-      const result = await browser.handleDialog(input.dialogAction, input.promptText, signal);
-      return { output: result };
-    }
-
-    case 'dialog_state': {
-      const state = await browser.getDialogState(signal);
-      if (!state.open) {
-        return { output: 'No open dialog found.' };
-      }
-      const message = state.message ? `\nMessage: ${state.message}` : '';
-      return { output: `Dialog is open (${state.type ?? 'unknown'})${message}` };
-    }
-
-    case 'search_page': {
-      if (!input.pattern) throw new Error('Missing required field: pattern');
-      const result = await browser.searchPage(
-        {
-          pattern: input.pattern,
-          regex: input.regex,
-          caseSensitive: input.caseSensitive,
-          contextChars: input.contextChars,
-          cssScope: input.cssScope,
-          maxResults: input.maxResults,
-        },
-        signal,
-      );
-      const matchLines = result.matches.map(
-        (m, i) => `  ${i + 1}. "${m.match}" — ...${m.context}...`,
-      );
-      const showing = result.matches.length;
-      const total = result.total;
-      const summary =
-        total === 0
-          ? `No matches for "${input.pattern}".`
-          : `Found ${total} match${total !== 1 ? 'es' : ''} for "${input.pattern}"${showing < total ? ` (showing ${showing})` : ''}:\n${matchLines.join('\n')}`;
-      return { output: summary };
-    }
-
-    case 'find_elements': {
-      if (!input.selector) throw new Error('Missing required field: selector');
-      const result = await browser.findElements(
-        {
-          selector: input.selector,
-          attributes: input.attributes,
-          maxResults: input.maxResults,
-          includeText: input.includeText,
-        },
-        signal,
-      );
-      const elemLines = result.elements.map((el, i) => {
-        let line = `  ${i + 1}. <${el.tag}>`;
-        if (el.text) line += ` "${el.text}"`;
-        if (el.attributes && Object.keys(el.attributes).length > 0) {
-          const attrStr = Object.entries(el.attributes)
-            .map(([k, v]) => `${k}="${v}"`)
-            .join(' ');
-          line += ` [${attrStr}]`;
-        }
-        return line;
-      });
-      const showing = result.elements.length;
-      const total = result.total;
-      const summary =
-        total === 0
-          ? `No elements matching "${input.selector}".`
-          : `Found ${total} element${total !== 1 ? 's' : ''} matching "${input.selector}"${showing < total ? ` (showing ${showing})` : ''}:\n${elemLines.join('\n')}`;
-      return { output: summary };
-    }
-  }
-}
-
-async function executeBrowserAction(input: BrowserInput, signal?: AbortSignal): Promise<unknown> {
-  // Multi-action batching: if `actions` array is provided, execute sequentially
-  if (input.actions && input.actions.length > 0) {
-    const browser = getBrowserManager();
-    const results: { action: string; result: unknown }[] = [];
-
-    for (let i = 0; i < input.actions.length; i++) {
-      const actionInput = input.actions[i] as BrowserInput;
-      let beforeState: string | null = null;
-
-      try {
-        beforeState = await browser.getExecutionState(signal);
-      } catch {
-        // Ignore state probing failures and continue.
-      }
-
-      try {
-        const result = await executeSingleAction(actionInput, signal);
-        results.push({ action: actionInput.action, result });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        results.push({ action: actionInput.action, result: { error: message } });
-        // Stop on error
-        if (i < input.actions.length - 1) {
-          results.push({
-            action: 'skipped',
-            result: {
-              output: `Stopped: remaining ${input.actions.length - i - 1} action(s) skipped due to error.`,
-            },
-          });
-        }
-        break;
-      }
-
-      let afterState: string | null = null;
-      try {
-        afterState = await browser.getExecutionState(signal);
-      } catch {
-        // Ignore state probing failures and continue.
-      }
-
-      if (beforeState && afterState && beforeState !== afterState && i < input.actions.length - 1) {
-        results.push({
-          action: 'skipped',
-          result: {
-            output: `Page changed after ${actionInput.action}. Remaining ${input.actions.length - i - 1} action(s) skipped. Take a new snapshot.`,
-          },
-        });
-        break;
-      }
-    }
-
-    // Format combined results
-    const outputLines = results.map((r, i) => {
-      const res = r.result as Record<string, unknown>;
-      const errorStr = typeof res.error === 'string' ? res.error : JSON.stringify(res.error);
-      const outputStr =
-        typeof res.output === 'string' ? res.output : JSON.stringify(res.output ?? '');
-      const text = res.error ? `ERROR: ${errorStr}` : outputStr;
-      return `[${i + 1}/${results.length}] ${r.action}: ${text}`;
-    });
-    return { output: outputLines.join('\n') };
-  }
-
-  // Single action execution
-  return executeSingleAction(input, signal);
-}
+Use this for efficient, single-goal chains like type + type + click. Actions execute in order and stop early on error or page change by default.`;
 
 const log = Log.create({ service: 'tools.browser' });
 
@@ -571,7 +297,6 @@ async function maybePromptProfileImport(
     return;
   }
 
-  // User chose to import — pick which profile
   let profileId: string;
   if (profiles.length === 1) {
     profileId = profiles[0].id;
@@ -607,48 +332,487 @@ async function maybePromptProfileImport(
   log.info({ profileId, profileLabel }, 'Importing Chrome profile from first-use prompt');
   await importChromeProfile(profileId);
   const timestamp = new Date().toISOString();
-  await saveSetting('browser.profileImported', `${profileLabel} — ${timestamp}`);
+  await saveSetting('browser.profileImported', `${profileLabel} - ${timestamp}`);
   await saveSetting('browser.activeProfile', `chrome/${profileId}`);
 }
 
-function createBrowserTool() {
-  return tool({
-    description: TOOL_DESCRIPTION,
-    inputSchema: browserInputSchema,
-    execute: async (input, { abortSignal }) => {
-      try {
-        return await executeBrowserAction(input, abortSignal);
-      } catch (error) {
-        if (error instanceof DOMException && error.name === 'AbortError') throw error;
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(message);
-      }
-    },
+async function runBrowserTool<TInput extends { headless?: boolean }>(
+  context: ToolContext,
+  input: TInput,
+  execContext: { toolCallId: string; abortSignal?: AbortSignal },
+  execute: (signal?: AbortSignal) => Promise<unknown>,
+): Promise<unknown> {
+  return runSerialized(async () => {
+    try {
+      await maybePromptProfileImport(context, execContext.toolCallId, execContext.abortSignal);
+    } catch (error) {
+      log.info(
+        { error: error instanceof Error ? error.message : String(error) },
+        'Profile import prompt skipped',
+      );
+    }
+
+    try {
+      const browser = getBrowserManager();
+      await browser.launch({ headless: input.headless });
+      return await execute(execContext.abortSignal);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') throw error;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(message);
+    }
   });
 }
 
-export function createRegisteredTool(context: ToolContext) {
-  const baseTool = createBrowserTool();
+type BatchAction = z.infer<typeof browserBatchActionSchema>;
 
-  const originalExecute = baseTool.execute!;
-  const wrappedExecute: typeof originalExecute = async (input, execContext) => {
-    return runSerialized(async () => {
-      try {
-        await maybePromptProfileImport(context, execContext.toolCallId, execContext.abortSignal);
-      } catch (error) {
-        // If the prompt was aborted or rejected, log and continue with a clean browser
-        log.info(
-          { error: error instanceof Error ? error.message : String(error) },
-          'Profile import prompt skipped',
-        );
-      }
-      return originalExecute(input, execContext);
-    });
-  };
+type OperationInput = BatchAction & {
+  tool: 'snapshot' | 'navigate' | 'interact' | 'wait' | 'screenshot' | 'dialog' | 'content';
+};
 
-  const toolWithImport = { ...baseTool, execute: wrappedExecute };
-  return withTruncation(toolWithImport, {
-    maxLines: 800,
-    maxBytes: 16 * 1024,
+function getRequiredOp(action: BatchAction): string {
+  if (!action.op) {
+    throw new Error(`Missing required field: op for tool ${action.tool}`);
+  }
+  return action.op;
+}
+
+function actionTerminatesSequence(action: BatchAction, op: string): boolean {
+  if (action.tool === 'navigate') {
+    return op !== 'tab_list' && op !== 'tab_close';
+  }
+  if (action.tool === 'interact') {
+    return op === 'evaluate';
+  }
+  return false;
+}
+
+function formatTabsOutput(tabs: BrowserTab[]) {
+  const tabList = tabs
+    .filter((t) => t.type === 'page')
+    .map((t) => `  ${t.id}: ${t.title || '(untitled)'} - ${t.url}`)
+    .join('\n');
+  return `Open tabs:\n${tabList}`;
+}
+
+function formatSearchPageSummary(pattern: string, result: SearchPageResult) {
+  const matchLines = result.matches.map((m, i) => `  ${i + 1}. "${m.match}" - ...${m.context}...`);
+  const showing = result.matches.length;
+  const total = result.total;
+  if (total === 0) {
+    return `No matches for "${pattern}".`;
+  }
+  return `Found ${total} match${total !== 1 ? 'es' : ''} for "${pattern}"${showing < total ? ` (showing ${showing})` : ''}:\n${matchLines.join('\n')}`;
+}
+
+function formatFindElementsSummary(
+  selector: string,
+  result: FindElementsResult,
+) {
+  const elemLines = result.elements.map((el, i) => {
+    let line = `  ${i + 1}. <${el.tag}>`;
+    if (el.text) line += ` "${el.text}"`;
+    if (el.attributes && Object.keys(el.attributes).length > 0) {
+      const attrStr = Object.entries(el.attributes)
+        .map(([k, v]) => `${k}="${v}"`)
+        .join(' ');
+      line += ` [${attrStr}]`;
+    }
+    return line;
   });
+  const showing = result.elements.length;
+  const total = result.total;
+  if (total === 0) {
+    return `No elements matching "${selector}".`;
+  }
+  return `Found ${total} element${total !== 1 ? 's' : ''} matching "${selector}"${showing < total ? ` (showing ${showing})` : ''}:\n${elemLines.join('\n')}`;
+}
+
+async function executeOperation(input: OperationInput, signal?: AbortSignal): Promise<unknown> {
+  const browser = getBrowserManager();
+
+  if (input.tool === 'snapshot') {
+    const tree = await browser.snapshot(signal);
+    return { output: tree };
+  }
+
+  if (input.tool === 'navigate') {
+    const op = getRequiredOp(input);
+    switch (op) {
+      case 'navigate': {
+        if (!input.url) throw new Error('Missing required field: url');
+        return { output: await browser.navigate(input.url, signal, input.timeoutMs) };
+      }
+      case 'search': {
+        if (!input.query) throw new Error('Missing required field: query');
+        return {
+          output: await browser.search(input.query, input.engine ?? 'google', signal, input.timeoutMs),
+        };
+      }
+      case 'go_back': {
+        return { output: await browser.goBack(signal, input.timeoutMs) };
+      }
+      case 'go_forward': {
+        return { output: await browser.goForward(signal, input.timeoutMs) };
+      }
+      case 'tab_new': {
+        const tab = await browser.newTab(input.url, { signal, timeoutMs: input.timeoutMs });
+        return { output: `Opened new tab: ${tab.id} (${tab.url})` };
+      }
+      case 'tab_list': {
+        const tabs = await browser.listTabs(signal);
+        return { output: formatTabsOutput(tabs) };
+      }
+      case 'tab_focus': {
+        if (!input.tabId) throw new Error('Missing required field: tabId');
+        await browser.focusTab(input.tabId, { signal, timeoutMs: input.timeoutMs });
+        return { output: `Focused tab: ${input.tabId}` };
+      }
+      case 'tab_close': {
+        await browser.closeTab(input.tabId, signal);
+        return { output: `Closed tab: ${input.tabId ?? 'active'}` };
+      }
+      default:
+        throw new Error(`Invalid op for navigate tool: ${op}`);
+    }
+  }
+
+  if (input.tool === 'interact') {
+    const op = getRequiredOp(input);
+    switch (op) {
+      case 'click': {
+        if (!input.ref) throw new Error('Missing required field: ref');
+        return {
+          output: await browser.click(input.ref, {
+            doubleClick: input.doubleClick,
+            button: input.button,
+            modifiers: input.modifiers,
+            signal,
+            timeoutMs: input.timeoutMs,
+          }),
+        };
+      }
+      case 'type': {
+        if (!input.ref) throw new Error('Missing required field: ref');
+        if (!input.text) throw new Error('Missing required field: text');
+        return {
+          output: await browser.type(input.ref, input.text, {
+            slowly: input.slowly,
+            submit: input.submit,
+            clear: input.clear,
+            signal,
+          }),
+        };
+      }
+      case 'press': {
+        if (!input.key) throw new Error('Missing required field: key');
+        return { output: await browser.press(input.key, signal, input.timeoutMs) };
+      }
+      case 'hover': {
+        if (!input.ref) throw new Error('Missing required field: ref');
+        return { output: await browser.hover(input.ref, signal) };
+      }
+      case 'select': {
+        if (!input.ref) throw new Error('Missing required field: ref');
+        if (!input.values) throw new Error('Missing required field: values');
+        return { output: await browser.select(input.ref, input.values, signal) };
+      }
+      case 'scroll': {
+        if (!input.direction) throw new Error('Missing required field: direction');
+        return { output: await browser.scroll(input.ref, input.direction as ScrollDirection, signal) };
+      }
+      case 'resize': {
+        if (!input.width) throw new Error('Missing required field: width');
+        if (!input.height) throw new Error('Missing required field: height');
+        return { output: await browser.resize(input.width, input.height, signal) };
+      }
+      case 'evaluate': {
+        if (!input.fn) throw new Error('Missing required field: fn');
+        const result = await browser.evaluate(input.fn, signal);
+        return {
+          output: typeof result === 'string' ? result : JSON.stringify(result, null, 2),
+        };
+      }
+      default:
+        throw new Error(`Invalid op for interact tool: ${op}`);
+    }
+  }
+
+  if (input.tool === 'wait') {
+    const mode = input.mode ?? input.op ?? 'time';
+    if (mode === 'time') {
+      if (input.timeMs === undefined) throw new Error('Missing required field: timeMs');
+      return { output: await browser.wait(input.timeMs, undefined, signal) };
+    }
+    if (!input.selector) throw new Error('Missing required field: selector');
+    return { output: await browser.wait(input.timeoutMs, input.selector, signal) };
+  }
+
+  if (input.tool === 'screenshot') {
+    const result = await browser.screenshot({
+      signal,
+      format: input.format,
+      quality: input.quality,
+      fullPage: input.fullPage,
+      ref: input.ref,
+    });
+    return {
+      output: `Screenshot taken (${result.format})`,
+      data: result.data,
+      format: result.format,
+    };
+  }
+
+  if (input.tool === 'dialog') {
+    const op = getRequiredOp(input);
+    if (op === 'state') {
+      const state = await browser.getDialogState(signal);
+      if (!state.open) {
+        return { output: 'No open dialog found.' };
+      }
+      const message = state.message ? `\nMessage: ${state.message}` : '';
+      return { output: `Dialog is open (${state.type ?? 'unknown'})${message}` };
+    }
+    if (op === 'handle') {
+      if (!input.dialogAction) throw new Error('Missing required field: dialogAction');
+      return { output: await browser.handleDialog(input.dialogAction, input.promptText, signal) };
+    }
+    throw new Error(`Invalid op for dialog tool: ${op}`);
+  }
+
+  if (input.tool === 'content') {
+    const op = getRequiredOp(input);
+    switch (op) {
+      case 'extract': {
+        if (!input.query) throw new Error('Missing required field: query');
+        const content = await browser.extractPageContent(signal, input.selector);
+        const selectorNote = input.selector ? `\n**Selector:** ${input.selector}` : '';
+        return {
+          output: `### Extracted Content\n**Query:** ${input.query}${selectorNote}\n\n${content}`,
+        };
+      }
+      case 'search_page': {
+        if (!input.pattern) throw new Error('Missing required field: pattern');
+        const result = await browser.searchPage(
+          {
+            pattern: input.pattern,
+            regex: input.regex,
+            caseSensitive: input.caseSensitive,
+            contextChars: input.contextChars,
+            cssScope: input.cssScope,
+            maxResults: input.maxResults,
+          },
+          signal,
+        );
+        return { output: formatSearchPageSummary(input.pattern, result) };
+      }
+      case 'find_elements': {
+        if (!input.selector) throw new Error('Missing required field: selector');
+        const result = await browser.findElements(
+          {
+            selector: input.selector,
+            attributes: input.attributes,
+            maxResults: input.maxResults,
+            includeText: input.includeText,
+          },
+          signal,
+        );
+        return { output: formatFindElementsSummary(input.selector, result) };
+      }
+      default:
+        throw new Error(`Invalid op for content tool: ${op}`);
+    }
+  }
+
+  throw new Error('Unsupported batch tool.');
+}
+
+function createSnapshotTool(context: ToolContext) {
+  return createBrowserTool(context, SNAPSHOT_DESCRIPTION, browserSnapshotInputSchema, (input, signal) => {
+    return executeOperation({ ...input, tool: 'snapshot' }, signal);
+  });
+}
+
+function createBrowserTool<TInput extends { headless?: boolean }>(
+  context: ToolContext,
+  description: string,
+  inputSchema: z.ZodType<TInput>,
+  executeAction: (input: TInput, signal?: AbortSignal) => Promise<unknown>,
+) {
+  const baseTool = tool({
+    description,
+    inputSchema,
+    execute: async (input, execContext) => {
+      return runBrowserTool(context, input, execContext, (signal) => executeAction(input, signal));
+    },
+  });
+
+  return withTruncation(baseTool, { maxLines: 800, maxBytes: 16 * 1024 });
+}
+
+function createNavigateTool(context: ToolContext) {
+  return createBrowserTool(context, NAVIGATE_DESCRIPTION, browserNavigateInputSchema, (input, signal) => {
+    return executeOperation({ ...input, tool: 'navigate', op: input.action }, signal);
+  });
+}
+
+function createInteractTool(context: ToolContext) {
+  return createBrowserTool(context, INTERACT_DESCRIPTION, browserInteractInputSchema, (input, signal) => {
+    return executeOperation({ ...input, tool: 'interact', op: input.action }, signal);
+  });
+}
+
+function createWaitTool(context: ToolContext) {
+  return createBrowserTool(context, WAIT_DESCRIPTION, browserWaitInputSchema, (input, signal) => {
+    return executeOperation({ ...input, tool: 'wait', op: input.mode }, signal);
+  });
+}
+
+function createScreenshotTool(context: ToolContext) {
+  return createBrowserTool(context, SCREENSHOT_DESCRIPTION, browserScreenshotInputSchema, (input, signal) => {
+    return executeOperation({ ...input, tool: 'screenshot', op: 'capture' }, signal);
+  });
+}
+
+function createDialogTool(context: ToolContext) {
+  return createBrowserTool(context, DIALOG_DESCRIPTION, browserDialogInputSchema, (input, signal) => {
+    return executeOperation({ ...input, tool: 'dialog', op: input.action }, signal);
+  });
+}
+
+function createContentTool(context: ToolContext) {
+  return createBrowserTool(context, CONTENT_DESCRIPTION, browserContentInputSchema, (input, signal) => {
+    return executeOperation({ ...input, tool: 'content', op: input.action }, signal);
+  });
+}
+
+function createBatchTool(context: ToolContext) {
+  const baseTool = tool({
+    description: BATCH_DESCRIPTION,
+    inputSchema: browserBatchInputSchema,
+    execute: async (input, execContext) => {
+      return runBrowserTool(context, input, execContext, async (signal) => {
+        const browser = getBrowserManager();
+        const results: Array<{
+          index: number;
+          tool: string;
+          op?: string;
+          status: 'ok' | 'error';
+          output?: unknown;
+          error?: string;
+        }> = [];
+
+        let stoppedReason: string | null = null;
+
+        for (let i = 0; i < input.actions.length; i++) {
+          const action = input.actions[i];
+          const op = action.op;
+
+          let beforeState: string | null = null;
+          try {
+            beforeState = await browser.getExecutionState(signal);
+          } catch {
+            beforeState = null;
+          }
+
+          try {
+            const result = await executeOperation(action, signal);
+            const resultRecord: {
+              index: number;
+              tool: string;
+              op?: string;
+              status: 'ok';
+              output: unknown;
+            } = {
+              index: i + 1,
+              tool: action.tool,
+              status: 'ok',
+              output: result,
+            };
+            if (op) {
+              resultRecord.op = op;
+            }
+            results.push(resultRecord);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            const errorRecord: {
+              index: number;
+              tool: string;
+              op?: string;
+              status: 'error';
+              error: string;
+            } = {
+              index: i + 1,
+              tool: action.tool,
+              status: 'error',
+              error: message,
+            };
+            if (op) {
+              errorRecord.op = op;
+            }
+            results.push(errorRecord);
+
+            if (input.stopOnError) {
+              stoppedReason = `Stopped on error at action ${i + 1}: ${message}`;
+              break;
+            }
+            continue;
+          }
+
+          if (i >= input.actions.length - 1) {
+            continue;
+          }
+
+          if (op && actionTerminatesSequence(action, op)) {
+            stoppedReason = `Stopped after ${action.tool}.${op}: terminates sequence.`;
+            break;
+          }
+
+          if (input.stopOnPageChange) {
+            let afterState: string | null = null;
+            try {
+              afterState = await browser.getExecutionState(signal);
+            } catch {
+              afterState = null;
+            }
+
+            if (beforeState && afterState && beforeState !== afterState) {
+              stoppedReason = `Stopped after action ${i + 1}: page state changed.`;
+              break;
+            }
+          }
+        }
+
+        const executed = results.length;
+        const total = input.actions.length;
+        const skipped = Math.max(total - executed, 0);
+        const summary = stoppedReason
+          ? `Batch executed ${executed}/${total} action(s). ${stoppedReason}`
+          : `Batch executed ${executed}/${total} action(s) successfully.`;
+
+        return {
+          output: summary,
+          results,
+          stoppedReason,
+          executed,
+          skipped,
+        };
+      });
+    },
+  });
+
+  return withTruncation(baseTool, { maxLines: 800, maxBytes: 16 * 1024 });
+}
+
+export function createRegisteredTools(context: ToolContext) {
+  return {
+    browser_snapshot: createSnapshotTool(context),
+    browser_navigate: createNavigateTool(context),
+    browser_interact: createInteractTool(context),
+    browser_wait: createWaitTool(context),
+    browser_screenshot: createScreenshotTool(context),
+    browser_dialog: createDialogTool(context),
+    browser_content: createContentTool(context),
+    browser_batch: createBatchTool(context),
+  };
 }

--- a/packages/server/src/tools/core/browser.ts
+++ b/packages/server/src/tools/core/browser.ts
@@ -11,6 +11,10 @@ import { isServiceError } from '@/lib/service-result.js';
 import type { ToolContext } from '@/tools/runtime/wrappers.js';
 import { withTruncation } from '@/tools/runtime/wrappers.js';
 
+const descriptionField = z
+  .string()
+  .describe('Short description of the task this browser action is performing. Shown to the user.');
+
 const headlessField = z
   .boolean()
   .optional()
@@ -22,10 +26,12 @@ const headlessField = z
 const timeoutField = z.number().optional().describe('Action timeout in milliseconds.');
 
 const browserSnapshotInputSchema = z.object({
+  description: descriptionField,
   headless: headlessField,
 });
 
 const browserNavigateInputSchema = z.object({
+  description: descriptionField,
   action: z
     .enum(['navigate', 'search', 'go_back', 'go_forward', 'tab_new', 'tab_list', 'tab_focus', 'tab_close'])
     .describe('Navigation action to perform.'),
@@ -38,6 +44,7 @@ const browserNavigateInputSchema = z.object({
 });
 
 const browserInteractInputSchema = z.object({
+  description: descriptionField,
   action: z
     .enum(['click', 'type', 'press', 'hover', 'select', 'scroll', 'resize', 'evaluate'])
     .describe('Interaction action to perform.'),
@@ -66,6 +73,7 @@ const browserInteractInputSchema = z.object({
 });
 
 const browserWaitInputSchema = z.object({
+  description: descriptionField,
   mode: z
     .enum(['time', 'selector'])
     .describe('Wait mode. Use time for timed waits and selector for CSS selector waits.'),
@@ -76,6 +84,7 @@ const browserWaitInputSchema = z.object({
 });
 
 const browserScreenshotInputSchema = z.object({
+  description: descriptionField,
   ref: z.string().optional().describe('Element ref for element screenshot.'),
   format: z.enum(['png', 'jpeg', 'webp']).optional().describe('Screenshot format. Default png.'),
   quality: z.number().optional().describe('Screenshot quality 0-100 for jpeg/webp.'),
@@ -84,6 +93,7 @@ const browserScreenshotInputSchema = z.object({
 });
 
 const browserDialogInputSchema = z.object({
+  description: descriptionField,
   action: z.enum(['state', 'handle']).describe('Dialog action to perform.'),
   dialogAction: z.enum(['accept', 'dismiss']).optional().describe('Whether to accept or dismiss a dialog.'),
   promptText: z.string().optional().describe('Optional prompt text when accepting prompt dialogs.'),
@@ -91,6 +101,7 @@ const browserDialogInputSchema = z.object({
 });
 
 const browserContentInputSchema = z.object({
+  description: descriptionField,
   action: z.enum(['extract', 'search_page', 'find_elements']).describe('Content action to perform.'),
   query: z.string().optional().describe('Extraction query for extract action.'),
   selector: z.string().optional().describe('CSS selector for extract or find_elements actions.'),
@@ -156,6 +167,7 @@ const browserBatchActionSchema = z.object({
 });
 
 const browserBatchInputSchema = z.object({
+  description: descriptionField,
   actions: z.array(browserBatchActionSchema).min(1).max(5).describe('Sequential actions to execute.'),
   stopOnPageChange: z
     .boolean()

--- a/packages/server/src/tools/core/browser.ts
+++ b/packages/server/src/tools/core/browser.ts
@@ -39,6 +39,7 @@ const browserInputSchema = z.object({
         format: z.enum(['png', 'jpeg', 'webp']).optional().describe('Screenshot format.'),
         quality: z.number().optional().describe('Screenshot quality for jpeg/webp (0-100).'),
         fullPage: z.boolean().optional().describe('Take a full-page screenshot.'),
+        timeoutMs: z.number().optional().describe('Action timeout in milliseconds.'),
         dialogAction: z.enum(['accept', 'dismiss']).optional().describe('Dialog action to take.'),
         promptText: z.string().optional().describe('Prompt text for accepted dialog prompts.'),
         pattern: z.string().optional().describe('Text pattern to search for.'),
@@ -118,6 +119,7 @@ const browserInputSchema = z.object({
     .optional()
     .describe('Screenshot quality 0-100 for jpeg/webp. For screenshot action.'),
   fullPage: z.boolean().optional().describe('Capture full page screenshot. For screenshot action.'),
+  timeoutMs: z.number().optional().describe('Action timeout in milliseconds.'),
   dialogAction: z
     .enum(['accept', 'dismiss'])
     .optional()
@@ -210,13 +212,18 @@ async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): P
 
     case 'navigate': {
       if (!input.url) throw new Error('Missing required field: url');
-      const result = await browser.navigate(input.url, signal);
+      const result = await browser.navigate(input.url, signal, input.timeoutMs);
       return { output: result };
     }
 
     case 'search': {
       if (!input.query) throw new Error('Missing required field: query');
-      const result = await browser.search(input.query, input.engine ?? 'google', signal);
+      const result = await browser.search(
+        input.query,
+        input.engine ?? 'google',
+        signal,
+        input.timeoutMs,
+      );
       return { output: result };
     }
 
@@ -236,6 +243,7 @@ async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): P
         button: input.button,
         modifiers: input.modifiers,
         signal,
+        timeoutMs: input.timeoutMs,
       });
       return { output: result };
     }
@@ -254,7 +262,7 @@ async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): P
 
     case 'press': {
       if (!input.key) throw new Error('Missing required field: key');
-      const result = await browser.press(input.key, signal);
+      const result = await browser.press(input.key, signal, input.timeoutMs);
       return { output: result };
     }
 
@@ -293,17 +301,17 @@ async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): P
     }
 
     case 'go_back': {
-      const result = await browser.goBack(signal);
+      const result = await browser.goBack(signal, input.timeoutMs);
       return { output: result };
     }
 
     case 'go_forward': {
-      const result = await browser.goForward(signal);
+      const result = await browser.goForward(signal, input.timeoutMs);
       return { output: result };
     }
 
     case 'tab_new': {
-      const tab = await browser.newTab(input.url, signal);
+      const tab = await browser.newTab(input.url, { signal, timeoutMs: input.timeoutMs });
       return { output: `Opened new tab: ${tab.id} (${tab.url})` };
     }
 
@@ -318,7 +326,7 @@ async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): P
 
     case 'tab_focus': {
       if (!input.tabId) throw new Error('Missing required field: tabId');
-      await browser.focusTab(input.tabId, signal);
+      await browser.focusTab(input.tabId, { signal, timeoutMs: input.timeoutMs });
       return { output: `Focused tab: ${input.tabId}` };
     }
 
@@ -336,7 +344,7 @@ async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): P
     }
 
     case 'wait': {
-      const result = await browser.wait(input.timeMs, input.selector, signal);
+      const result = await browser.wait(input.timeMs ?? input.timeoutMs, input.selector, signal);
       return { output: result };
     }
 

--- a/packages/server/src/tools/core/browser.ts
+++ b/packages/server/src/tools/core/browser.ts
@@ -36,6 +36,11 @@ const browserInputSchema = z.object({
         tabId: z.string().optional().describe('Tab ID.'),
         timeMs: z.number().optional().describe('Wait time in ms.'),
         selector: z.string().optional().describe('CSS selector.'),
+        format: z.enum(['png', 'jpeg', 'webp']).optional().describe('Screenshot format.'),
+        quality: z.number().optional().describe('Screenshot quality for jpeg/webp (0-100).'),
+        fullPage: z.boolean().optional().describe('Take a full-page screenshot.'),
+        dialogAction: z.enum(['accept', 'dismiss']).optional().describe('Dialog action to take.'),
+        promptText: z.string().optional().describe('Prompt text for accepted dialog prompts.'),
         pattern: z.string().optional().describe('Text pattern to search for.'),
         regex: z.boolean().optional().describe('Treat pattern as regex.'),
         caseSensitive: z.boolean().optional().describe('Case-sensitive search.'),
@@ -104,6 +109,23 @@ const browserInputSchema = z.object({
     .describe(
       'CSS selector. For wait, find_elements, or extract (scopes extraction to element) actions.',
     ),
+  format: z
+    .enum(['png', 'jpeg', 'webp'])
+    .optional()
+    .describe('Screenshot format. For screenshot action. Default png.'),
+  quality: z
+    .number()
+    .optional()
+    .describe('Screenshot quality 0-100 for jpeg/webp. For screenshot action.'),
+  fullPage: z.boolean().optional().describe('Capture full page screenshot. For screenshot action.'),
+  dialogAction: z
+    .enum(['accept', 'dismiss'])
+    .optional()
+    .describe('Whether to accept or dismiss a dialog. For handle_dialog action.'),
+  promptText: z
+    .string()
+    .optional()
+    .describe('Optional prompt text for accepted prompt dialogs. For handle_dialog action.'),
   pattern: z.string().optional().describe('Text pattern to search for. For search_page action.'),
   regex: z.boolean().optional().describe('Treat pattern as regex. For search_page action.'),
   caseSensitive: z.boolean().optional().describe('Case-sensitive search. For search_page action.'),
@@ -171,18 +193,8 @@ Note: The top-level \`action\` field is ignored when \`actions\` is provided.
 - **find_elements**: Query DOM by CSS selector (set \`selector\`). Zero cost, instant.
 - **evaluate**: Run JavaScript in the page (set \`fn\`). Last resort.
 - **wait**: Wait for time or selector
-- **resize**: Resize viewport`;
-
-// Page-changing actions that should stop multi-action batching if they trigger navigation
-const PAGE_CHANGING_ACTIONS = new Set([
-  'navigate',
-  'search',
-  'go_back',
-  'go_forward',
-  'tab_new',
-  'tab_focus',
-  'evaluate',
-]);
+- **resize**: Resize viewport
+- **handle_dialog**: Accept or dismiss an open browser dialog`;
 
 async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): Promise<unknown> {
   const browser = getBrowserManager();
@@ -266,7 +278,13 @@ async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): P
     }
 
     case 'screenshot': {
-      const result = await browser.screenshot(signal);
+      const result = await browser.screenshot({
+        signal,
+        format: input.format,
+        quality: input.quality,
+        fullPage: input.fullPage,
+        ref: input.ref,
+      });
       return {
         output: `Screenshot taken (${result.format})`,
         data: result.data,
@@ -326,6 +344,12 @@ async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): P
       if (!input.width) throw new Error('Missing required field: width');
       if (!input.height) throw new Error('Missing required field: height');
       const result = await browser.resize(input.width, input.height, signal);
+      return { output: result };
+    }
+
+    case 'handle_dialog': {
+      if (!input.dialogAction) throw new Error('Missing required field: dialogAction');
+      const result = await browser.handleDialog(input.dialogAction, input.promptText, signal);
       return { output: result };
     }
 
@@ -390,10 +414,18 @@ async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): P
 async function executeBrowserAction(input: BrowserInput, signal?: AbortSignal): Promise<unknown> {
   // Multi-action batching: if `actions` array is provided, execute sequentially
   if (input.actions && input.actions.length > 0) {
+    const browser = getBrowserManager();
     const results: { action: string; result: unknown }[] = [];
 
     for (let i = 0; i < input.actions.length; i++) {
       const actionInput = input.actions[i] as BrowserInput;
+      let beforeState: string | null = null;
+
+      try {
+        beforeState = await browser.getExecutionState(signal);
+      } catch {
+        // Ignore state probing failures and continue.
+      }
 
       try {
         const result = await executeSingleAction(actionInput, signal);
@@ -413,8 +445,14 @@ async function executeBrowserAction(input: BrowserInput, signal?: AbortSignal): 
         break;
       }
 
-      // Stop after page-changing actions (navigation already happened)
-      if (PAGE_CHANGING_ACTIONS.has(actionInput.action) && i < input.actions.length - 1) {
+      let afterState: string | null = null;
+      try {
+        afterState = await browser.getExecutionState(signal);
+      } catch {
+        // Ignore state probing failures and continue.
+      }
+
+      if (beforeState && afterState && beforeState !== afterState && i < input.actions.length - 1) {
         results.push({
           action: 'skipped',
           result: {
@@ -442,6 +480,26 @@ async function executeBrowserAction(input: BrowserInput, signal?: AbortSignal): 
 }
 
 const log = Log.create({ service: 'tools.browser' });
+
+let queueTail: Promise<void> = Promise.resolve();
+
+async function runSerialized<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = queueTail.catch(() => {});
+  let release: () => void = () => {};
+  queueTail = previous.then(
+    () =>
+      new Promise<void>((resolve) => {
+        release = resolve;
+      }),
+  );
+
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
 
 let hasPromptedImport = false;
 
@@ -556,16 +614,18 @@ export function createRegisteredTool(context: ToolContext) {
 
   const originalExecute = baseTool.execute!;
   const wrappedExecute: typeof originalExecute = async (input, execContext) => {
-    try {
-      await maybePromptProfileImport(context, execContext.toolCallId, execContext.abortSignal);
-    } catch (error) {
-      // If the prompt was aborted or rejected, log and continue with a clean browser
-      log.info(
-        { error: error instanceof Error ? error.message : String(error) },
-        'Profile import prompt skipped',
-      );
-    }
-    return originalExecute(input, execContext);
+    return runSerialized(async () => {
+      try {
+        await maybePromptProfileImport(context, execContext.toolCallId, execContext.abortSignal);
+      } catch (error) {
+        // If the prompt was aborted or rejected, log and continue with a clean browser
+        log.info(
+          { error: error instanceof Error ? error.message : String(error) },
+          'Profile import prompt skipped',
+        );
+      }
+      return originalExecute(input, execContext);
+    });
   };
 
   const toolWithImport = { ...baseTool, execute: wrappedExecute };

--- a/packages/server/src/tools/core/browser.ts
+++ b/packages/server/src/tools/core/browser.ts
@@ -196,7 +196,8 @@ Note: The top-level \`action\` field is ignored when \`actions\` is provided.
 - **evaluate**: Run JavaScript in the page (set \`fn\`). Last resort.
 - **wait**: Wait for time or selector
 - **resize**: Resize viewport
-- **handle_dialog**: Accept or dismiss an open browser dialog`;
+- **handle_dialog**: Accept or dismiss an open browser dialog
+- **dialog_state**: Check whether a browser dialog is currently open`;
 
 async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): Promise<unknown> {
   const browser = getBrowserManager();
@@ -359,6 +360,15 @@ async function executeSingleAction(input: BrowserInput, signal?: AbortSignal): P
       if (!input.dialogAction) throw new Error('Missing required field: dialogAction');
       const result = await browser.handleDialog(input.dialogAction, input.promptText, signal);
       return { output: result };
+    }
+
+    case 'dialog_state': {
+      const state = await browser.getDialogState(signal);
+      if (!state.open) {
+        return { output: 'No open dialog found.' };
+      }
+      const message = state.message ? `\nMessage: ${state.message}` : '';
+      return { output: `Dialog is open (${state.type ?? 'unknown'})${message}` };
     }
 
     case 'search_page': {

--- a/packages/server/src/tools/toolsets/browser.ts
+++ b/packages/server/src/tools/toolsets/browser.ts
@@ -1,5 +1,5 @@
 import { BROWSER_TOOL_INSTRUCTIONS } from '@/lib/browser/tool-config.js';
-import { createRegisteredTool } from '@/tools/core/browser.js';
+import { createRegisteredTools } from '@/tools/core/browser.js';
 import type { Toolset } from '@/tools/toolsets/types.js';
 
 export function createBrowserToolset(): Toolset {
@@ -11,13 +11,39 @@ export function createBrowserToolset(): Toolset {
     instructions: BROWSER_TOOL_INSTRUCTIONS,
     tools: () => [
       {
-        name: 'browser',
+        name: 'browser_snapshot',
+        description: 'Capture a fresh snapshot with refs, URL, tabs, and page state.',
+      },
+      {
+        name: 'browser_navigate',
+        description: 'Navigate URLs, run web search, and manage tab focus/history.',
+      },
+      {
+        name: 'browser_interact',
+        description: 'Click, type, press, hover, select, scroll, resize, or evaluate scripts.',
+      },
+      {
+        name: 'browser_wait',
+        description: 'Wait by time or selector for deterministic page readiness.',
+      },
+      {
+        name: 'browser_screenshot',
+        description: 'Capture viewport, full-page, or element screenshots.',
+      },
+      {
+        name: 'browser_dialog',
+        description: 'Inspect and handle alert/confirm/prompt dialogs.',
+      },
+      {
+        name: 'browser_content',
+        description: 'Extract content, search visible text, and find DOM elements by selector.',
+      },
+      {
+        name: 'browser_batch',
         description:
-          'Control a Chrome browser instance with actions like navigate, click, type, screenshot, scroll, and evaluate JavaScript.',
+          'Run up to 5 browser actions in sequence with page-change and error stopping rules.',
       },
     ],
-    activate: async (context) => ({
-      browser: createRegisteredTool(context),
-    }),
+    activate: async (context) => createRegisteredTools(context),
   };
 }


### PR DESCRIPTION
## Change Summary

Adds a required `description` field to all browser tool input schemas so the model must always provide a human-readable summary of what each browser action is doing. This description is now displayed as a subtitle on the tool card in the UI, giving users clear visibility into browser activity.

### New Features
- **Browser tool description**: All 8 browser tools (`browser_snapshot`, `browser_navigate`, `browser_interact`, `browser_wait`, `browser_screenshot`, `browser_dialog`, `browser_content`, `browser_batch`) now require a `description` field that is shown on the tool card subtitle

### Improvements & Refactors
- Fixed `tool-call-block.tsx` to route all `browser_*` tool names to `BrowserToolBlock` (previously only matched the literal string `"browser"`, causing all browser tools to fall through to the generic block with no description)
- Simplified `BrowserToolBlock` by removing the now-redundant `getBrowserActionLabel` derived-label logic in favour of the model-supplied description
- Tool card title now uses `formatToolDisplayName` for proper capitalisation of `browser_navigate` to "Browser Navigate" etc.