### PR TITLE
fix: silence net::ERR_INTERNET_DISCONNECTED in auto-updater

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -3,6 +3,20 @@ import { autoUpdater, type ProgressInfo, type UpdateInfo } from 'electron-update
 
 import type { BrowserWindow } from 'electron';
 
+const NETWORK_ERROR_CODES = [
+  'ERR_INTERNET_DISCONNECTED',
+  'ERR_NETWORK_CHANGED',
+  'ERR_NAME_NOT_RESOLVED',
+  'ERR_CONNECTION_REFUSED',
+  'ERR_CONNECTION_TIMED_OUT',
+  'ENOTFOUND',
+  'ECONNREFUSED',
+];
+
+function isNetworkError(error: Error): boolean {
+  return NETWORK_ERROR_CODES.some((code) => error.message.includes(code));
+}
+
 type UpdaterStatus =
   | 'idle'
   | 'checking'
@@ -82,6 +96,10 @@ export function createUpdater(options: UpdaterOptions) {
     });
 
     autoUpdater.on('error', (error) => {
+      if (isNetworkError(error)) {
+        emit({ status: 'idle' });
+        return;
+      }
       emit({ status: 'error', error: error.message });
     });
   }
@@ -96,6 +114,10 @@ export function createUpdater(options: UpdaterOptions) {
       await autoUpdater.checkForUpdates();
       return state;
     } catch (error) {
+      if (error instanceof Error && isNetworkError(error)) {
+        emit({ status: 'idle' });
+        return state;
+      }
       const message = error instanceof Error ? error.message : String(error);
       emit({ status: 'error', error: message });
       return state;


### PR DESCRIPTION
## 🚀 Change Summary

Prevents the auto-updater from surfacing a visible error state to users when the machine is simply offline or has no network connectivity. Previously, any `net::ERR_INTERNET_DISCONNECTED` (and similar network errors) from `electron-updater` would propagate as `status: "error"` to the renderer — causing unnecessary error UI on every periodic update check while offline.

### 🐛 Bug Fixes
- **Auto-updater offline noise**: Network connectivity errors (`ERR_INTERNET_DISCONNECTED`, `ERR_NETWORK_CHANGED`, `ERR_NAME_NOT_RESOLVED`, `ERR_CONNECTION_REFUSED`, `ERR_CONNECTION_TIMED_OUT`, `ENOTFOUND`, `ECONNREFUSED`) now silently reset the updater to `idle` instead of broadcasting an error. Real update failures (bad metadata, code-signing issues, etc.) still surface as `status: "error"`.