### PR TITLE
Improve MCP toolset discovery and display

### DIFF
--- a/apps/web/src/components/chat/message-bubble/tool-call/mcp-tool-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/mcp-tool-block.tsx
@@ -1,13 +1,15 @@
 import { WrenchIcon } from 'lucide-react';
 import * as React from 'react';
 
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
 import { parseMcpToolName } from '@stitch/shared/mcp/types';
 import type { McpServer } from '@stitch/shared/mcp/types';
 
 import { ToolCard, getToolLabel } from './card-primitives';
+
+import { knownMcpToolsQueryOptions } from '@/lib/queries/tools';
 
 type McpToolBlockProps = {
   toolName: string;
@@ -17,6 +19,7 @@ type McpToolBlockProps = {
 
 type KnownMcpTool = {
   name: string;
+  displayName: string;
   serverName: string;
   serverIconPath?: string;
   toolIconPath?: string;
@@ -24,16 +27,18 @@ type KnownMcpTool = {
 
 export function McpToolBlock({ toolName, status, error }: McpToolBlockProps) {
   const queryClient = useQueryClient();
+  const { data: fetchedMcpTools } = useQuery(knownMcpToolsQueryOptions);
   const parsed = parseMcpToolName(toolName);
   const label = getToolLabel(status, error);
 
   const mcpTool = React.useMemo(() => {
-    const knownMcpTools = queryClient.getQueryData<KnownMcpTool[]>([
+    const cachedMcpTools = queryClient.getQueryData<KnownMcpTool[]>([
       'tools-config',
       'known-mcp-tools',
     ]);
+    const knownMcpTools = fetchedMcpTools ?? cachedMcpTools;
     return knownMcpTools?.find((tool) => tool.name === toolName) ?? null;
-  }, [queryClient, toolName]);
+  }, [fetchedMcpTools, queryClient, toolName]);
 
   const serverName = React.useMemo(() => {
     if (!parsed) return null;
@@ -42,7 +47,7 @@ export function McpToolBlock({ toolName, status, error }: McpToolBlockProps) {
     return servers?.find((server) => server.id === parsed.serverId)?.name ?? null;
   }, [mcpTool?.serverName, parsed, queryClient]);
 
-  const displayName = parsed?.toolName ?? toolName;
+  const displayName = mcpTool?.displayName ?? parsed?.toolName ?? toolName;
 
   return (
     <ToolCard.Root status={status}>

--- a/apps/web/src/components/chat/message-bubble/tool-call/toolset-tool-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/toolset-tool-block.tsx
@@ -7,12 +7,15 @@ import {
 } from 'lucide-react';
 import * as React from 'react';
 
+import { useQuery } from '@tanstack/react-query';
+
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
 import type { ConnectorIconSource } from '@stitch/shared/connectors/types';
 
 import { ToolCard, getToolCardState, getToolLabel } from './card-primitives';
 
 import { ConnectorIcon } from '@/components/connectors/connector-icon';
+import { knownToolsetsQueryOptions } from '@/lib/queries/tools';
 import { cn } from '@/lib/utils';
 
 const TOOLSET_TOOL_CONFIG: Record<
@@ -25,6 +28,7 @@ const TOOLSET_TOOL_CONFIG: Record<
 };
 
 type ToolsetCatalogItem = {
+  id?: string;
   name: string;
   description: string;
 };
@@ -36,6 +40,7 @@ type ToolsetTool = {
 };
 
 type ToolsetDetail = {
+  toolsetId?: string;
   name: string;
   description: string;
   tools: ToolsetTool[];
@@ -49,6 +54,12 @@ function getToolsetId(args: unknown): string | null {
 function getResultMessage(result: unknown): string | null {
   if (!result || typeof result !== 'object') return null;
   const value = (result as Record<string, unknown>).message;
+  return typeof value === 'string' ? value : null;
+}
+
+function getResultToolsetName(result: unknown): string | null {
+  if (!result || typeof result !== 'object') return null;
+  const value = (result as Record<string, unknown>).toolsetName;
   return typeof value === 'string' ? value : null;
 }
 
@@ -77,12 +88,14 @@ function getToolsetCatalog(result: unknown): ToolsetCatalogItem[] | null {
     if (!item || typeof item !== 'object') continue;
 
     const typed = item as Record<string, unknown>;
+    const id = typeof typed.id === 'string' ? typed.id : undefined;
     const name = typeof typed.name === 'string' ? typed.name : null;
     const description = typeof typed.description === 'string' ? typed.description : null;
 
     if (!name || !description) continue;
 
     items.push({
+      id,
       name,
       description,
     });
@@ -95,6 +108,7 @@ function getToolsetDetail(result: unknown): ToolsetDetail | null {
   if (!result || typeof result !== 'object') return null;
 
   const typed = result as Record<string, unknown>;
+  const toolsetId = typeof typed.toolsetId === 'string' ? typed.toolsetId : undefined;
   const name = typeof typed.name === 'string' ? typed.name : null;
   const description = typeof typed.description === 'string' ? typed.description : null;
   const toolsValue = typed.tools;
@@ -120,6 +134,7 @@ function getToolsetDetail(result: unknown): ToolsetDetail | null {
   }
 
   return {
+    toolsetId,
     name,
     description,
     tools,
@@ -135,6 +150,7 @@ type ToolsetToolBlockProps = {
 };
 
 export function ToolsetToolBlock({ toolName, status, args, result, error }: ToolsetToolBlockProps) {
+  const { data: knownToolsets } = useQuery(knownToolsetsQueryOptions);
   const { isActive } = getToolCardState(status);
   const config = TOOLSET_TOOL_CONFIG[toolName] ?? {
     label: 'Toolset',
@@ -143,6 +159,10 @@ export function ToolsetToolBlock({ toolName, status, args, result, error }: Tool
   };
   const Icon = config.icon;
   const toolsetId = getToolsetId(args);
+  const knownToolset = toolsetId
+    ? knownToolsets?.find((toolset) => toolset.id === toolsetId)
+    : undefined;
+  const toolsetDisplayName = getResultToolsetName(result) ?? knownToolset?.name ?? toolsetId;
   const resultMessage = getResultMessage(result);
   const resultIcon = getResultIcon(result);
   const catalog = toolName === 'list_toolsets' ? getToolsetCatalog(result) : null;
@@ -153,7 +173,7 @@ export function ToolsetToolBlock({ toolName, status, args, result, error }: Tool
 
   const description = isActive
     ? toolsetId
-      ? `${config.verb} "${toolsetId}"...`
+      ? `${config.verb} "${toolsetDisplayName}"...`
       : `${config.verb}...`
     : detail
       ? `${detail.tools.length} tool${detail.tools.length === 1 ? '' : 's'} fetched`
@@ -175,15 +195,15 @@ export function ToolsetToolBlock({ toolName, status, args, result, error }: Tool
             <div className="min-w-0 flex-1 space-y-1">
               <div className="flex items-center gap-2">
                 <ToolCard.Title>{config.label}</ToolCard.Title>
-                {toolsetId ? (
+                {toolsetDisplayName ? (
                   <span className="inline-flex items-center gap-1 rounded-sm border border-border/50 bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                    <span className="inline-flex items-center gap-1">
+                    <span className="inline-flex items-center gap-1" title={toolsetId ?? undefined}>
                       {resultIcon ? (
                         <ConnectorIcon icon={resultIcon} className="size-2.5" />
                       ) : (
                         <Icon className="size-2.5" />
                       )}
-                      {toolsetId}
+                      {toolsetDisplayName}
                     </span>
                   </span>
                 ) : null}
@@ -205,15 +225,15 @@ export function ToolsetToolBlock({ toolName, status, args, result, error }: Tool
             <div className="min-w-0 flex-1 space-y-1">
               <div className="flex items-center gap-2">
                 <ToolCard.Title>{config.label}</ToolCard.Title>
-                {toolsetId ? (
+                {toolsetDisplayName ? (
                   <span className="inline-flex items-center gap-1 rounded-sm border border-border/50 bg-muted/40 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                    <span className="inline-flex items-center gap-1">
+                    <span className="inline-flex items-center gap-1" title={toolsetId ?? undefined}>
                       {resultIcon ? (
                         <ConnectorIcon icon={resultIcon} className="size-2.5" />
                       ) : (
                         <Icon className="size-2.5" />
                       )}
-                      {toolsetId}
+                      {toolsetDisplayName}
                     </span>
                   </span>
                 ) : null}

--- a/packages/server/__test__/mcp/tool-executor.test.ts
+++ b/packages/server/__test__/mcp/tool-executor.test.ts
@@ -2,7 +2,12 @@ import { beforeEach, describe, expect, test } from 'vitest';
 
 import type { McpServerWithTools } from '@/mcp/service.js';
 import { refreshMcpToolsets } from '@/mcp/tool-executor.js';
-import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
+import {
+  getToolset,
+  listToolsetIds,
+  registerToolset,
+  unregisterToolset,
+} from '@/tools/toolsets/registry.js';
 
 function clearToolsets(): void {
   for (const id of listToolsetIds()) {
@@ -33,6 +38,7 @@ describe('refreshMcpToolsets', () => {
         }),
         fetchServerInfo: async () => null,
         fetchServerPrompts: async () => [],
+        findRegistryServer: async () => null,
         buildServerPresentation: async () => ({
           serverId: TEST_SERVER.id,
           name: TEST_SERVER.name,
@@ -62,6 +68,7 @@ describe('refreshMcpToolsets', () => {
         }),
         fetchServerInfo: async () => null,
         fetchServerPrompts: async () => [],
+        findRegistryServer: async () => null,
         buildServerPresentation: async () => ({
           serverId: TEST_SERVER.id,
           name: TEST_SERVER.name,
@@ -71,5 +78,81 @@ describe('refreshMcpToolsets', () => {
     );
 
     expect(listToolsetIds()).not.toContain('mcp:stale-server');
+  });
+
+  test('uses registry metadata for MCP toolset name and description', async () => {
+    await refreshMcpToolsets(
+      { refreshTools: true },
+      {
+        getMcpServersWithCachedTools: async () => [TEST_SERVER],
+        fetchMcpTools: async () => ({
+          data: [{ name: 'lookup', description: 'Lookup data', inputSchema: {} }],
+        }),
+        fetchServerInfo: async () => null,
+        fetchServerPrompts: async () => [],
+        findRegistryServer: async () => ({
+          id: 'registry-test',
+          name: 'Registry Server',
+          description: 'Curated registry description for model discovery.',
+          docsUrl: 'https://example.com/docs',
+          tags: ['search'],
+          install: {
+            name: TEST_SERVER.name,
+            transport: 'http',
+            url: TEST_SERVER.url,
+            authConfig: { type: 'none' },
+          },
+        }),
+        buildServerPresentation: async () => ({
+          serverId: TEST_SERVER.id,
+          name: 'Registry Server',
+          description: 'Curated registry description for model discovery.',
+          tools: {},
+        }),
+      },
+    );
+
+    expect(getToolset('mcp:mcp_test_server')).toMatchObject({
+      name: 'Registry Server',
+      description: 'Curated registry description for model discovery.',
+    });
+  });
+
+  test('prefers registry display name over noisy live server name', async () => {
+    await refreshMcpToolsets(
+      { refreshTools: true },
+      {
+        getMcpServersWithCachedTools: async () => [TEST_SERVER],
+        fetchMcpTools: async () => ({
+          data: [{ name: 'lookup', description: 'Lookup data', inputSchema: {} }],
+        }),
+        fetchServerInfo: async () => ({
+          name: 'mcp-typescript server on vercel',
+          title: 'mcp-typescript server on vercel',
+        }),
+        fetchServerPrompts: async () => [],
+        findRegistryServer: async () => ({
+          id: 'registry-test',
+          name: 'Exa',
+          description: 'Web and code search tools from Exa.',
+          docsUrl: 'https://example.com/docs',
+          tags: ['search'],
+          install: {
+            name: TEST_SERVER.name,
+            transport: 'http',
+            url: TEST_SERVER.url,
+            authConfig: { type: 'none' },
+          },
+        }),
+        buildServerPresentation: async () => ({
+          serverId: TEST_SERVER.id,
+          name: 'Exa',
+          title: 'Exa',
+          tools: {},
+        }),
+      },
+    );
+
+    expect(getToolset('mcp:mcp_test_server')?.name).toBe('Exa');
   });
 });

--- a/packages/server/__test__/tools/toolset-management.test.ts
+++ b/packages/server/__test__/tools/toolset-management.test.ts
@@ -77,6 +77,7 @@ describe('toolset management tools', () => {
 
     expect(result).toMatchObject({
       toolsetId: 'test-toolset',
+      toolsetName: 'Test Toolset',
       status: 'activated',
       hasInstructions: true,
       promptCount: 1,
@@ -120,6 +121,33 @@ describe('toolset management tools', () => {
       instructions: 'Use this toolset carefully.',
       prompts: [{ name: 'demo', description: 'Demo prompt' }],
     });
+  });
+
+  test('activate_toolset humanizes MCP tool names in message', async () => {
+    registerTestToolset({
+      id: 'mcp:mcp_12345678901234567890123456',
+      name: 'Exa',
+      tools: () => [
+        {
+          name: 'mcp_12345678901234567890123456_web_search_exa',
+          description: 'Search the web',
+        },
+      ],
+      activate: async () => ({
+        mcp_12345678901234567890123456_web_search_exa: makeTool('Search the web'),
+      }),
+    });
+    const manager = createManager();
+    const tools = createToolsetTools(manager, TEST_SESSION_ID);
+    const result = (await tools.activate_toolset.execute?.(
+      { toolsetId: 'mcp:mcp_12345678901234567890123456' },
+      {} as never,
+    )) as { message: string; toolsetName: string; toolDisplayNames: string[] };
+
+    expect(result.toolsetName).toBe('Exa');
+    expect(result.toolDisplayNames).toEqual(['Web Search Exa']);
+    expect(result.message).toContain('Toolset "Exa" activated');
+    expect(result.message).not.toContain('mcp_12345678901234567890123456_web_search_exa');
   });
 
   test('list_toolsets throws when unknown toolsetId is requested', async () => {

--- a/packages/server/src/llm/prompt/base-system-prompt.txt
+++ b/packages/server/src/llm/prompt/base-system-prompt.txt
@@ -49,6 +49,9 @@ Additional capabilities are organized into **toolsets** — groups of related to
 - After completing a task that required a toolset, deactivate it immediately with deactivate_toolset.
 - Do not activate all toolsets at once — this wastes context space.
 - If unsure whether a toolset has what you need, use `list_toolsets` first to check.
+- If the available toolset catalog clearly matches the task, activate that toolset directly instead of relying only on core tools.
+- For web search, current information, or external research tasks, prefer relevant web-search MCP toolsets when available.
+- For GitHub repository or codebase documentation questions, prefer relevant repository-knowledge MCP toolsets when available.
 - If the capability you need does not appear in the `list_toolsets` catalog, it is not available. Do not try alternative names, IDs, or queries — the catalog is the complete and filtered list of what you can use.
 
 ## Delegating Work

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -34,6 +34,7 @@ import { createToolsetTools } from '@/tools/core/toolset-management.js';
 import { createTools, MAX_STEPS, MAX_STEPS_WARNING } from '@/tools/runtime/registry.js';
 import { withToolResultHandling, withToolResultHandlingRecord } from '@/tools/runtime/wrappers.js';
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
+import { getToolset } from '@/tools/toolsets/registry.js';
 import { recordUsageEvent } from '@/usage/ledger.js';
 import { calculateMessageCostUsd } from '@/utils/cost.js';
 import * as Usage from '@/utils/usage.js';
@@ -192,6 +193,31 @@ const DEFAULT_DEPS: StreamRunnerDeps = {
   broadcast: Sse.broadcast,
   now: Date.now,
 };
+
+async function buildAvailableToolsetsPrompt(manager: ToolsetManager): Promise<string> {
+  const catalog = await manager.getCatalogWithState();
+  if (catalog.length === 0) return '';
+
+  const lines = catalog.map((item) => {
+    const toolset = getToolset(item.id);
+    const tools = toolset
+      ?.tools()
+      .slice(0, 3)
+      .map((tool) => `${tool.name}: ${tool.description}`)
+      .join('; ');
+    const active = item.active ? 'active' : 'inactive';
+    const toolSummary = tools ? ` Tools: ${tools}.` : '';
+    return `- ${item.name} (${item.id}, ${active}): ${item.description}.${toolSummary}`;
+  });
+
+  return [
+    '## Available Toolsets',
+    '',
+    'Use `activate_toolset` when a listed toolset clearly matches the task. For web/current-info tasks, prefer relevant web-search MCP toolsets when available. For GitHub repository questions, prefer relevant repository-knowledge MCP toolsets when available. Do not activate unrelated toolsets.',
+    '',
+    ...lines,
+  ].join('\n');
+}
 
 type InternalRunStreamOptions = RunStreamOptions & {
   coreTools: Record<string, Tool>;
@@ -1331,12 +1357,14 @@ export async function runStream(opts: {
 
   const messages = opts.llmMessages;
   const codeModePrompt = codeModeResult.getSystemPrompt();
+  const toolsetsPrompt = await buildAvailableToolsetsPrompt(toolsetManager);
   if (messages.length > 0 && messages[0]?.role === 'system') {
     const sysMsg = messages[0];
     const existingContent = typeof sysMsg.content === 'string' ? sysMsg.content : '';
+    const promptAdditions = [codeModePrompt, toolsetsPrompt].filter(Boolean).join('\n\n');
     messages[0] = {
       role: 'system',
-      content: `${existingContent}\n\n${codeModePrompt}`,
+      content: `${existingContent}\n\n${promptAdditions}`,
     };
   }
 

--- a/packages/server/src/mcp/registry-service.ts
+++ b/packages/server/src/mcp/registry-service.ts
@@ -157,6 +157,24 @@ export async function listMcpRegistryServers(
   return ok(normalizeServers(refreshed.data));
 }
 
+export async function findMcpRegistryServerForInstall(input: {
+  name: string;
+  url: string;
+}): Promise<McpRegistryServer | null> {
+  const result = await listMcpRegistryServers();
+  if (isServiceError(result)) return null;
+
+  const normalizedUrl = input.url.trim().toLowerCase();
+  const normalizedName = input.name.trim().toLowerCase();
+
+  return (
+    result.data.find((server) => server.install.url.trim().toLowerCase() === normalizedUrl) ??
+    result.data.find((server) => server.install.name.trim().toLowerCase() === normalizedName) ??
+    result.data.find((server) => server.name.trim().toLowerCase() === normalizedName) ??
+    null
+  );
+}
+
 export function clearMcpRegistryCacheForTests(): void {
   inMemoryRegistry = null;
 }

--- a/packages/server/src/mcp/tool-executor.ts
+++ b/packages/server/src/mcp/tool-executor.ts
@@ -1,11 +1,12 @@
 import { formatMcpToolName } from '@stitch/shared/mcp/types';
-import type { McpIcon } from '@stitch/shared/mcp/types';
+import type { McpIcon, McpRegistryServer } from '@stitch/shared/mcp/types';
 
 import * as Log from '@/lib/log.js';
 import { isServiceError } from '@/lib/service-result.js';
 import { buildAuthHeaders } from '@/mcp/auth.js';
 import { getMcpClient, withMcpClient } from '@/mcp/client.js';
 import { cacheMcpIcon } from '@/mcp/icons.js';
+import { findMcpRegistryServerForInstall } from '@/mcp/registry-service.js';
 import { fetchMcpTools, getMcpServersWithCachedTools } from '@/mcp/service.js';
 import type { McpServerWithTools } from '@/mcp/service.js';
 import type { ToolContext } from '@/tools/runtime/wrappers.js';
@@ -41,6 +42,7 @@ type McpToolExecutorDeps = {
   fetchMcpTools: typeof fetchMcpTools;
   fetchServerInfo: typeof fetchServerInfo;
   fetchServerPrompts: typeof fetchServerPrompts;
+  findRegistryServer: typeof findMcpRegistryServerForInstall;
   buildServerPresentation: typeof buildServerPresentation;
 };
 
@@ -49,6 +51,7 @@ const DEFAULT_DEPS: McpToolExecutorDeps = {
   fetchMcpTools,
   fetchServerInfo,
   fetchServerPrompts,
+  findRegistryServer: findMcpRegistryServerForInstall,
   buildServerPresentation,
 };
 
@@ -174,9 +177,23 @@ function buildMcpToolsetId(server: McpServerWithTools): string {
 function buildToolsetDescription(
   server: McpServerWithTools,
   liveInfo: McpServerLiveInfo | null,
+  registryServer: McpRegistryServer | null,
 ): string {
   if (liveInfo?.description) {
     return liveInfo.description;
+  }
+
+  if (registryServer?.description) {
+    return registryServer.description;
+  }
+
+  const toolDescriptions = (server.tools ?? [])
+    .map((tool) => tool.description?.trim())
+    .filter((description): description is string => !!description)
+    .slice(0, 2);
+
+  if (toolDescriptions.length > 0) {
+    return toolDescriptions.join(' ');
   }
 
   const toolCount = server.tools?.length ?? 0;
@@ -207,12 +224,13 @@ async function resolveIconPath(input: {
 function createMcpToolset(
   server: McpServerWithTools,
   liveInfo: McpServerLiveInfo | null,
+  registryServer: McpRegistryServer | null,
   prompts: ToolsetPrompt[],
 ): Toolset {
   const toolsetId = buildMcpToolsetId(server);
   const cachedTools = server.tools ?? [];
-  const displayName = liveInfo?.title ?? liveInfo?.name ?? server.name;
-  const description = buildToolsetDescription(server, liveInfo);
+  const displayName = registryServer?.name ?? server.name ?? liveInfo?.title ?? liveInfo?.name;
+  const description = buildToolsetDescription(server, liveInfo, registryServer);
 
   return {
     id: toolsetId,
@@ -232,6 +250,7 @@ function createMcpToolset(
 async function buildServerPresentation(
   server: McpServerWithTools,
   liveInfo: McpServerLiveInfo | null,
+  registryServer?: McpRegistryServer | null,
 ): Promise<McpServerPresentation> {
   const tools = server.tools ?? [];
   const toolPresentations = await Promise.all(
@@ -260,9 +279,9 @@ async function buildServerPresentation(
 
   return {
     serverId: server.id,
-    name: liveInfo?.name ?? server.name,
-    title: liveInfo?.title,
-    description: liveInfo?.description,
+    name: registryServer?.name ?? server.name ?? liveInfo?.name,
+    title: registryServer?.name ?? liveInfo?.title,
+    description: liveInfo?.description ?? registryServer?.description,
     instructions: liveInfo?.instructions,
     iconPath,
     tools: Object.fromEntries(toolPresentations),
@@ -328,11 +347,18 @@ async function refreshMcpToolsetsInternal(
 
   const infoResults = await Promise.allSettled(serverSnapshots.map(deps.fetchServerInfo));
   const promptResults = await Promise.allSettled(serverSnapshots.map(deps.fetchServerPrompts));
+  const registryResults = await Promise.allSettled(
+    serverSnapshots.map((server) =>
+      deps.findRegistryServer({ name: server.name, url: server.url }),
+    ),
+  );
 
   const registeredIds: string[] = [];
   for (const [index, server] of serverSnapshots.entries()) {
     const liveInfo = infoResults[index]?.status === 'fulfilled' ? infoResults[index].value : null;
     const prompts = promptResults[index]?.status === 'fulfilled' ? promptResults[index].value : [];
+    const registryServer =
+      registryResults[index]?.status === 'fulfilled' ? registryResults[index].value : null;
 
     if (liveInfo) {
       log.info(
@@ -350,11 +376,11 @@ async function refreshMcpToolsetsInternal(
       );
     }
 
-    const toolset = createMcpToolset(server, liveInfo, prompts);
+    const toolset = createMcpToolset(server, liveInfo, registryServer, prompts);
     registerToolset(toolset);
     registeredIds.push(toolset.id);
 
-    const presentation = await deps.buildServerPresentation(server, liveInfo);
+    const presentation = await deps.buildServerPresentation(server, liveInfo, registryServer);
     serverPresentationById.set(server.id, presentation);
   }
 

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 
 import type { PrefixedString } from '@stitch/shared/id';
+import { parseMcpToolName } from '@stitch/shared/mcp/types';
 
 import { setSessionActiveToolsetIds } from '@/llm/stream/session-toolsets.js';
 import { isToolEnabled } from '@/tools/enabled-service.js';
@@ -14,7 +15,7 @@ import { getToolset } from '@/tools/toolsets/registry.js';
  */
 export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedString<'ses'>) {
   const humanizeToolName = (name: string) =>
-    name
+    (parseMcpToolName(name)?.toolName ?? name)
       .split(/[_-]+/)
       .filter(Boolean)
       .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
@@ -106,6 +107,7 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
     execute: async ({ toolsetId, persist, verbose }) => {
       if (manager.isActive(toolsetId)) {
         const wasPersisted = manager.isPersisted(toolsetId);
+        const toolsetName = getToolset(toolsetId)?.name ?? toolsetId;
         if (persist === true) {
           manager.pin(toolsetId);
           setSessionActiveToolsetIds(sessionId, manager.getPersistedIds());
@@ -113,13 +115,14 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
 
         return {
           toolsetId,
+          toolsetName,
           status: 'already_active',
           icon: getToolset(toolsetId)?.icon ?? null,
           persisted: manager.isPersisted(toolsetId),
           message:
             persist === true && !wasPersisted
-              ? `Toolset "${toolsetId}" is already active and will now persist for future turns.`
-              : `Toolset "${toolsetId}" is already active.`,
+              ? `Toolset "${toolsetName}" is already active and will now persist for future turns.`
+              : `Toolset "${toolsetName}" is already active.`,
         };
       }
 
@@ -142,19 +145,21 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
 
       const { toolNames, collisions } = result;
       const toolset = getToolset(toolsetId);
+      const toolsetName = toolset?.name ?? toolsetId;
       const shouldIncludeVerbose = verbose === true;
       const persisted = manager.isPersisted(toolsetId);
 
       return {
         toolsetId,
+        toolsetName,
         status: 'activated',
         persisted,
         tools: toolNames,
         toolDisplayNames: toolNames.map(humanizeToolName),
         icon: toolset?.icon ?? null,
         message: persisted
-          ? `Toolset "${toolsetId}" activated and will persist for future turns. ${toolNames.length} tool(s) now available: ${toolNames.map(humanizeToolName).join(', ')}. Call deactivate_toolset("${toolsetId}") when you no longer need it to keep context clean.`
-          : `Toolset "${toolsetId}" activated for this run only. ${toolNames.length} tool(s) now available: ${toolNames.map(humanizeToolName).join(', ')}. Call deactivate_toolset("${toolsetId}") when you no longer need it to keep context clean. Set persist=true on activation only when you expect to need it again in future turns.`,
+          ? `Toolset "${toolsetName}" activated and will persist for future turns. ${toolNames.length} tool(s) now available: ${toolNames.map(humanizeToolName).join(', ')}. Call deactivate_toolset("${toolsetId}") when you no longer need it to keep context clean.`
+          : `Toolset "${toolsetName}" activated for this run only. ${toolNames.length} tool(s) now available: ${toolNames.map(humanizeToolName).join(', ')}. Call deactivate_toolset("${toolsetId}") when you no longer need it to keep context clean. Set persist=true on activation only when you expect to need it again in future turns.`,
         hasInstructions: !!toolset?.instructions,
         promptCount: toolset?.prompts?.length ?? 0,
         instructions: shouldIncludeVerbose ? (toolset?.instructions ?? null) : null,
@@ -179,13 +184,16 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
       toolsetId: z.string().describe('The toolset ID to deactivate'),
     }),
     execute: async ({ toolsetId }) => {
+      const toolset = getToolset(toolsetId);
+      const toolsetName = toolset?.name ?? toolsetId;
       const removed = manager.deactivate(toolsetId);
       if (!removed) {
         return {
           toolsetId,
+          toolsetName,
           status: 'not_active',
-          icon: getToolset(toolsetId)?.icon ?? null,
-          message: `Toolset "${toolsetId}" was not active.`,
+          icon: toolset?.icon ?? null,
+          message: `Toolset "${toolsetName}" was not active.`,
         };
       }
 
@@ -193,9 +201,10 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
 
       return {
         toolsetId,
+        toolsetName,
         status: 'deactivated',
-        icon: getToolset(toolsetId)?.icon ?? null,
-        message: `Toolset "${toolsetId}" deactivated. Its tools are no longer available.`,
+        icon: toolset?.icon ?? null,
+        message: `Toolset "${toolsetName}" deactivated. Its tools are no longer available.`,
       };
     },
   });


### PR DESCRIPTION
## 🚀 Change Summary

Improves MCP toolset discovery and chat visibility so installed MCP servers are easier for the assistant to choose and easier for users to understand in tool-call cards.

### ✨ New Features
- **MCP Toolset Discovery Context**: Adds an available-toolsets prompt block with concise tool summaries so the assistant can activate relevant MCP capabilities more reliably.
- **Registry Metadata Fallbacks**: Uses MCP registry metadata for server names and descriptions when live server metadata is missing or noisy.

### 🛠 Improvements & Refactors
- Shows friendly toolset names in activation/deactivation results while preserving raw toolset IDs in structured output.
- Humanizes MCP tool names in activation messages by stripping prefixed server IDs.
- Updates chat tool-call cards to resolve and display MCP server/toolset names like Exa instead of raw IDs.

### 🐛 Bug Fixes
- Prevents noisy live MCP names like "mcp-typescript server on vercel" from overriding curated registry/configured server names.
