### PR TITLE
fix(toolsets): hide disabled toolsets from LLM and return clear activation errors

### DIFF
--- a/packages/server/__test__/tools/runtime-filtering.test.ts
+++ b/packages/server/__test__/tools/runtime-filtering.test.ts
@@ -1,15 +1,16 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
+import type { ToolEnabledScope } from '@stitch/shared/tools/types';
+
 import { createTools } from '@/tools/runtime/registry.js';
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
 import type { Toolset } from '@/tools/toolsets/types.js';
-import type { ToolEnabledScope } from '@stitch/shared/tools/types';
 import type { Tool } from 'ai';
 
-const mockIsToolEnabled = vi.fn<(opts: { scope: ToolEnabledScope; identifier: string }) => Promise<boolean>>(
-  async () => true,
-);
+const mockIsToolEnabled = vi.fn<
+  (opts: { scope: ToolEnabledScope; identifier: string }) => Promise<boolean>
+>(async () => true);
 const mockGetDisabledToolIdentifiers = vi.fn<(scope: ToolEnabledScope) => Promise<Set<string>>>(
   async () => new Set<string>(),
 );
@@ -76,7 +77,7 @@ describe('runtime tool filtering', () => {
 
     const result = await manager.activate('toolset-disabled');
 
-    expect(result).toBeNull();
+    expect(result.status).toBe('disabled');
     expect(manager.getActiveTools()).toEqual({});
   });
 
@@ -108,7 +109,8 @@ describe('runtime tool filtering', () => {
     const result = await manager.activate('mcp:test-server');
     const activeTools = manager.getActiveTools();
 
-    expect(result?.toolNames).toEqual(['mcp_beta']);
+    expect(result.status).toBe('activated');
+    expect(result.status === 'activated' && result.toolNames).toEqual(['mcp_beta']);
     expect(Object.keys(activeTools)).toEqual(['mcp_beta']);
   });
 });

