### PR TITLE
improvement(notifications): add desktop recording suggestion notifications

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,6 +4,7 @@ import {
   dialog,
   ipcMain,
   nativeImage,
+  Notification,
   shell,
   systemPreferences,
 } from 'electron';
@@ -281,6 +282,50 @@ ipcMain.handle('permissions:openScreenCaptureSettings', () => {
     );
   }
 });
+
+ipcMain.handle(
+  'notifications:show',
+  (
+    _event,
+    input:
+      | {
+          title: string;
+          body?: string;
+          silent?: boolean;
+          clickAction?: {
+            kind: 'start-recording';
+            platform: 'google-meet' | 'teams' | 'zoom' | 'slack' | 'discord';
+            key: string;
+          } | null;
+        }
+      | null
+      | undefined,
+  ): boolean => {
+    if (!Notification.isSupported()) return false;
+    if (!input || typeof input.title !== 'string' || input.title.trim().length === 0) {
+      return false;
+    }
+
+    const notification = new Notification({
+      title: input.title,
+      body: input.body,
+      silent: input.silent,
+    });
+
+    notification.on('click', () => {
+      if (input.clickAction && mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('notification:click-action', input.clickAction);
+      }
+
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      mainWindow.show();
+      mainWindow.focus();
+    });
+
+    notification.show();
+    return true;
+  },
+);
 
 ipcMain.handle('updater:check', () => {
   return updater.checkForUpdates();

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -61,4 +61,16 @@ contextBridge.exposeInMainWorld('api', {
     openScreenCaptureSettings: () =>
       ipcRenderer.invoke('permissions:openScreenCaptureSettings') as Promise<void>,
   },
+  notifications: {
+    show: (input: {
+      title: string;
+      body?: string;
+      silent?: boolean;
+      clickAction?: {
+        kind: 'start-recording';
+        platform: 'google-meet' | 'teams' | 'zoom' | 'slack' | 'discord';
+        key: string;
+      } | null;
+    }) => ipcRenderer.invoke('notifications:show', input) as Promise<boolean>,
+  },
 });

--- a/apps/web/src/components/recordings/meeting-recording-banner.tsx
+++ b/apps/web/src/components/recordings/meeting-recording-banner.tsx
@@ -8,7 +8,9 @@ import type { MeetingCallDetectedPayload } from '@stitch/shared/chat/realtime';
 
 import { Button } from '@/components/ui/button';
 import { useSSE } from '@/hooks/sse/sse-context';
+import { notifyAppEvent } from '@/lib/notifications';
 import { recordingsQueryOptions, useStartRecording } from '@/lib/queries/recordings';
+import { settingsQueryOptions } from '@/lib/queries/settings';
 
 const WARNING_LABELS: Record<string, string> = {
   input_backpressure: 'Audio input is falling behind — some audio may be dropped.',
@@ -45,9 +47,38 @@ export function MeetingRecordingBanner() {
 
   const startRecording = useStartRecording();
   const { data } = useQuery(recordingsQueryOptions({ page: 1, pageSize: 10 }));
+  const { data: settings } = useQuery(settingsQueryOptions);
 
   const activeRecordingIdRef = React.useRef(data?.activeRecordingId ?? null);
   activeRecordingIdRef.current = data?.activeRecordingId ?? null;
+
+  React.useEffect(() => {
+    const unsub = window.electron?.on('notification:click-action', (raw) => {
+      if (!raw || typeof raw !== 'object') return;
+
+      const payload = raw as Record<string, unknown>;
+      if (payload['kind'] !== 'start-recording') return;
+      if (typeof payload['platform'] !== 'string') return;
+      if (typeof payload['key'] !== 'string') return;
+      if (activeRecordingIdRef.current || startRecording.isPending) return;
+
+      void startRecording
+        .mutateAsync({
+          platform: payload['platform'] as MeetingCallDetectedPayload['platform'],
+        })
+        .then(
+          () => {
+            setDetection((current) => (current?.key === payload['key'] ? null : current));
+            toast.success('Recording started');
+          },
+          (error: unknown) => {
+            toast.error(error instanceof Error ? error.message : 'Failed to start recording');
+          },
+        );
+    });
+
+    return () => unsub?.();
+  }, [startRecording]);
 
   useSSE({
     'meeting-call-detected': (payload) => {
@@ -55,13 +86,19 @@ export function MeetingRecordingBanner() {
         return;
       }
 
-      setDetection((current) => {
-        if (dismissedKeys.has(payload.key)) {
-          return current;
-        }
+      if (dismissedKeys.has(payload.key)) {
+        return;
+      }
 
-        return payload;
-      });
+      void notifyAppEvent(
+        {
+          kind: 'recording-suggestion',
+          payload,
+        },
+        settings,
+      );
+
+      setDetection(payload);
     },
     'meeting-call-ended': ({ key }) => {
       setDetection((current) => {

--- a/apps/web/src/components/settings/general.tsx
+++ b/apps/web/src/components/settings/general.tsx
@@ -327,26 +327,78 @@ function NotificationsContent() {
   const { data: settings } = useSuspenseQuery(settingsQueryOptions);
 
   const soundEnabled = settings['notifications.sound.enabled'] !== 'false';
+  const osEnabled = settings['notifications.os.enabled'] !== 'false';
+  const recordingSuggestionsEnabled =
+    settings['notifications.os.recordingSuggestions.enabled'] !== 'false';
 
-  const saveMutation = useMutation(
+  const saveSoundMutation = useMutation(
     saveSettingMutationOptions('notifications.sound.enabled', queryClient, { silent: true }),
+  );
+  const saveOsMutation = useMutation(
+    saveSettingMutationOptions('notifications.os.enabled', queryClient, { silent: true }),
+  );
+  const saveRecordingSuggestionsMutation = useMutation(
+    saveSettingMutationOptions('notifications.os.recordingSuggestions.enabled', queryClient, {
+      silent: true,
+    }),
   );
 
   function handleSoundToggle(checked: boolean) {
-    saveMutation.mutate(checked ? 'true' : 'false');
+    saveSoundMutation.mutate(checked ? 'true' : 'false');
+  }
+
+  function handleOsToggle(checked: boolean) {
+    saveOsMutation.mutate(checked ? 'true' : 'false');
+  }
+
+  function handleRecordingSuggestionsToggle(checked: boolean) {
+    saveRecordingSuggestionsMutation.mutate(checked ? 'true' : 'false');
   }
 
   return (
-    <div className="flex items-center justify-between gap-4 py-3">
-      <div className="flex min-w-0 flex-col gap-0.5">
-        <Label htmlFor="sound-toggle" className="text-sm font-medium">
-          Sound alerts
-        </Label>
-        <p className="text-xs text-muted-foreground">
-          Play an attention sound when the AI needs your input
-        </p>
+    <div className="flex flex-col">
+      <div className="flex items-center justify-between gap-4 py-3">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <Label htmlFor="sound-toggle" className="text-sm font-medium">
+            Sound alerts
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Play an attention sound when the AI needs your input
+          </p>
+        </div>
+        <Switch id="sound-toggle" checked={soundEnabled} onCheckedChange={handleSoundToggle} />
       </div>
-      <Switch id="sound-toggle" checked={soundEnabled} onCheckedChange={handleSoundToggle} />
+      <div className="flex items-center justify-between gap-4 border-t border-border/50 py-3">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <Label htmlFor="desktop-notifications-toggle" className="text-sm font-medium">
+            Desktop notifications
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Show system notifications for important app events
+          </p>
+        </div>
+        <Switch
+          id="desktop-notifications-toggle"
+          checked={osEnabled}
+          onCheckedChange={handleOsToggle}
+        />
+      </div>
+      <div className="flex items-center justify-between gap-4 border-t border-border/50 py-3">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <Label htmlFor="recording-suggestions-toggle" className="text-sm font-medium">
+            Recording suggestions
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Notify when a meeting call is detected and recording can start
+          </p>
+        </div>
+        <Switch
+          id="recording-suggestions-toggle"
+          checked={recordingSuggestionsEnabled}
+          onCheckedChange={handleRecordingSuggestionsToggle}
+          disabled={!osEnabled}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,3 +1,5 @@
+import type { MeetingPlatform } from '@stitch/shared/recordings/types';
+
 export type ContextMenuParams = {
   x: number;
   y: number;
@@ -27,6 +29,17 @@ export type DesktopUpdaterState = {
   version?: string;
   progress?: number;
   error?: string;
+};
+
+type DesktopNotificationInput = {
+  title: string;
+  body?: string;
+  silent?: boolean;
+  clickAction?: {
+    kind: 'start-recording';
+    platform: MeetingPlatform;
+    key: string;
+  } | null;
 };
 
 declare global {
@@ -69,6 +82,9 @@ declare global {
         requestMicrophone: () => Promise<boolean>;
         getScreenCaptureStatus: () => Promise<string>;
         openScreenCaptureSettings: () => Promise<void>;
+      };
+      notifications?: {
+        show: (input: DesktopNotificationInput) => Promise<boolean>;
       };
     };
   }

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -1,0 +1,64 @@
+import type { MeetingCallDetectedPayload } from '@stitch/shared/chat/realtime';
+
+type UserSettings = Record<string, string> | undefined;
+
+type AppNotificationEvent = {
+  kind: 'recording-suggestion';
+  payload: MeetingCallDetectedPayload;
+};
+
+function isEnabled(settings: UserSettings, key: string): boolean {
+  return settings?.[key] !== 'false';
+}
+
+function platformLabel(platform: MeetingCallDetectedPayload['platform']): string {
+  if (platform === 'google-meet') return 'Google Meet';
+  if (platform === 'teams') return 'Microsoft Teams';
+  if (platform === 'zoom') return 'Zoom';
+  if (platform === 'slack') return 'Slack';
+  return 'Discord';
+}
+
+function toDesktopNotification(event: AppNotificationEvent): { title: string; body: string } {
+  if (event.kind === 'recording-suggestion') {
+    return {
+      title: 'Recording suggestion',
+      body: `Active call detected in ${platformLabel(event.payload.platform)}. Start recording?`,
+    };
+  }
+
+  return {
+    title: 'Stitch',
+    body: 'You have a new notification.',
+  };
+}
+
+export async function notifyAppEvent(event: AppNotificationEvent, settings: UserSettings) {
+  if (!isEnabled(settings, 'notifications.os.enabled')) return;
+  if (!window.api?.notifications?.show) return;
+
+  if (event.kind === 'recording-suggestion') {
+    if (!isEnabled(settings, 'notifications.os.recordingSuggestions.enabled')) return;
+  }
+
+  const notification = toDesktopNotification(event);
+  const soundEnabled = isEnabled(settings, 'notifications.sound.enabled');
+
+  try {
+    await window.api.notifications.show({
+      title: notification.title,
+      body: notification.body,
+      silent: !soundEnabled,
+      clickAction:
+        event.kind === 'recording-suggestion'
+          ? {
+              kind: 'start-recording',
+              platform: event.payload.platform,
+              key: event.payload.key,
+            }
+          : null,
+    });
+  } catch {
+    // no-op
+  }
+}

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -17,6 +17,8 @@ export const SETTINGS_KEYS = [
   'profile.name',
   'profile.timezone',
   'notifications.sound.enabled',
+  'notifications.os.enabled',
+  'notifications.os.recordingSuggestions.enabled',
   'browser.profileImported',
   'browser.activeProfile',
   'browser.headless',
@@ -66,6 +68,8 @@ export const SETTINGS_SCHEMAS: Record<SettingsKey, z.ZodType> = {
   'profile.name': z.string().min(1).max(80),
   'profile.timezone': z.string().min(1).max(120),
   'notifications.sound.enabled': z.coerce.boolean(),
+  'notifications.os.enabled': z.coerce.boolean(),
+  'notifications.os.recordingSuggestions.enabled': z.coerce.boolean(),
   'browser.profileImported': z.string(),
   'browser.activeProfile': z.string(),
   'browser.headless': z.coerce.boolean(),
@@ -185,6 +189,17 @@ export const SETTINGS_DEFAULTS: SettingDefault[] = [
     key: 'notifications.sound.enabled',
     value: 'true',
     description: 'Play an attention sound when the AI needs your input (question or permission).',
+  },
+  {
+    key: 'notifications.os.enabled',
+    value: 'true',
+    description: 'Show desktop notifications for in-app events.',
+  },
+  {
+    key: 'notifications.os.recordingSuggestions.enabled',
+    value: 'true',
+    description:
+      'Show desktop notifications when a meeting call is detected and recording is suggested.',
   },
   {
     key: 'browser.profileImported',


### PR DESCRIPTION
## 🚀 Change Summary
Adds a reusable desktop notification pipeline and wires it to meeting-call recording suggestions so users can get OS notifications and click them to immediately start recording.

### ✨ New Features
- Added a shared app notification interface in the web app for event-driven desktop notifications.
- Added Electron IPC support for showing OS notifications with typed click actions.
- Added click-to-start behavior so selecting a recording suggestion notification immediately triggers recording start.

### 🛠 Improvements & Refactors
- Extended notification settings with a master desktop toggle and a recording-suggestion-specific toggle.
- Updated General settings UI to manage sound alerts, desktop notifications, and recording suggestion notifications.
- Kept notification sound behavior aligned with existing sound setting via silent notification support.

### 🐛 Bug Fixes
- Avoids duplicate suggestion prompts for already-dismissed meeting keys before emitting desktop notifications.