### PR TITLE
improvement(gmail): add idsOnly option to gmail_search tool

### DIFF
--- a/connectors/google/src/gmail/api.ts
+++ b/connectors/google/src/gmail/api.ts
@@ -107,14 +107,17 @@ type GmailMessage = {
 };
 
 type GmailSearchResult = {
-  messages: {
-    id: string;
-    threadId: string;
-    snippet: string;
-    from: string | undefined;
-    subject: string | undefined;
-    date: string | undefined;
-  }[];
+  messages: (
+    | { id: string; threadId: string }
+    | {
+        id: string;
+        threadId: string;
+        snippet: string;
+        from: string | undefined;
+        subject: string | undefined;
+        date: string | undefined;
+      }
+  )[];
   nextPageToken: string | undefined;
   totalEstimate: number;
 };
@@ -212,6 +215,7 @@ export async function searchMessages(
   query: string,
   maxResults = 10,
   pageToken?: string,
+  idsOnly = true,
 ): Promise<GmailSearchResult> {
   const params = new URLSearchParams({ q: query, maxResults: String(maxResults) });
   if (pageToken) params.set('pageToken', pageToken);
@@ -222,6 +226,14 @@ export async function searchMessages(
 
   if (!list.messages?.length) {
     return { messages: [], nextPageToken: undefined, totalEstimate: 0 };
+  }
+
+  if (idsOnly) {
+    return {
+      messages: list.messages.map((msg) => ({ id: msg.id, threadId: msg.threadId })),
+      nextPageToken: list.nextPageToken,
+      totalEstimate: list.resultSizeEstimate ?? 0,
+    };
   }
 
   // Fetch metadata for each message in chunks to avoid overwhelming the network

--- a/connectors/google/src/gmail/tools.ts
+++ b/connectors/google/src/gmail/tools.ts
@@ -13,6 +13,11 @@ const gmailSearchSchema = z.object({
   query: z.string().describe('Gmail search query (same syntax as Gmail search bar)'),
   maxResults: z.number().optional().default(10).describe('Max results to return (default 10)'),
   pageToken: z.string().optional().describe('Pagination token from a previous search'),
+  idsOnly: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe('When true (default), returns only message IDs without fetching metadata'),
 });
 
 const gmailReadSchema = z.object({
@@ -155,6 +160,7 @@ export function createGmailTools(
           input.query,
           input.maxResults,
           input.pageToken,
+          input.idsOnly,
         );
         return { ...result, usedAccount };
       },
@@ -243,7 +249,10 @@ export const GMAIL_TOOL_SUMMARIES = [
   { name: 'gmail_search', description: 'Search Gmail messages using Gmail search syntax' },
   { name: 'gmail_read', description: 'Read the full content of a Gmail message by ID' },
   { name: 'gmail_send', description: 'Send an email or reply to a thread (requires write access)' },
-  { name: 'gmail_list_labels', description: 'List Gmail labels with metadata and visibility settings' },
+  {
+    name: 'gmail_list_labels',
+    description: 'List Gmail labels with metadata and visibility settings',
+  },
   { name: 'gmail_get_label', description: 'Get details for a single Gmail label by ID' },
   {
     name: 'gmail_modify_labels',

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -24,8 +24,16 @@ const config: KnipConfig = {
       entry: ['src/index.{ts,tsx}', '__test__/**/*.test.{ts,tsx}'],
       project: ['src/**/*.{ts,tsx}'],
     },
+    'packages/audio-capture': {
+      entry: ['src/index.{ts,tsx}', 'src/**/*.test.{ts,tsx}'],
+      project: ['src/**/*.{ts,tsx}'],
+    },
     'connectors/*': {
-      entry: ['src/index.{ts,tsx}', '__test__/**/*.test.{ts,tsx}'],
+      entry: ['src/index.{ts,tsx}', 'src/__test__/**/*.test.{ts,tsx}'],
+      project: ['src/**/*.{ts,tsx}'],
+    },
+    'connectors/sdk': {
+      entry: ['src/index.{ts,tsx}'],
       project: ['src/**/*.{ts,tsx}'],
     },
   },
@@ -40,7 +48,7 @@ const config: KnipConfig = {
     'tailwindcss',
     '@tailwindcss/typography',
   ],
-  ignoreBinaries: ['gh'],
+  ignoreBinaries: [],
 };
 
 export default config;


### PR DESCRIPTION
## 🚀 Change Summary

Adds an `idsOnly` boolean field to the `gmail_search` tool that allows agents to fetch only message IDs from a search query, skipping the per-message metadata API calls. This defaults to `true`, making the common "find then read" pattern significantly faster and cheaper by avoiding N unnecessary network requests.

### ✨ New Features
- **`idsOnly` search option**: When `true` (default), `gmail_search` returns only `{ id, threadId }` per result — no metadata fetched. Set to `false` to get the full summary (from, subject, date, snippet) as before.