--- a/packages/server/__test__/tools/toolset-manager-ordering.test.ts
+++ b/packages/server/__test__/tools/toolset-manager-ordering.test.ts
@@ -49,7 +49,8 @@ describe('ToolsetManager.activate collision detection', () => {
     await manager.activate('ts-a');
     const result = await manager.activate('ts-b');
 
-    expect(result?.collisions).toEqual([]);
+    expect(result.status).toBe('activated');
+    expect(result.status === 'activated' && result.collisions).toEqual([]);
   });
 
   test('reports collisions when two toolsets share a tool name', async () => {
@@ -79,7 +80,8 @@ describe('ToolsetManager.activate collision detection', () => {
     await manager.activate('ts-x');
     const result = await manager.activate('ts-y');
 
-    expect(result?.collisions).toEqual(['search']);
+    expect(result.status).toBe('activated');
+    expect(result.status === 'activated' && result.collisions).toEqual(['search']);
   });
 
   test('returns no collisions when activating the first toolset', async () => {
@@ -94,7 +96,8 @@ describe('ToolsetManager.activate collision detection', () => {
     const manager = createManager();
     const result = await manager.activate('ts-only');
 
-    expect(result?.collisions).toEqual([]);
+    expect(result.status).toBe('activated');
+    expect(result.status === 'activated' && result.collisions).toEqual([]);
   });
 
   test('already-active toolset returns empty collisions', async () => {
@@ -110,7 +113,8 @@ describe('ToolsetManager.activate collision detection', () => {
     await manager.activate('ts-once');
     const result = await manager.activate('ts-once');
 
-    expect(result?.collisions).toEqual([]);
+    expect(result.status).toBe('activated');
+    expect(result.status === 'activated' && result.collisions).toEqual([]);
   });
 });
 

--- a/packages/server/src/llm/prompt/base-system-prompt.txt
+++ b/packages/server/src/llm/prompt/base-system-prompt.txt
@@ -39,6 +39,7 @@ Additional capabilities are organized into **toolsets** — groups of related to
 - After completing a task that required a toolset, deactivate it immediately with deactivate_toolset.
 - Do not activate all toolsets at once — this wastes context space.
 - If unsure whether a toolset has what you need, use `list_toolsets` first to check.
+- If the capability you need does not appear in the `list_toolsets` catalog, it is not available. Do not try alternative names, IDs, or queries — the catalog is the complete and filtered list of what you can use.
 
 ## Delegating Work
 

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -1,6 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 
+import { isToolEnabled } from '@/tools/enabled-service.js';
 import type { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
 
@@ -30,7 +31,7 @@ export function createToolsetTools(manager: ToolsetManager) {
     }),
     execute: async ({ toolsetId, query }) => {
       if (!toolsetId) {
-        const fullCatalog = manager.getCatalogWithState();
+        const fullCatalog = await manager.getCatalogWithState();
 
         if (!query) {
           return { toolsets: fullCatalog };
@@ -51,6 +52,13 @@ export function createToolsetTools(manager: ToolsetManager) {
       if (!toolset) {
         throw new Error(
           `Unknown toolset: "${toolsetId}". Use list_toolsets with no arguments to see available IDs.`,
+        );
+      }
+
+      const enabled = await isToolEnabled({ scope: 'toolset', identifier: toolsetId });
+      if (!enabled) {
+        throw new Error(
+          `Toolset "${toolsetId}" is not in the catalog. Use list_toolsets with no arguments to see available IDs.`,
         );
       }
 
@@ -98,9 +106,14 @@ export function createToolsetTools(manager: ToolsetManager) {
       }
 
       const result = await manager.activate(toolsetId);
-      if (result === null) {
+      if (result.status === 'not_found') {
         throw new Error(
           `Unknown toolset: "${toolsetId}". Use list_toolsets with no arguments to see available IDs.`,
+        );
+      }
+      if (result.status === 'disabled') {
+        throw new Error(
+          `Toolset "${toolsetId}" has been disabled by the user. Do not attempt to activate it or search for alternatives.`,
         );
       }
 

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -29,11 +29,21 @@ export class ToolsetManager {
 
   /**
    * Activate a toolset by ID.
-   * Returns the newly available tool names and any collision warnings, or null if not found.
+   * Returns a discriminated result: activated with tool names, not_found, or disabled.
    */
-  async activate(toolsetId: string): Promise<{ toolNames: string[]; collisions: string[] } | null> {
+  async activate(
+    toolsetId: string,
+  ): Promise<
+    | { status: 'activated'; toolNames: string[]; collisions: string[] }
+    | { status: 'not_found' }
+    | { status: 'disabled' }
+  > {
     if (this.activeIds.has(toolsetId)) {
-      return { toolNames: Object.keys(this.activeToolCache.get(toolsetId) ?? {}), collisions: [] };
+      return {
+        status: 'activated',
+        toolNames: Object.keys(this.activeToolCache.get(toolsetId) ?? {}),
+        collisions: [],
+      };
     }
 
     const toolset = getToolset(toolsetId);
@@ -42,7 +52,7 @@ export class ToolsetManager {
         { event: 'toolset.activate.not_found', toolsetId },
         'attempted to activate unknown toolset',
       );
-      return null;
+      return { status: 'not_found' };
     }
 
     const toolsetEnabled = await isToolEnabled({ scope: 'toolset', identifier: toolsetId });
@@ -51,7 +61,7 @@ export class ToolsetManager {
         { event: 'toolset.activate.disabled', toolsetId },
         'attempted to activate disabled toolset',
       );
-      return null;
+      return { status: 'disabled' };
     }
 
     const allTools = withToolResultHandlingRecord(await toolset.activate(this.context));
@@ -87,7 +97,7 @@ export class ToolsetManager {
       'toolset activated',
     );
 
-    return { toolNames: Object.keys(tools), collisions };
+    return { status: 'activated', toolNames: Object.keys(tools), collisions };
   }
 
   /** Deactivate a toolset, removing its tools from the active set. */
@@ -127,25 +137,31 @@ export class ToolsetManager {
 
   /**
    * Build a brief catalog of all available (registered) toolsets with their activation state.
+   * Disabled toolsets are excluded so the LLM never sees or attempts to use them.
    * Used by the list_toolsets meta-tool.
    */
-  getCatalogWithState(): Array<{
-    id: string;
-    name: string;
-    description: string;
-    icon?: ConnectorIconSource;
-    active: boolean;
-    hasInstructions: boolean;
-    promptCount: number;
-  }> {
-    return listToolsets().map((ts) => ({
-      id: ts.id,
-      name: ts.name,
-      description: ts.description,
-      icon: ts.icon,
-      active: this.activeIds.has(ts.id),
-      hasInstructions: !!ts.instructions,
-      promptCount: ts.prompts?.length ?? 0,
-    }));
+  async getCatalogWithState(): Promise<
+    Array<{
+      id: string;
+      name: string;
+      description: string;
+      icon?: ConnectorIconSource;
+      active: boolean;
+      hasInstructions: boolean;
+      promptCount: number;
+    }>
+  > {
+    const disabledIds = await getDisabledToolIdentifiers('toolset');
+    return listToolsets()
+      .filter((ts) => !disabledIds.has(ts.id))
+      .map((ts) => ({
+        id: ts.id,
+        name: ts.name,
+        description: ts.description,
+        icon: ts.icon,
+        active: this.activeIds.has(ts.id),
+        hasInstructions: !!ts.instructions,
+        promptCount: ts.prompts?.length ?? 0,
+      }));
   }
 }


### PR DESCRIPTION
## Change Summary

Fixes a loop pattern where the LLM repeatedly called list_toolsets and tried to activate toolsets the user had disabled, burning tokens and making no progress. Root cause: disabled toolsets were visible in the catalog and activation returned a misleading 'Unknown toolset' error, causing the LLM to keep retrying with different names and queries.

### Bug Fixes
- **Disabled toolsets hidden from catalog**: getCatalogWithState() is now async and filters out toolsets disabled in tool_enabled, so the LLM never sees them in list_toolsets output
- **Distinct error for disabled vs unknown**: activate() now returns a discriminated union (activated / not_found / disabled) instead of null for both failure cases — the activation error message now explicitly tells the LLM the toolset is disabled by the user and to stop searching for alternatives
- **list_toolsets with toolsetId also gated**: Direct inspection of a disabled toolset ID now also returns a not-in-catalog error
- **System prompt updated**: Added a guideline that if a capability is absent from the catalog it is not available and the LLM should not retry with alternative names