### PR TITLE
fix(code-mode): prevent hang when hoisted tools fail or WASM crashes

### DIFF
--- a/packages/server/src/code-mode/bindings/tool-binding.ts
+++ b/packages/server/src/code-mode/bindings/tool-binding.ts
@@ -19,7 +19,10 @@ function extractJsonSchema(schema: unknown): Record<string, unknown> {
   return { type: 'object', properties: {} };
 }
 
-export function toolsToBindings(tools: Record<string, Tool>): Record<string, ToolBinding> {
+export function toolsToBindings(
+  tools: Record<string, Tool>,
+  abortSignal?: AbortSignal,
+): Record<string, ToolBinding> {
   const bindings: Record<string, ToolBinding> = {};
 
   for (const [name, tool] of Object.entries(tools)) {
@@ -37,13 +40,15 @@ export function toolsToBindings(tools: Record<string, Tool>): Record<string, Too
       name: bindingName,
       description,
       inputSchema: schema,
-      execute: async (input: unknown) => {
+      execute: async (input: unknown, signal?: AbortSignal) => {
+        const effectiveSignal = signal ?? abortSignal;
         return execute(
           input as Parameters<typeof execute>[0],
           {
             toolCallId: `code-mode-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
             messages: [],
             skipTruncation: true,
+            abortSignal: effectiveSignal,
           } as unknown as Parameters<typeof execute>[1],
         );
       },

--- a/packages/server/src/code-mode/isolate/quickjs-driver.ts
+++ b/packages/server/src/code-mode/isolate/quickjs-driver.ts
@@ -14,16 +14,48 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_STACK_SIZE = 512 * 1024;
 // Cap per-tool-result JSON at 512 KB before it enters the WASM heap
 const MAX_RESULT_BYTES = 512 * 1024;
+// Per-tool call timeout: slightly under the sandbox timeout so a hung tool
+// unblocks before the outer timer fires
+const TOOL_TIMEOUT_BUFFER_MS = 5_000;
+// Absolute wall-clock ceiling regardless of pause state — last-resort hang guard
+const ABSOLUTE_TIMEOUT_MS = 5 * 60 * 1000;
 
 function wrapWithPausableTimeout(
-  execute: (input: unknown) => Promise<unknown>,
+  execute: (input: unknown, abortSignal?: AbortSignal) => Promise<unknown>,
   pauseTimer: () => void,
   resumeTimer: () => void,
+  toolTimeoutMs: number,
+  abortSignal?: AbortSignal,
 ): (input: unknown) => Promise<unknown> {
   return async (input) => {
     pauseTimer();
     try {
-      return await execute(input);
+      const toolTimeoutPromise = new Promise<never>((_, reject) => {
+        const id = setTimeout(
+          () => reject(new Error(`Tool call timed out after ${toolTimeoutMs}ms`)),
+          toolTimeoutMs,
+        );
+        // Clean up timer if signal fires first
+        abortSignal?.addEventListener('abort', () => clearTimeout(id), { once: true });
+      });
+
+      const abortPromise =
+        abortSignal !== undefined
+          ? new Promise<never>((_, reject) => {
+              if (abortSignal.aborted) {
+                reject(new Error('Tool call aborted'));
+                return;
+              }
+              abortSignal.addEventListener('abort', () => reject(new Error('Tool call aborted')), {
+                once: true,
+              });
+            })
+          : null;
+
+      const raceTargets: Promise<unknown>[] = [execute(input, abortSignal), toolTimeoutPromise];
+      if (abortPromise !== null) raceTargets.push(abortPromise);
+
+      return await Promise.race(raceTargets);
     } finally {
       resumeTimer();
     }
@@ -38,6 +70,8 @@ export function createQuickJSDriver(): IsolateDriver {
     ): Promise<IsolateContext> {
       const memoryLimitMb = options.memoryLimit ?? DEFAULT_MEMORY_LIMIT_MB;
       const timeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
+      const abortSignal = options.abortSignal;
+      const toolTimeoutMs = Math.max(1_000, timeoutMs - TOOL_TIMEOUT_BUFFER_MS);
 
       const module = await newQuickJSAsyncWASMModuleFromVariant(quickJSVariant);
       const runtime = module.newRuntime();
@@ -46,6 +80,7 @@ export function createQuickJSDriver(): IsolateDriver {
 
       const vm = runtime.newContext();
       const logs: string[] = [];
+      let runtimeAlive = true;
 
       const consoleHandle = vm.newObject();
       for (const level of ['log', 'info', 'warn', 'error', 'debug'] as const) {
@@ -81,7 +116,13 @@ export function createQuickJSDriver(): IsolateDriver {
       };
 
       for (const [name, binding] of Object.entries(bindings)) {
-        const wrappedExecute = wrapWithPausableTimeout(binding.execute, pauseTimer, resumeTimer);
+        const wrappedExecute = wrapWithPausableTimeout(
+          binding.execute,
+          pauseTimer,
+          resumeTimer,
+          toolTimeoutMs,
+          abortSignal,
+        );
 
         const fn = vm.newAsyncifiedFunction(name, async (...args) => {
           const inputHandle = args[0];
@@ -97,8 +138,13 @@ export function createQuickJSDriver(): IsolateDriver {
             result = await wrappedExecute(input);
           } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
+            // Guard against returning a handle into a dead WASM runtime
+            if (!runtimeAlive) return vm.undefined;
             return vm.newString(JSON.stringify({ __error: message }));
           }
+
+          // Guard against returning a handle into a dead WASM runtime
+          if (!runtimeAlive) return vm.undefined;
 
           try {
             let serialized = JSON.stringify(result ?? null);
@@ -147,59 +193,121 @@ export function createQuickJSDriver(): IsolateDriver {
 `;
 
           const startedAt = Date.now();
-          let timeoutId: ReturnType<typeof setTimeout> | null = null;
+          let pausableTimeoutId: ReturnType<typeof setTimeout> | null = null;
+          let absoluteTimeoutId: ReturnType<typeof setTimeout> | null = null;
           let timedOut = false;
 
           const timeoutPromise = new Promise<never>((_, reject) => {
-            const check = () => {
+            // Pausable timeout: only counts time the sandbox is actually running
+            const checkPausable = () => {
               const paused = pausedAt !== null ? Date.now() - pausedAt : 0;
               const elapsed = Date.now() - startedAt - totalPausedMs - paused;
               if (elapsed >= timeoutMs) {
                 timedOut = true;
                 reject(new Error(`Code mode execution timed out after ${timeoutMs}ms`));
               } else {
-                timeoutId = setTimeout(check, 100);
+                pausableTimeoutId = setTimeout(checkPausable, 100);
               }
             };
-            timeoutId = setTimeout(check, 100);
+            pausableTimeoutId = setTimeout(checkPausable, 100);
+
+            // Absolute wall-clock timeout: fires regardless of pause state
+            absoluteTimeoutId = setTimeout(() => {
+              timedOut = true;
+              reject(
+                new Error(
+                  `Code mode execution exceeded absolute limit of ${ABSOLUTE_TIMEOUT_MS}ms`,
+                ),
+              );
+            }, ABSOLUTE_TIMEOUT_MS);
           });
+
+          // Abort signal fires immediately if already aborted, or on abort event
+          const abortPromise =
+            abortSignal !== undefined
+              ? new Promise<never>((_, reject) => {
+                  if (abortSignal.aborted) {
+                    reject(new Error('Code mode execution aborted'));
+                    return;
+                  }
+                  abortSignal.addEventListener(
+                    'abort',
+                    () => reject(new Error('Code mode execution aborted')),
+                    { once: true },
+                  );
+                })
+              : null;
+
+          const clearTimers = () => {
+            if (pausableTimeoutId !== null) clearTimeout(pausableTimeoutId);
+            if (absoluteTimeoutId !== null) clearTimeout(absoluteTimeoutId);
+          };
 
           let result: unknown;
           try {
-            const evalResult = await Promise.race([vm.evalCodeAsync(wrappedCode), timeoutPromise]);
+            let evalResult: unknown;
+            try {
+              const evalPromise = vm.evalCodeAsync(wrappedCode);
+              const raceTargets: Promise<unknown>[] = [evalPromise, timeoutPromise];
+              if (abortPromise !== null) raceTargets.push(abortPromise);
+              evalResult = await Promise.race(raceTargets);
+            } catch (syncErr) {
+              // WASM errors can throw synchronously from evalCodeAsync before
+              // returning a promise — catch and convert to a rejection
+              throw syncErr instanceof Error ? syncErr : new Error(String(syncErr));
+            }
 
-            if (timeoutId !== null) clearTimeout(timeoutId);
+            clearTimers();
 
             if (evalResult && typeof evalResult === 'object' && 'error' in evalResult) {
-              const err = evalResult.error;
-              result = { error: String(err ? vm.dump(err) : 'Unknown error') };
+              const err = (evalResult as { error: unknown }).error;
+              result = {
+                error: String(
+                  err ? vm.dump(err as Parameters<typeof vm.dump>[0]) : 'Unknown error',
+                ),
+              };
             } else if (evalResult && typeof evalResult === 'object' && 'value' in evalResult) {
-              const promiseHandle = evalResult.value;
+              const promiseHandle = (evalResult as { value: unknown }).value;
               if (!promiseHandle) {
                 result = null;
               } else {
-                const nativePromise = vm.resolvePromise(promiseHandle);
-                promiseHandle.dispose();
-                runtime.executePendingJobs();
+                let nativePromise: Promise<unknown>;
+                try {
+                  nativePromise = vm.resolvePromise(
+                    promiseHandle as Parameters<typeof vm.resolvePromise>[0],
+                  );
+                  (promiseHandle as { dispose?: () => void }).dispose?.();
+                  runtime.executePendingJobs();
+                } catch (syncErr) {
+                  throw syncErr instanceof Error ? syncErr : new Error(String(syncErr));
+                }
 
-                const resolvedResult = await Promise.race([nativePromise, timeoutPromise]);
-                if (timeoutId !== null) clearTimeout(timeoutId);
+                const resolveRaceTargets: Promise<unknown>[] = [nativePromise, timeoutPromise];
+                if (abortPromise !== null) resolveRaceTargets.push(abortPromise);
+                const resolvedResult = await Promise.race(resolveRaceTargets);
+                clearTimers();
 
                 if (
                   resolvedResult &&
                   typeof resolvedResult === 'object' &&
                   'error' in resolvedResult
                 ) {
-                  const err = resolvedResult.error;
-                  result = { error: String(err ? vm.dump(err) : 'Unknown error') };
+                  const err = (resolvedResult as { error: unknown }).error;
+                  result = {
+                    error: String(
+                      err ? vm.dump(err as Parameters<typeof vm.dump>[0]) : 'Unknown error',
+                    ),
+                  };
                 } else if (
                   resolvedResult &&
                   typeof resolvedResult === 'object' &&
                   'value' in resolvedResult
                 ) {
-                  const valueHandle = resolvedResult.value;
-                  result = valueHandle ? vm.dump(valueHandle) : null;
-                  valueHandle?.dispose();
+                  const valueHandle = (resolvedResult as { value: unknown }).value;
+                  result = valueHandle
+                    ? vm.dump(valueHandle as Parameters<typeof vm.dump>[0])
+                    : null;
+                  (valueHandle as { dispose?: () => void } | null)?.dispose?.();
                 } else {
                   result = null;
                 }
@@ -208,7 +316,7 @@ export function createQuickJSDriver(): IsolateDriver {
               result = null;
             }
           } catch (err) {
-            if (timeoutId !== null) clearTimeout(timeoutId);
+            clearTimers();
             result = timedOut
               ? { error: `Execution timed out after ${timeoutMs}ms` }
               : { error: err instanceof Error ? err.message : String(err) };
@@ -222,15 +330,16 @@ export function createQuickJSDriver(): IsolateDriver {
         },
 
         dispose() {
+          runtimeAlive = false;
           try {
             vm.dispose();
           } catch {
-            /* ignore */
+            /* ignore WASM errors on teardown */
           }
           try {
             runtime.dispose();
           } catch {
-            /* ignore */
+            /* ignore WASM errors on teardown */
           }
         },
       };

--- a/packages/server/src/code-mode/isolate/types.ts
+++ b/packages/server/src/code-mode/isolate/types.ts
@@ -2,7 +2,7 @@ export type ToolBinding = {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
-  execute: (input: unknown) => Promise<unknown>;
+  execute: (input: unknown, abortSignal?: AbortSignal) => Promise<unknown>;
 };
 
 export type IsolateExecuteResult = {
@@ -20,6 +20,8 @@ export type IsolateOptions = {
   memoryLimit?: number;
   /** Execution timeout in ms, excluding time spent waiting for permissions (default: 120_000) */
   timeout?: number;
+  /** AbortSignal to cancel execution and all in-flight tool calls */
+  abortSignal?: AbortSignal;
 };
 
 export type IsolateDriver = {

--- a/packages/server/src/code-mode/tool.ts
+++ b/packages/server/src/code-mode/tool.ts
@@ -19,6 +19,7 @@ type CodeModeOptions = {
   driver?: IsolateDriver;
   filter?: CodeModeToolFilter;
   isolateOptions?: IsolateOptions;
+  abortSignal?: AbortSignal;
 };
 
 type CodeModeToolResult = {
@@ -56,7 +57,8 @@ Use this when you need to:
 The sandbox has access to all active tools as \`external_*\` async functions.
 The sandbox has no filesystem, network, or Node.js access beyond these functions.`,
     inputSchema: codeModeInputSchema,
-    execute: async ({ code, description }) => {
+    execute: async ({ code, description }, { abortSignal: callAbortSignal }) => {
+      const abortSignal = callAbortSignal ?? options.abortSignal;
       const startedAt = Date.now();
 
       const stripped = stripTypeScript(code);
@@ -73,7 +75,7 @@ The sandbox has no filesystem, network, or Node.js access beyond these functions
 
       const activeTools = options.getTools();
       const filteredTools = applyToolFilter(activeTools, filter);
-      const bindings = toolsToBindings(filteredTools);
+      const bindings = toolsToBindings(filteredTools, abortSignal);
 
       log.info(
         {
@@ -85,13 +87,20 @@ The sandbox has no filesystem, network, or Node.js access beyond these functions
         'executing code mode',
       );
 
-      const context = await driver.createContext(bindings, isolateOptions);
+      const context = await driver.createContext(bindings, { ...isolateOptions, abortSignal });
 
       let execResult: { result: unknown; logs: string[] };
       try {
         execResult = await context.execute(stripped.code);
       } finally {
-        context.dispose();
+        try {
+          context.dispose();
+        } catch (disposeErr) {
+          log.warn(
+            { event: 'code-mode.dispose.error', error: String(disposeErr) },
+            'context dispose failed',
+          );
+        }
       }
 
       const durationMs = Date.now() - startedAt;

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -1318,6 +1318,7 @@ export async function runStream(opts: {
         ...dynamic,
       };
     },
+    abortSignal: opts.abortSignal,
   });
 
   // Combine all always-active tools


### PR DESCRIPTION
## 🚀 Change Summary

This PR fixes a hang in the `execute_typescript` (code mode) tool where a failed or stalled hoisted tool call would leave the QuickJS sandbox permanently suspended, causing the sidecar process to hang indefinitely with a `QuickJS: cannot handle error in suspended function` / `RuntimeError: Out of bounds memory access` error.

### 🐛 Bug Fixes

- **Hoisted tool hang**: A stalled hoisted tool (`external_*`) call paused the sandbox clock via `pauseTimer()`, meaning the existing pausable timeout never advanced and the execution promise never settled. A per-tool timeout (sandbox limit minus a 5s buffer) now ensures a hung tool throws rather than blocking forever.

- **WASM out-of-bounds crash causes silent hang**: A `RuntimeError: Out of bounds memory access` thrown synchronously from `vm.evalCodeAsync`, `vm.resolvePromise`, or `runtime.executePendingJobs` bypassed all async try/catch blocks, leaving the outer `Promise.race` unresettled. These calls are now wrapped in synchronous try/catch that converts WASM throws into proper rejections.

- **Use-after-dispose WASM crash**: The asyncified tool callback could attempt to return a `vm.newString()` handle after the runtime had already been disposed (e.g. when execution timed out and `dispose()` ran concurrently), triggering a second WASM memory fault. A `runtimeAlive` boolean flag — set to `false` in `dispose()` — guards all handle creation in the callback.

- **`dispose()` masking execution errors**: A WASM crash inside `context.dispose()` (called in the `finally` block of `tool.ts`) would replace the original execution error with a teardown error. `dispose()` is now wrapped in its own try/catch with a warning log.

### ✨ New Features

- **Stream AbortSignal propagation**: The chat stream's `AbortSignal` is now forwarded all the way from `runStream` → `createCodeModeTool` → `toolsToBindings` → each hoisted tool's execute context. Cancelling a chat now also cancels any in-flight tool calls inside the sandbox.

- **Absolute wall-clock timeout**: A secondary 5-minute hard ceiling fires unconditionally regardless of pause state, acting as a last-resort guard against any hang scenario not covered by the pausable timeout.