### PR TITLE
improvement(chat): move to ServiceResult and full Zod validation

### DIFF
--- a/packages/server/__test__/tools/task.test.ts
+++ b/packages/server/__test__/tools/task.test.ts
@@ -72,8 +72,10 @@ describe('task tool', () => {
     const messageId = 'msg_parent' as PrefixedString<'msg'>;
 
     mocks.createSessionMock.mockResolvedValue({
-      id: childSessionId,
-      title: 'Investigate bug',
+      data: {
+        id: childSessionId,
+        title: 'Investigate bug',
+      },
     });
     mocks.broadcastMock.mockResolvedValue(undefined);
     mocks.valuesMock.mockResolvedValue(undefined);

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -17,7 +17,7 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { createSession, sendMessage } from '@/chat/service.js';
 import { getDb } from '@/db/client.js';
 import { automations, sessions } from '@/db/schema.js';
-import { err, ok } from '@/lib/service-result.js';
+import { err, isServiceError, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { validateProviderModel } from '@/llm/resolve-model.js';
 
@@ -261,11 +261,13 @@ export async function runAutomation(
   }
 
   const title = `${automation.title} #${updatedAutomation.runCount}`;
-  const session = await createSession({
+  const sessionResult = await createSession({
     title,
     type: 'automation',
     automationId: automation.id,
   });
+  if (isServiceError(sessionResult)) return sessionResult;
+  const session = sessionResult.data;
 
   const assistantMessageId = createMessageId();
   const sendResult = await sendMessage({
@@ -275,9 +277,7 @@ export async function runAutomation(
     modelId: automation.modelId,
     assistantMessageId,
   });
-  if ('error' in sendResult) {
-    return sendResult;
-  }
+  if (isServiceError(sendResult)) return sendResult;
 
   return ok({
     sessionId: session.id,

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -49,7 +49,9 @@ type SendMessageInput = {
   assistantMessageId: string;
 };
 
-export async function createSession(input: CreateSessionInput) {
+export async function createSession(
+  input: CreateSessionInput,
+): Promise<ServiceResult<typeof sessions.$inferSelect>> {
   const db = getDb();
   const id = createSessionId();
   const now = Date.now();
@@ -69,12 +71,19 @@ export async function createSession(input: CreateSessionInput) {
     })
     .returning();
 
-  return session;
+  return ok(session);
 }
 
-export async function listSessions(type: 'chat' | 'automation' = 'chat') {
+export async function listSessions(
+  type: 'chat' | 'automation' = 'chat',
+): Promise<ServiceResult<(typeof sessions.$inferSelect)[]>> {
   const db = getDb();
-  return db.select().from(sessions).where(eq(sessions.type, type)).orderBy(asc(sessions.createdAt));
+  const rows = await db
+    .select()
+    .from(sessions)
+    .where(eq(sessions.type, type))
+    .orderBy(asc(sessions.createdAt));
+  return ok(rows);
 }
 
 export async function getSessionById(sessionId: PrefixedString<'ses'>) {
@@ -87,7 +96,7 @@ export async function listSessionMessages(
   sessionId: PrefixedString<'ses'>,
   limit?: number,
   cursor?: number,
-) {
+): Promise<ServiceResult<{ messages: (typeof messages.$inferSelect)[]; hasMore: boolean }>> {
   const db = getDb();
   const pageSize = limit ? Math.min(Math.max(limit, 1), 200) : DEFAULT_PAGE_SIZE;
 
@@ -106,16 +115,19 @@ export async function listSessionMessages(
   const hasMore = rows.length > pageSize;
   const page = hasMore ? rows.slice(0, pageSize) : rows;
   page.reverse();
-  return { messages: page, hasMore };
+  return ok({ messages: page, hasMore });
 }
 
-export async function deleteSession(sessionId: PrefixedString<'ses'>) {
+export async function deleteSession(
+  sessionId: PrefixedString<'ses'>,
+): Promise<ServiceResult<{ id: string }>> {
   const db = getDb();
   const result = await db
     .delete(sessions)
     .where(eq(sessions.id, sessionId))
     .returning({ id: sessions.id });
-  return result.length > 0;
+  if (result.length === 0) return err('Session not found', 404);
+  return ok(result[0]);
 }
 
 export async function renameSession(sessionId: PrefixedString<'ses'>, title: string) {

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -1,6 +1,6 @@
+import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
-
-import type { PrefixedString } from '@stitch/shared/id';
+import { z } from 'zod';
 
 import { generateAutomationDraft } from '@/automations/generation.js';
 import {
@@ -19,145 +19,173 @@ import {
   splitSession,
 } from '@/chat/service.js';
 import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
-import type { DoomLoopResponse } from '@/llm/stream/doom-loop.js';
+import { routeSchemas } from '@/lib/route-schemas.js';
+
+const sessionIdParamSchema = z.object({ id: routeSchemas.sessionId });
+
+const splitParamSchema = z.object({
+  id: routeSchemas.sessionId,
+  msgId: routeSchemas.messageId,
+});
+
+const createSessionSchema = z.object({
+  title: z.string().trim().min(1).optional(),
+  parentSessionId: z.string().optional(),
+});
+
+const listSessionsQuerySchema = z.object({
+  type: z.enum(['chat', 'automation']).optional(),
+});
+
+const listMessagesQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  cursor: z.coerce.number().int().optional(),
+});
+
+const renameSessionSchema = z.object({
+  title: z.string().trim().min(1),
+});
+
+const sendMessageSchema = z.object({
+  content: z.string().min(1),
+  providerId: z.string().min(1),
+  modelId: z.string().min(1),
+  assistantMessageId: routeSchemas.messageId,
+  attachments: z
+    .array(
+      z.object({
+        path: z.string().min(1),
+        mime: z.string().min(1),
+        filename: z.string().min(1),
+      }),
+    )
+    .optional(),
+});
+
+const doomLoopResponseSchema = z.object({
+  response: z.enum(['continue', 'stop']),
+});
 
 export const chatRouter = new Hono();
 
-chatRouter.post('/sessions', async (c) => {
-  const body = await c.req.json<{ title?: string; parentSessionId?: string }>();
-  const session = await createSession(body);
-  return c.json(session, 201);
+chatRouter.post('/sessions', zValidator('json', createSessionSchema), async (c) => {
+  const body = c.req.valid('json');
+  const result = await createSession(body);
+  return unwrapResult(c, result, 201);
 });
 
-chatRouter.get('/sessions', async (c) => {
-  const type = c.req.query('type');
+chatRouter.get('/sessions', zValidator('query', listSessionsQuerySchema), async (c) => {
+  const { type } = c.req.valid('query');
   const sessionType = type === 'automation' ? 'automation' : 'chat';
-  const rows = await listSessions(sessionType);
-  return c.json(rows);
-});
-
-chatRouter.get('/sessions/:id', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-
-  const result = requireFound(await getSessionById(sessionId), 'Session');
+  const result = await listSessions(sessionType);
   return unwrapResult(c, result);
 });
 
-chatRouter.get('/sessions/:id/stats', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-
-  const result = await getSessionStats(sessionId);
+chatRouter.get('/sessions/:id', zValidator('param', sessionIdParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  const result = requireFound(await getSessionById(id), 'Session');
   return unwrapResult(c, result);
 });
 
-chatRouter.get('/sessions/:id/messages', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-
-  const limitParam = c.req.query('limit');
-  const cursorParam = c.req.query('cursor');
-  const limit = limitParam ? Number(limitParam) : undefined;
-  const cursor = cursorParam ? Number(cursorParam) : undefined;
-
-  const page = await listSessionMessages(sessionId, limit, cursor);
-  return c.json(page);
+chatRouter.get('/sessions/:id/stats', zValidator('param', sessionIdParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  const result = await getSessionStats(id);
+  return unwrapResult(c, result);
 });
 
-chatRouter.delete('/sessions/:id', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
+chatRouter.get(
+  '/sessions/:id/messages',
+  zValidator('param', sessionIdParamSchema),
+  zValidator('query', listMessagesQuerySchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const { limit, cursor } = c.req.valid('query');
+    const result = await listSessionMessages(id, limit, cursor);
+    return unwrapResult(c, result);
+  },
+);
 
-  const deleted = await deleteSession(sessionId);
-  const result = requireFound(deleted, 'Session');
+chatRouter.delete('/sessions/:id', zValidator('param', sessionIdParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  const result = await deleteSession(id);
   return unwrapResult(c, result, 204);
 });
 
-chatRouter.patch('/sessions/:id', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-  const body = await c.req.json<{ title: string }>();
+chatRouter.patch(
+  '/sessions/:id',
+  zValidator('param', sessionIdParamSchema),
+  zValidator('json', renameSessionSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const { title } = c.req.valid('json');
+    const updated = await renameSession(id, title);
+    const result = requireFound(updated, 'Session');
+    return unwrapResult(c, result);
+  },
+);
 
-  if (!body.title) {
-    return c.json({ error: 'Title is required' }, 400);
-  }
-
-  const updated = await renameSession(sessionId, body.title);
-  const result = requireFound(updated, 'Session');
-  return unwrapResult(c, result);
-});
-
-chatRouter.patch('/sessions/:id/read', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-  const updated = await markSessionRead(sessionId);
+chatRouter.patch('/sessions/:id/read', zValidator('param', sessionIdParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  const updated = await markSessionRead(id);
   const result = requireFound(updated, 'Session');
   return unwrapResult(c, result, 204);
 });
 
-chatRouter.post('/sessions/:id/messages', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-  const body = await c.req.json<{
-    content: string;
-    providerId: string;
-    modelId: string;
-    assistantMessageId: string;
-    attachments?: Array<{
-      path: string;
-      mime: string;
-      filename: string;
-    }>;
-  }>();
+chatRouter.post(
+  '/sessions/:id/messages',
+  zValidator('param', sessionIdParamSchema),
+  zValidator('json', sendMessageSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const body = c.req.valid('json');
+    const result = await sendMessage({
+      sessionId: id,
+      content: body.content,
+      attachments: body.attachments,
+      providerId: body.providerId,
+      modelId: body.modelId,
+      assistantMessageId: body.assistantMessageId,
+    });
+    return unwrapResult(c, result, 202);
+  },
+);
 
-  if (!body.content || !body.providerId || !body.modelId || !body.assistantMessageId) {
-    return c.json(
-      { error: 'content, providerId, modelId, and assistantMessageId are required' },
-      400,
-    );
-  }
+chatRouter.post(
+  '/sessions/:id/doom-loop-response',
+  zValidator('param', sessionIdParamSchema),
+  zValidator('json', doomLoopResponseSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const { response } = c.req.valid('json');
+    const result = resolveDoomLoop(id, response);
+    return unwrapResult(c, result);
+  },
+);
 
-  const result = await sendMessage({
-    sessionId,
-    content: body.content,
-    attachments: body.attachments,
-    providerId: body.providerId,
-    modelId: body.modelId,
-    assistantMessageId: body.assistantMessageId,
-  });
-  return unwrapResult(c, result, 202);
-});
-
-chatRouter.post('/sessions/:id/doom-loop-response', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-  const body = await c.req.json<{ response: DoomLoopResponse }>();
-
-  if (body.response !== 'continue' && body.response !== 'stop') {
-    return c.json({ error: 'response must be "continue" or "stop"' }, 400);
-  }
-
-  const result = resolveDoomLoop(sessionId, body.response);
-  return unwrapResult(c, result);
-});
-
-chatRouter.post('/sessions/:id/abort', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-  await abortSessionRun(sessionId);
+chatRouter.post('/sessions/:id/abort', zValidator('param', sessionIdParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  await abortSessionRun(id);
   return c.json({ ok: true });
 });
 
-chatRouter.post('/sessions/:id/split/:msgId', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-  const msgId = c.req.param('msgId') as PrefixedString<'msg'>;
-
-  const result = await splitSession(sessionId, msgId);
+chatRouter.post('/sessions/:id/split/:msgId', zValidator('param', splitParamSchema), async (c) => {
+  const { id, msgId } = c.req.valid('param');
+  const result = await splitSession(id, msgId);
   return unwrapResult(c, result, 201);
 });
 
-chatRouter.post('/sessions/:id/compact', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-
-  const result = await requestCompaction(sessionId);
+chatRouter.post('/sessions/:id/compact', zValidator('param', sessionIdParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  const result = await requestCompaction(id);
   return unwrapResult(c, result, 202);
 });
 
-chatRouter.post('/sessions/:id/generate-automation', async (c) => {
-  const sessionId = c.req.param('id') as PrefixedString<'ses'>;
-
-  const result = await generateAutomationDraft(sessionId);
-  return unwrapResult(c, result, 201);
-});
+chatRouter.post(
+  '/sessions/:id/generate-automation',
+  zValidator('param', sessionIdParamSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const result = await generateAutomationDraft(id);
+    return unwrapResult(c, result, 201);
+  },
+);

--- a/packages/server/src/tools/core/task.ts
+++ b/packages/server/src/tools/core/task.ts
@@ -11,6 +11,7 @@ import { getDb } from '@/db/client.js';
 import { messages } from '@/db/schema.js';
 import * as AbortRegistry from '@/lib/abort-registry.js';
 import * as Log from '@/lib/log.js';
+import { isServiceError } from '@/lib/service-result.js';
 import * as Sse from '@/lib/sse.js';
 import { buildCompactedHistory } from '@/llm/compaction.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
@@ -59,10 +60,18 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
         .describe('Additional toolset IDs to activate in the child session beyond inherited ones'),
     }),
     execute: async ({ title, task, toolsets: additionalToolsets }, { toolCallId }) => {
-      const childSession = await createSession({
+      const sessionResult = await createSession({
         title,
         parentSessionId: deps.parentSessionId,
       });
+      if (isServiceError(sessionResult)) {
+        return {
+          childSessionId: null,
+          childSessionName: null,
+          summary: `Task failed: could not create child session — ${sessionResult.error}`,
+        };
+      }
+      const childSession = sessionResult.data;
 
       const childSessionId = childSession.id;
 


### PR DESCRIPTION
## 🚀 Change Summary

Completes the chat module migration to uniform `ServiceResult` returns and full Zod validation on all routes, eliminating ad-hoc manual checks and inconsistent error handling.

### ✨ New Features
- **Full Zod validation on chat routes**: All params, query strings, and request bodies are now validated via `zValidator` — invalid requests return 400 automatically without manual `if (!body.field)` guards
- **Prefixed ID enforcement**: Route params (`id`, `msgId`) are now validated against `routeSchemas.sessionId` / `routeSchemas.messageId`, rejecting malformed IDs at the boundary

### 🛠 Improvements & Refactors
- `createSession`, `listSessions`, `listSessionMessages`, and `deleteSession` in `chat/service.ts` now consistently return `ServiceResult`
- All `isServiceError` / `requireFound` / `unwrapResult` patterns used uniformly throughout chat routes and callers (`automations/service.ts`, `tools/core/task.ts`)
- Replaced remaining `'error' in result` inline checks with `isServiceError()` in `automations/service.ts`

Closes #71