### PR TITLE
improvement(queue, shortcuts): convert to ServiceResult-first services with Zod validation

### DIFF
--- a/packages/server/src/queue/service.ts
+++ b/packages/server/src/queue/service.ts
@@ -6,6 +6,9 @@ import type { PrefixedString } from '@stitch/shared/id';
 
 import { getDb } from '@/db/client.js';
 import { queuedMessages } from '@/db/schema.js';
+import { requireFound } from '@/lib/route-helpers.js';
+import { ok } from '@/lib/service-result.js';
+import type { ServiceResult } from '@/lib/service-result.js';
 
 type AddToQueueInput = {
   sessionId: PrefixedString<'ses'>;
@@ -18,17 +21,22 @@ type UpdateQueuedMessageInput = {
   attachments?: QueuedMessageAttachment[];
 };
 
-export function listQueuedMessages(sessionId: PrefixedString<'ses'>) {
+type QueuedMessageRow = typeof queuedMessages.$inferSelect;
+
+export function listQueuedMessages(
+  sessionId: PrefixedString<'ses'>,
+): ServiceResult<QueuedMessageRow[]> {
   const db = getDb();
-  return db
+  const rows = db
     .select()
     .from(queuedMessages)
     .where(eq(queuedMessages.sessionId, sessionId))
     .orderBy(asc(queuedMessages.position))
     .all();
+  return ok(rows);
 }
 
-export function addToQueue(input: AddToQueueInput) {
+export function addToQueue(input: AddToQueueInput): ServiceResult<QueuedMessageRow> {
   const db = getDb();
   const id = createQueuedMessageId();
   const now = Date.now();
@@ -55,10 +63,13 @@ export function addToQueue(input: AddToQueueInput) {
     .returning()
     .get();
 
-  return row;
+  return ok(row);
 }
 
-export function updateQueuedMessage(id: PrefixedString<'qmsg'>, input: UpdateQueuedMessageInput) {
+export function updateQueuedMessage(
+  id: PrefixedString<'qmsg'>,
+  input: UpdateQueuedMessageInput,
+): ServiceResult<QueuedMessageRow> {
   const db = getDb();
   const now = Date.now();
 
@@ -73,13 +84,13 @@ export function updateQueuedMessage(id: PrefixedString<'qmsg'>, input: UpdateQue
     .returning()
     .get();
 
-  return row ?? null;
+  return requireFound(row, 'Queued message');
 }
 
-export function removeFromQueue(id: PrefixedString<'qmsg'>) {
+export function removeFromQueue(id: PrefixedString<'qmsg'>): ServiceResult<QueuedMessageRow> {
   const db = getDb();
 
   const row = db.delete(queuedMessages).where(eq(queuedMessages.id, id)).returning().get();
 
-  return row ?? null;
+  return requireFound(row, 'Queued message');
 }

--- a/packages/server/src/routes/queue.ts
+++ b/packages/server/src/routes/queue.ts
@@ -1,9 +1,9 @@
+import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
+import { z } from 'zod';
 
-import type { QueuedMessageAttachment } from '@stitch/shared/chat/queue';
-import type { PrefixedString } from '@stitch/shared/id';
-
-import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
+import { unwrapResult } from '@/lib/route-helpers.js';
+import { routeSchemas } from '@/lib/route-schemas.js';
 import {
   addToQueue,
   listQueuedMessages,
@@ -11,54 +11,74 @@ import {
   updateQueuedMessage,
 } from '@/queue/service.js';
 
+const attachmentSchema = z.object({
+  path: z.string(),
+  mime: z.string(),
+  filename: z.string(),
+});
+
+const addToQueueSchema = z
+  .object({
+    content: z.string().default(''),
+    attachments: z.array(attachmentSchema).optional(),
+  })
+  .refine(
+    (data) => data.content.trim().length > 0 || (data.attachments && data.attachments.length > 0),
+    { message: 'content or attachments are required' },
+  );
+
+const updateQueuedMessageSchema = z.object({
+  content: z.string().optional(),
+  attachments: z.array(attachmentSchema).optional(),
+});
+
+const sessionParamSchema = z.object({ id: routeSchemas.sessionId });
+const queueParamSchema = z.object({
+  id: routeSchemas.sessionId,
+  queueId: routeSchemas.queuedMessageId,
+});
+
 export const queueRouter = new Hono();
 
-queueRouter.get('/sessions/:id/queue', (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-  const rows = listQueuedMessages(sessionId);
-  return c.json(rows);
-});
-
-queueRouter.post('/sessions/:id/queue', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-  const body = await c.req.json<{
-    content: string;
-    attachments?: QueuedMessageAttachment[];
-  }>();
-
-  if (!body.content?.trim() && (!body.attachments || body.attachments.length === 0)) {
-    return c.json({ error: 'content or attachments are required' }, 400);
-  }
-
-  const row = addToQueue({
-    sessionId,
-    content: body.content ?? '',
-    attachments: body.attachments,
-  });
-
-  return c.json(row, 201);
-});
-
-queueRouter.patch('/sessions/:id/queue/:queueId', async (c) => {
-  const queueId = c.req.param('queueId') as PrefixedString<'qmsg'>;
-  const body = await c.req.json<{
-    content?: string;
-    attachments?: QueuedMessageAttachment[];
-  }>();
-
-  const row = updateQueuedMessage(queueId, {
-    content: body.content,
-    attachments: body.attachments,
-  });
-
-  const result = requireFound(row, 'Queued message');
+queueRouter.get('/sessions/:id/queue', zValidator('param', sessionParamSchema), (c) => {
+  const { id: sessionId } = c.req.valid('param');
+  const result = listQueuedMessages(sessionId);
   return unwrapResult(c, result);
 });
 
-queueRouter.delete('/sessions/:id/queue/:queueId', (c) => {
-  const queueId = c.req.param('queueId') as PrefixedString<'qmsg'>;
+queueRouter.post(
+  '/sessions/:id/queue',
+  zValidator('param', sessionParamSchema),
+  zValidator('json', addToQueueSchema),
+  (c) => {
+    const { id: sessionId } = c.req.valid('param');
+    const body = c.req.valid('json');
+    const result = addToQueue({
+      sessionId,
+      content: body.content,
+      attachments: body.attachments,
+    });
+    return unwrapResult(c, result, 201);
+  },
+);
 
-  const row = removeFromQueue(queueId);
-  const result = requireFound(row, 'Queued message');
+queueRouter.patch(
+  '/sessions/:id/queue/:queueId',
+  zValidator('param', queueParamSchema),
+  zValidator('json', updateQueuedMessageSchema),
+  (c) => {
+    const { queueId } = c.req.valid('param');
+    const body = c.req.valid('json');
+    const result = updateQueuedMessage(queueId, {
+      content: body.content,
+      attachments: body.attachments,
+    });
+    return unwrapResult(c, result);
+  },
+);
+
+queueRouter.delete('/sessions/:id/queue/:queueId', zValidator('param', queueParamSchema), (c) => {
+  const { queueId } = c.req.valid('param');
+  const result = removeFromQueue(queueId);
   return unwrapResult(c, result, 204);
 });

--- a/packages/server/src/routes/shortcuts.ts
+++ b/packages/server/src/routes/shortcuts.ts
@@ -3,7 +3,6 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 
 import { unwrapResult } from '@/lib/route-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
 import {
   deleteShortcut,
   listShortcuts,
@@ -19,20 +18,19 @@ export const shortcutsRouter = new Hono();
 
 shortcutsRouter.get('/', async (c) => {
   const result = await listShortcuts();
-  return c.json(result);
+  return unwrapResult(c, result);
 });
 
 shortcutsRouter.put('/:actionId', zValidator('json', shortcutSchema), async (c) => {
   const actionId = c.req.param('actionId');
   const { hotkey } = c.req.valid('json');
   const result = await saveShortcut(actionId, hotkey);
-  if (isServiceError(result)) return unwrapResult(c, result);
   return unwrapResult(c, result, 204);
 });
 
 shortcutsRouter.delete('/', async (c) => {
-  await resetShortcuts();
-  return c.body(null, 204);
+  const result = await resetShortcuts();
+  return unwrapResult(c, result, 204);
 });
 
 shortcutsRouter.delete('/:actionId', async (c) => {

--- a/packages/server/src/shortcuts/service.ts
+++ b/packages/server/src/shortcuts/service.ts
@@ -22,16 +22,18 @@ function isAllowedActionId(actionId: string): boolean {
   return ALLOWED_ACTION_IDS.has(actionId);
 }
 
-export async function listShortcuts(): Promise<ShortcutRow[]> {
+export async function listShortcuts(): Promise<ServiceResult<ShortcutRow[]>> {
   const db = getDb();
   const rows = await db.select().from(keyboardShortcuts);
-  return rows.map((row) => ({
-    actionId: row.actionId,
-    hotkey: row.hotkey,
-    isSequence: row.isSequence,
-    label: row.label,
-    category: row.category,
-  }));
+  return ok(
+    rows.map((row) => ({
+      actionId: row.actionId,
+      hotkey: row.hotkey,
+      isSequence: row.isSequence,
+      label: row.label,
+      category: row.category,
+    })),
+  );
 }
 
 export async function saveShortcut(
@@ -55,7 +57,7 @@ export async function saveShortcut(
   return ok(null);
 }
 
-export async function resetShortcuts(): Promise<void> {
+export async function resetShortcuts(): Promise<ServiceResult<null>> {
   const db = getDb();
   const now = Date.now();
   for (const def of SHORTCUT_DEFAULTS) {
@@ -64,6 +66,7 @@ export async function resetShortcuts(): Promise<void> {
       .set({ hotkey: def.hotkey, isSequence: def.isSequence, updatedAt: now })
       .where(eq(keyboardShortcuts.actionId, def.actionId));
   }
+  return ok(null);
 }
 
 export async function deleteShortcut(actionId: string): Promise<ServiceResult<null>> {


### PR DESCRIPTION
## 🚀 Change Summary

Implements the architecture cleanup outlined in #76 — converting queue and shortcuts services to the `ServiceResult`-first pattern with strict Zod validation across all endpoints.

### 🛠 Improvements & Refactors

- **Queue service**: All four operations (list/add/update/remove) now return `ServiceResult<T>` instead of raw rows or null, with not-found handled at the service level via `requireFound`
- **Queue routes**: Full Zod validation on all param and body inputs using `routeSchemas.sessionId` / `routeSchemas.queuedMessageId` prefixed-ID validators; manual content/attachments check replaced with a Zod `.refine()`
- **Shortcuts service**: `listShortcuts` and `resetShortcuts` now return `ServiceResult` for consistency with `saveShortcut` and `deleteShortcut`
- **Shortcuts routes**: All handlers use `unwrapResult` — the manual `isServiceError` check removed from the PUT handler

Closes #76