### PR TITLE
fix(task): prevent nested task tool calls in child sessions

### DIFF
--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -358,6 +358,7 @@ export async function sendMessage(
     llmMessages,
     credentials: config.credentials,
     abortSignal,
+    allowTaskTool: session.parentSessionId === null,
   })
     .catch((error) => {
       log.error(

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -1249,10 +1249,13 @@ export async function runStream(opts: {
   abortSignal: AbortSignal;
   /** Toolset IDs to pre-activate (e.g. inherited from parent task) */
   activeToolsetIds?: string[];
+  /** Child sessions are not allowed to invoke task recursively. */
+  allowTaskTool?: boolean;
   model?: ReturnType<ReturnType<typeof createProvider>>;
   deps?: Partial<StreamRunnerDeps>;
 }): Promise<void> {
   const streamRunId = randomUUID();
+  const canUseTaskTool = opts.allowTaskTool ?? true;
 
   const toolContext = {
     sessionId: opts.sessionId,
@@ -1287,17 +1290,19 @@ export async function runStream(opts: {
     createToolsetTools(toolsetManager, toolContext.sessionId),
   );
 
-  // Build task tool (bound to this session's context)
-  const taskTool = withToolResultHandling(
-    createTaskTool(toolContext, {
-      parentSessionId: opts.sessionId,
-      parentAbortSignal: opts.abortSignal,
-      credentials: opts.credentials,
-      modelId: opts.modelId,
-      providerId: opts.credentials.providerId,
-      toolsetManager,
-    }),
-  );
+  // Build task tool (bound to this session's context), but never for child sessions.
+  const taskTool = canUseTaskTool
+    ? withToolResultHandling(
+        createTaskTool(toolContext, {
+          parentSessionId: opts.sessionId,
+          parentAbortSignal: opts.abortSignal,
+          credentials: opts.credentials,
+          modelId: opts.modelId,
+          providerId: opts.credentials.providerId,
+          toolsetManager,
+        }),
+      )
+    : null;
 
   // Build code mode tool with a lazy getter for always-current active tools.
   // The getter merges core tools + dynamic toolset tools at call time so
@@ -1305,7 +1310,12 @@ export async function runStream(opts: {
   const codeModeResult = createCodeModeTool({
     getTools: () => {
       const dynamic = toolsetManager.getActiveTools();
-      return { ...coreStitchTools, ...toolsetMetaTools, task: taskTool, ...dynamic };
+      return {
+        ...coreStitchTools,
+        ...toolsetMetaTools,
+        ...(taskTool ? { task: taskTool } : {}),
+        ...dynamic,
+      };
     },
   });
 
@@ -1313,7 +1323,7 @@ export async function runStream(opts: {
   const coreTools: Record<string, Tool> = {
     ...coreStitchTools,
     ...toolsetMetaTools,
-    task: taskTool,
+    ...(taskTool ? { task: taskTool } : {}),
     execute_typescript: codeModeResult.tool,
   };
 

--- a/packages/server/src/tools/core/task.ts
+++ b/packages/server/src/tools/core/task.ts
@@ -149,6 +149,7 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
           credentials: deps.credentials,
           abortSignal: childAbortSignal,
           activeToolsetIds: allToolsetIds,
+          allowTaskTool: false,
         });
 
         log.info(


### PR DESCRIPTION
## 🚀 Change Summary
This prevents recursive task spawning by ensuring child sessions do not receive the 	ask tool, while keeping task execution available for top-level sessions.

### 🐛 Bug Fixes
- Added an llowTaskTool gate in stream setup so 	ask is only registered when explicitly allowed.
- Passed llowTaskTool from chat service based on whether the current session is a root or child session.
- Forced child streams launched by the task tool to run with llowTaskTool: false.