### PR TITLE
feat(google): Gmail filter management

### DIFF
--- a/connectors/google/src/__test__/rate-limit.test.ts
+++ b/connectors/google/src/__test__/rate-limit.test.ts
@@ -35,6 +35,36 @@ describe('resolveGoogleQuotaOperation', () => {
     ).toEqual({ service: 'gmail', quotaCost: 10 });
   });
 
+  it('maps Gmail settings.filters endpoints to correct quota costs', () => {
+    expect(
+      resolveGoogleQuotaOperation(
+        'https://gmail.googleapis.com/gmail/v1/users/me/settings/filters',
+        'GET',
+      ),
+    ).toEqual({ service: 'gmail', quotaCost: 1 });
+
+    expect(
+      resolveGoogleQuotaOperation(
+        'https://gmail.googleapis.com/gmail/v1/users/me/settings/filters',
+        'POST',
+      ),
+    ).toEqual({ service: 'gmail', quotaCost: 5 });
+
+    expect(
+      resolveGoogleQuotaOperation(
+        'https://gmail.googleapis.com/gmail/v1/users/me/settings/filters/filter-id-123',
+        'GET',
+      ),
+    ).toEqual({ service: 'gmail', quotaCost: 1 });
+
+    expect(
+      resolveGoogleQuotaOperation(
+        'https://gmail.googleapis.com/gmail/v1/users/me/settings/filters/filter-id-123',
+        'DELETE',
+      ),
+    ).toEqual({ service: 'gmail', quotaCost: 5 });
+  });
+
   it('maps non-Gmail services to request-count quota units', () => {
     expect(
       resolveGoogleQuotaOperation('https://www.googleapis.com/drive/v3/files?q=test', 'GET'),

--- a/connectors/google/src/__test__/toolsets.test.ts
+++ b/connectors/google/src/__test__/toolsets.test.ts
@@ -44,6 +44,22 @@ describe('buildGoogleToolsets', () => {
       'gmail_get_label',
       'gmail_modify_labels',
       'gmail_modify_messages',
+      'gmail_filters',
+    ]);
+  });
+
+  it('exposes gmail_filters with gmail.settings.basic scope but not modify tools', () => {
+    const settingsOnly = buildGoogleToolsets({
+      scopes: ['https://www.googleapis.com/auth/gmail.settings.basic'],
+      capabilities: ['google.gmail.read', 'google.gmail.write'],
+    }).find((toolset) => toolset.id === 'google-gmail');
+
+    expect(settingsOnly?.tools().map((tool) => tool.name)).toEqual([
+      'gmail_search',
+      'gmail_read',
+      'gmail_list_labels',
+      'gmail_get_label',
+      'gmail_filters',
     ]);
   });
 

--- a/connectors/google/src/connector.ts
+++ b/connectors/google/src/connector.ts
@@ -13,6 +13,7 @@ import {
   GOOGLE_SCOPE_GMAIL_MODIFY,
   GOOGLE_SCOPE_GMAIL_READONLY,
   GOOGLE_SCOPE_GMAIL_SEND,
+  GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC,
   GOOGLE_SCOPE_USERINFO_EMAIL,
 } from './scopes.js';
 import {
@@ -94,7 +95,7 @@ export const googleConnectorModule: ConnectorModule = {
     description: 'Connect Gmail, Drive, and Calendar in one place.',
     icon: { type: 'simpleIcons', slug: 'google' },
     enabled: true,
-    currentVersion: 2,
+    currentVersion: 3,
     versionHistory: [
       {
         version: 1,
@@ -118,6 +119,14 @@ export const googleConnectorModule: ConnectorModule = {
         action: 'reauthorize',
         capabilities: [GOOGLE_CAPABILITY_DOCS_READ, GOOGLE_CAPABILITY_DOCS_WRITE],
         requiredScopes: [GOOGLE_SCOPE_DOCS],
+      },
+      {
+        version: 3,
+        title: 'Gmail filter management',
+        description: 'Adds tools to create, view, and delete Gmail inbox filters.',
+        action: 'reauthorize',
+        capabilities: [],
+        requiredScopes: [GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC],
       },
     ],
     serviceIcons: {

--- a/connectors/google/src/gmail/api.ts
+++ b/connectors/google/src/gmail/api.ts
@@ -378,6 +378,212 @@ export async function modifyLabels(
   };
 }
 
+// ─── Filters ─────────────────────────────────────────────────────────────────
+
+type GmailFilterCriteria = {
+  from?: string;
+  to?: string;
+  subject?: string;
+  query?: string;
+  negatedQuery?: string;
+  hasAttachment?: boolean;
+  excludeChats?: boolean;
+  size?: number;
+  sizeComparison?: 'smaller' | 'larger' | 'unspecified';
+};
+
+type GmailFilterAction = {
+  addLabelIds?: string[];
+  removeLabelIds?: string[];
+  forward?: string;
+};
+
+type GmailFilterRaw = {
+  id: string;
+  criteria?: GmailFilterCriteria;
+  action?: GmailFilterAction;
+};
+
+type GmailFilterListResponse = {
+  filter?: GmailFilterRaw[];
+};
+
+type GmailFilter = {
+  id: string;
+  criteria: GmailFilterCriteria;
+  action: GmailFilterAction;
+  /** Human-readable summary for the LLM, e.g. "from: boss@co.com → add IMPORTANT, skip inbox" */
+  summary: string;
+};
+
+type GmailFilterInput = {
+  criteria?: GmailFilterCriteria;
+  action?: GmailFilterAction;
+};
+
+/**
+ * Build a concise human-readable summary of a filter so the LLM can reason about
+ * what each filter does without parsing raw label ID arrays.
+ */
+function summarizeFilter(criteria: GmailFilterCriteria, action: GmailFilterAction): string {
+  const parts: string[] = [];
+
+  // Criteria
+  if (criteria.from) parts.push(`from: ${criteria.from}`);
+  if (criteria.to) parts.push(`to: ${criteria.to}`);
+  if (criteria.subject) parts.push(`subject contains "${criteria.subject}"`);
+  if (criteria.query) parts.push(`query: ${criteria.query}`);
+  if (criteria.negatedQuery) parts.push(`not matching: ${criteria.negatedQuery}`);
+  if (criteria.hasAttachment) parts.push('has attachment');
+  if (criteria.excludeChats) parts.push('exclude chats');
+  if (
+    criteria.size !== undefined &&
+    criteria.sizeComparison &&
+    criteria.sizeComparison !== 'unspecified'
+  ) {
+    const bytes = criteria.size;
+    const kb = bytes / 1024;
+    const mb = kb / 1024;
+    const sizeStr =
+      mb >= 1 ? `${mb.toFixed(1)} MB` : kb >= 1 ? `${kb.toFixed(0)} KB` : `${bytes} B`;
+    parts.push(`size ${criteria.sizeComparison} ${sizeStr}`);
+  }
+
+  const matchStr = parts.length > 0 ? parts.join(', ') : 'all messages';
+
+  // Actions
+  const actions: string[] = [];
+
+  const LABEL_NAMES: Record<string, string> = {
+    INBOX: 'inbox',
+    UNREAD: 'unread',
+    SPAM: 'spam',
+    TRASH: 'trash',
+    IMPORTANT: 'important',
+    STARRED: 'starred',
+    SENT: 'sent',
+    DRAFT: 'drafts',
+    CATEGORY_PERSONAL: 'category:personal',
+    CATEGORY_SOCIAL: 'category:social',
+    CATEGORY_PROMOTIONS: 'category:promotions',
+    CATEGORY_UPDATES: 'category:updates',
+    CATEGORY_FORUMS: 'category:forums',
+  };
+
+  function labelName(id: string): string {
+    return LABEL_NAMES[id] ?? id;
+  }
+
+  if (action.addLabelIds?.length) {
+    const effects: string[] = [];
+    if (action.addLabelIds.includes('TRASH')) effects.push('delete');
+    if (action.addLabelIds.includes('STARRED')) effects.push('star');
+    if (action.addLabelIds.includes('IMPORTANT')) effects.push('mark important');
+    const userLabels = action.addLabelIds.filter((id) => !LABEL_NAMES[id]);
+    if (userLabels.length) effects.push(`label as: ${userLabels.join(', ')}`);
+    const remainder = action.addLabelIds.filter(
+      (id) => id !== 'TRASH' && id !== 'STARRED' && id !== 'IMPORTANT' && LABEL_NAMES[id],
+    );
+    if (remainder.length) effects.push(`add labels: ${remainder.map(labelName).join(', ')}`);
+
+    if (effects.length) actions.push(effects.join('; '));
+  }
+
+  if (action.removeLabelIds?.length) {
+    const effects: string[] = [];
+    if (action.removeLabelIds.includes('INBOX')) effects.push('skip inbox (archive)');
+    if (action.removeLabelIds.includes('UNREAD')) effects.push('mark as read');
+    if (action.removeLabelIds.includes('SPAM')) effects.push('never spam');
+    if (action.removeLabelIds.includes('IMPORTANT')) effects.push('never mark important');
+    const remainder = action.removeLabelIds.filter(
+      (id) => id !== 'INBOX' && id !== 'UNREAD' && id !== 'SPAM' && id !== 'IMPORTANT',
+    );
+    if (remainder.length) effects.push(`remove labels: ${remainder.map(labelName).join(', ')}`);
+
+    if (effects.length) actions.push(effects.join('; '));
+  }
+
+  if (action.removeLabelIds?.length) {
+    const names = action.removeLabelIds.map(labelName);
+
+    const effects: string[] = [];
+    if (names.includes('inbox')) effects.push('skip inbox (archive)');
+    if (names.includes('unread')) effects.push('mark as read');
+    if (names.includes('spam')) effects.push('never spam');
+    if (names.includes('important')) effects.push('never mark important');
+    const remainder = names.filter(
+      (n) => n !== 'inbox' && n !== 'unread' && n !== 'spam' && n !== 'important',
+    );
+    if (remainder.length) effects.push(`remove labels: ${remainder.join(', ')}`);
+
+    if (effects.length) actions.push(effects.join('; '));
+  }
+
+  if (action.forward) actions.push(`forward to ${action.forward}`);
+
+  const actionStr = actions.length > 0 ? actions.join(' + ') : 'no action';
+
+  return `Match [${matchStr}] → ${actionStr}`;
+}
+
+function mapFilter(raw: GmailFilterRaw): GmailFilter {
+  const criteria = raw.criteria ?? {};
+  const action = raw.action ?? {};
+  return {
+    id: raw.id,
+    criteria,
+    action,
+    summary: summarizeFilter(criteria, action),
+  };
+}
+
+export async function listFilters(client: GoogleClient): Promise<{ filters: GmailFilter[] }> {
+  const response = await client.request<GmailFilterListResponse>(`${GMAIL_API}/settings/filters`);
+  return {
+    filters: (response.filter ?? []).map(mapFilter),
+  };
+}
+
+export async function getFilter(client: GoogleClient, filterId: string): Promise<GmailFilter> {
+  const raw = await client.request<GmailFilterRaw>(
+    `${GMAIL_API}/settings/filters/${encodeURIComponent(filterId)}`,
+  );
+  return mapFilter(raw);
+}
+
+export async function createFilter(
+  client: GoogleClient,
+  input: GmailFilterInput,
+): Promise<GmailFilter> {
+  const criteria = input.criteria ?? {};
+
+  const hasCriteria = Object.values(criteria).some((v) => v !== undefined);
+  if (!hasCriteria) {
+    throw new Error(
+      'A filter must have at least one criteria field (e.g. from, to, subject, query, hasAttachment).',
+    );
+  }
+
+  const raw = await client.request<GmailFilterRaw>(`${GMAIL_API}/settings/filters`, {
+    method: 'POST',
+    body: JSON.stringify({
+      criteria,
+      action: input.action ?? {},
+    }),
+  });
+  return mapFilter(raw);
+}
+
+export async function deleteFilter(
+  client: GoogleClient,
+  filterId: string,
+): Promise<{ filterId: string; deleted: true }> {
+  await client.request(`${GMAIL_API}/settings/filters/${encodeURIComponent(filterId)}`, {
+    method: 'DELETE',
+  });
+  return { filterId, deleted: true };
+}
+
 export async function modifyMessages(
   client: GoogleClient,
   input: {

--- a/connectors/google/src/gmail/tools.ts
+++ b/connectors/google/src/gmail/tools.ts
@@ -141,13 +141,96 @@ const gmailModifyMessagesSchema = z
     },
   );
 
+const gmailFiltersSchema = z.discriminatedUnion('operation', [
+  z.object({
+    account: z
+      .string()
+      .optional()
+      .describe('Optional account email or label when multiple Google accounts are connected'),
+    operation: z.literal('list'),
+  }),
+  z.object({
+    account: z
+      .string()
+      .optional()
+      .describe('Optional account email or label when multiple Google accounts are connected'),
+    operation: z.literal('get'),
+    filterId: z.string().describe('Server-assigned filter ID'),
+  }),
+  z.object({
+    account: z
+      .string()
+      .optional()
+      .describe('Optional account email or label when multiple Google accounts are connected'),
+    operation: z.literal('create'),
+    criteria: z
+      .object({
+        from: z.string().optional().describe("Filter messages from this sender's email or name"),
+        to: z
+          .string()
+          .optional()
+          .describe("Filter messages to this recipient's email or name (includes cc/bcc)"),
+        subject: z
+          .string()
+          .optional()
+          .describe('Filter messages containing this phrase in the subject (case-insensitive)'),
+        query: z
+          .string()
+          .optional()
+          .describe('Filter using Gmail advanced search syntax (e.g. "is:unread has:attachment")'),
+        negatedQuery: z
+          .string()
+          .optional()
+          .describe('Exclude messages matching this Gmail search query'),
+        hasAttachment: z.boolean().optional().describe('Only match messages with attachments'),
+        excludeChats: z.boolean().optional().describe('Exclude chat messages from matching'),
+        size: z.number().int().optional().describe('Message size threshold in bytes'),
+        sizeComparison: z
+          .enum(['smaller', 'larger'])
+          .optional()
+          .describe('Whether to match messages smaller or larger than the size threshold'),
+      })
+      .optional()
+      .describe('Criteria that incoming messages must meet for the filter to fire'),
+    action: z
+      .object({
+        addLabelIds: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Label IDs to add. System labels: INBOX, UNREAD, SPAM, TRASH, IMPORTANT, STARRED. Pass a user label ID to tag the message.',
+          ),
+        removeLabelIds: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Label IDs to remove. Common: INBOX (archive/skip inbox), UNREAD (mark read), SPAM (never spam), IMPORTANT (never mark important).',
+          ),
+        forward: z
+          .string()
+          .optional()
+          .describe('Forward matching messages to this verified email address'),
+      })
+      .optional()
+      .describe('Actions to apply to messages that match the criteria'),
+  }),
+  z.object({
+    account: z
+      .string()
+      .optional()
+      .describe('Optional account email or label when multiple Google accounts are connected'),
+    operation: z.literal('delete'),
+    filterId: z.string().describe('Server-assigned filter ID to permanently delete'),
+  }),
+]);
+
 export function createGmailTools(
   resolveClient: (
     account?: string,
   ) => Promise<{ client: GoogleClient; usedAccount: string | null }>,
-  permissions: { canSend: boolean; canModify: boolean },
+  permissions: { canSend: boolean; canModify: boolean; canManageFilters: boolean },
 ) {
-  const { canSend, canModify } = permissions;
+  const { canSend, canModify, canManageFilters } = permissions;
   const tools: Record<string, Tool> = {
     gmail_search: tool({
       description:
@@ -242,6 +325,39 @@ export function createGmailTools(
     });
   }
 
+  if (canManageFilters) {
+    tools['gmail_filters'] = tool({
+      description:
+        'Manage Gmail filters that automatically label, archive, delete, or forward incoming messages. Operations: list (all filters), get (one filter by ID), create (new filter with criteria + action), delete (permanently remove a filter). Note: the Gmail API has no update endpoint — to modify a filter, delete it and create a new one.',
+      inputSchema: gmailFiltersSchema,
+      execute: async (input: z.infer<typeof gmailFiltersSchema>) => {
+        const { client, usedAccount } = await resolveClient(input.account);
+
+        if (input.operation === 'list') {
+          const result = await GmailApi.listFilters(client);
+          return { ...result, usedAccount };
+        }
+
+        if (input.operation === 'get') {
+          const result = await GmailApi.getFilter(client, input.filterId);
+          return { ...result, usedAccount };
+        }
+
+        if (input.operation === 'create') {
+          const result = await GmailApi.createFilter(client, {
+            criteria: input.criteria,
+            action: input.action,
+          });
+          return { ...result, usedAccount };
+        }
+
+        // delete
+        const result = await GmailApi.deleteFilter(client, input.filterId);
+        return { ...result, usedAccount };
+      },
+    });
+  }
+
   return tools;
 }
 
@@ -261,5 +377,10 @@ export const GMAIL_TOOL_SUMMARIES = [
   {
     name: 'gmail_modify_messages',
     description: 'Add or remove labels on messages (or threads with modifyThreads=true)',
+  },
+  {
+    name: 'gmail_filters',
+    description:
+      'List, get, create, or delete Gmail filters that auto-label, archive, or forward incoming messages (requires settings access)',
   },
 ];

--- a/connectors/google/src/rate-limit.ts
+++ b/connectors/google/src/rate-limit.ts
@@ -61,6 +61,9 @@ const GMAIL_METHOD_COSTS = {
   LABELS_GET: 1,
   LABELS_MUTATE: 5,
   THREADS_MODIFY: 10,
+  FILTERS_LIST: 1,
+  FILTERS_GET: 1,
+  FILTERS_MUTATE: 5,
   DEFAULT: 5,
 } as const;
 
@@ -109,6 +112,14 @@ function resolveGmailQuotaCost(pathname: string, method: string): number {
 
   if (/\/labels\/[^/]+$/.test(withoutQuery)) {
     return method === 'GET' ? GMAIL_METHOD_COSTS.LABELS_GET : GMAIL_METHOD_COSTS.LABELS_MUTATE;
+  }
+
+  if (withoutQuery.endsWith('/settings/filters')) {
+    return method === 'GET' ? GMAIL_METHOD_COSTS.FILTERS_LIST : GMAIL_METHOD_COSTS.FILTERS_MUTATE;
+  }
+
+  if (/\/settings\/filters\/[^/]+$/.test(withoutQuery)) {
+    return method === 'GET' ? GMAIL_METHOD_COSTS.FILTERS_GET : GMAIL_METHOD_COSTS.FILTERS_MUTATE;
   }
 
   return GMAIL_METHOD_COSTS.DEFAULT;
@@ -185,7 +196,7 @@ class SlidingWindowLimiter {
 
   private pruneExpired(now: number): void {
     const expiredCount = this.events.findIndex((event) => now - event.timestamp < this.windowMs);
-    
+
     if (expiredCount === -1 && this.events.length > 0) {
       // All events are expired
       this.usedWeight = 0;

--- a/connectors/google/src/scopes.ts
+++ b/connectors/google/src/scopes.ts
@@ -10,6 +10,8 @@ export const GOOGLE_SCOPE_USERINFO_EMAIL = 'https://www.googleapis.com/auth/user
 export const GOOGLE_SCOPE_GMAIL_READONLY = 'https://www.googleapis.com/auth/gmail.readonly';
 export const GOOGLE_SCOPE_GMAIL_SEND = 'https://www.googleapis.com/auth/gmail.send';
 export const GOOGLE_SCOPE_GMAIL_MODIFY = 'https://www.googleapis.com/auth/gmail.modify';
+export const GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC =
+  'https://www.googleapis.com/auth/gmail.settings.basic';
 
 export const GOOGLE_SCOPE_DRIVE_READONLY = 'https://www.googleapis.com/auth/drive.readonly';
 export const GOOGLE_SCOPE_DRIVE_FILE = 'https://www.googleapis.com/auth/drive.file';
@@ -27,6 +29,7 @@ const GMAIL_SCOPES = [
   GOOGLE_SCOPE_GMAIL_READONLY,
   GOOGLE_SCOPE_GMAIL_SEND,
   GOOGLE_SCOPE_GMAIL_MODIFY,
+  GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC,
 ] as const;
 
 const DRIVE_SCOPES = [
@@ -97,4 +100,11 @@ export function hasGmailSendAccess(grantedScopes: string[]): boolean {
 /** Check if granted scopes can modify Gmail resources (labels, message labels). */
 export function hasGmailModifyAccess(grantedScopes: string[]): boolean {
   return grantedScopes.some((s) => s === GOOGLE_SCOPE_GMAIL_MODIFY);
+}
+
+/** Check if granted scopes can manage Gmail settings (filters, etc.). */
+export function hasGmailSettingsAccess(grantedScopes: string[]): boolean {
+  return grantedScopes.some(
+    (s) => s === GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC || s === GOOGLE_SCOPE_GMAIL_MODIFY,
+  );
 }

--- a/connectors/google/src/toolsets.ts
+++ b/connectors/google/src/toolsets.ts
@@ -15,6 +15,7 @@ import { GMAIL_TOOL_SUMMARIES, createGmailTools } from './gmail/tools.js';
 import {
   hasGmailModifyAccess,
   hasGmailSendAccess,
+  hasGmailSettingsAccess,
   hasServiceAccess,
   hasWriteAccess,
 } from './scopes.js';
@@ -103,9 +104,11 @@ function createGmailToolset(scopes: string[], capabilities: string[]): GoogleToo
   const canWriteCapability = hasCapability(capabilities, GOOGLE_CAPABILITY_GMAIL_WRITE);
   const canSend = hasGmailSendAccess(scopes) && canWriteCapability;
   const canModify = hasGmailModifyAccess(scopes) && canWriteCapability;
+  const canManageFilters = hasGmailSettingsAccess(scopes) && canWriteCapability;
   const summaries = GMAIL_TOOL_SUMMARIES.filter((t) => {
     if (t.name === 'gmail_send') return canSend;
     if (t.name === 'gmail_modify_labels' || t.name === 'gmail_modify_messages') return canModify;
+    if (t.name === 'gmail_filters') return canManageFilters;
     return true;
   });
 
@@ -125,9 +128,13 @@ function createGmailToolset(scopes: string[], capabilities: string[]): GoogleToo
       canModify
         ? 'You have label modify access. Use gmail_modify_labels and gmail_modify_messages to manage labels and archive messages.'
         : 'You have read-only label access. Use gmail_list_labels and gmail_get_label to inspect labels.',
+      canManageFilters
+        ? 'You have settings access. Use gmail_filters to list, get, create, or delete inbox filters. To update a filter, delete it and recreate it.'
+        : 'You do not have settings access. Managing Gmail filters is not available.',
     ].join('\n'),
     tools: () => summaries,
-    activate: (resolveClient) => createGmailTools(resolveClient, { canSend, canModify }),
+    activate: (resolveClient) =>
+      createGmailTools(resolveClient, { canSend, canModify, canManageFilters }),
   };
 }
 


### PR DESCRIPTION
## 🚀 Change Summary

Adds a `gmail_filters` tool to the Google Gmail toolset, enabling the agent to fully manage Gmail inbox filters — listing, inspecting, creating, and deleting rules that automatically label, archive, forward, or delete incoming messages.

### ✨ New Features
- **Gmail Filter Management**: New `gmail_filters` tool with `list`, `get`, `create`, and `delete` operations using a discriminated union schema, consistent with existing Gmail tools
- **LLM-readable filter summaries**: Each filter includes a `summary` field (e.g. `"Match [from: boss@co.com] → skip inbox (archive)"`) so the agent can reason about filters without parsing raw label ID arrays
- **Connector version 3**: Bumps the Google connector version to trigger an upgrade prompt for existing users, adding the `gmail.settings.basic` OAuth scope via the standard reauthorization flow

### 🛠 Improvements & Refactors
- Added `GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC` scope constant and `hasGmailSettingsAccess()` helper; tool is gated on this scope with `canManageFilters`
- Accurate quota costs for `settings.filters` endpoints (`list`/`get` = 1, `create`/`delete` = 5) replacing the previous `DEFAULT: 5` fallback
- Client-side validation in `createFilter` catches empty criteria before hitting the API, returning a clear error message instead of a cryptic `GoogleApiError`
- Fixed a bug in `summarizeFilter` where label ID comparisons were made against mapped lowercase values instead of the original uppercase IDs (`INBOX`, `TRASH`, etc.)