### PR TITLE
fix(logs): rotate daily files reliably in production

### DIFF
--- a/packages/server/__test__/lib/log.test.ts
+++ b/packages/server/__test__/lib/log.test.ts
@@ -29,16 +29,21 @@ describe('Log.init', () => {
     }
   });
 
-  test('does not delete files when threshold exceeded by 5', async () => {
+  test('deletes one old file when startup also creates a current log', async () => {
     const startingAt = new Date('2020-01-01');
     const oldFiles = createLogFiles(CLEANUP_THRESHOLD + 5, startingAt, ONE_DAY);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-11-02T00:00:00.000Z'));
     await writeFiles(oldFiles);
 
     await Log.init({ print: false });
 
-    for (const filename of oldFiles) {
+    expect(await fileExists(path.join(PATHS.logDir, '2020-01-01T000000.log'))).toBe(false);
+    for (const filename of oldFiles.slice(1)) {
       expect(await fileExists(path.join(PATHS.logDir, filename))).toBe(true);
     }
+    expect(await fileExists(path.join(PATHS.logDir, '2025-11-02.log'))).toBe(true);
   });
 
   test('deletes the oldest file when threshold exceeded by 6', async () => {
@@ -51,17 +56,20 @@ describe('Log.init', () => {
     expect(await fileExists(path.join(PATHS.logDir, '2020-01-01T000000.log'))).toBe(false);
   });
 
-  test('preserves the newest 10 files when threshold exceeded by 6', async () => {
+  test('preserves nine newest old files plus the current log at startup', async () => {
     const startingAt = new Date('2020-01-01');
     const oldFiles = createLogFiles(CLEANUP_THRESHOLD + 6, startingAt, ONE_DAY);
-    const newestFiles = oldFiles.slice(-10);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-11-02T00:00:00.000Z'));
     await writeFiles(oldFiles);
 
     await Log.init({ print: false });
 
-    for (const filename of newestFiles) {
+    for (const filename of oldFiles.slice(-9)) {
       expect(await fileExists(path.join(PATHS.logDir, filename))).toBe(true);
     }
+    expect(await fileExists(path.join(PATHS.logDir, '2025-11-02.log'))).toBe(true);
   });
 
   test('does not delete dev.log during cleanup', async () => {
@@ -84,7 +92,49 @@ describe('Log.init', () => {
     await Log.init({ print: false });
 
     expect(await fileExists(path.join(PATHS.logDir, '2020-01-01T000000.log'))).toBe(false);
-    expect(await fileExists(path.join(PATHS.logDir, '2025-11-02T000000.log'))).toBe(true);
+    expect(await fileExists(path.join(PATHS.logDir, '2025-11-02.log'))).toBe(true);
+  });
+
+  test('rotates to a new daily log file after midnight in production', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-11-02T23:59:59.000Z'));
+
+    await Log.init({ print: false });
+    const log = Log.create({ service: 'test' });
+
+    expect(await fileExists(path.join(PATHS.logDir, '2025-11-02.log'))).toBe(true);
+
+    vi.setSystemTime(new Date('2025-11-03T00:00:01.000Z'));
+    log.info('rotated');
+
+    vi.useRealTimers();
+    await waitForFileExists(path.join(PATHS.logDir, '2025-11-03.log'));
+    expect(await fileExists(path.join(PATHS.logDir, '2025-11-03.log'))).toBe(true);
+  });
+
+  test('cleanup deletes the oldest daily log and preserves the newest 10', async () => {
+    const dailyFiles = createDailyLogFiles(11, new Date('2025-11-01'));
+    await writeFiles(dailyFiles);
+
+    await Log.init({ print: true });
+
+    expect(await fileExists(path.join(PATHS.logDir, '2025-11-01.log'))).toBe(false);
+    for (const filename of dailyFiles.slice(-10)) {
+      expect(await fileExists(path.join(PATHS.logDir, filename))).toBe(true);
+    }
+  });
+
+  test('cleanup preserves the current daily log with legacy timestamped logs present', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-11-11T12:00:00.000Z'));
+
+    const legacyFiles = createLogFiles(10, new Date('2025-11-01'), ONE_DAY);
+    await writeFiles(legacyFiles);
+
+    await Log.init({ print: false });
+
+    expect(await fileExists(path.join(PATHS.logDir, '2025-11-11.log'))).toBe(true);
+    expect(await fileExists(path.join(PATHS.logDir, '2025-11-01T000000.log'))).toBe(false);
   });
 });
 
@@ -93,6 +143,15 @@ async function fileExists(filepath: string): Promise<boolean> {
     () => true,
     () => false,
   );
+}
+
+async function waitForFileExists(filepath: string): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (await fileExists(filepath)) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error(`Timed out waiting for file: ${filepath}`);
 }
 
 async function clearLogDir() {
@@ -119,5 +178,13 @@ function createLogFiles(count: number, startDate: Date, increment = ONE_DAY): st
     const creationOffset = index * increment;
     const fileCreatedAt = new Date(startDate.getTime() + creationOffset);
     return fileCreatedAt.toISOString().split('.')[0].replace(/:/g, '') + '.log';
+  });
+}
+
+function createDailyLogFiles(count: number, startDate: Date, increment = ONE_DAY): string[] {
+  return Array.from({ length: count }, (_, index) => {
+    const creationOffset = index * increment;
+    const fileCreatedAt = new Date(startDate.getTime() + creationOffset);
+    return `${fileCreatedAt.toISOString().slice(0, 10)}.log`;
   });
 }

--- a/packages/server/src/lib/log.ts
+++ b/packages/server/src/lib/log.ts
@@ -31,7 +31,7 @@ type Logger = StitchLogger & {
   clone(): Logger;
   time(
     message: string,
-    extra?: Record<string, any>,
+    extra?: Record<string, unknown>,
   ): {
     stop(): void;
     [Symbol.dispose](): void;
@@ -46,24 +46,152 @@ interface Options {
   level?: Level;
 }
 
+interface CleanupPlan {
+  files: string[];
+  maxFiles: number;
+}
+
 let logpath = '';
-let write = (msg: any) => {
+let logStream: ReturnType<typeof createWriteStream> | null = null;
+let logOptions: Options | null = null;
+let rotationPromise: Promise<void> | null = null;
+const CLEANUP_THRESHOLD = 5;
+const MAX_LOG_FILES = 10;
+let nextRotationAt = Number.POSITIVE_INFINITY;
+let rotationTimer: ReturnType<typeof setTimeout> | null = null;
+let write: (msg: string) => number | Promise<number> = (msg: string) => {
   process.stderr.write(msg);
   return msg.length;
 };
 
+function getLogFilename(options: Options, now = new Date()): string {
+  return options.dev ? 'dev.log' : `${now.toISOString().slice(0, 10)}.log`;
+}
+
+function getNextRotationAt(now = new Date()): number {
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1);
+}
+
+function isProductionFileLogging(options: Options | null): options is Options {
+  return Boolean(options && !options.dev && !options.print);
+}
+
+function getLogPath(options: Options, now = new Date()): string {
+  return path.join(PATHS.logDir, getLogFilename(options, now));
+}
+
+function shouldRotate(options: Options, now: Date): boolean {
+  if (!logStream) return true;
+  if (options.dev) return !logpath;
+  return now.getTime() >= nextRotationAt;
+}
+
+function resetLogState(): void {
+  clearRotationTimer();
+  logpath = '';
+  nextRotationAt = Number.POSITIVE_INFINITY;
+}
+
+function createCleanupPlan(files: string[], dir: string): CleanupPlan {
+  const preservedFilename =
+    dir === PATHS.logDir && isProductionFileLogging(logOptions) ? getLogFilename(logOptions) : null;
+
+  if (!preservedFilename) {
+    return { files, maxFiles: MAX_LOG_FILES };
+  }
+
+  return {
+    files: files.filter((file) => path.basename(file) !== preservedFilename),
+    maxFiles: MAX_LOG_FILES - 1,
+  };
+}
+
+function clearRotationTimer(): void {
+  if (!rotationTimer) return;
+  clearTimeout(rotationTimer);
+  rotationTimer = null;
+}
+
+function scheduleRotation(options: Options): void {
+  clearRotationTimer();
+  if (options.dev || options.print || !Number.isFinite(nextRotationAt)) return;
+
+  const delayMs = Math.max(0, nextRotationAt - Date.now());
+  rotationTimer = setTimeout(() => {
+    rotationTimer = null;
+    if (!logOptions || logOptions.dev || logOptions.print) return;
+    ensureLogStream(logOptions).catch(() => {});
+  }, delayMs);
+}
+
+async function closeLogStream(): Promise<void> {
+  const stream = logStream;
+  logStream = null;
+  if (!stream) return;
+
+  await new Promise<void>((resolve) => {
+    stream.end(() => resolve());
+  });
+}
+
+async function ensureLogStream(options: Options): Promise<void> {
+  const now = new Date();
+  if (!shouldRotate(options, now)) {
+    return;
+  }
+
+  const nextLogpath = getLogPath(options, now);
+  if (nextLogpath === logpath && logStream) return;
+
+  if (rotationPromise) {
+    await rotationPromise;
+  }
+  if (nextLogpath === logpath && logStream) return;
+
+  rotationPromise = (async () => {
+    const rotationNow = new Date();
+    const resolvedLogpath = getLogPath(options, rotationNow);
+    if (resolvedLogpath === logpath && logStream) return;
+
+    await fs.mkdir(PATHS.logDir, { recursive: true });
+    if (options.dev) {
+      await fs.writeFile(resolvedLogpath, '');
+    } else {
+      await fs.writeFile(resolvedLogpath, '', { flag: 'a' });
+    }
+
+    const nextStream = createWriteStream(resolvedLogpath, { flags: 'a' });
+    await closeLogStream();
+    logStream = nextStream;
+    logpath = resolvedLogpath;
+    nextRotationAt = options.dev ? Number.POSITIVE_INFINITY : getNextRotationAt(rotationNow);
+    scheduleRotation(options);
+  })().finally(() => {
+    rotationPromise = null;
+  });
+
+  await rotationPromise;
+}
+
 export async function init(options: Options) {
   if (options.level) level = options.level;
+  logOptions = options;
+  await closeLogStream();
+  resetLogState();
   await cleanup();
   if (options.print) return;
-  logpath = path.join(
-    PATHS.logDir,
-    options.dev ? 'dev.log' : new Date().toISOString().split('.')[0].replace(/:/g, '') + '.log',
-  );
-  await fs.mkdir(PATHS.logDir, { recursive: true });
-  await fs.writeFile(logpath, '');
-  const stream = createWriteStream(logpath, { flags: 'a' });
-  write = async (msg: any) => {
+  await ensureLogStream(options);
+  write = async (msg: string) => {
+    if (logOptions) {
+      await ensureLogStream(logOptions);
+    }
+
+    const stream = logStream;
+    if (!stream) {
+      process.stderr.write(msg);
+      return msg.length;
+    }
+
     return new Promise((resolve, reject) => {
       stream.write(msg, (err) => {
         if (err) reject(err);
@@ -74,14 +202,17 @@ export async function init(options: Options) {
 }
 
 export async function cleanup(dir = PATHS.logDir) {
-  const files = await Glob.scan('????-??-??T??????.log', {
+  const files = await Glob.scan('{????-??-??.log,????-??-??T??????.log}', {
     cwd: dir,
     absolute: true,
     include: 'file',
   });
-  if (files.length <= 5) return;
 
-  const filesToDelete = files.sort().slice(0, -10);
+  const plan = createCleanupPlan(files, dir);
+
+  if (plan.files.length <= CLEANUP_THRESHOLD) return;
+
+  const filesToDelete = plan.files.sort().slice(0, -plan.maxFiles);
   await Promise.all(filesToDelete.map((file) => fs.unlink(file).catch(() => {})));
 }
 
@@ -102,22 +233,25 @@ function serializeValue(value: unknown): unknown {
   return value;
 }
 
-export function create(tags?: Record<string, any>) {
+export function create(tags?: Record<string, unknown>) {
   tags = tags || {};
 
   const service = tags['service'];
   if (service && typeof service === 'string') {
     const cached = loggers.get(service);
-    if (cached) {
-      return cached;
-    }
+    if (cached) return cached;
   }
 
-  function build(lvl: string, extra: Record<string, any>, message: string) {
+  function emit(lvl: Level, extraOrMessage: Record<string, unknown> | string, message?: string) {
+    if (!shouldLog(lvl)) return;
+
+    const [extra, msg] =
+      typeof extraOrMessage === 'string' ? [{}, extraOrMessage] : [extraOrMessage, message!];
+
     const entry: Record<string, unknown> = {
-      level: lvl,
+      level: lvl.toLowerCase(),
       time: new Date().toISOString(),
-      msg: message,
+      msg,
     };
 
     for (const [key, value] of Object.entries({ ...tags, ...extra })) {
@@ -126,37 +260,21 @@ export function create(tags?: Record<string, any>) {
       }
     }
 
-    return JSON.stringify(entry) + '\n';
+    void write(JSON.stringify(entry) + '\n');
   }
 
   const result: Logger = {
-    debug(extraOrMessage: Record<string, any> | string, message?: string) {
-      if (shouldLog('DEBUG')) {
-        const [extra, msg] =
-          typeof extraOrMessage === 'string' ? [{}, extraOrMessage] : [extraOrMessage, message!];
-        write(build('debug', extra, msg));
-      }
+    debug(extraOrMessage: Record<string, unknown> | string, message?: string) {
+      emit('DEBUG', extraOrMessage, message);
     },
-    info(extraOrMessage: Record<string, any> | string, message?: string) {
-      if (shouldLog('INFO')) {
-        const [extra, msg] =
-          typeof extraOrMessage === 'string' ? [{}, extraOrMessage] : [extraOrMessage, message!];
-        write(build('info', extra, msg));
-      }
+    info(extraOrMessage: Record<string, unknown> | string, message?: string) {
+      emit('INFO', extraOrMessage, message);
     },
-    error(extraOrMessage: Record<string, any> | string, message?: string) {
-      if (shouldLog('ERROR')) {
-        const [extra, msg] =
-          typeof extraOrMessage === 'string' ? [{}, extraOrMessage] : [extraOrMessage, message!];
-        write(build('error', extra, msg));
-      }
+    warn(extraOrMessage: Record<string, unknown> | string, message?: string) {
+      emit('WARN', extraOrMessage, message);
     },
-    warn(extraOrMessage: Record<string, any> | string, message?: string) {
-      if (shouldLog('WARN')) {
-        const [extra, msg] =
-          typeof extraOrMessage === 'string' ? [{}, extraOrMessage] : [extraOrMessage, message!];
-        write(build('warn', extra, msg));
-      }
+    error(extraOrMessage: Record<string, unknown> | string, message?: string) {
+      emit('ERROR', extraOrMessage, message);
     },
     tag(key: string, value: string) {
       if (tags) tags[key] = value;
@@ -165,18 +283,11 @@ export function create(tags?: Record<string, any>) {
     clone() {
       return create({ ...tags });
     },
-    time(message: string, extra?: Record<string, any>) {
+    time(message: string, extra?: Record<string, unknown>) {
       const now = Date.now();
       result.info({ status: 'started', ...extra }, message);
       function stop() {
-        result.info(
-          {
-            status: 'completed',
-            duration: Date.now() - now,
-            ...extra,
-          },
-          message,
-        );
+        result.info({ status: 'completed', duration: Date.now() - now, ...extra }, message);
       }
       return {
         stop,


### PR DESCRIPTION
## Change Summary
This updates server log handling so production rotates to a new daily file without requiring a restart, while keeping cleanup and retention behavior aligned with the new filename format.

### Improvements & Refactors
- rotate production logs on UTC day boundaries with a scheduled rollover and write-time fallback
- preserve the active production log during cleanup while pruning both legacy timestamped files and new daily files
- simplify the logger internals by tightening rotation, stream, and cleanup helpers

### Bug Fixes
- fix the long-running production case where logs stayed in a single file until restart
- add regression coverage for midnight rotation, mixed legacy/current filenames, and retention behavior