### PR TITLE
feature(skills): add DB-backed agent skills system with skills.sh import

### DIFF
--- a/apps/web/src/components/chat/message-bubble/tool-call-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-block.tsx
@@ -11,6 +11,7 @@ import { GenericToolBlock } from '@/components/chat/message-bubble/tool-call/gen
 import { McpToolBlock } from '@/components/chat/message-bubble/tool-call/mcp-tool-block';
 import { QuestionToolBlock } from '@/components/chat/message-bubble/tool-call/question-tool-block';
 import { SearchToolBlock } from '@/components/chat/message-bubble/tool-call/search-tool-block';
+import { SkillToolBlock } from '@/components/chat/message-bubble/tool-call/skill-tool-block';
 import { ToolsetToolBlock } from '@/components/chat/message-bubble/tool-call/toolset-tool-block';
 import { WebfetchToolBlock } from '@/components/chat/message-bubble/tool-call/webfetch-tool-block';
 
@@ -70,6 +71,10 @@ export function ToolCallBlock({
 
   if (toolName === 'question' && hasArgs) {
     return <QuestionToolBlock toolName={toolName} status={status} args={args} result={result} />;
+  }
+
+  if (toolName === 'skill' && hasArgs) {
+    return <SkillToolBlock status={status} args={args} result={result} error={error} />;
   }
 
   if (toolName === 'webfetch' && hasArgs) {

--- a/apps/web/src/components/chat/message-bubble/tool-call/skill-tool-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/skill-tool-block.tsx
@@ -1,0 +1,46 @@
+import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
+
+import { ToolCard, getToolLabel } from './card-primitives';
+
+type SkillToolBlockProps = {
+  status: ToolCallStatus;
+  args?: unknown;
+  result?: unknown;
+  error?: string;
+};
+
+function getSkillName(args: unknown, result: unknown): string | null {
+  const argName = (args as { name?: unknown } | undefined)?.name;
+  if (typeof argName === 'string' && argName.trim().length > 0) return argName.trim();
+
+  const resultName = (result as { name?: unknown } | undefined)?.name;
+  if (typeof resultName === 'string' && resultName.trim().length > 0) return resultName.trim();
+
+  return null;
+}
+
+export function SkillToolBlock({ status, args, result, error }: SkillToolBlockProps) {
+  const skillName = getSkillName(args, result);
+  const label = getToolLabel(status, error);
+
+  return (
+    <ToolCard.Root status={status}>
+      <ToolCard.Header>
+        <ToolCard.StatusIndicator status={status} />
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex items-center gap-2">
+            <ToolCard.Title>Skill</ToolCard.Title>
+            {skillName ? (
+              <span className="rounded-sm border border-border/50 bg-muted/40 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                {skillName}
+              </span>
+            ) : null}
+          </div>
+          <ToolCard.TitleContent truncate className="block">
+            {label ?? (status === 'completed' ? 'Loaded skill instructions' : 'Loading skill')}
+          </ToolCard.TitleContent>
+        </div>
+      </ToolCard.Header>
+    </ToolCard.Root>
+  );
+}

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -10,6 +10,7 @@ import {
   MonitorIcon,
   CpuIcon,
   MicIcon,
+  WandSparklesIcon,
 } from 'lucide-react';
 import * as React from 'react';
 
@@ -24,6 +25,7 @@ import { ToolsSettings } from '@/components/settings/permissions';
 import { ProvidersSettings } from '@/components/settings/providers';
 import { RecordingsSettings } from '@/components/settings/recordings';
 import { ShortcutsSettings } from '@/components/settings/shortcuts';
+import { SkillsSettings } from '@/components/settings/skills';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useDialogContext } from '@/context/dialog-context';
@@ -64,6 +66,7 @@ const SECTIONS: SettingsSection[] = [
       { id: 'providers', label: 'Providers', icon: <ServerIcon className="size-4" /> },
       { id: 'models', label: 'Models', icon: <CpuIcon className="size-4" /> },
       { id: 'memory', label: 'Memory', icon: <BrainIcon className="size-4" /> },
+      { id: 'skills', label: 'Skills', icon: <WandSparklesIcon className="size-4" /> },
       { id: 'tools', label: 'Tools', icon: <WrenchIcon className="size-4" /> },
       { id: 'mcp-servers', label: 'MCP Servers', icon: <NetworkIcon className="size-4" /> },
     ],
@@ -141,6 +144,8 @@ function SettingsContent({ activeItem }: { activeItem: string }) {
       return <ModelsSettings />;
     case 'memory':
       return <MemorySettings />;
+    case 'skills':
+      return <SkillsSettings />;
     case 'tools':
       return <ToolsSettings />;
     case 'mcp-servers':

--- a/apps/web/src/components/settings/skills.tsx
+++ b/apps/web/src/components/settings/skills.tsx
@@ -1,0 +1,300 @@
+import { ArrowLeftIcon, DownloadIcon, PlusIcon, Trash2Icon } from 'lucide-react';
+import * as React from 'react';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import type { Skill } from '@stitch/shared/skills/types';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  skillsQueryOptions,
+  useCreateSkill,
+  useDeleteSkill,
+  useImportSkill,
+  useSearchSkills,
+  useUpdateSkill,
+} from '@/lib/queries/skills';
+
+type SkillDraft = {
+  name: string;
+  description: string;
+  content: string;
+};
+
+const EMPTY_DRAFT: SkillDraft = {
+  name: '',
+  description: '',
+  content: '',
+};
+
+function toDraft(skill: Skill | null): SkillDraft {
+  if (!skill) return EMPTY_DRAFT;
+  return {
+    name: skill.name,
+    description: skill.description,
+    content: skill.content,
+  };
+}
+
+type SkillView = { type: 'list' } | { type: 'editor'; skill: Skill | null } | { type: 'import' };
+
+function formatInstalls(installs: number): string {
+  if (installs >= 1_000_000) return `${(installs / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+  if (installs >= 1_000) return `${(installs / 1_000).toFixed(1).replace(/\.0$/, '')}K`;
+  return installs.toString();
+}
+
+function ImportSkillView({ onBack }: { onBack: () => void }) {
+  const [search, setSearch] = React.useState('');
+  const importSkill = useImportSkill();
+  const { data: searchResults = [], isFetching: isSearching } = useSearchSkills(search);
+
+  function handleImport(skill: { source: string; name: string; slug: string }) {
+    importSkill.mutate(skill, { onSuccess: onBack });
+  }
+
+  return (
+    <div className="flex h-[36rem] max-h-[36rem] flex-col overflow-hidden">
+      <div className="mb-6 flex items-center gap-2">
+        <Button variant="ghost" size="icon-sm" onClick={onBack} aria-label="Back to skills">
+          <ArrowLeftIcon className="size-4" />
+        </Button>
+        <div>
+          <h2 className="text-sm font-semibold">Import Skill</h2>
+          <p className="text-xs text-muted-foreground">
+            Search the public agent skills directory and import into Stitch.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-4">
+        <Input
+          autoFocus
+          value={search}
+          placeholder="Search skills, e.g. frontend design"
+          onChange={(event) => setSearch(event.target.value)}
+        />
+        <div className="thin-scrollbar min-h-0 flex-1 overflow-auto rounded-lg border border-border/50">
+          {search.trim().length < 2 ? (
+            <div className="px-4 py-6 text-center text-xs text-muted-foreground">
+              Type at least 2 characters to search
+            </div>
+          ) : searchResults.length === 0 ? (
+            <div className="px-4 py-6 text-center text-xs text-muted-foreground">
+              {isSearching ? 'Searching...' : 'No skills found'}
+            </div>
+          ) : (
+            searchResults.map((skill) => (
+              <div
+                key={`${skill.source}/${skill.slug}`}
+                className="flex items-center justify-between gap-4 border-b border-border/50 px-4 py-3 last:border-b-0"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">{skill.name}</p>
+                  <p className="mt-0.5 truncate text-xs text-muted-foreground">
+                    {skill.source} - {formatInstalls(skill.installs)} installs
+                  </p>
+                </div>
+                <Button
+                  variant={skill.isImported ? 'secondary' : 'outline'}
+                  size="sm"
+                  disabled={skill.isImported || importSkill.isPending}
+                  onClick={() => handleImport(skill)}
+                >
+                  {skill.isImported ? 'Imported' : 'Import'}
+                </Button>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SkillEditor({ skill, onBack }: { skill: Skill | null; onBack: () => void }) {
+  const createSkill = useCreateSkill();
+  const updateSkill = useUpdateSkill();
+  const [draft, setDraft] = React.useState<SkillDraft>(() => toDraft(skill));
+
+  React.useEffect(() => {
+    setDraft(toDraft(skill));
+  }, [skill]);
+
+  const isEditing = !!skill;
+  const isSaving = createSkill.isPending || updateSkill.isPending;
+  const canSave =
+    draft.name.trim().length > 0 &&
+    draft.description.trim().length > 0 &&
+    draft.content.trim().length > 0;
+
+  async function handleSave() {
+    const input = {
+      name: draft.name.trim(),
+      description: draft.description.trim(),
+      content: draft.content.trim(),
+    };
+
+    if (skill) {
+      await updateSkill.mutateAsync({ id: skill.id, input });
+    } else {
+      await createSkill.mutateAsync(input);
+    }
+
+    onBack();
+  }
+
+  return (
+    <div className="flex h-[36rem] max-h-[36rem] flex-col overflow-hidden">
+      <div className="mb-6 flex items-center gap-2">
+        <Button variant="ghost" size="icon-sm" onClick={onBack} aria-label="Back to skills">
+          <ArrowLeftIcon className="size-4" />
+        </Button>
+        <div>
+          <h2 className="text-sm font-semibold">{isEditing ? 'Edit Skill' : 'Add Skill'}</h2>
+          <p className="text-xs text-muted-foreground">
+            Markdown instructions the agent can load when a task matches the description.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-5">
+        <div className="grid gap-2">
+          <Label htmlFor="skill-name">Name</Label>
+          <Input
+            id="skill-name"
+            value={draft.name}
+            placeholder="example-skill"
+            onChange={(event) => setDraft((prev) => ({ ...prev, name: event.target.value }))}
+          />
+          <p className="text-xs text-muted-foreground">
+            Lowercase letters, numbers, and single hyphens only. Names must be unique.
+          </p>
+        </div>
+
+        <div className="grid gap-2">
+          <Label htmlFor="skill-description">Description</Label>
+          <Textarea
+            id="skill-description"
+            value={draft.description}
+            rows={3}
+            placeholder="What this skill does and when the agent should use it."
+            onChange={(event) => setDraft((prev) => ({ ...prev, description: event.target.value }))}
+          />
+        </div>
+
+        <div className="grid min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)] gap-2">
+          <Label htmlFor="skill-content">Markdown instructions</Label>
+          <Textarea
+            id="skill-content"
+            value={draft.content}
+            placeholder="# Skill Instructions\n\nDescribe the workflow, constraints, examples, and expected behavior."
+            className="min-h-0 resize-none overflow-auto font-mono text-xs"
+            onChange={(event) => setDraft((prev) => ({ ...prev, content: event.target.value }))}
+          />
+        </div>
+
+        <div className="mt-auto flex justify-end gap-2 border-t border-border/50 pt-4">
+          <Button variant="outline" onClick={onBack} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSave()} disabled={!canSave || isSaving}>
+            {isSaving ? 'Saving...' : 'Save skill'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SkillsSettings() {
+  const { data: skills } = useSuspenseQuery(skillsQueryOptions);
+  const deleteSkill = useDeleteSkill();
+  const [view, setView] = React.useState<SkillView>({ type: 'list' });
+
+  function handleAdd() {
+    setView({ type: 'editor', skill: null });
+  }
+
+  function handleEdit(skill: Skill) {
+    setView({ type: 'editor', skill });
+  }
+
+  function handleDelete(skill: Skill) {
+    const confirmed = window.confirm(`Delete skill "${skill.name}"?`);
+    if (!confirmed) return;
+    deleteSkill.mutate(skill.id);
+  }
+
+  if (view.type === 'editor') {
+    return <SkillEditor skill={view.skill} onBack={() => setView({ type: 'list' })} />;
+  }
+
+  if (view.type === 'import') {
+    return <ImportSkillView onBack={() => setView({ type: 'list' })} />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-semibold">Skills</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Add reusable Markdown instructions the agent can load as a default tool.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => setView({ type: 'import' })}>
+            <DownloadIcon className="size-4" />
+            Import
+          </Button>
+          <Button onClick={handleAdd}>
+            <PlusIcon className="size-4" />
+            Add Skill
+          </Button>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-border/60 bg-card/40">
+        {skills.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center">
+            <p className="text-sm font-medium">No skills yet</p>
+            <p className="max-w-sm text-xs text-muted-foreground">
+              Create a skill with a trigger-focused description and Markdown instructions.
+            </p>
+          </div>
+        ) : (
+          skills.map((skill) => (
+            <div
+              key={skill.id}
+              className="flex items-center justify-between gap-4 border-b border-border/50 px-4 py-3 last:border-b-0"
+            >
+              <button
+                type="button"
+                onClick={() => handleEdit(skill)}
+                className="min-w-0 flex-1 text-left"
+              >
+                <p className="truncate text-sm font-medium">{skill.name}</p>
+                <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                  {skill.description}
+                </p>
+              </button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => handleDelete(skill)}
+                disabled={deleteSkill.isPending}
+                aria-label={`Delete ${skill.name}`}
+              >
+                <Trash2Icon className="size-4" />
+              </Button>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/queries/skills.ts
+++ b/apps/web/src/lib/queries/skills.ts
@@ -1,0 +1,130 @@
+import * as React from 'react';
+import { toast } from 'sonner';
+
+import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type {
+  Skill,
+  SkillCreateInput,
+  SkillImportInput,
+  SkillSearchResult,
+  SkillUpdateInput,
+} from '@stitch/shared/skills/types';
+
+import { serverFetch } from '@/lib/api';
+
+const skillKeys = {
+  all: ['skills'] as const,
+  list: () => [...skillKeys.all, 'list'] as const,
+  search: (query: string) => [...skillKeys.all, 'search', query] as const,
+};
+
+export const skillsQueryOptions = queryOptions({
+  queryKey: skillKeys.list(),
+  staleTime: Infinity,
+  queryFn: async (): Promise<Skill[]> => {
+    const res = await serverFetch('/skills');
+    if (!res.ok) throw new Error('Failed to fetch skills');
+    return res.json() as Promise<Skill[]>;
+  },
+});
+
+export function useSearchSkills(query: string) {
+  const trimmedQuery = query.trim();
+  const [debouncedQuery, setDebouncedQuery] = React.useState(trimmedQuery);
+
+  React.useEffect(() => {
+    const id = setTimeout(() => setDebouncedQuery(trimmedQuery), 300);
+    return () => clearTimeout(id);
+  }, [trimmedQuery]);
+
+  return useQuery({
+    queryKey: skillKeys.search(debouncedQuery),
+    enabled: debouncedQuery.length >= 2,
+    queryFn: async (): Promise<SkillSearchResult[]> => {
+      const res = await serverFetch(`/skills/search?q=${encodeURIComponent(debouncedQuery)}`);
+      if (!res.ok) throw await parseError(res, 'Failed to search skills');
+      return res.json() as Promise<SkillSearchResult[]>;
+    },
+  });
+}
+
+async function parseError(res: Response, fallback: string): Promise<Error> {
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return new Error(body.error ?? fallback);
+}
+
+export function useCreateSkill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: SkillCreateInput) => {
+      const res = await serverFetch('/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+      if (!res.ok) throw await parseError(res, 'Failed to create skill');
+      return res.json() as Promise<Skill>;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: skillKeys.all });
+      toast.success('Skill created');
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+}
+
+export function useUpdateSkill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, input }: { id: string; input: SkillUpdateInput }) => {
+      const res = await serverFetch(`/skills/${id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+      if (!res.ok) throw await parseError(res, 'Failed to update skill');
+      return res.json() as Promise<Skill>;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: skillKeys.all });
+      toast.success('Skill saved');
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+}
+
+export function useDeleteSkill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const res = await serverFetch(`/skills/${id}`, { method: 'DELETE' });
+      if (!res.ok) throw await parseError(res, 'Failed to delete skill');
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: skillKeys.all });
+      toast.success('Skill deleted');
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+}
+
+export function useImportSkill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: SkillImportInput) => {
+      const res = await serverFetch('/skills/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      });
+      if (!res.ok) throw await parseError(res, 'Failed to import skill');
+      return res.json() as Promise<Skill>;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: skillKeys.all });
+      toast.success('Skill imported');
+    },
+    onError: (error: Error) => toast.error(error.message),
+  });
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -47,6 +47,7 @@ const settingsSearchSchema = z.object({
       'providers',
       'models',
       'tools',
+      'skills',
       'mcp-servers',
       'memory',
     ])

