### PR TITLE
improvement(chat): expand list toolsets tool card

### DIFF
--- a/apps/web/src/components/chat/message-bubble/tool-call/toolset-tool-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/toolset-tool-block.tsx
@@ -1,4 +1,11 @@
-import { PackageIcon, PackagePlusIcon, PackageMinusIcon, PackageSearchIcon } from 'lucide-react';
+import {
+  ChevronRightIcon,
+  PackageIcon,
+  PackagePlusIcon,
+  PackageMinusIcon,
+  PackageSearchIcon,
+} from 'lucide-react';
+import * as React from 'react';
 
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
 import type { ConnectorIconSource } from '@stitch/shared/connectors/types';
@@ -6,14 +13,32 @@ import type { ConnectorIconSource } from '@stitch/shared/connectors/types';
 import { ToolCard, getToolCardState, getToolLabel } from './card-primitives';
 
 import { ConnectorIcon } from '@/components/connectors/connector-icon';
+import { cn } from '@/lib/utils';
 
 const TOOLSET_TOOL_CONFIG: Record<
   string,
   { label: string; icon: typeof PackageIcon; verb: string }
 > = {
-  list_toolsets: { label: 'List Toolset', icon: PackageSearchIcon, verb: 'Inspecting' },
+  list_toolsets: { label: 'List Toolsets', icon: PackageSearchIcon, verb: 'Inspecting' },
   activate_toolset: { label: 'Activate Toolset', icon: PackagePlusIcon, verb: 'Activating' },
   deactivate_toolset: { label: 'Deactivate Toolset', icon: PackageMinusIcon, verb: 'Deactivating' },
+};
+
+type ToolsetCatalogItem = {
+  name: string;
+  description: string;
+};
+
+type ToolsetTool = {
+  name: string;
+  displayName?: string;
+  description: string;
+};
+
+type ToolsetDetail = {
+  name: string;
+  description: string;
+  tools: ToolsetTool[];
 };
 
 function getToolsetId(args: unknown): string | null {
@@ -41,6 +66,66 @@ function getResultIcon(result: unknown): ConnectorIconSource | null {
   return null;
 }
 
+function getToolsetCatalog(result: unknown): ToolsetCatalogItem[] | null {
+  if (!result || typeof result !== 'object') return null;
+  const value = (result as { toolsets?: unknown }).toolsets;
+  if (!Array.isArray(value)) return null;
+
+  const items: ToolsetCatalogItem[] = [];
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+
+    const typed = item as Record<string, unknown>;
+    const name = typeof typed.name === 'string' ? typed.name : null;
+    const description = typeof typed.description === 'string' ? typed.description : null;
+
+    if (!name || !description) continue;
+
+    items.push({
+      name,
+      description,
+    });
+  }
+
+  return items;
+}
+
+function getToolsetDetail(result: unknown): ToolsetDetail | null {
+  if (!result || typeof result !== 'object') return null;
+
+  const typed = result as Record<string, unknown>;
+  const name = typeof typed.name === 'string' ? typed.name : null;
+  const description = typeof typed.description === 'string' ? typed.description : null;
+  const toolsValue = typed.tools;
+
+  if (!name || !description || !Array.isArray(toolsValue)) return null;
+
+  const tools: ToolsetTool[] = [];
+
+  for (const tool of toolsValue) {
+    if (!tool || typeof tool !== 'object') continue;
+    const toolRecord = tool as Record<string, unknown>;
+    const toolName = typeof toolRecord.name === 'string' ? toolRecord.name : null;
+    const toolDescription =
+      typeof toolRecord.description === 'string' ? toolRecord.description : null;
+
+    if (!toolName || !toolDescription) continue;
+
+    tools.push({
+      name: toolName,
+      displayName: typeof toolRecord.displayName === 'string' ? toolRecord.displayName : undefined,
+      description: toolDescription,
+    });
+  }
+
+  return {
+    name,
+    description,
+    tools,
+  };
+}
+
 type ToolsetToolBlockProps = {
   toolName: string;
   status: ToolCallStatus;
@@ -60,37 +145,138 @@ export function ToolsetToolBlock({ toolName, status, args, result, error }: Tool
   const toolsetId = getToolsetId(args);
   const resultMessage = getResultMessage(result);
   const resultIcon = getResultIcon(result);
+  const catalog = toolName === 'list_toolsets' ? getToolsetCatalog(result) : null;
+  const detail = toolName === 'list_toolsets' ? getToolsetDetail(result) : null;
   const label = getToolLabel(status, error);
+  const hasExpandedResults = toolName === 'list_toolsets' && (catalog?.length || detail);
+  const [open, setOpen] = React.useState(Boolean(hasExpandedResults && !isActive));
+
+  React.useEffect(() => {
+    if (hasExpandedResults && !isActive) {
+      setOpen(true);
+    }
+  }, [hasExpandedResults, isActive]);
 
   const description = isActive
     ? toolsetId
       ? `${config.verb} "${toolsetId}"...`
       : `${config.verb}...`
-    : (resultMessage ?? label ?? 'Done');
+    : detail
+      ? `${detail.tools.length} tool${detail.tools.length === 1 ? '' : 's'} fetched`
+      : catalog
+        ? `${catalog.length} toolset${catalog.length === 1 ? '' : 's'} available`
+        : (resultMessage ?? label ?? 'Done');
 
   return (
     <ToolCard.Root status={status}>
       <ToolCard.Header>
-        <ToolCard.StatusIndicator status={status} />
-        <div className="min-w-0 flex-1 space-y-1">
-          <div className="flex items-center gap-2">
-            <ToolCard.Title>{config.label}</ToolCard.Title>
-            {toolsetId ? (
-              <span className="inline-flex items-center gap-1 rounded-sm border border-border/50 bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                {resultIcon ? (
-                  <ConnectorIcon icon={resultIcon} className="size-2.5" />
-                ) : (
-                  <Icon className="size-2.5" />
-                )}
-                {toolsetId}
-              </span>
-            ) : null}
-          </div>
-          <ToolCard.TitleContent truncate className="block">
-            {description}
-          </ToolCard.TitleContent>
-        </div>
+        {hasExpandedResults ? (
+          <button
+            type="button"
+            onClick={() => setOpen((current) => !current)}
+            aria-expanded={open}
+            className="group flex min-w-0 flex-1 items-center gap-2 text-left text-foreground"
+          >
+            <ToolCard.StatusIndicator status={status} />
+            <div className="min-w-0 flex-1 space-y-1">
+              <div className="flex items-center gap-2">
+                <ToolCard.Title>{config.label}</ToolCard.Title>
+                {toolsetId ? (
+                  <span className="inline-flex items-center gap-1 rounded-sm border border-border/50 bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                    <span className="inline-flex items-center gap-1">
+                      {resultIcon ? (
+                        <ConnectorIcon icon={resultIcon} className="size-2.5" />
+                      ) : (
+                        <Icon className="size-2.5" />
+                      )}
+                      {toolsetId}
+                    </span>
+                  </span>
+                ) : null}
+              </div>
+              <ToolCard.TitleContent truncate className="block">
+                {description}
+              </ToolCard.TitleContent>
+            </div>
+            <ChevronRightIcon
+              className={cn(
+                'size-3 shrink-0 text-muted-foreground transition-transform',
+                open && 'rotate-90',
+              )}
+            />
+          </button>
+        ) : (
+          <>
+            <ToolCard.StatusIndicator status={status} />
+            <div className="min-w-0 flex-1 space-y-1">
+              <div className="flex items-center gap-2">
+                <ToolCard.Title>{config.label}</ToolCard.Title>
+                {toolsetId ? (
+                  <span className="inline-flex items-center gap-1 rounded-sm border border-border/50 bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                    <span className="inline-flex items-center gap-1">
+                      {resultIcon ? (
+                        <ConnectorIcon icon={resultIcon} className="size-2.5" />
+                      ) : (
+                        <Icon className="size-2.5" />
+                      )}
+                      {toolsetId}
+                    </span>
+                  </span>
+                ) : null}
+              </div>
+              <ToolCard.TitleContent truncate className="block">
+                {description}
+              </ToolCard.TitleContent>
+            </div>
+          </>
+        )}
       </ToolCard.Header>
+
+      <ToolCard.Content open={open && Boolean(hasExpandedResults)}>
+        {detail ? (
+          <div className="space-y-3">
+            <div className="rounded-md border border-border/50 bg-muted/20 p-3">
+              <div className="space-y-1">
+                <div className="text-sm font-medium text-foreground">{detail.name}</div>
+                <div className="text-xs text-muted-foreground">{detail.description}</div>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div className="text-xs font-medium text-foreground">Tools</div>
+              <div className="space-y-2">
+                {detail.tools.map((tool) => (
+                  <div
+                    key={tool.name}
+                    className="rounded-md border border-border/50 bg-background/60 p-3"
+                  >
+                    <div className="space-y-1">
+                      <div className="text-xs font-medium text-foreground">
+                        {tool.displayName ?? tool.name}
+                      </div>
+                      <div className="text-xs text-muted-foreground">{tool.description}</div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        ) : catalog ? (
+          <div className="space-y-2">
+            {catalog.map((item) => (
+              <div
+                key={`${item.name}-${item.description}`}
+                className="rounded-md border border-border/50 bg-background/60 p-3"
+              >
+                <div className="space-y-1">
+                  <div className="text-sm font-medium text-foreground">{item.name}</div>
+                  <div className="text-xs text-muted-foreground">{item.description}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </ToolCard.Content>
     </ToolCard.Root>
   );
 }


### PR DESCRIPTION
## 🚀 Change Summary
This updates the `list_toolsets` tool result card so toolsets are easier to inspect directly in chat without reading a compact summary line.

### ✨ New Features
- Adds an expandable custom card for `list_toolsets` results in the chat tool call UI
- Renders returned toolsets in an expanded view using simple name and description rows
- Shows fetched tools for a specific toolset using the same simplified name and description presentation