### PR TITLE
fix(recordings): gracefully stop active recording on app quit

### DIFF
--- a/packages/server/src/shutdown.ts
+++ b/packages/server/src/shutdown.ts
@@ -2,6 +2,7 @@ import { shutdownConnectorRuntime } from '@/connectors/runtime.js';
 import { closeDb } from '@/db/client.js';
 import * as Log from '@/lib/log.js';
 import { stopMeetingDetection } from '@/recordings/meeting-detection.js';
+import { stopRecording } from '@/recordings/service.js';
 import { stopScheduler } from '@/scheduler/runtime.js';
 
 const log = Log.create({ service: 'shutdown' });
@@ -10,6 +11,9 @@ async function shutdown(signal: string) {
   log.info({ signal }, 'shutting down');
   await stopScheduler();
   stopMeetingDetection();
+  await stopRecording().catch((error) => {
+    log.warn({ error }, 'failed to stop recording during shutdown');
+  });
   await shutdownConnectorRuntime();
   closeDb();
   process.exit(0);


### PR DESCRIPTION
## 🚀 Change Summary

Fixes a bug where quitting the app while a recording was in progress would leave the recording in a broken state — the audio file could be corrupted and the database record stuck permanently in `recording` status.

### 🐛 Bug Fixes
- **Graceful recording shutdown**: The server's `shutdown()` handler now calls `stopRecording()` before tearing down connectors and the database. This sends a proper `stop` command to the native audio capture binary so it can finalize and flush the audio file, and updates the database record with `completed` status, duration, and file size.
- The call is wrapped in `.catch()` so failures (e.g. no active recording) never block the rest of the shutdown sequence.