--- a/packages/server/__test__/skills/parse-skill-markdown.test.ts
+++ b/packages/server/__test__/skills/parse-skill-markdown.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseSkillMarkdown } from '@/skills/parse-skill-markdown.js';
+
+describe('parseSkillMarkdown', () => {
+  it('parses bare (unquoted) name and description', () => {
+    const md = `---\nname: my-skill\ndescription: Does something useful\n---\n# Body\n`;
+    const result = parseSkillMarkdown(md);
+    expect(result).toEqual({
+      name: 'my-skill',
+      description: 'Does something useful',
+      content: '# Body\n',
+    });
+  });
+
+  it('parses double-quoted name and description', () => {
+    const md = `---\nname: "my-skill"\ndescription: "Does something useful"\n---\nBody\n`;
+    const result = parseSkillMarkdown(md);
+    expect(result).toEqual({
+      name: 'my-skill',
+      description: 'Does something useful',
+      content: 'Body\n',
+    });
+  });
+
+  it('parses single-quoted name and description', () => {
+    const md = `---\nname: 'my-skill'\ndescription: 'Does something useful'\n---\nBody\n`;
+    const result = parseSkillMarkdown(md);
+    expect(result).toEqual({
+      name: 'my-skill',
+      description: 'Does something useful',
+      content: 'Body\n',
+    });
+  });
+
+  it('unescapes \\\" inside double-quoted description (real skills.sh case)', () => {
+    const md = `---\nname: grill-me\ndescription: "Interview the user relentlessly until reaching shared understanding, resolving each branch. Use when user wants to \\"grill me\\"."\n---\n\nBody\n`;
+    const result = parseSkillMarkdown(md);
+    expect(result?.description).toContain('"grill me"');
+    expect(result?.name).toBe('grill-me');
+  });
+
+  it('parses description with colon in bare value', () => {
+    const md = `---\nname: my-skill\ndescription: Use this skill: it does things\n---\n\nBody\n`;
+    const result = parseSkillMarkdown(md);
+    expect(result?.description).toBe('Use this skill: it does things');
+  });
+
+  it('parses description with double-quote characters in bare value', () => {
+    const md = `---\nname: grill-me\ndescription: Interview until "shared understanding" is reached\n---\n\nBody\n`;
+    const result = parseSkillMarkdown(md);
+    expect(result?.description).toBe('Interview until "shared understanding" is reached');
+  });
+
+  it('preserves multiline body content', () => {
+    const md = `---\nname: my-skill\ndescription: A skill\n---\n# Step 1\n\nDo a thing.\n\n# Step 2\n\nDo another thing.\n`;
+    const result = parseSkillMarkdown(md);
+    expect(result?.content).toBe('# Step 1\n\nDo a thing.\n\n# Step 2\n\nDo another thing.\n');
+  });
+
+  it('handles CRLF line endings', () => {
+    const md = `---\r\nname: my-skill\r\ndescription: A skill\r\n---\r\n\r\nBody\r\n`;
+    const result = parseSkillMarkdown(md);
+    expect(result?.name).toBe('my-skill');
+    expect(result?.description).toBe('A skill');
+  });
+
+  it('returns null when frontmatter block is missing', () => {
+    expect(parseSkillMarkdown('# No frontmatter\n\nJust a body.')).toBeNull();
+  });
+
+  it('returns null when name is missing', () => {
+    const md = `---\ndescription: A skill\n---\n\nBody\n`;
+    expect(parseSkillMarkdown(md)).toBeNull();
+  });
+
+  it('returns null when description is missing', () => {
+    const md = `---\nname: my-skill\n---\n\nBody\n`;
+    expect(parseSkillMarkdown(md)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(parseSkillMarkdown('')).toBeNull();
+  });
+
+  it('parses content as empty string when body is absent', () => {
+    const md = `---\nname: my-skill\ndescription: A skill\n---\n`;
+    const result = parseSkillMarkdown(md);
+    expect(result?.content).toBe('');
+  });
+});

--- a/packages/server/drizzle/0022_wise_blue_blade.sql
+++ b/packages/server/drizzle/0022_wise_blue_blade.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `skills` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text NOT NULL,
+	`content` text NOT NULL,
+	`hash` text NOT NULL,
+	`is_external` integer DEFAULT false NOT NULL,
+	`source` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `skills_name_uidx` ON `skills` (`name`);--> statement-breakpoint
+CREATE UNIQUE INDEX `skills_hash_uidx` ON `skills` (`hash`);

--- a/packages/server/drizzle/meta/0022_snapshot.json
+++ b/packages/server/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,2590 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "08090a39-aceb-4fca-baac-33e8af6c3bd4",
+  "prevId": "c343dda7-de35-4605-a374-759b7314fe6e",
+  "tables": {
+    "agenda_item_events": {
+      "name": "agenda_item_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_item_events_item_id_idx": {
+          "name": "agenda_item_events_item_id_idx",
+          "columns": ["item_id"],
+          "isUnique": false
+        },
+        "agenda_item_events_created_at_idx": {
+          "name": "agenda_item_events_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_item_events_item_id_agenda_items_id_fk": {
+          "name": "agenda_item_events_item_id_agenda_items_id_fk",
+          "tableFrom": "agenda_item_events",
+          "tableTo": "agenda_items",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_item_events_type_check": {
+          "name": "agenda_item_events_type_check",
+          "value": "\"agenda_item_events\".\"type\" in ('created', 'status_change', 'updated', 'comment')"
+        }
+      }
+    },
+    "agenda_items": {
+      "name": "agenda_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'todo'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_items_list_id_idx": {
+          "name": "agenda_items_list_id_idx",
+          "columns": ["list_id"],
+          "isUnique": false
+        },
+        "agenda_items_status_idx": {
+          "name": "agenda_items_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "agenda_items_due_at_idx": {
+          "name": "agenda_items_due_at_idx",
+          "columns": ["due_at"],
+          "isUnique": false
+        },
+        "agenda_items_created_at_idx": {
+          "name": "agenda_items_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_items_list_id_agenda_lists_id_fk": {
+          "name": "agenda_items_list_id_agenda_lists_id_fk",
+          "tableFrom": "agenda_items",
+          "tableTo": "agenda_lists",
+          "columnsFrom": ["list_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_items_type_check": {
+          "name": "agenda_items_type_check",
+          "value": "\"agenda_items\".\"type\" in ('todo', 'reminder', 'checkup')"
+        },
+        "agenda_items_status_check": {
+          "name": "agenda_items_status_check",
+          "value": "\"agenda_items\".\"status\" in ('open', 'in_progress', 'done', 'cancelled')"
+        },
+        "agenda_items_priority_check": {
+          "name": "agenda_items_priority_check",
+          "value": "\"agenda_items\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      }
+    },
+    "agenda_lists": {
+      "name": "agenda_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_lists_name_uidx": {
+          "name": "agenda_lists_name_uidx",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "agenda_lists_created_at_idx": {
+          "name": "agenda_lists_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "auth_issue": {
+          "name": "auth_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": ["connector_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lance_migrations": {
+      "name": "lance_migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "prev_id": {
+          "name": "prev_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'applied'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "is_attributable": {
+          "name": "is_attributable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_index": {
+          "name": "attempt_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_run_id_idx": {
+          "name": "llm_usage_events_run_id_idx",
+          "columns": ["run_id"],
+          "isUnique": false
+        },
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ollama_models": {
+      "name": "ollama_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_limit": {
+          "name": "input_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_limit": {
+          "name": "output_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_cost_per_million": {
+          "name": "input_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_cost_per_million": {
+          "name": "output_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_cost_per_million": {
+          "name": "cache_read_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_per_million": {
+          "name": "cache_write_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_tool_calls": {
+          "name": "supports_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_vision": {
+          "name": "supports_vision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_reasoning": {
+          "name": "supports_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permission_responses": {
+      "name": "permission_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_reminder": {
+          "name": "system_reminder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_responses_session_id_sessions_id_fk": {
+          "name": "permission_responses_session_id_sessions_id_fk",
+          "tableFrom": "permission_responses",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_messages": {
+      "name": "queued_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "queued_messages_session_id_sessions_id_fk": {
+          "name": "queued_messages_session_id_sessions_id_fk",
+          "tableFrom": "queued_messages",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_analyses": {
+      "name": "recording_analyses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topics": {
+          "name": "topics",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_sections": {
+          "name": "topic_sections",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "action_items": {
+          "name": "action_items",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blockers": {
+          "name": "blockers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_provider_id": {
+          "name": "transcription_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_model_id": {
+          "name": "transcription_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_provider_id": {
+          "name": "analysis_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_model_id": {
+          "name": "analysis_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recording_analyses_recording_id_uidx": {
+          "name": "recording_analyses_recording_id_uidx",
+          "columns": ["recording_id"],
+          "isUnique": true
+        },
+        "recording_analyses_status_idx": {
+          "name": "recording_analyses_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recording_analyses_recording_id_recordings_id_fk": {
+          "name": "recording_analyses_recording_id_recordings_id_fk",
+          "tableFrom": "recording_analyses",
+          "tableTo": "recordings",
+          "columnsFrom": ["recording_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recording_analyses_status_check": {
+          "name": "recording_analyses_status_check",
+          "value": "\"recording_analyses\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "recordings": {
+      "name": "recordings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'recording'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'audio/ogg'"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recordings_created_at_idx": {
+          "name": "recordings_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "recordings_status_idx": {
+          "name": "recordings_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recordings_status_check": {
+          "name": "recordings_status_check",
+          "value": "\"recordings\".\"status\" in ('recording', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": ["job_id"],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": ["key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "queue_enabled": {
+          "name": "queue_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": ["key"],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": ["next_run_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "session_todos": {
+      "name": "session_todos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_todos_session_id_idx": {
+          "name": "session_todos_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        },
+        "session_todos_order_idx": {
+          "name": "session_todos_order_idx",
+          "columns": ["session_id", "sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_todos_session_id_sessions_id_fk": {
+          "name": "session_todos_session_id_sessions_id_fk",
+          "tableFrom": "session_todos",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "active_toolset_ids": {
+          "name": "active_toolset_ids",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_automation_id_automations_id_fk": {
+          "name": "sessions_automation_id_automations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "automations",
+          "columnsFrom": ["automation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": ["parent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_external": {
+          "name": "is_external",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "skills_name_uidx": {
+          "name": "skills_name_uidx",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "skills_hash_uidx": {
+          "name": "skills_hash_uidx",
+          "columns": ["hash"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_enabled": {
+      "name": "tool_enabled",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_enabled_scope_identifier_uidx": {
+          "name": "tool_enabled_scope_identifier_uidx",
+          "columns": ["scope", "identifier"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": ["tool_name", "pattern"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1778973792670,
       "tag": "0021_stale_micromax",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1778977588099,
+      "tag": "0022_wise_blue_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -45,6 +45,7 @@ import type {
 } from '@stitch/shared/recordings/types';
 import type { SettingsKey } from '@stitch/shared/settings/types';
 import type { ShortcutActionId, ShortcutCategory } from '@stitch/shared/shortcuts/types';
+import type { SkillId } from '@stitch/shared/skills/types';
 
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import type { LanguageModelUsage } from 'ai';
@@ -331,6 +332,29 @@ export const toolEnabled = sqliteTable(
       .$defaultFn(() => Date.now()),
   },
   (table) => [uniqueIndex('tool_enabled_scope_identifier_uidx').on(table.scope, table.identifier)],
+);
+
+export const skills = sqliteTable(
+  'skills',
+  {
+    id: text('id').$type<SkillId>().primaryKey(),
+    name: text('name').notNull(),
+    description: text('description').notNull(),
+    content: text('content').notNull(),
+    hash: text('hash').notNull(),
+    isExternal: integer('is_external', { mode: 'boolean' }).notNull().default(false),
+    source: text('source'),
+    createdAt: integer('created_at', { mode: 'number' })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+    updatedAt: integer('updated_at', { mode: 'number' })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (table) => [
+    uniqueIndex('skills_name_uidx').on(table.name),
+    uniqueIndex('skills_hash_uidx').on(table.hash),
+  ],
 );
 
 export const mcpServers = sqliteTable('mcp_servers', {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -24,6 +24,7 @@ import { queueRouter } from '@/routes/queue.js';
 import { recordingsRouter } from '@/routes/recordings.js';
 import { settingsRouter } from '@/routes/settings.js';
 import { shortcutsRouter } from '@/routes/shortcuts.js';
+import { skillsRouter } from '@/routes/skills.js';
 import { usageRouter } from '@/routes/usage.js';
 import { registerShutdownHandlers } from '@/shutdown.js';
 
@@ -67,6 +68,7 @@ app.route('/llm/models', modelsRouter);
 app.route('/llm/provider', providerRouter);
 app.route('/llm/ollama/models', ollamaModelsRouter);
 app.route('/settings', settingsRouter);
+app.route('/skills', skillsRouter);
 app.route('/recordings', recordingsRouter);
 app.route('/shortcuts', shortcutsRouter);
 app.route('/usage', usageRouter);

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -29,6 +29,7 @@ import {
 } from '@/llm/stream/session-toolsets.js';
 import { executeStepWithRetry, type StepOptions } from '@/llm/stream/step-executor.js';
 import { processMemories } from '@/memory/processor.js';
+import { buildSkillsSystemPrompt } from '@/skills/service.js';
 import { createTaskTool } from '@/tools/core/task.js';
 import { createToolsetTools } from '@/tools/core/toolset-management.js';
 import { createTools, MAX_STEPS, MAX_STEPS_WARNING } from '@/tools/runtime/registry.js';
@@ -1358,10 +1359,13 @@ export async function runStream(opts: {
   const messages = opts.llmMessages;
   const codeModePrompt = codeModeResult.getSystemPrompt();
   const toolsetsPrompt = await buildAvailableToolsetsPrompt(toolsetManager);
+  const skillsPrompt = await buildSkillsSystemPrompt();
   if (messages.length > 0 && messages[0]?.role === 'system') {
     const sysMsg = messages[0];
     const existingContent = typeof sysMsg.content === 'string' ? sysMsg.content : '';
-    const promptAdditions = [codeModePrompt, toolsetsPrompt].filter(Boolean).join('\n\n');
+    const promptAdditions = [codeModePrompt, toolsetsPrompt, skillsPrompt]
+      .filter(Boolean)
+      .join('\n\n');
     messages[0] = {
       role: 'system',
       content: `${existingContent}\n\n${promptAdditions}`,

--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -1,0 +1,63 @@
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import { z } from 'zod';
+
+import {
+  createSkillSchema,
+  importSkillSchema,
+  updateSkillSchema,
+} from '@stitch/shared/skills/types';
+import type { SkillId } from '@stitch/shared/skills/types';
+
+import { unwrapResult } from '@/lib/route-helpers.js';
+import {
+  createSkill,
+  deleteSkill,
+  importSkillFromDirectory,
+  listSkills,
+  searchSkillsDirectory,
+  updateSkill,
+} from '@/skills/service.js';
+
+const skillIdSchema = z.object({ id: z.string().min(1) });
+const searchSkillsSchema = z.object({ q: z.string().default('') });
+
+export const skillsRouter = new Hono();
+
+skillsRouter.get('/', async (c) => {
+  const result = await listSkills();
+  return unwrapResult(c, result);
+});
+
+skillsRouter.get('/search', zValidator('query', searchSkillsSchema), async (c) => {
+  const { q } = c.req.valid('query');
+  const result = await searchSkillsDirectory(q);
+  return unwrapResult(c, result);
+});
+
+skillsRouter.post('/', zValidator('json', createSkillSchema), async (c) => {
+  const result = await createSkill(c.req.valid('json'));
+  return unwrapResult(c, result, 201);
+});
+
+skillsRouter.post('/import', zValidator('json', importSkillSchema), async (c) => {
+  const result = await importSkillFromDirectory(c.req.valid('json'));
+  return unwrapResult(c, result, 201);
+});
+
+skillsRouter.put(
+  '/:id',
+  zValidator('param', skillIdSchema),
+  zValidator('json', updateSkillSchema),
+  async (c) => {
+    const { id } = c.req.valid('param');
+    const result = await updateSkill(id as SkillId, c.req.valid('json'));
+    return unwrapResult(c, result);
+  },
+);
+
+skillsRouter.delete('/:id', zValidator('param', skillIdSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  const result = await deleteSkill(id as SkillId);
+  return unwrapResult(c, result, 204);
+});

--- a/packages/server/src/skills/parse-skill-markdown.ts
+++ b/packages/server/src/skills/parse-skill-markdown.ts
@@ -1,0 +1,36 @@
+import type { SkillCreateInput } from '@stitch/shared/skills/types';
+
+/**
+ * Parse a SKILL.md string into a SkillCreateInput.
+ *
+ * Handles all three YAML scalar styles for `name` and `description`:
+ *   - Double-quoted:  description: "foo \"bar\" baz"
+ *   - Single-quoted:  description: 'foo bar'
+ *   - Bare:           description: foo bar
+ *
+ * Returns null if the frontmatter block is missing or either required
+ * field cannot be extracted.
+ */
+export function parseSkillMarkdown(markdown: string): SkillCreateInput | null {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(markdown);
+  if (!match) return null;
+
+  const frontmatter = match[1] ?? '';
+  const content = (match[2] ?? '').replace(/^\n/, '');
+
+  const nameMatch =
+    /^name:\s*"((?:[^"\\]|\\.)*)"\s*$/m.exec(frontmatter) ??
+    /^name:\s*'((?:[^'\\]|\\.)*)'\s*$/m.exec(frontmatter) ??
+    /^name:\s*(.+?)\s*$/m.exec(frontmatter);
+
+  const descMatch =
+    /^description:\s*"((?:[^"\\]|\\.)*)"\s*$/m.exec(frontmatter) ??
+    /^description:\s*'((?:[^'\\]|\\.)*)'\s*$/m.exec(frontmatter) ??
+    /^description:\s*(.+?)\s*$/m.exec(frontmatter);
+
+  const name = nameMatch?.[1]?.replace(/\\"/g, '"').replace(/\\'/g, "'").trim();
+  const description = descMatch?.[1]?.replace(/\\"/g, '"').replace(/\\'/g, "'").trim();
+
+  if (!name || !description) return null;
+  return { name, description, content };
+}

--- a/packages/server/src/skills/service.ts
+++ b/packages/server/src/skills/service.ts
@@ -1,0 +1,344 @@
+import { and, eq, inArray, ne, or } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
+
+import { createSkillId } from '@stitch/shared/id';
+import {
+  createSkillSchema,
+  importSkillSchema,
+  updateSkillSchema,
+} from '@stitch/shared/skills/types';
+import type {
+  Skill,
+  SkillCreateInput,
+  SkillId,
+  SkillImportInput,
+  SkillSearchResult,
+  SkillUpdateInput,
+} from '@stitch/shared/skills/types';
+
+import { getDb, isDbInitialized } from '@/db/client.js';
+import { skills } from '@/db/schema.js';
+import * as Log from '@/lib/log.js';
+import { err, ok } from '@/lib/service-result.js';
+import type { ServiceResult } from '@/lib/service-result.js';
+import { parseSkillMarkdown } from '@/skills/parse-skill-markdown.js';
+
+const log = Log.create({ service: 'skills' });
+
+type SkillsSearchApiResponse = {
+  skills?: Array<{
+    id?: unknown;
+    name?: unknown;
+    installs?: unknown;
+    source?: unknown;
+  }>;
+};
+
+type SkillsDownloadResponse = {
+  files?: Array<{
+    path?: unknown;
+    contents?: unknown;
+  }>;
+  hash?: unknown;
+};
+
+const SKILLS_API_BASE = 'https://skills.sh';
+const FETCH_TIMEOUT_MS = 10_000;
+
+function normalizeSkillValue(value: string): string {
+  return value.trim();
+}
+
+function computeSkillHash(input: SkillCreateInput): string {
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        name: normalizeSkillValue(input.name),
+        description: normalizeSkillValue(input.description),
+        content: normalizeSkillValue(input.content),
+      }),
+      'utf8',
+    )
+    .digest('hex');
+}
+
+function toSourceKey(source: string, slug: string): string {
+  return `${source.trim().toLowerCase()}/${slug.trim().toLowerCase()}`;
+}
+
+async function skillHashExists(hash: string, exceptId?: SkillId): Promise<boolean> {
+  const query = exceptId
+    ? getDb()
+        .select({ id: skills.id })
+        .from(skills)
+        .where(and(eq(skills.hash, hash), ne(skills.id, exceptId)))
+    : getDb().select({ id: skills.id }).from(skills).where(eq(skills.hash, hash));
+
+  const existing = query.get();
+  return !!existing;
+}
+
+export async function listSkills(): Promise<ServiceResult<Skill[]>> {
+  const rows = await getDb().select().from(skills).orderBy(skills.name);
+  return ok(rows);
+}
+
+export async function getSkillByName(name: string): Promise<ServiceResult<Skill>> {
+  const skill = getDb().select().from(skills).where(eq(skills.name, name)).get();
+  if (!skill) return err(`Skill "${name}" not found`, 404);
+  return ok(skill);
+}
+
+async function skillNameExists(name: string, exceptId?: SkillId): Promise<boolean> {
+  const query = exceptId
+    ? getDb()
+        .select({ id: skills.id })
+        .from(skills)
+        .where(and(eq(skills.name, name), ne(skills.id, exceptId)))
+    : getDb().select({ id: skills.id }).from(skills).where(eq(skills.name, name));
+
+  const existing = query.get();
+  return !!existing;
+}
+
+export async function createSkill(input: SkillCreateInput): Promise<ServiceResult<Skill>> {
+  const parsed = createSkillSchema.safeParse(input);
+  if (!parsed.success) return err(parsed.error.issues[0]?.message ?? 'Invalid skill', 400);
+
+  const value = parsed.data;
+  if (await skillNameExists(value.name)) {
+    return err(`Skill name "${value.name}" already exists`, 409);
+  }
+
+  const now = Date.now();
+  const row = {
+    id: createSkillId(),
+    name: value.name,
+    description: value.description.trim(),
+    content: value.content.trim(),
+    hash: computeSkillHash(value),
+    isExternal: false,
+    source: null,
+    createdAt: now,
+    updatedAt: now,
+  } satisfies Skill;
+
+  if (await skillHashExists(row.hash)) {
+    return err('A skill with the same instructions already exists', 409);
+  }
+
+  await getDb().insert(skills).values(row);
+  return ok(row);
+}
+
+export async function updateSkill(
+  id: SkillId,
+  input: SkillUpdateInput,
+): Promise<ServiceResult<Skill>> {
+  const parsed = updateSkillSchema.safeParse(input);
+  if (!parsed.success) return err(parsed.error.issues[0]?.message ?? 'Invalid skill', 400);
+
+  const existing = getDb().select({ id: skills.id }).from(skills).where(eq(skills.id, id)).get();
+  if (!existing) return err('Skill not found', 404);
+
+  const value = parsed.data;
+  if (await skillNameExists(value.name, id)) {
+    return err(`Skill name "${value.name}" already exists`, 409);
+  }
+
+  const hash = computeSkillHash(value);
+  if (await skillHashExists(hash, id)) {
+    return err('A skill with the same instructions already exists', 409);
+  }
+
+  const updatedAt = Date.now();
+  const [updated] = await getDb()
+    .update(skills)
+    .set({
+      name: value.name,
+      description: value.description.trim(),
+      content: value.content.trim(),
+      hash,
+      updatedAt,
+    })
+    .where(eq(skills.id, id))
+    .returning();
+
+  if (!updated) return err('Skill not found', 404);
+  return ok(updated);
+}
+
+export async function deleteSkill(id: SkillId): Promise<ServiceResult<null>> {
+  const deleted = await getDb()
+    .delete(skills)
+    .where(eq(skills.id, id))
+    .returning({ id: skills.id });
+  if (deleted.length === 0) return err('Skill not found', 404);
+  return ok(null);
+}
+
+export async function searchSkillsDirectory(
+  query: string,
+): Promise<ServiceResult<SkillSearchResult[]>> {
+  const trimmedQuery = query.trim();
+  if (trimmedQuery.length < 2) return ok([]);
+
+  try {
+    const url = `${SKILLS_API_BASE}/api/search?q=${encodeURIComponent(trimmedQuery)}&limit=10`;
+    const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      log.error({ url, status: response.status, body }, 'skills.sh search request failed');
+      return err('Failed to search skills directory', 500);
+    }
+
+    const body = (await response.json()) as SkillsSearchApiResponse;
+    const results = (body.skills ?? [])
+      .flatMap((skill): SkillSearchResult[] => {
+        if (
+          typeof skill.id !== 'string' ||
+          typeof skill.name !== 'string' ||
+          typeof skill.source !== 'string'
+        ) {
+          return [];
+        }
+
+        return [
+          {
+            name: skill.name,
+            slug: skill.id,
+            source: skill.source,
+            installs: typeof skill.installs === 'number' ? skill.installs : 0,
+            isImported: false,
+          },
+        ];
+      })
+      .sort((a, b) => b.installs - a.installs);
+
+    const sourceKeys = results.map((skill) => toSourceKey(skill.source, skill.slug));
+    if (sourceKeys.length === 0) return ok(results);
+
+    const existing = await getDb()
+      .select({ source: skills.source })
+      .from(skills)
+      .where(inArray(skills.source, sourceKeys));
+    const importedSources = new Set(
+      existing.flatMap((skill) => (skill.source ? [skill.source] : [])),
+    );
+
+    return ok(
+      results.map((skill) => ({
+        ...skill,
+        isImported: importedSources.has(toSourceKey(skill.source, skill.slug)),
+      })),
+    );
+  } catch (error) {
+    log.error({ error, query: trimmedQuery }, 'skills.sh search threw');
+    return err('Failed to search skills directory', 500);
+  }
+}
+
+export async function importSkillFromDirectory(
+  input: SkillImportInput,
+): Promise<ServiceResult<Skill>> {
+  const parsed = importSkillSchema.safeParse(input);
+  if (!parsed.success) return err(parsed.error.issues[0]?.message ?? 'Invalid skill import', 400);
+
+  const { source, slug } = parsed.data;
+  if (!source.includes('/')) return err('Skill source must be an owner/repo value', 400);
+
+  const sourceKey = toSourceKey(source, slug);
+  const existingSource = getDb().select().from(skills).where(eq(skills.source, sourceKey)).get();
+  if (existingSource) return ok(existingSource);
+
+  try {
+    const encodedSlug = slug.split('/').map(encodeURIComponent).join('/');
+    const url = `${SKILLS_API_BASE}/api/download/${encodedSlug}`;
+    const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      log.error(
+        { url, status: response.status, body, source, slug },
+        'skills.sh download request failed',
+      );
+      return err('Failed to download skill', 500);
+    }
+
+    const body = (await response.json()) as SkillsDownloadResponse;
+    const skillFile = (body.files ?? []).find(
+      (file) => typeof file.path === 'string' && file.path.toLowerCase().endsWith('skill.md'),
+    );
+    if (!skillFile || typeof skillFile.contents !== 'string') {
+      log.error(
+        {
+          source,
+          slug,
+          fileCount: body.files?.length ?? 0,
+          filePaths: (body.files ?? []).map((f) => f.path),
+        },
+        'downloaded skill missing SKILL.md',
+      );
+      return err('Downloaded skill did not include a SKILL.md file', 422);
+    }
+
+    const skillInput = parseSkillMarkdown(skillFile.contents);
+    if (!skillInput) {
+      log.error(
+        { source, slug, contents: skillFile.contents.slice(0, 500) },
+        'SKILL.md frontmatter parse failed',
+      );
+      return err('Downloaded skill has invalid frontmatter', 422);
+    }
+
+    const createParsed = createSkillSchema.safeParse(skillInput);
+    if (!createParsed.success) {
+      log.error(
+        { source, slug, issues: createParsed.error.issues },
+        'downloaded skill failed schema validation',
+      );
+      return err(createParsed.error.issues[0]?.message ?? 'Downloaded skill is invalid', 422);
+    }
+
+    const value = createParsed.data;
+    if (await skillNameExists(value.name)) {
+      return err(`Skill name "${value.name}" already exists`, 409);
+    }
+
+    const hash = computeSkillHash(value);
+    const existingHash = getDb()
+      .select({ id: skills.id })
+      .from(skills)
+      .where(or(eq(skills.hash, hash), eq(skills.source, sourceKey)))
+      .get();
+    if (existingHash) return err('A skill with the same instructions already exists', 409);
+
+    const now = Date.now();
+    const row = {
+      id: createSkillId(),
+      name: value.name,
+      description: value.description.trim(),
+      content: value.content.trim(),
+      hash,
+      isExternal: true,
+      source: sourceKey,
+      createdAt: now,
+      updatedAt: now,
+    } satisfies Skill;
+
+    await getDb().insert(skills).values(row);
+    return ok(row);
+  } catch (error) {
+    log.error({ error, source, slug }, 'skills.sh import threw');
+    return err('Failed to import skill', 500);
+  }
+}
+
+export async function buildSkillsSystemPrompt(): Promise<string> {
+  if (!isDbInitialized()) return '';
+
+  const result = await listSkills();
+  if ('error' in result || result.data.length === 0) return '';
+
+  const lines = result.data.map((skill) => `- ${skill.name}: ${skill.description}`);
+  return `Available skills provide task-specific instructions. Use the \`skill\` tool to load a skill when the user's request matches its description.\n\n${lines.join('\n')}`;
+}

--- a/packages/server/src/tools/core/skill.ts
+++ b/packages/server/src/tools/core/skill.ts
@@ -1,0 +1,28 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+
+import { getSkillByName } from '@/skills/service.js';
+
+export const DISPLAY_NAME = 'Skills';
+
+const skillInputSchema = z.object({
+  name: z.string().min(1).describe('The exact skill name to load'),
+});
+
+export function createRegisteredTool() {
+  return tool({
+    description:
+      'Load task-specific skill instructions by name. Use this when the available skills list says a skill matches the user request.',
+    inputSchema: skillInputSchema,
+    execute: async ({ name }) => {
+      const result = await getSkillByName(name);
+      if ('error' in result) return { error: result.error };
+
+      return {
+        name: result.data.name,
+        description: result.data.description,
+        content: result.data.content,
+      };
+    },
+  });
+}

--- a/packages/server/src/tools/runtime/registry.ts
+++ b/packages/server/src/tools/runtime/registry.ts
@@ -34,6 +34,10 @@ import {
   DISPLAY_NAME as READ_DISPLAY_NAME,
 } from '@/tools/core/read.js';
 import {
+  createRegisteredTool as createSkillRegisteredTool,
+  DISPLAY_NAME as SKILL_DISPLAY_NAME,
+} from '@/tools/core/skill.js';
+import {
   createRegisteredTool as createTodoRegisteredTool,
   DISPLAY_NAME as TODO_DISPLAY_NAME,
 } from '@/tools/core/todo.js';
@@ -96,15 +100,20 @@ const STITCH_TOOL_MODULES = {
     displayName: TODO_DISPLAY_NAME,
     createRegisteredTool: createTodoRegisteredTool,
   },
+  skill: {
+    displayName: SKILL_DISPLAY_NAME,
+    createRegisteredTool: createSkillRegisteredTool,
+    alwaysActive: true,
+  },
 } as const;
 
-export const STITCH_KNOWN_TOOLS: KnownTool[] = Object.entries(STITCH_TOOL_MODULES).map(
-  ([name, mod]) => ({
+export const STITCH_KNOWN_TOOLS: KnownTool[] = Object.entries(STITCH_TOOL_MODULES)
+  .filter(([, mod]) => !('alwaysActive' in mod && mod.alwaysActive))
+  .map(([name, mod]) => ({
     toolType: 'stitch',
     toolName: name,
     displayName: mod.displayName,
-  }),
-);
+  }));
 
 export async function createTools(context: {
   sessionId: PrefixedString<'ses'>;
@@ -133,7 +142,9 @@ export async function createTools(context: {
   });
 
   const disabledTools = await getDisabledToolIdentifiers('tool');
-  const enabledToolEntries = toolEntries.filter(([name]) => !disabledTools.has(name));
+  const enabledToolEntries = toolEntries.filter(
+    ([name, mod]) => ('alwaysActive' in mod && mod.alwaysActive) || !disabledTools.has(name),
+  );
 
   return withToolResultHandlingRecord(
     Object.fromEntries(

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,6 +28,7 @@
     "./connectors/types": "./src/connectors/types.ts",
     "./memory/types": "./src/memory/types.ts",
     "./agenda/types": "./src/agenda/types.ts",
+    "./skills/types": "./src/skills/types.ts",
     "./logger": "./src/logger.ts"
   },
   "scripts": {

--- a/packages/shared/src/id/index.ts
+++ b/packages/shared/src/id/index.ts
@@ -20,6 +20,7 @@ export const ID_PREFIXES = {
   agendaItem: 'aitm',
   agendaItemEvent: 'aevt',
   todo: 'todo',
+  skill: 'skill',
 } as const;
 
 export type IdPrefix = (typeof ID_PREFIXES)[keyof typeof ID_PREFIXES];
@@ -84,6 +85,7 @@ export const createAgendaListId = createIdFactory(ID_PREFIXES.agendaList);
 export const createAgendaItemId = createIdFactory(ID_PREFIXES.agendaItem);
 export const createAgendaItemEventId = createIdFactory(ID_PREFIXES.agendaItemEvent);
 export const createTodoId = createIdFactory(ID_PREFIXES.todo);
+export const createSkillId = createIdFactory(ID_PREFIXES.skill);
 
 export function extractTimestamp(id: string): number {
   const prefix = id.split('_')[0];

--- a/packages/shared/src/skills/types.ts
+++ b/packages/shared/src/skills/types.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+
+import type { PrefixedString } from '@stitch/shared/id';
+
+export type SkillId = PrefixedString<'skill'>;
+
+export type Skill = {
+  id: SkillId;
+  name: string;
+  description: string;
+  content: string;
+  hash: string;
+  isExternal: boolean;
+  source: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type SkillSearchResult = {
+  name: string;
+  slug: string;
+  source: string;
+  installs: number;
+  isImported: boolean;
+};
+
+const SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const skillNameSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(
+    SKILL_NAME_PATTERN,
+    'Use lowercase letters, numbers, and single hyphens only. Do not start or end with a hyphen.',
+  );
+
+const skillDescriptionSchema = z.string().trim().min(1).max(1024);
+
+const skillContentSchema = z.string().trim().min(1);
+
+export const createSkillSchema = z.object({
+  name: skillNameSchema,
+  description: skillDescriptionSchema,
+  content: skillContentSchema,
+});
+
+export const updateSkillSchema = createSkillSchema.extend({});
+
+export const importSkillSchema = z.object({
+  source: z.string().trim().min(1),
+  name: z.string().trim().min(1),
+  slug: z.string().trim().min(1),
+});
+
+export type SkillCreateInput = z.infer<typeof createSkillSchema>;
+export type SkillUpdateInput = z.infer<typeof updateSkillSchema>;
+export type SkillImportInput = z.infer<typeof importSkillSchema>;


### PR DESCRIPTION
## 🚀 Change Summary

Introduces a complete agent skills system with a built-in directory search and one-click import from skills.sh.

### ✨ New Features

- **Agent Skills**: Store named Markdown instruction sets in the DB. The agent's system prompt is extended with available skill names/descriptions, and it can call the always-active \skill\ tool to load full instructions when a task matches.
- **Skills Settings UI**: New Settings → Skills section with inline Add, Edit, and Import subviews (Back button navigation, matching existing settings patterns).
- **skills.sh Import**: Search the public agent skills directory and import any skill in one click. Duplicate detection prevents re-importing the same skill by source key or content hash.

### 🛠 Improvements & Refactors

- \parseSkillMarkdown\ extracted into its own module with full test coverage (bare, double-quoted, single-quoted YAML scalars, escaped quotes, CRLF, missing fields).
- Skills DB table includes \hash\, \is_external\, and \source\ for provenance tracking and deduplication. Migration \