### PR TITLE
Add session todo tool

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-gitloops"],
   "agent": {
     "explore": {
       "model": "google/gemini-3-flash-preview"

--- a/.opencode/skills/refactor/SKILL.md
+++ b/.opencode/skills/refactor/SKILL.md
@@ -1,0 +1,645 @@
+---
+name: refactor
+description: 'Surgical code refactoring to improve maintainability without changing behavior. Covers extracting functions, renaming variables, breaking down god functions, improving type safety, eliminating code smells, and applying design patterns. Less drastic than repo-rebuilder; use for gradual improvements.'
+license: MIT
+---
+
+# Refactor
+
+## Overview
+
+Improve code structure and readability without changing external behavior. Refactoring is gradual evolution, not revolution. Use this for improving existing code, not rewriting from scratch.
+
+## When to Use
+
+Use this skill when:
+
+- Code is hard to understand or maintain
+- Functions/classes are too large
+- Code smells need addressing
+- Adding features is difficult due to code structure
+- User asks "clean up this code", "refactor this", "improve this"
+
+---
+
+## Refactoring Principles
+
+### The Golden Rules
+
+1. **Behavior is preserved** - Refactoring doesn't change what the code does, only how
+2. **Small steps** - Make tiny changes, test after each
+3. **Version control is your friend** - Commit before and after each safe state
+4. **Tests are essential** - Without tests, you're not refactoring, you're editing
+5. **One thing at a time** - Don't mix refactoring with feature changes
+
+### When NOT to Refactor
+
+```
+- Code that works and won't change again (if it ain't broke...)
+- Critical production code without tests (add tests first)
+- When you're under a tight deadline
+- "Just because" - need a clear purpose
+```
+
+---
+
+## Common Code Smells & Fixes
+
+### 1. Long Method/Function
+
+```diff
+# BAD: 200-line function that does everything
+- async function processOrder(orderId) {
+-   // 50 lines: fetch order
+-   // 30 lines: validate order
+-   // 40 lines: calculate pricing
+-   // 30 lines: update inventory
+-   // 20 lines: create shipment
+-   // 30 lines: send notifications
+- }
+
+# GOOD: Broken into focused functions
++ async function processOrder(orderId) {
++   const order = await fetchOrder(orderId);
++   validateOrder(order);
++   const pricing = calculatePricing(order);
++   await updateInventory(order);
++   const shipment = await createShipment(order);
++   await sendNotifications(order, pricing, shipment);
++   return { order, pricing, shipment };
++ }
+```
+
+### 2. Duplicated Code
+
+```diff
+# BAD: Same logic in multiple places
+- function calculateUserDiscount(user) {
+-   if (user.membership === 'gold') return user.total * 0.2;
+-   if (user.membership === 'silver') return user.total * 0.1;
+-   return 0;
+- }
+-
+- function calculateOrderDiscount(order) {
+-   if (order.user.membership === 'gold') return order.total * 0.2;
+-   if (order.user.membership === 'silver') return order.total * 0.1;
+-   return 0;
+- }
+
+# GOOD: Extract common logic
++ function getMembershipDiscountRate(membership) {
++   const rates = { gold: 0.2, silver: 0.1 };
++   return rates[membership] || 0;
++ }
++
++ function calculateUserDiscount(user) {
++   return user.total * getMembershipDiscountRate(user.membership);
++ }
++
++ function calculateOrderDiscount(order) {
++   return order.total * getMembershipDiscountRate(order.user.membership);
++ }
+```
+
+### 3. Large Class/Module
+
+```diff
+# BAD: God object that knows too much
+- class UserManager {
+-   createUser() { /* ... */ }
+-   updateUser() { /* ... */ }
+-   deleteUser() { /* ... */ }
+-   sendEmail() { /* ... */ }
+-   generateReport() { /* ... */ }
+-   handlePayment() { /* ... */ }
+-   validateAddress() { /* ... */ }
+-   // 50 more methods...
+- }
+
+# GOOD: Single responsibility per class
++ class UserService {
++   create(data) { /* ... */ }
++   update(id, data) { /* ... */ }
++   delete(id) { /* ... */ }
++ }
++
++ class EmailService {
++   send(to, subject, body) { /* ... */ }
++ }
++
++ class ReportService {
++   generate(type, params) { /* ... */ }
++ }
++
++ class PaymentService {
++   process(amount, method) { /* ... */ }
++ }
+```
+
+### 4. Long Parameter List
+
+```diff
+# BAD: Too many parameters
+- function createUser(email, password, name, age, address, city, country, phone) {
+-   /* ... */
+- }
+
+# GOOD: Group related parameters
++ interface UserData {
++   email: string;
++   password: string;
++   name: string;
++   age?: number;
++   address?: Address;
++   phone?: string;
++ }
++
++ function createUser(data: UserData) {
++   /* ... */
++ }
+
+# EVEN BETTER: Use builder pattern for complex construction
++ const user = UserBuilder
++   .email('test@example.com')
++   .password('secure123')
++   .name('Test User')
++   .address(address)
++   .build();
+```
+
+### 5. Feature Envy
+
+```diff
+# BAD: Method that uses another object's data more than its own
+- class Order {
+-   calculateDiscount(user) {
+-     if (user.membershipLevel === 'gold') {
++       return this.total * 0.2;
++     }
++     if (user.accountAge > 365) {
++       return this.total * 0.1;
++     }
++     return 0;
++   }
++ }
+
+# GOOD: Move logic to the object that owns the data
++ class User {
++   getDiscountRate(orderTotal) {
++     if (this.membershipLevel === 'gold') return 0.2;
++     if (this.accountAge > 365) return 0.1;
++     return 0;
++   }
++ }
++
++ class Order {
++   calculateDiscount(user) {
++     return this.total * user.getDiscountRate(this.total);
++   }
++ }
+```
+
+### 6. Primitive Obsession
+
+```diff
+# BAD: Using primitives for domain concepts
+- function sendEmail(to, subject, body) { /* ... */ }
+- sendEmail('user@example.com', 'Hello', '...');
+
+- function createPhone(country, number) {
+-   return `${country}-${number}`;
+- }
+
+# GOOD: Use domain types
++ class Email {
++   private constructor(public readonly value: string) {
++     if (!Email.isValid(value)) throw new Error('Invalid email');
++   }
++   static create(value: string) { return new Email(value); }
++   static isValid(email: string) { return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email); }
++ }
++
++ class PhoneNumber {
++   constructor(
++     public readonly country: string,
++     public readonly number: string
++   ) {
++     if (!PhoneNumber.isValid(country, number)) throw new Error('Invalid phone');
++   }
++   toString() { return `${this.country}-${this.number}`; }
++   static isValid(country: string, number: string) { /* ... */ }
++ }
++
++ // Usage
++ const email = Email.create('user@example.com');
++ const phone = new PhoneNumber('1', '555-1234');
+```
+
+### 7. Magic Numbers/Strings
+
+```diff
+# BAD: Unexplained values
+- if (user.status === 2) { /* ... */ }
+- const discount = total * 0.15;
+- setTimeout(callback, 86400000);
+
+# GOOD: Named constants
++ const UserStatus = {
++   ACTIVE: 1,
++   INACTIVE: 2,
++   SUSPENDED: 3
++ } as const;
++
++ const DISCOUNT_RATES = {
++   STANDARD: 0.1,
++   PREMIUM: 0.15,
++   VIP: 0.2
++ } as const;
++
++ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
++
++ if (user.status === UserStatus.INACTIVE) { /* ... */ }
++ const discount = total * DISCOUNT_RATES.PREMIUM;
++ setTimeout(callback, ONE_DAY_MS);
+```
+
+### 8. Nested Conditionals
+
+```diff
+# BAD: Arrow code
+- function process(order) {
+-   if (order) {
+-     if (order.user) {
+-       if (order.user.isActive) {
+-         if (order.total > 0) {
+-           return processOrder(order);
++         } else {
++           return { error: 'Invalid total' };
++         }
++       } else {
++         return { error: 'User inactive' };
++       }
++     } else {
++       return { error: 'No user' };
++     }
++   } else {
++     return { error: 'No order' };
++   }
++ }
+
+# GOOD: Guard clauses / early returns
++ function process(order) {
++   if (!order) return { error: 'No order' };
++   if (!order.user) return { error: 'No user' };
++   if (!order.user.isActive) return { error: 'User inactive' };
++   if (order.total <= 0) return { error: 'Invalid total' };
++   return processOrder(order);
++ }
+
+# EVEN BETTER: Using Result type
++ function process(order): Result<ProcessedOrder, Error> {
++   return Result.combine([
++     validateOrderExists(order),
++     validateUserExists(order),
++     validateUserActive(order.user),
++     validateOrderTotal(order)
++   ]).flatMap(() => processOrder(order));
++ }
+```
+
+### 9. Dead Code
+
+```diff
+# BAD: Unused code lingers
+- function oldImplementation() { /* ... */ }
+- const DEPRECATED_VALUE = 5;
+- import { unusedThing } from './somewhere';
+- // Commented out code
+- // function oldCode() { /* ... */ }
+
+# GOOD: Remove it
++ // Delete unused functions, imports, and commented code
++ // If you need it again, git history has it
+```
+
+### 10. Inappropriate Intimacy
+
+```diff
+# BAD: One class reaches deep into another
+- class OrderProcessor {
+-   process(order) {
+-     order.user.profile.address.street;  // Too intimate
+-     order.repository.connection.config;  // Breaking encapsulation
++   }
++ }
+
+# GOOD: Ask, don't tell
++ class OrderProcessor {
++   process(order) {
++     order.getShippingAddress();  // Order knows how to get it
++     order.save();  // Order knows how to save itself
++   }
++ }
+```
+
+---
+
+## Extract Method Refactoring
+
+### Before and After
+
+```diff
+# Before: One long function
+- function printReport(users) {
+-   console.log('USER REPORT');
+-   console.log('============');
+-   console.log('');
+-   console.log(`Total users: ${users.length}`);
+-   console.log('');
+-   console.log('ACTIVE USERS');
+-   console.log('------------');
+-   const active = users.filter(u => u.isActive);
+-   active.forEach(u => {
+-     console.log(`- ${u.name} (${u.email})`);
+-   });
+-   console.log('');
+-   console.log(`Active: ${active.length}`);
+-   console.log('');
+-   console.log('INACTIVE USERS');
+-   console.log('--------------');
+-   const inactive = users.filter(u => !u.isActive);
+-   inactive.forEach(u => {
+-     console.log(`- ${u.name} (${u.email})`);
+-   });
+-   console.log('');
+-   console.log(`Inactive: ${inactive.length}`);
+- }
+
+# After: Extracted methods
++ function printReport(users) {
++   printHeader('USER REPORT');
++   console.log(`Total users: ${users.length}\n`);
++   printUserSection('ACTIVE USERS', users.filter(u => u.isActive));
++   printUserSection('INACTIVE USERS', users.filter(u => !u.isActive));
++ }
++
++ function printHeader(title) {
++   const line = '='.repeat(title.length);
++   console.log(title);
++   console.log(line);
++   console.log('');
++ }
++
++ function printUserSection(title, users) {
++   console.log(title);
++   console.log('-'.repeat(title.length));
++   users.forEach(u => console.log(`- ${u.name} (${u.email})`));
++   console.log('');
++   console.log(`${title.split(' ')[0]}: ${users.length}`);
++   console.log('');
++ }
+```
+
+---
+
+## Introducing Type Safety
+
+### From Untyped to Typed
+
+```diff
+# Before: No types
+- function calculateDiscount(user, total, membership, date) {
+-   if (membership === 'gold' && date.getDay() === 5) {
+-     return total * 0.25;
+-   }
+-   if (membership === 'gold') return total * 0.2;
+-   return total * 0.1;
+- }
+
+# After: Full type safety
++ type Membership = 'bronze' | 'silver' | 'gold';
++
++ interface User {
++   id: string;
++   name: string;
++   membership: Membership;
++ }
++
++ interface DiscountResult {
++   original: number;
++   discount: number;
++   final: number;
++   rate: number;
++ }
++
++ function calculateDiscount(
++   user: User,
++   total: number,
++   date: Date = new Date()
++ ): DiscountResult {
++   if (total < 0) throw new Error('Total cannot be negative');
++
++   let rate = 0.1; // Default bronze
++
++   if (user.membership === 'gold' && date.getDay() === 5) {
++     rate = 0.25; // Friday bonus for gold
++   } else if (user.membership === 'gold') {
++     rate = 0.2;
++   } else if (user.membership === 'silver') {
++     rate = 0.15;
++   }
++
++   const discount = total * rate;
++
++   return {
++     original: total,
++     discount,
++     final: total - discount,
++     rate
++   };
++ }
+```
+
+---
+
+## Design Patterns for Refactoring
+
+### Strategy Pattern
+
+```diff
+# Before: Conditional logic
+- function calculateShipping(order, method) {
+-   if (method === 'standard') {
+-     return order.total > 50 ? 0 : 5.99;
+-   } else if (method === 'express') {
+-     return order.total > 100 ? 9.99 : 14.99;
++   } else if (method === 'overnight') {
++     return 29.99;
++   }
++ }
+
+# After: Strategy pattern
++ interface ShippingStrategy {
++   calculate(order: Order): number;
++ }
++
++ class StandardShipping implements ShippingStrategy {
++   calculate(order: Order) {
++     return order.total > 50 ? 0 : 5.99;
++   }
++ }
++
++ class ExpressShipping implements ShippingStrategy {
++   calculate(order: Order) {
++     return order.total > 100 ? 9.99 : 14.99;
++   }
++ }
++
++ class OvernightShipping implements ShippingStrategy {
++   calculate(order: Order) {
++     return 29.99;
++   }
++ }
++
++ function calculateShipping(order: Order, strategy: ShippingStrategy) {
++   return strategy.calculate(order);
++ }
+```
+
+### Chain of Responsibility
+
+```diff
+# Before: Nested validation
+- function validate(user) {
+-   const errors = [];
+-   if (!user.email) errors.push('Email required');
++   else if (!isValidEmail(user.email)) errors.push('Invalid email');
++   if (!user.name) errors.push('Name required');
++   if (user.age < 18) errors.push('Must be 18+');
++   if (user.country === 'blocked') errors.push('Country not supported');
++   return errors;
++ }
+
+# After: Chain of responsibility
++ abstract class Validator {
++   abstract validate(user: User): string | null;
++   setNext(validator: Validator): Validator {
++     this.next = validator;
++     return validator;
++   }
++   validate(user: User): string | null {
++     const error = this.doValidate(user);
++     if (error) return error;
++     return this.next?.validate(user) ?? null;
++   }
++ }
++
++ class EmailRequiredValidator extends Validator {
++   doValidate(user: User) {
++     return !user.email ? 'Email required' : null;
++   }
++ }
++
++ class EmailFormatValidator extends Validator {
++   doValidate(user: User) {
++     return user.email && !isValidEmail(user.email) ? 'Invalid email' : null;
++   }
++ }
++
++ // Build the chain
++ const validator = new EmailRequiredValidator()
++   .setNext(new EmailFormatValidator())
++   .setNext(new NameRequiredValidator())
++   .setNext(new AgeValidator())
++   .setNext(new CountryValidator());
+```
+
+---
+
+## Refactoring Steps
+
+### Safe Refactoring Process
+
+```
+1. PREPARE
+   - Ensure tests exist (write them if missing)
+   - Commit current state
+   - Create feature branch
+
+2. IDENTIFY
+   - Find the code smell to address
+   - Understand what the code does
+   - Plan the refactoring
+
+3. REFACTOR (small steps)
+   - Make one small change
+   - Run tests
+   - Commit if tests pass
+   - Repeat
+
+4. VERIFY
+   - All tests pass
+   - Manual testing if needed
+   - Performance unchanged or improved
+
+5. CLEAN UP
+   - Update comments
+   - Update documentation
+   - Final commit
+```
+
+---
+
+## Refactoring Checklist
+
+### Code Quality
+
+- [ ] Functions are small (< 50 lines)
+- [ ] Functions do one thing
+- [ ] No duplicated code
+- [ ] Descriptive names (variables, functions, classes)
+- [ ] No magic numbers/strings
+- [ ] Dead code removed
+
+### Structure
+
+- [ ] Related code is together
+- [ ] Clear module boundaries
+- [ ] Dependencies flow in one direction
+- [ ] No circular dependencies
+
+### Type Safety
+
+- [ ] Types defined for all public APIs
+- [ ] No `any` types without justification
+- [ ] Nullable types explicitly marked
+
+### Testing
+
+- [ ] Refactored code is tested
+- [ ] Tests cover edge cases
+- [ ] All tests pass
+
+---
+
+## Common Refactoring Operations
+
+| Operation                                     | Description                           |
+| --------------------------------------------- | ------------------------------------- |
+| Extract Method                                | Turn code fragment into method        |
+| Extract Class                                 | Move behavior to new class            |
+| Extract Interface                             | Create interface from implementation  |
+| Inline Method                                 | Move method body back to caller       |
+| Inline Class                                  | Move class behavior to caller         |
+| Pull Up Method                                | Move method to superclass             |
+| Push Down Method                              | Move method to subclass               |
+| Rename Method/Variable                        | Improve clarity                       |
+| Introduce Parameter Object                    | Group related parameters              |
+| Replace Conditional with Polymorphism         | Use polymorphism instead of switch/if |
+| Replace Magic Number with Constant            | Named constants                       |
+| Decompose Conditional                         | Break complex conditions              |
+| Consolidate Conditional                       | Combine duplicate conditions          |
+| Replace Nested Conditional with Guard Clauses | Early returns                         |
+| Introduce Null Object                         | Eliminate null checks                 |
+| Replace Type Code with Class/Enum             | Strong typing                         |
+| Replace Inheritance with Delegation           | Composition over inheritance          |

--- a/apps/web/src/components/chat/docks/todo-dock.tsx
+++ b/apps/web/src/components/chat/docks/todo-dock.tsx
@@ -1,0 +1,50 @@
+import type { SessionTodo } from '@stitch/shared/todos/types';
+
+import { cn } from '@/lib/utils';
+
+type TodoDockProps = {
+  todos: SessionTodo[];
+};
+
+function statusLabel(status: SessionTodo['status']): string {
+  return status.replace('_', ' ');
+}
+
+export function TodoDock({ todos }: TodoDockProps) {
+  return (
+    <div className="space-y-2">
+      {todos.map((todo) => (
+        <div
+          key={todo.id}
+          className="flex items-start gap-3 rounded-xl border border-border/60 px-3 py-2"
+        >
+          <div
+            className={cn(
+              'mt-1 size-2 rounded-full',
+              todo.status === 'in_progress' && 'bg-primary',
+              todo.status === 'completed' && 'bg-success',
+              todo.status === 'cancelled' && 'bg-muted-foreground/40',
+              todo.status === 'pending' && 'bg-warning',
+            )}
+          />
+          <div className="min-w-0 flex-1">
+            <div
+              className={cn(
+                'text-sm leading-5',
+                todo.status === 'completed' && 'text-muted-foreground line-through',
+                todo.status === 'cancelled' && 'text-muted-foreground',
+              )}
+            >
+              {todo.content}
+            </div>
+            <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+              <span className="capitalize">{statusLabel(todo.status)}</span>
+              <span aria-hidden="true">/</span>
+              <span className="capitalize">{todo.priority}</span>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/session/session-chat-pane.tsx
+++ b/apps/web/src/components/session/session-chat-pane.tsx
@@ -25,6 +25,7 @@ import { useCompactionUpdates } from '@/hooks/sse/use-compaction-updates';
 import { usePermissionResponseSync } from '@/hooks/sse/use-permission-response-sync';
 import { useQuestionSync } from '@/hooks/sse/use-question-sync';
 import { useSessionStream } from '@/hooks/sse/use-session-stream';
+import { useTodoSync } from '@/hooks/sse/use-todo-sync';
 import { useSessionStreamState } from '@/hooks/use-session-stream-state';
 import { setNextSessionInputSeed } from '@/lib/chat-input-transition-seed';
 import {
@@ -35,6 +36,7 @@ import {
   useSplitSession,
 } from '@/lib/queries/chat';
 import { useAddToQueue } from '@/lib/queries/queue';
+import { sessionTodosQueryOptions } from '@/lib/queries/todos';
 import { cn } from '@/lib/utils';
 import { useStreamStore } from '@/stores/stream-store';
 
@@ -58,6 +60,7 @@ export function SessionChatPane({
   const { data: session } = useSuspenseQuery(sessionQueryOptions(id));
   const isChildSession = session.parentSessionId !== null;
   const messagesQuery = useSuspenseInfiniteQuery(sessionMessagesInfiniteQueryOptions(id));
+  const { data: todos } = useSuspenseQuery(sessionTodosQueryOptions(id));
   const messages = React.useMemo(() => flattenMessages(messagesQuery.data), [messagesQuery.data]);
 
   const lastUsedModel = React.useMemo(
@@ -82,6 +85,7 @@ export function SessionChatPane({
 
   useQuestionSync(id);
   usePermissionResponseSync(id);
+  useTodoSync(id);
   useSessionStream({ sessionId: id });
 
   const docks = useSessionDocks({
@@ -90,6 +94,7 @@ export function SessionChatPane({
     doomLoop: streamState.doomLoop,
     pendingQuestions: pendingItems.pendingQuestions,
     pendingPermissionResponses: pendingItems.pendingPermissionResponses,
+    todos,
     replyQuestion: pendingItems.replyQuestion,
     rejectQuestion: pendingItems.rejectQuestion,
     allowPermissionResponse: pendingItems.allowPermissionResponse,

--- a/apps/web/src/hooks/session/use-session-docks.tsx
+++ b/apps/web/src/hooks/session/use-session-docks.tsx
@@ -5,12 +5,14 @@ import type { UseMutationResult } from '@tanstack/react-query';
 import { parseMcpToolName } from '@stitch/shared/mcp/types';
 import type { PermissionResponse } from '@stitch/shared/permissions/types';
 import type { QuestionRequest } from '@stitch/shared/questions/types';
+import type { SessionTodo } from '@stitch/shared/todos/types';
 
 import type { DockItem } from '@/components/chat/docks/dock';
 import { DoomLoopDock } from '@/components/chat/docks/doom-loop-dock';
 import { PermissionResponseDock } from '@/components/chat/docks/permission-response-dock';
 import { QuestionDock } from '@/components/chat/docks/question-dock';
 import { RetryDock } from '@/components/chat/docks/retry-dock';
+import { TodoDock } from '@/components/chat/docks/todo-dock';
 import type { RetryInfo, DoomLoopInfo } from '@/stores/stream-store';
 
 type UseSessionDocksOptions = {
@@ -19,6 +21,7 @@ type UseSessionDocksOptions = {
   doomLoop: DoomLoopInfo | null;
   pendingQuestions: QuestionRequest[];
   pendingPermissionResponses: PermissionResponse[];
+  todos: SessionTodo[];
   replyQuestion: UseMutationResult<
     unknown,
     Error,
@@ -56,6 +59,7 @@ export function useSessionDocks({
   doomLoop,
   pendingQuestions,
   pendingPermissionResponses,
+  todos,
   replyQuestion,
   rejectQuestion,
   allowPermissionResponse,
@@ -184,12 +188,27 @@ export function useSessionDocks({
       });
     }
 
+    if (todos.length > 0) {
+      const activeCount = todos.filter(
+        (todo) => todo.status === 'pending' || todo.status === 'in_progress',
+      ).length;
+
+      items.push({
+        id: 'todos',
+        title: activeCount > 0 ? `Todos (${activeCount} active)` : 'Todos',
+        defaultExpanded: todos.some((todo) => todo.status === 'in_progress'),
+        variant: 'default',
+        children: <TodoDock todos={todos} />,
+      });
+    }
+
     return items;
   }, [
     doomLoop,
     retry,
     pendingQuestions,
     pendingPermissionResponses,
+    todos,
     sessionId,
     replyQuestion,
     rejectQuestion,

--- a/apps/web/src/hooks/sse/use-todo-sync.ts
+++ b/apps/web/src/hooks/sse/use-todo-sync.ts
@@ -1,0 +1,15 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useSSE } from '@/hooks/sse/sse-context';
+import { todoKeys } from '@/lib/queries/todos';
+
+export function useTodoSync(sessionId: string): void {
+  const queryClient = useQueryClient();
+
+  useSSE({
+    'session-todos-updated': (payload) => {
+      if (payload.sessionId !== sessionId) return;
+      void queryClient.invalidateQueries({ queryKey: todoKeys.list(sessionId) });
+    },
+  });
+}

--- a/apps/web/src/lib/queries/todos.ts
+++ b/apps/web/src/lib/queries/todos.ts
@@ -1,0 +1,21 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import type { SessionTodo } from '@stitch/shared/todos/types';
+
+import { serverFetch } from '@/lib/api';
+
+export const todoKeys = {
+  all: ['todos'] as const,
+  list: (sessionId: string) => [...todoKeys.all, 'list', sessionId] as const,
+};
+
+export function sessionTodosQueryOptions(sessionId: string) {
+  return queryOptions({
+    queryKey: todoKeys.list(sessionId),
+    queryFn: async (): Promise<SessionTodo[]> => {
+      const res = await serverFetch(`/chat/sessions/${sessionId}/todos`);
+      if (!res.ok) throw new Error('Failed to fetch todos');
+      return res.json() as Promise<SessionTodo[]>;
+    },
+  });
+}

--- a/packages/server/drizzle/0021_stale_micromax.sql
+++ b/packages/server/drizzle/0021_stale_micromax.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `session_todos` (
+	`id` text PRIMARY KEY NOT NULL,
+	`session_id` text NOT NULL,
+	`content` text NOT NULL,
+	`status` text NOT NULL,
+	`priority` text NOT NULL,
+	`sort_order` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`session_id`) REFERENCES `sessions`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `session_todos_session_id_idx` ON `session_todos` (`session_id`);--> statement-breakpoint
+CREATE INDEX `session_todos_order_idx` ON `session_todos` (`session_id`,`sort_order`);

--- a/packages/server/drizzle/meta/0021_snapshot.json
+++ b/packages/server/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,2505 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c343dda7-de35-4605-a374-759b7314fe6e",
+  "prevId": "1a3a4a11-4901-4309-b1af-c533520c0393",
+  "tables": {
+    "agenda_item_events": {
+      "name": "agenda_item_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_item_events_item_id_idx": {
+          "name": "agenda_item_events_item_id_idx",
+          "columns": ["item_id"],
+          "isUnique": false
+        },
+        "agenda_item_events_created_at_idx": {
+          "name": "agenda_item_events_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_item_events_item_id_agenda_items_id_fk": {
+          "name": "agenda_item_events_item_id_agenda_items_id_fk",
+          "tableFrom": "agenda_item_events",
+          "tableTo": "agenda_items",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_item_events_type_check": {
+          "name": "agenda_item_events_type_check",
+          "value": "\"agenda_item_events\".\"type\" in ('created', 'status_change', 'updated', 'comment')"
+        }
+      }
+    },
+    "agenda_items": {
+      "name": "agenda_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'todo'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_items_list_id_idx": {
+          "name": "agenda_items_list_id_idx",
+          "columns": ["list_id"],
+          "isUnique": false
+        },
+        "agenda_items_status_idx": {
+          "name": "agenda_items_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "agenda_items_due_at_idx": {
+          "name": "agenda_items_due_at_idx",
+          "columns": ["due_at"],
+          "isUnique": false
+        },
+        "agenda_items_created_at_idx": {
+          "name": "agenda_items_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_items_list_id_agenda_lists_id_fk": {
+          "name": "agenda_items_list_id_agenda_lists_id_fk",
+          "tableFrom": "agenda_items",
+          "tableTo": "agenda_lists",
+          "columnsFrom": ["list_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_items_type_check": {
+          "name": "agenda_items_type_check",
+          "value": "\"agenda_items\".\"type\" in ('todo', 'reminder', 'checkup')"
+        },
+        "agenda_items_status_check": {
+          "name": "agenda_items_status_check",
+          "value": "\"agenda_items\".\"status\" in ('open', 'in_progress', 'done', 'cancelled')"
+        },
+        "agenda_items_priority_check": {
+          "name": "agenda_items_priority_check",
+          "value": "\"agenda_items\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      }
+    },
+    "agenda_lists": {
+      "name": "agenda_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_lists_name_uidx": {
+          "name": "agenda_lists_name_uidx",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "agenda_lists_created_at_idx": {
+          "name": "agenda_lists_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "auth_issue": {
+          "name": "auth_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": ["connector_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lance_migrations": {
+      "name": "lance_migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "prev_id": {
+          "name": "prev_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'applied'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "is_attributable": {
+          "name": "is_attributable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_index": {
+          "name": "attempt_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_run_id_idx": {
+          "name": "llm_usage_events_run_id_idx",
+          "columns": ["run_id"],
+          "isUnique": false
+        },
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ollama_models": {
+      "name": "ollama_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_limit": {
+          "name": "input_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_limit": {
+          "name": "output_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_cost_per_million": {
+          "name": "input_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_cost_per_million": {
+          "name": "output_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_cost_per_million": {
+          "name": "cache_read_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_per_million": {
+          "name": "cache_write_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_tool_calls": {
+          "name": "supports_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_vision": {
+          "name": "supports_vision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_reasoning": {
+          "name": "supports_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permission_responses": {
+      "name": "permission_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_reminder": {
+          "name": "system_reminder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_responses_session_id_sessions_id_fk": {
+          "name": "permission_responses_session_id_sessions_id_fk",
+          "tableFrom": "permission_responses",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_messages": {
+      "name": "queued_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "queued_messages_session_id_sessions_id_fk": {
+          "name": "queued_messages_session_id_sessions_id_fk",
+          "tableFrom": "queued_messages",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_analyses": {
+      "name": "recording_analyses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_sections": {
+          "name": "topic_sections",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockers": {
+          "name": "blockers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_provider_id": {
+          "name": "transcription_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_model_id": {
+          "name": "transcription_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_provider_id": {
+          "name": "analysis_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_model_id": {
+          "name": "analysis_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recording_analyses_recording_id_uidx": {
+          "name": "recording_analyses_recording_id_uidx",
+          "columns": ["recording_id"],
+          "isUnique": true
+        },
+        "recording_analyses_status_idx": {
+          "name": "recording_analyses_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recording_analyses_recording_id_recordings_id_fk": {
+          "name": "recording_analyses_recording_id_recordings_id_fk",
+          "tableFrom": "recording_analyses",
+          "tableTo": "recordings",
+          "columnsFrom": ["recording_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recording_analyses_status_check": {
+          "name": "recording_analyses_status_check",
+          "value": "\"recording_analyses\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "recordings": {
+      "name": "recordings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'recording'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'audio/ogg'"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recordings_created_at_idx": {
+          "name": "recordings_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "recordings_status_idx": {
+          "name": "recordings_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recordings_status_check": {
+          "name": "recordings_status_check",
+          "value": "\"recordings\".\"status\" in ('recording', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": ["job_id"],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": ["key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "queue_enabled": {
+          "name": "queue_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": ["key"],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": ["next_run_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "session_todos": {
+      "name": "session_todos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_todos_session_id_idx": {
+          "name": "session_todos_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        },
+        "session_todos_order_idx": {
+          "name": "session_todos_order_idx",
+          "columns": ["session_id", "sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_todos_session_id_sessions_id_fk": {
+          "name": "session_todos_session_id_sessions_id_fk",
+          "tableFrom": "session_todos",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "active_toolset_ids": {
+          "name": "active_toolset_ids",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_automation_id_automations_id_fk": {
+          "name": "sessions_automation_id_automations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "automations",
+          "columnsFrom": ["automation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": ["parent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_enabled": {
+      "name": "tool_enabled",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_enabled_scope_identifier_uidx": {
+          "name": "tool_enabled_scope_identifier_uidx",
+          "columns": ["scope", "identifier"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": ["tool_name", "pattern"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1778712024721,
       "tag": "0020_acoustic_longshot",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1778973792670,
+      "tag": "0021_stale_micromax",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -28,6 +28,7 @@ import type {
   PermissionSuggestion,
 } from '@stitch/shared/permissions/types';
 import type { QuestionInfo, QuestionRequestStatus } from '@stitch/shared/questions/types';
+import type { TodoPriority, TodoStatus } from '@stitch/shared/todos/types';
 import type { ToolEnabledScope } from '@stitch/shared/tools/types';
 
 /** @deprecated Type field is no longer used but kept for DB compatibility */
@@ -149,6 +150,31 @@ export const messages = sqliteTable('messages', {
   startedAt: integer('started_at', { mode: 'number' }).notNull(),
   duration: integer('duration_ms'),
 });
+
+export const sessionTodos = sqliteTable(
+  'session_todos',
+  {
+    id: text('id').$type<PrefixedString<'todo'>>().primaryKey(),
+    sessionId: text('session_id')
+      .$type<PrefixedString<'ses'>>()
+      .notNull()
+      .references(() => sessions.id, { onDelete: 'cascade' }),
+    content: text('content').notNull(),
+    status: text('status').$type<TodoStatus>().notNull(),
+    priority: text('priority').$type<TodoPriority>().notNull(),
+    sortOrder: integer('sort_order', { mode: 'number' }).notNull(),
+    createdAt: integer('created_at', { mode: 'number' })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+    updatedAt: integer('updated_at', { mode: 'number' })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (table) => [
+    index('session_todos_session_id_idx').on(table.sessionId),
+    index('session_todos_order_idx').on(table.sessionId, table.sortOrder),
+  ],
+);
 
 export const llmUsageEvents = sqliteTable(
   'llm_usage_events',

--- a/packages/server/src/lib/route-schemas.ts
+++ b/packages/server/src/lib/route-schemas.ts
@@ -35,4 +35,5 @@ export const routeSchemas = {
   agendaListId: prefixedId(ID_PREFIXES.agendaList),
   agendaItemId: prefixedId(ID_PREFIXES.agendaItem),
   agendaItemEventId: prefixedId(ID_PREFIXES.agendaItemEvent),
+  todoId: prefixedId(ID_PREFIXES.todo),
 } as const;

--- a/packages/server/src/llm/compaction.ts
+++ b/packages/server/src/llm/compaction.ts
@@ -21,6 +21,7 @@ import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
 import { mapAIError, toStreamErrorDetails } from '@/llm/stream/ai-error-mapper.js';
 import { getSessionActiveToolsetIds } from '@/llm/stream/session-toolsets.js';
 import { retrieveMemoryContext } from '@/memory/retriever.js';
+import { getSessionTodosPromptBlock } from '@/todos/service.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
 import { recordUsageEvent } from '@/usage/ledger.js';
 import { calculateMessageCostUsd } from '@/utils/cost.js';
@@ -210,6 +211,8 @@ Use the following markdown sections in your response. Do not wrap your response 
 
 [What work has been completed, what work is still in progress, and what work is left?]
 
+If the system prompt includes a <todos> block, preserve those current todo items in this section.
+
 ## Relevant files / directories
 
 [Construct a structured list of relevant files that have been read, edited, or created that pertain to the task at hand. If all the files in a directory are relevant, include the path to the directory.]
@@ -279,10 +282,11 @@ export async function compact(input: {
   try {
     log.info({ sessionId, auto: input.auto }, 'compaction starting');
 
-    const [compactionSettings, promptUserContext, resolved] = await Promise.all([
+    const [compactionSettings, promptUserContext, resolved, todoContext] = await Promise.all([
       input.compactionSettings ?? getCompactionSettings(),
       getPromptUserContext(),
       resolveCompactionModel(input.providerId, input.modelId),
+      getSessionTodosPromptBlock(sessionId),
     ]);
 
     await Sse.broadcast('compaction-start', { sessionId, messageId: summaryMessageId });
@@ -342,6 +346,7 @@ export async function compact(input: {
       systemPrompt: null,
       userName: promptUserContext.userName,
       userTimezone: promptUserContext.userTimezone,
+      todoContext,
     });
 
     const provider = createProvider(resolved.credentials);
@@ -512,7 +517,7 @@ export async function buildCompactedHistory(
 ): Promise<ModelMessage[]> {
   const db = getDb();
 
-  const [msgs, promptUserContext, sessionRow] = await Promise.all([
+  const [msgs, promptUserContext, sessionRow, todoContext] = await Promise.all([
     db
       .select()
       .from(messages)
@@ -525,6 +530,7 @@ export async function buildCompactedHistory(
         })
       : getPromptUserContext(),
     db.select({ type: sessions.type }).from(sessions).where(eq(sessions.id, sessionId)).limit(1),
+    getSessionTodosPromptBlock(sessionId),
   ]);
 
   // Automations can read all memories; chat only sees 'chat' memories
@@ -559,6 +565,7 @@ export async function buildCompactedHistory(
     userName: promptUserContext.userName,
     userTimezone: promptUserContext.userTimezone,
     memoryContext,
+    todoContext,
     codeModePrompt: promptConfig?.codeModePrompt ?? null,
   });
 

--- a/packages/server/src/llm/history-messages.ts
+++ b/packages/server/src/llm/history-messages.ts
@@ -69,6 +69,7 @@ export function buildHistoryMessages(
     userName?: string | null;
     userTimezone?: string | null;
     memoryContext?: string | null;
+    todoContext?: string | null;
     codeModePrompt?: string | null;
   },
 ): ModelMessage[] {
@@ -276,6 +277,7 @@ export function buildHistoryMessages(
         userName: promptConfig?.userName ?? null,
         userTimezone: promptConfig?.userTimezone ?? null,
         memoryContext: promptConfig?.memoryContext ?? null,
+        todoContext: promptConfig?.todoContext ?? null,
         codeModePrompt: promptConfig?.codeModePrompt ?? null,
       }),
     });

--- a/packages/server/src/llm/prompt/base-system-prompt.txt
+++ b/packages/server/src/llm/prompt/base-system-prompt.txt
@@ -20,11 +20,30 @@ You are assisting users on their local machine.
 - If you must ask, include: the question, your recommended default, and what changes based on the answer.
 - Prefer minimal, reversible changes.
 - If a task is large, break it into small steps and report progress briefly.
-- It is important to keep track of your tasks and progress.
+
+## Todo Tracking
+
+The `todo` tool is the source of truth for visible task progress in the current session. Use it proactively and keep it accurate.
+
+Use `todo` when:
+- The task has three or more meaningful steps.
+- The user asks for multiple things in one request.
+- You are implementing, debugging, refactoring, researching, or verifying non-trivial work.
+- You discover follow-up work that must be tracked to finish the user's goal.
+
+Do not use `todo` for single-step answers, quick factual responses, or purely conversational turns.
+
+Rules:
+- Write the initial todo list before starting substantial work.
+- Keep exactly one item `in_progress` while actively working.
+- Mark an item `completed` only after the work is actually done, including required verification.
+- If work becomes blocked, keep the blocked item `in_progress` and add or update a todo that states the blocker.
+- Update the todo list as soon as progress changes. Do not batch all updates at the end.
+- The todo tool replaces the full list each time, so always send the complete current list.
 
 ## Tool Management
 
-You have a set of core tools always available: bash, read, write, edit, glob, grep, question, webfetch.
+You have a set of core tools always available: bash, read, write, edit, glob, grep, question, webfetch, todo.
 
 Prefer the most specific tool for the job:
 - Use `glob` to find files by name or path pattern. Do not use `grep` for filename discovery.

--- a/packages/server/src/llm/prompt/builder.ts
+++ b/packages/server/src/llm/prompt/builder.ts
@@ -26,6 +26,7 @@ export function buildSystemPrompt(input: {
   userName?: string | null;
   userTimezone?: string | null;
   memoryContext?: string | null;
+  todoContext?: string | null;
   codeModePrompt?: string | null;
 }): string {
   const userPrompt = input.systemPrompt?.trim() ?? '';
@@ -48,6 +49,10 @@ export function buildSystemPrompt(input: {
 
   if (input.memoryContext) {
     result = `${result}\n\n<memory>\n${input.memoryContext}\n</memory>`;
+  }
+
+  if (input.todoContext) {
+    result = `${result}\n\n${input.todoContext}`;
   }
 
   return result;

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -20,6 +20,7 @@ import {
 } from '@/chat/service.js';
 import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
 import { routeSchemas } from '@/lib/route-schemas.js';
+import { listSessionTodos } from '@/todos/service.js';
 
 const sessionIdParamSchema = z.object({ id: routeSchemas.sessionId });
 
@@ -90,6 +91,12 @@ chatRouter.get('/sessions/:id', zValidator('param', sessionIdParamSchema), async
 chatRouter.get('/sessions/:id/stats', zValidator('param', sessionIdParamSchema), async (c) => {
   const { id } = c.req.valid('param');
   const result = await getSessionStats(id);
+  return unwrapResult(c, result);
+});
+
+chatRouter.get('/sessions/:id/todos', zValidator('param', sessionIdParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  const result = await listSessionTodos(id);
   return unwrapResult(c, result);
 });
 

--- a/packages/server/src/todos/service.ts
+++ b/packages/server/src/todos/service.ts
@@ -1,0 +1,78 @@
+import { asc, eq } from 'drizzle-orm';
+
+import type { PrefixedString } from '@stitch/shared/id';
+import { createTodoId } from '@stitch/shared/id';
+import type { SessionTodo, TodoInput } from '@stitch/shared/todos/types';
+
+import { getDb } from '@/db/client.js';
+import { sessionTodos, sessions } from '@/db/schema.js';
+import { err, isServiceError, ok, type ServiceResult } from '@/lib/service-result.js';
+import { broadcast } from '@/lib/sse.js';
+
+type TodoRow = typeof sessionTodos.$inferSelect;
+
+function toSessionTodo(row: TodoRow): SessionTodo {
+  return row;
+}
+
+export async function listSessionTodos(
+  sessionId: PrefixedString<'ses'>,
+): Promise<ServiceResult<SessionTodo[]>> {
+  const db = getDb();
+  const rows = await db
+    .select()
+    .from(sessionTodos)
+    .where(eq(sessionTodos.sessionId, sessionId))
+    .orderBy(asc(sessionTodos.sortOrder), asc(sessionTodos.createdAt));
+
+  return ok(rows.map(toSessionTodo));
+}
+
+export async function replaceSessionTodos(input: {
+  sessionId: PrefixedString<'ses'>;
+  todos: TodoInput[];
+  broadcastUpdate?: boolean;
+}): Promise<ServiceResult<SessionTodo[]>> {
+  const db = getDb();
+  const [session] = await db
+    .select({ id: sessions.id })
+    .from(sessions)
+    .where(eq(sessions.id, input.sessionId))
+    .limit(1);
+  if (!session) return err(`Session not found: ${input.sessionId}`, 404);
+
+  const now = Date.now();
+  const rows = input.todos.map((todo, index) => ({
+    id: todo.id ?? createTodoId(),
+    sessionId: input.sessionId,
+    content: todo.content,
+    status: todo.status,
+    priority: todo.priority,
+    sortOrder: index,
+    createdAt: now,
+    updatedAt: now,
+  }));
+
+  const updated = await db.transaction(async (tx) => {
+    await tx.delete(sessionTodos).where(eq(sessionTodos.sessionId, input.sessionId));
+    if (rows.length === 0) return [];
+    return tx.insert(sessionTodos).values(rows).returning();
+  });
+
+  if (input.broadcastUpdate ?? true) {
+    await broadcast('session-todos-updated', { sessionId: input.sessionId });
+  }
+
+  return ok(updated.map(toSessionTodo));
+}
+
+export async function getSessionTodosPromptBlock(
+  sessionId: PrefixedString<'ses'>,
+): Promise<string | null> {
+  const result = await listSessionTodos(sessionId);
+  if (isServiceError(result) || result.data.length === 0) return null;
+
+  const lines = result.data.map((todo) => `- [${todo.status}] (${todo.priority}) ${todo.content}`);
+
+  return `<todos>\n${lines.join('\n')}\n</todos>`;
+}

--- a/packages/server/src/tools/core/todo.ts
+++ b/packages/server/src/tools/core/todo.ts
@@ -1,0 +1,74 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+
+import { TODO_PRIORITIES, TODO_STATUSES } from '@stitch/shared/todos/types';
+import type { SessionTodo, TodoInput } from '@stitch/shared/todos/types';
+
+import { isServiceError } from '@/lib/service-result.js';
+import { listSessionTodos, replaceSessionTodos } from '@/todos/service.js';
+import type { ToolContext } from '@/tools/runtime/wrappers.js';
+
+export const DISPLAY_NAME = 'Todo';
+
+const todoItemSchema = z.object({
+  content: z.string().trim().min(1).describe('Specific task description.'),
+  status: z.enum(TODO_STATUSES).describe('Current todo status.'),
+  priority: z.enum(TODO_PRIORITIES).describe('Task priority.'),
+});
+
+const todoInputSchema = z.object({
+  action: z.enum(['read', 'write']).describe('Read or replace the session todo list.'),
+  todos: z
+    .array(todoItemSchema)
+    .optional()
+    .describe('Full replacement todo list. Required for action="write".'),
+});
+
+function formatSummary(todos: TodoInput[]): string {
+  if (todos.length === 0) return 'No todos.';
+
+  return todos
+    .map((todo, index) => `${index + 1}. [${todo.status}] (${todo.priority}) ${todo.content}`)
+    .join('\n');
+}
+
+function toAgentTodos(todos: SessionTodo[]): TodoInput[] {
+  return todos.map((todo) => ({
+    content: todo.content,
+    status: todo.status,
+    priority: todo.priority,
+  }));
+}
+
+export function createRegisteredTool(context: ToolContext) {
+  return tool({
+    description: `Read or update the current session todo list. Use this for multi-step work, visible progress tracking, and scratchpad planning. For write, provide the complete desired list, not a partial patch. Keep exactly one todo in_progress when actively working. Mark completed only after the work is done.`,
+    inputSchema: todoInputSchema,
+    execute: async (input) => {
+      if (input.action === 'read') {
+        const result = await listSessionTodos(context.sessionId);
+        if (isServiceError(result)) return { output: result.error };
+
+        return {
+          output: formatSummary(result.data),
+          todos: toAgentTodos(result.data),
+        };
+      }
+
+      if (!input.todos) {
+        return { output: 'Provide todos when action="write".' };
+      }
+
+      const result = await replaceSessionTodos({
+        sessionId: context.sessionId,
+        todos: input.todos,
+      });
+      if (isServiceError(result)) return { output: result.error };
+
+      return {
+        output: `Updated session todos:\n${formatSummary(result.data)}`,
+        todos: toAgentTodos(result.data),
+      };
+    },
+  });
+}

--- a/packages/server/src/tools/runtime/registry.ts
+++ b/packages/server/src/tools/runtime/registry.ts
@@ -34,6 +34,10 @@ import {
   DISPLAY_NAME as READ_DISPLAY_NAME,
 } from '@/tools/core/read.js';
 import {
+  createRegisteredTool as createTodoRegisteredTool,
+  DISPLAY_NAME as TODO_DISPLAY_NAME,
+} from '@/tools/core/todo.js';
+import {
   createRegisteredTool as createWebfetchRegisteredTool,
   DISPLAY_NAME as WEBFETCH_DISPLAY_NAME,
 } from '@/tools/core/webfetch.js';
@@ -87,6 +91,10 @@ const STITCH_TOOL_MODULES = {
   memory: {
     displayName: MEMORY_DISPLAY_NAME,
     createRegisteredTool: createMemoryRegisteredTool,
+  },
+  todo: {
+    displayName: TODO_DISPLAY_NAME,
+    createRegisteredTool: createTodoRegisteredTool,
   },
 } as const;
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,6 +20,7 @@
     "./recordings/types": "./src/recordings/types.ts",
     "./settings/types": "./src/settings/types.ts",
     "./shortcuts/types": "./src/shortcuts/types.ts",
+    "./todos/types": "./src/todos/types.ts",
     "./tools/bash-families": "./src/tools/bash-families.ts",
     "./tools/bash-presets": "./src/tools/bash-presets.ts",
     "./tools/types": "./src/tools/types.ts",

--- a/packages/shared/src/chat/realtime.ts
+++ b/packages/shared/src/chat/realtime.ts
@@ -134,6 +134,10 @@ export type PermissionResponseResolvedPayload = {
   sessionId: PrefixedString<'ses'>;
 };
 
+export type SessionTodosUpdatedPayload = {
+  sessionId: PrefixedString<'ses'>;
+};
+
 export type MeetingCallDetectedPayload = {
   key: string;
   platform: MeetingPlatform;
@@ -185,6 +189,7 @@ export const SSE_EVENT_NAMES = [
   'question-rejected',
   'permission-response-requested',
   'permission-response-resolved',
+  'session-todos-updated',
   'meeting-call-detected',
   'meeting-call-ended',
   'recording-analysis-updated',
@@ -214,6 +219,7 @@ export type SseEventPayloadMap = {
   'question-rejected': QuestionRejectedPayload;
   'permission-response-requested': PermissionResponseRequestedPayload;
   'permission-response-resolved': PermissionResponseResolvedPayload;
+  'session-todos-updated': SessionTodosUpdatedPayload;
   'meeting-call-detected': MeetingCallDetectedPayload;
   'meeting-call-ended': MeetingCallEndedPayload;
   'recording-analysis-updated': RecordingAnalysisUpdatedPayload;

--- a/packages/shared/src/id/index.ts
+++ b/packages/shared/src/id/index.ts
@@ -19,6 +19,7 @@ export const ID_PREFIXES = {
   agendaList: 'alist',
   agendaItem: 'aitm',
   agendaItemEvent: 'aevt',
+  todo: 'todo',
 } as const;
 
 export type IdPrefix = (typeof ID_PREFIXES)[keyof typeof ID_PREFIXES];
@@ -82,6 +83,7 @@ export const createRecordingAnalysisId = createIdFactory(ID_PREFIXES.recordingAn
 export const createAgendaListId = createIdFactory(ID_PREFIXES.agendaList);
 export const createAgendaItemId = createIdFactory(ID_PREFIXES.agendaItem);
 export const createAgendaItemEventId = createIdFactory(ID_PREFIXES.agendaItemEvent);
+export const createTodoId = createIdFactory(ID_PREFIXES.todo);
 
 export function extractTimestamp(id: string): number {
   const prefix = id.split('_')[0];

--- a/packages/shared/src/todos/types.ts
+++ b/packages/shared/src/todos/types.ts
@@ -1,0 +1,25 @@
+import type { PrefixedString } from '../id/index.js';
+
+export const TODO_STATUSES = ['pending', 'in_progress', 'completed', 'cancelled'] as const;
+export const TODO_PRIORITIES = ['high', 'medium', 'low'] as const;
+
+export type TodoStatus = (typeof TODO_STATUSES)[number];
+export type TodoPriority = (typeof TODO_PRIORITIES)[number];
+
+export type SessionTodo = {
+  id: PrefixedString<'todo'>;
+  sessionId: PrefixedString<'ses'>;
+  content: string;
+  status: TodoStatus;
+  priority: TodoPriority;
+  sortOrder: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type TodoInput = {
+  id?: PrefixedString<'todo'>;
+  content: string;
+  status: TodoStatus;
+  priority: TodoPriority;
+};


### PR DESCRIPTION
## 🚀 Change Summary

Adds a DB-backed session todo tool that is always available to the agent, surfaces current todos in the chat UI, and preserves todo context through compaction.

### ✨ New Features
- **Session Todo Tool**: Adds an always-active core todo tool for reading and replacing per-session todo lists.
- **Chat Todo UI**: Displays session todos in the chat dock and refreshes via SSE when the agent updates them.

### 🛠 Improvements & Refactors
- Persists todos in SQLite with session cascade behavior and injects active todos into prompts and compaction context.
- Adds stronger base prompt guidance for todo usage during multi-step work.
- Adds a project opencode refactor skill and removes the gitloops plugin from project config.