### PR TITLE
improvement(questions/permissions): enforce route->service boundary and ServiceResult contracts

### DIFF
--- a/packages/server/src/question/service.ts
+++ b/packages/server/src/question/service.ts
@@ -7,6 +7,8 @@ import type { QuestionInfo, QuestionRequest } from '@stitch/shared/questions/typ
 import { getDb } from '@/db/client.js';
 import { questions } from '@/db/schema.js';
 import * as Log from '@/lib/log.js';
+import { err, ok } from '@/lib/service-result.js';
+import type { ServiceResult } from '@/lib/service-result.js';
 import { broadcast } from '@/lib/sse.js';
 import { QuestionAbortedError } from '@/llm/stream/errors.js';
 
@@ -20,6 +22,32 @@ function toQuestionRequest(row: QuestionRow): QuestionRequest {
     answers: row.answers ?? undefined,
     answeredAt: row.answeredAt ?? undefined,
   };
+}
+
+export async function createQuestion(opts: {
+  sessionId: PrefixedString<'ses'>;
+  questions: QuestionInfo[];
+  toolCallId: string;
+  messageId: PrefixedString<'msg'>;
+}): Promise<QuestionRequest> {
+  const db = getDb();
+  const id = createQuestionId();
+  const now = Date.now();
+
+  const [row] = await db
+    .insert(questions)
+    .values({
+      id,
+      sessionId: opts.sessionId,
+      questions: opts.questions,
+      status: 'pending',
+      toolCallId: opts.toolCallId,
+      messageId: opts.messageId,
+      createdAt: now,
+    })
+    .returning();
+
+  return toQuestionRequest(row);
 }
 
 type PendingQuestion = {
@@ -101,7 +129,7 @@ export async function askQuestion(opts: {
 export async function replyQuestion(
   questionId: PrefixedString<'quest'>,
   answers: string[][],
-): Promise<void> {
+): Promise<ServiceResult<null>> {
   const db = getDb();
   const now = Date.now();
 
@@ -116,7 +144,7 @@ export async function replyQuestion(
     .returning();
 
   if (!question) {
-    throw new Error(`Question not found: ${questionId}`);
+    return err(`Question not found: ${questionId}`, 404);
   }
 
   await broadcast('question-replied', {
@@ -143,15 +171,18 @@ export async function replyQuestion(
   }
 
   log.info({ questionId }, 'question replied');
+  return ok(null);
 }
 
-export async function rejectQuestion(questionId: PrefixedString<'quest'>): Promise<void> {
+export async function rejectQuestion(
+  questionId: PrefixedString<'quest'>,
+): Promise<ServiceResult<null>> {
   const db = getDb();
   const now = Date.now();
 
   const [question] = await db.select().from(questions).where(eq(questions.id, questionId));
   if (!question) {
-    throw new Error(`Question not found: ${questionId}`);
+    return err(`Question not found: ${questionId}`, 404);
   }
 
   await db
@@ -185,6 +216,7 @@ export async function rejectQuestion(questionId: PrefixedString<'quest'>): Promi
   }
 
   log.info({ questionId }, 'question rejected');
+  return ok(null);
 }
 
 export async function getPendingQuestions(

--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -1,12 +1,8 @@
 import { zValidator } from '@hono/zod-validator';
-import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod';
 
-import type { PrefixedString } from '@stitch/shared/id';
-
-import { getDb } from '@/db/client.js';
-import { sessions } from '@/db/schema.js';
+import { getSessionById } from '@/chat/service.js';
 import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
 import { isServiceError } from '@/lib/service-result.js';
 import {
@@ -15,6 +11,15 @@ import {
   getPendingPermissionResponses,
   rejectPermissionResponse,
 } from '@/permission/service.js';
+
+const sessionParamSchema = z.object({
+  id: z.templateLiteral(['ses_', z.string()]),
+});
+
+const permissionResponseParamSchema = z.object({
+  sessionId: z.templateLiteral(['ses_', z.string()]),
+  permissionResponseId: z.templateLiteral(['permres_', z.string()]),
+});
 
 const setPermissionRuleSchema = z.object({
   permission: z.enum(['allow', 'deny', 'ask']),
@@ -27,56 +32,55 @@ const alternativeBodySchema = z.object({
 
 export const permissionsRouter = new Hono();
 
-permissionsRouter.get('/sessions/:id/permission-responses', async (c) => {
-  const db = getDb();
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
+permissionsRouter.get(
+  '/sessions/:id/permission-responses',
+  zValidator('param', sessionParamSchema),
+  async (c) => {
+    const { id: sessionId } = c.req.valid('param');
 
-  const [session] = await db
-    .select({ id: sessions.id })
-    .from(sessions)
-    .where(eq(sessions.id, sessionId));
-  const sessionResult = requireFound(session, 'Session');
-  if (isServiceError(sessionResult)) return unwrapResult(c, sessionResult);
+    const sessionResult = requireFound(await getSessionById(sessionId), 'Session');
+    if (isServiceError(sessionResult)) return unwrapResult(c, sessionResult);
 
-  const rows = await getPendingPermissionResponses(sessionId);
-  return c.json(rows);
-});
+    const rows = await getPendingPermissionResponses(sessionId);
+    return c.json(rows);
+  },
+);
 
 permissionsRouter.post(
   '/sessions/:sessionId/permission-responses/:permissionResponseId/allow',
+  zValidator('param', permissionResponseParamSchema),
   zValidator('json', z.object({ setPermission: setPermissionRuleSchema.optional() })),
   async (c) => {
-    const permissionResponseId = c.req.param('permissionResponseId') as PrefixedString<'permres'>;
+    const { permissionResponseId } = c.req.valid('param');
     const { setPermission } = c.req.valid('json');
 
     const result = await allowPermissionResponse(permissionResponseId, setPermission);
-    if (isServiceError(result)) return unwrapResult(c, result);
-    return c.json({ ok: true });
+    return unwrapResult(c, result);
   },
 );
 
 permissionsRouter.post(
   '/sessions/:sessionId/permission-responses/:permissionResponseId/reject',
+  zValidator('param', permissionResponseParamSchema),
   zValidator('json', z.object({ setPermission: setPermissionRuleSchema.optional() })),
   async (c) => {
-    const permissionResponseId = c.req.param('permissionResponseId') as PrefixedString<'permres'>;
+    const { permissionResponseId } = c.req.valid('param');
     const { setPermission } = c.req.valid('json');
 
     const result = await rejectPermissionResponse(permissionResponseId, setPermission);
-    if (isServiceError(result)) return unwrapResult(c, result);
-    return c.json({ ok: true });
+    return unwrapResult(c, result);
   },
 );
 
 permissionsRouter.post(
   '/sessions/:sessionId/permission-responses/:permissionResponseId/alternative',
+  zValidator('param', permissionResponseParamSchema),
   zValidator('json', alternativeBodySchema),
   async (c) => {
-    const permissionResponseId = c.req.param('permissionResponseId') as PrefixedString<'permres'>;
+    const { permissionResponseId } = c.req.valid('param');
     const { entry } = c.req.valid('json');
 
     const result = await alternativePermissionResponse(permissionResponseId, entry.trim());
-    if (isServiceError(result)) return unwrapResult(c, result);
-    return c.json({ ok: true });
+    return unwrapResult(c, result);
   },
 );

--- a/packages/server/src/routes/questions.ts
+++ b/packages/server/src/routes/questions.ts
@@ -1,16 +1,25 @@
 import { zValidator } from '@hono/zod-validator';
-import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod';
 
-import type { PrefixedString } from '@stitch/shared/id';
-import { createQuestionId } from '@stitch/shared/id';
-
-import { getDb } from '@/db/client.js';
-import { questions, sessions } from '@/db/schema.js';
+import { getSessionById } from '@/chat/service.js';
 import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
 import { isServiceError } from '@/lib/service-result.js';
-import { replyQuestion, rejectQuestion, getPendingQuestions } from '@/question/service.js';
+import {
+  createQuestion,
+  getPendingQuestions,
+  rejectQuestion,
+  replyQuestion,
+} from '@/question/service.js';
+
+const sessionParamSchema = z.object({
+  id: z.templateLiteral(['ses_', z.string()]),
+});
+
+const questionParamSchema = z.object({
+  sessionId: z.templateLiteral(['ses_', z.string()]),
+  questionId: z.templateLiteral(['quest_', z.string()]),
+});
 
 const questionOptionSchema = z.object({
   label: z.string(),
@@ -37,53 +46,38 @@ const replySchema = z.object({
 
 export const questionsRouter = new Hono();
 
-questionsRouter.get('/sessions/:id/questions', async (c) => {
-  const db = getDb();
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
+questionsRouter.get(
+  '/sessions/:id/questions',
+  zValidator('param', sessionParamSchema),
+  async (c) => {
+    const { id: sessionId } = c.req.valid('param');
 
-  const [session] = await db
-    .select({ id: sessions.id })
-    .from(sessions)
-    .where(eq(sessions.id, sessionId));
-  const sessionResult = requireFound(session, 'Session');
-  if (isServiceError(sessionResult)) return unwrapResult(c, sessionResult);
+    const sessionResult = requireFound(await getSessionById(sessionId), 'Session');
+    if (isServiceError(sessionResult)) return unwrapResult(c, sessionResult);
 
-  const rows = await getPendingQuestions(sessionId);
-
-  return c.json(rows);
-});
+    const rows = await getPendingQuestions(sessionId);
+    return c.json(rows);
+  },
+);
 
 questionsRouter.post(
   '/sessions/:id/questions',
+  zValidator('param', sessionParamSchema),
   zValidator('json', createQuestionsSchema),
   async (c) => {
-    const db = getDb();
-    const sessionId = c.req.param('id') as PrefixedString<'ses'>;
+    const { id: sessionId } = c.req.valid('param');
 
-    const [session] = await db
-      .select({ id: sessions.id })
-      .from(sessions)
-      .where(eq(sessions.id, sessionId));
-    const sessionResult = requireFound(session, 'Session');
+    const sessionResult = requireFound(await getSessionById(sessionId), 'Session');
     if (isServiceError(sessionResult)) return unwrapResult(c, sessionResult);
 
     const body = c.req.valid('json');
 
-    const id = createQuestionId();
-    const now = Date.now();
-
-    const [row] = await db
-      .insert(questions)
-      .values({
-        id,
-        sessionId,
-        questions: body.questions,
-        status: 'pending',
-        toolCallId: body.toolCallId,
-        messageId: body.messageId,
-        createdAt: now,
-      })
-      .returning();
+    const row = await createQuestion({
+      sessionId,
+      questions: body.questions,
+      toolCallId: body.toolCallId,
+      messageId: body.messageId,
+    });
 
     return c.json(row, 201);
   },
@@ -91,21 +85,24 @@ questionsRouter.post(
 
 questionsRouter.post(
   '/sessions/:sessionId/questions/:questionId/reply',
+  zValidator('param', questionParamSchema),
   zValidator('json', replySchema),
   async (c) => {
-    const questionId = c.req.param('questionId') as PrefixedString<'quest'>;
+    const { questionId } = c.req.valid('param');
     const { answers } = c.req.valid('json');
 
-    await replyQuestion(questionId, answers);
-
-    return c.json({ ok: true });
+    const result = await replyQuestion(questionId, answers);
+    return unwrapResult(c, result);
   },
 );
 
-questionsRouter.post('/sessions/:sessionId/questions/:questionId/reject', async (c) => {
-  const questionId = c.req.param('questionId') as PrefixedString<'quest'>;
+questionsRouter.post(
+  '/sessions/:sessionId/questions/:questionId/reject',
+  zValidator('param', questionParamSchema),
+  async (c) => {
+    const { questionId } = c.req.valid('param');
 
-  await rejectQuestion(questionId);
-
-  return c.json({ ok: true });
-});
+    const result = await rejectQuestion(questionId);
+    return unwrapResult(c, result);
+  },
+);


### PR DESCRIPTION
## 🚀 Change Summary

Enforces a clean route->service boundary for question and permission routes, standardises `ServiceResult` contracts, and adds strict Zod param validation -- closing out the architecture cleanup tracked in #72.

### ✨ New Features
- **`createQuestion` service method**: DB insert for question creation moved out of the route handler and into the service layer

### 🛠 Improvements & Refactors
- Route handlers for questions and permissions no longer access the database directly -- all DB interaction goes through services
- `replyQuestion` and `rejectQuestion` now return `ServiceResult<null>` instead of throwing, enabling consistent error propagation
- Zod `param` validators added to all question and permission routes with prefixed template literal schemas (`ses_*`, `quest_*`, `permres_*`)
- `unwrapResult` used consistently throughout; manual `isServiceError` + `c.json` patterns eliminated

Closes #72
