### PR TITLE
fix(logs): replace custom logger with pino + pino-roll

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/desktop": {
       "name": "@stitch/desktop",
-      "version": "0.3.6",
+      "version": "0.3.9",
       "dependencies": {
         "electron-updater": "^6.8.3",
         "tree-kill": "1.2.2",
@@ -29,7 +29,7 @@
     },
     "apps/web": {
       "name": "@stitch/web",
-      "version": "0.3.6",
+      "version": "0.3.9",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@stitch/shared": "workspace:*",
@@ -158,6 +158,8 @@
         "drizzle-orm": "^0.45.1",
         "glob": "13.0.6",
         "hono": "^4.12.7",
+        "pino": "^10.3.1",
+        "pino-roll": "^4.0.0",
         "quickjs-emscripten-core": "^0.32.0",
         "turndown": "^7.2.2",
         "zod": "catalog:",
@@ -167,6 +169,7 @@
         "@types/node": "^25.5.0",
         "@types/turndown": "^5.0.6",
         "drizzle-kit": "^0.31.9",
+        "pino-pretty": "^13.1.3",
         "typescript": "catalog:",
         "vitest": "catalog:testing",
       },
@@ -713,6 +716,8 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-xkE7puteDS/vUyRngLXW0t8WgdWoS/tfxXjhP/P7SMqPDx+hs44SpssO3h3qmTqECYEuXBUPzcAw5257Ka+ofA=="],
 
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
@@ -1127,6 +1132,8 @@
 
     "at-least-node": ["at-least-node@1.0.0", "", {}, "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="],
 
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
     "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.12", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig=="],
@@ -1245,6 +1252,8 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
@@ -1294,6 +1303,8 @@
     "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "date-fns-jalali": ["date-fns-jalali@4.1.0-0", "", {}, "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="],
+
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -1443,11 +1454,15 @@
 
     "extsprintf": ["extsprintf@1.4.1", "", {}, "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="],
 
+    "fast-copy": ["fast-copy@4.0.3", "", {}, "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
@@ -1577,6 +1592,8 @@
 
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
     "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
 
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "^6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
@@ -1678,6 +1695,8 @@
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
@@ -1949,6 +1968,8 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -2017,6 +2038,16 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
+
+    "pino-roll": ["pino-roll@4.0.0", "", { "dependencies": { "date-fns": "^4.1.0", "sonic-boom": "^4.0.1" } }, "sha512-axI1aQaIxXdw1F4OFFli1EDxIrdYNGLowkw/ZoZogX8oCSLHUghzwVVXUS8U+xD/Savwa5IXpiXmsSGKFX/7Sg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
@@ -2034,6 +2065,8 @@
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
     "proc-log": ["proc-log@5.0.0", "", {}, "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ=="],
+
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
@@ -2054,6 +2087,8 @@
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
 
@@ -2086,6 +2121,8 @@
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
@@ -2147,6 +2184,8 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "sanitize-filename": ["sanitize-filename@1.6.4", "", { "dependencies": { "truncate-utf8-bytes": "^1.0.0" } }, "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg=="],
@@ -2154,6 +2193,8 @@
     "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -2205,6 +2246,8 @@
 
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
@@ -2214,6 +2257,8 @@
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
@@ -2278,6 +2323,8 @@
     "temp": ["temp@0.9.4", "", { "dependencies": { "mkdirp": "^0.5.1", "rimraf": "~2.6.2" } }, "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA=="],
 
     "temp-file": ["temp-file@3.4.0", "", { "dependencies": { "async-exit-hook": "^2.0.1", "fs-extra": "^10.0.0" } }, "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg=="],
+
+    "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
 
     "tiny-async-pool": ["tiny-async-pool@1.3.0", "", { "dependencies": { "semver": "^5.5.0" } }, "sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA=="],
 
@@ -2732,6 +2779,8 @@
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
 
     "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -47,6 +47,9 @@ const config: KnipConfig = {
     'tw-animate-css',
     'tailwindcss',
     '@tailwindcss/typography',
+    // Loaded at runtime as pino.transport() string targets, not static imports
+    'pino-roll',
+    'pino-pretty',
   ],
   ignoreBinaries: [],
 };

--- a/packages/server/__test__/lib/log.test.ts
+++ b/packages/server/__test__/lib/log.test.ts
@@ -1,190 +1,144 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
 
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
 
-describe('Log.init', () => {
-  const CLEANUP_THRESHOLD = 5;
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
+async function fileExists(filepath: string): Promise<boolean> {
+  return fs
+    .access(filepath)
+    .then(() => true)
+    .catch(() => false);
+}
+
+async function clearLogDir() {
+  const entries = await fs.readdir(PATHS.logDir).catch(() => []);
+  await Promise.all(entries.map((f) => fs.unlink(path.join(PATHS.logDir, f)).catch(() => {})));
+}
+
+async function writeLogFiles(names: string[]) {
+  await fs.mkdir(PATHS.logDir, { recursive: true });
+  await Promise.all(
+    names.map((name) => fs.writeFile(path.join(PATHS.logDir, name), 'test', 'utf-8')),
+  );
+}
+
+// Generates filenames matching pino-roll's Extension Last format: app.<date>.<count>.log
+function dailyLogNames(count: number, startDate = new Date('2020-01-01')): string[] {
+  return Array.from({ length: count }, (_, i) => {
+    const d = new Date(startDate.getTime() + i * 86_400_000);
+    return `app.${d.toISOString().slice(0, 10)}.${i + 1}.log`;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Log.cleanup
+// ---------------------------------------------------------------------------
+
+describe('Log.cleanup', () => {
   beforeEach(async () => {
     await fs.mkdir(PATHS.logDir, { recursive: true });
     await clearLogDir();
   });
+
   afterEach(async () => {
-    vi.useRealTimers();
     await clearLogDir();
   });
 
-  test('does not delete files when at threshold', async () => {
-    const startingAt = new Date('2020-01-01');
-    const oldFiles = createLogFiles(CLEANUP_THRESHOLD, startingAt, ONE_DAY);
-    await writeFiles(oldFiles);
+  test('does nothing when there are 10 or fewer log files', async () => {
+    const files = dailyLogNames(10);
+    await writeLogFiles(files);
 
-    await Log.init({ print: false });
+    await Log.cleanup();
 
-    for (const filename of oldFiles) {
-      expect(await fileExists(path.join(PATHS.logDir, filename))).toBe(true);
+    for (const name of files) {
+      expect(await fileExists(path.join(PATHS.logDir, name))).toBe(true);
     }
   });
 
-  test('deletes one old file when startup also creates a current log', async () => {
-    const startingAt = new Date('2020-01-01');
-    const oldFiles = createLogFiles(CLEANUP_THRESHOLD + 5, startingAt, ONE_DAY);
+  test('deletes the oldest file when there are 11 log files', async () => {
+    const files = dailyLogNames(11);
+    await writeLogFiles(files);
 
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-11-02T00:00:00.000Z'));
-    await writeFiles(oldFiles);
+    await Log.cleanup();
 
-    await Log.init({ print: false });
-
-    expect(await fileExists(path.join(PATHS.logDir, '2020-01-01T000000.log'))).toBe(false);
-    for (const filename of oldFiles.slice(1)) {
-      expect(await fileExists(path.join(PATHS.logDir, filename))).toBe(true);
-    }
-    expect(await fileExists(path.join(PATHS.logDir, '2025-11-02.log'))).toBe(true);
-  });
-
-  test('deletes the oldest file when threshold exceeded by 6', async () => {
-    const startingAt = new Date('2020-01-01');
-    const oldFiles = createLogFiles(CLEANUP_THRESHOLD + 6, startingAt, ONE_DAY);
-    await writeFiles(oldFiles);
-
-    await Log.init({ print: false });
-
-    expect(await fileExists(path.join(PATHS.logDir, '2020-01-01T000000.log'))).toBe(false);
-  });
-
-  test('preserves nine newest old files plus the current log at startup', async () => {
-    const startingAt = new Date('2020-01-01');
-    const oldFiles = createLogFiles(CLEANUP_THRESHOLD + 6, startingAt, ONE_DAY);
-
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-11-02T00:00:00.000Z'));
-    await writeFiles(oldFiles);
-
-    await Log.init({ print: false });
-
-    for (const filename of oldFiles.slice(-9)) {
-      expect(await fileExists(path.join(PATHS.logDir, filename))).toBe(true);
-    }
-    expect(await fileExists(path.join(PATHS.logDir, '2025-11-02.log'))).toBe(true);
-  });
-
-  test('does not delete dev.log during cleanup', async () => {
-    const startingAt = new Date('2020-01-01');
-    const oldFiles = createLogFiles(CLEANUP_THRESHOLD + 6, startingAt, ONE_DAY);
-    await writeFiles([...oldFiles, 'dev.log']);
-
-    await Log.init({ print: false });
-
-    expect(await fileExists(path.join(PATHS.logDir, 'dev.log'))).toBe(true);
-  });
-
-  test('creates new log file after cleanup runs', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-11-02T00:00:00.000Z'));
-    const startingAt = new Date('2020-01-01');
-    const oldFiles = createLogFiles(CLEANUP_THRESHOLD + 6, startingAt, ONE_DAY);
-    await writeFiles(oldFiles);
-
-    await Log.init({ print: false });
-
-    expect(await fileExists(path.join(PATHS.logDir, '2020-01-01T000000.log'))).toBe(false);
-    expect(await fileExists(path.join(PATHS.logDir, '2025-11-02.log'))).toBe(true);
-  });
-
-  test('rotates to a new daily log file after midnight in production', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-11-02T23:59:59.000Z'));
-
-    await Log.init({ print: false });
-    const log = Log.create({ service: 'test' });
-
-    expect(await fileExists(path.join(PATHS.logDir, '2025-11-02.log'))).toBe(true);
-
-    vi.setSystemTime(new Date('2025-11-03T00:00:01.000Z'));
-    log.info('rotated');
-
-    vi.useRealTimers();
-    await waitForFileExists(path.join(PATHS.logDir, '2025-11-03.log'));
-    expect(await fileExists(path.join(PATHS.logDir, '2025-11-03.log'))).toBe(true);
-  });
-
-  test('cleanup deletes the oldest daily log and preserves the newest 10', async () => {
-    const dailyFiles = createDailyLogFiles(11, new Date('2025-11-01'));
-    await writeFiles(dailyFiles);
-
-    await Log.init({ print: true });
-
-    expect(await fileExists(path.join(PATHS.logDir, '2025-11-01.log'))).toBe(false);
-    for (const filename of dailyFiles.slice(-10)) {
-      expect(await fileExists(path.join(PATHS.logDir, filename))).toBe(true);
+    expect(await fileExists(path.join(PATHS.logDir, files[0]))).toBe(false);
+    for (const name of files.slice(1)) {
+      expect(await fileExists(path.join(PATHS.logDir, name))).toBe(true);
     }
   });
 
-  test('cleanup preserves the current daily log with legacy timestamped logs present', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-11-11T12:00:00.000Z'));
+  test('keeps the 10 newest files when there are many', async () => {
+    const files = dailyLogNames(20);
+    await writeLogFiles(files);
 
-    const legacyFiles = createLogFiles(10, new Date('2025-11-01'), ONE_DAY);
-    await writeFiles(legacyFiles);
+    await Log.cleanup();
 
-    await Log.init({ print: false });
+    for (const name of files.slice(0, 10)) {
+      expect(await fileExists(path.join(PATHS.logDir, name))).toBe(false);
+    }
+    for (const name of files.slice(-10)) {
+      expect(await fileExists(path.join(PATHS.logDir, name))).toBe(true);
+    }
+  });
 
-    expect(await fileExists(path.join(PATHS.logDir, '2025-11-11.log'))).toBe(true);
-    expect(await fileExists(path.join(PATHS.logDir, '2025-11-01T000000.log'))).toBe(false);
+  test('does nothing when the log directory does not exist', async () => {
+    await fs.rm(PATHS.logDir, { recursive: true, force: true });
+    await expect(Log.cleanup()).resolves.not.toThrow();
   });
 });
 
-async function fileExists(filepath: string): Promise<boolean> {
-  return fs.access(filepath).then(
-    () => true,
-    () => false,
-  );
-}
+// ---------------------------------------------------------------------------
+// Log.create
+// ---------------------------------------------------------------------------
 
-async function waitForFileExists(filepath: string): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    if (await fileExists(filepath)) return;
-    await new Promise<void>((resolve) => setTimeout(resolve, 10));
-  }
-
-  throw new Error(`Timed out waiting for file: ${filepath}`);
-}
-
-async function clearLogDir() {
-  const existingLogFiles = await fs.readdir(PATHS.logDir).catch(() => []);
-
-  await Promise.all(
-    existingLogFiles.map((existingLogFile) => {
-      const filepath = path.join(PATHS.logDir, existingLogFile);
-      return fs.unlink(filepath).catch(() => {});
-    }),
-  );
-}
-
-function writeFiles(filenames: string[]) {
-  return Promise.all(
-    filenames.map((f) => fs.writeFile(path.join(PATHS.logDir, f), 'test', 'utf-8')),
-  );
-}
-
-const ONE_DAY = 1000 * 60 * 60 * 24;
-
-function createLogFiles(count: number, startDate: Date, increment = ONE_DAY): string[] {
-  return Array.from({ length: count }, (_, index) => {
-    const creationOffset = index * increment;
-    const fileCreatedAt = new Date(startDate.getTime() + creationOffset);
-    return fileCreatedAt.toISOString().split('.')[0].replace(/:/g, '') + '.log';
+describe('Log.create', () => {
+  test('returns a logger with all required methods', () => {
+    const log = Log.create({ service: 'test-create' });
+    expect(typeof log.debug).toBe('function');
+    expect(typeof log.info).toBe('function');
+    expect(typeof log.warn).toBe('function');
+    expect(typeof log.error).toBe('function');
+    expect(typeof log.tag).toBe('function');
+    expect(typeof log.clone).toBe('function');
+    expect(typeof log.time).toBe('function');
   });
-}
 
-function createDailyLogFiles(count: number, startDate: Date, increment = ONE_DAY): string[] {
-  return Array.from({ length: count }, (_, index) => {
-    const creationOffset = index * increment;
-    const fileCreatedAt = new Date(startDate.getTime() + creationOffset);
-    return `${fileCreatedAt.toISOString().slice(0, 10)}.log`;
+  test('tag() returns the same logger instance for chaining', () => {
+    const log = Log.create({ service: 'test-tag' });
+    const chained = log.tag('requestId', 'abc123');
+    expect(chained).toBe(log);
   });
-}
+
+  test('clone() returns a different logger instance', () => {
+    const log = Log.create({ service: 'test-clone' });
+    const cloned = log.clone();
+    expect(cloned).not.toBe(log);
+  });
+
+  test('returns the cached instance for the same service', () => {
+    const a = Log.create({ service: 'test-cache' });
+    const b = Log.create({ service: 'test-cache' });
+    expect(a).toBe(b);
+  });
+
+  test('time() returns stop() and [Symbol.dispose]', () => {
+    const log = Log.create({ service: 'test-time' });
+    const timer = log.time('my-op');
+    expect(typeof timer.stop).toBe('function');
+    expect(typeof timer[Symbol.dispose]).toBe('function');
+    timer.stop();
+  });
+
+  test('time() using-block calls stop via [Symbol.dispose]', () => {
+    const log = Log.create({ service: 'test-using' });
+    expect(() => {
+      using _t = log.time('block-op');
+    }).not.toThrow();
+  });
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,6 +36,7 @@
     "drizzle-orm": "^0.45.1",
     "glob": "13.0.6",
     "hono": "^4.12.7",
+    "pino": "^10.3.1",
     "quickjs-emscripten-core": "^0.32.0",
     "turndown": "^7.2.2",
     "zod": "catalog:"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,6 +37,7 @@
     "glob": "13.0.6",
     "hono": "^4.12.7",
     "pino": "^10.3.1",
+    "pino-roll": "^4.0.0",
     "quickjs-emscripten-core": "^0.32.0",
     "turndown": "^7.2.2",
     "zod": "catalog:"
@@ -46,6 +47,7 @@
     "@types/node": "^25.5.0",
     "@types/turndown": "^5.0.6",
     "drizzle-kit": "^0.31.9",
+    "pino-pretty": "^13.1.3",
     "typescript": "catalog:",
     "vitest": "catalog:testing"
   }

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -12,7 +12,7 @@ import { registerDefaultToolsets } from '@/tools/toolsets/register-default-tools
 const log = Log.create({ service: 'init' });
 
 export async function init() {
-  await Log.init({ print: false });
+  await Log.init({});
 
   await initDb();
   await runPendingMigrations(getDb());

--- a/packages/server/src/lib/log.ts
+++ b/packages/server/src/lib/log.ts
@@ -1,11 +1,10 @@
-import { createWriteStream } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
+import pino from 'pino';
 import z from 'zod';
 
 import { type StitchLogger } from '@stitch/shared/logger';
 
-import * as Glob from '@/lib/glob.js';
 import { PATHS } from '@/lib/paths.js';
 
 const Level = z
@@ -13,18 +12,12 @@ const Level = z
   .meta({ ref: 'LogLevel', description: 'Log level' });
 type Level = z.infer<typeof Level>;
 
-const levelPriority: Record<Level, number> = {
-  DEBUG: 0,
-  INFO: 1,
-  WARN: 2,
-  ERROR: 3,
+const pinoLevel: Record<Level, pino.Level> = {
+  DEBUG: 'debug',
+  INFO: 'info',
+  WARN: 'warn',
+  ERROR: 'error',
 };
-
-let level: Level = 'INFO';
-
-function shouldLog(input: Level): boolean {
-  return levelPriority[input] >= levelPriority[level];
-}
 
 type Logger = StitchLogger & {
   tag(key: string, value: string): Logger;
@@ -38,250 +31,105 @@ type Logger = StitchLogger & {
   };
 };
 
-const loggers = new Map<string, Logger>();
-
 interface Options {
-  print: boolean;
   dev?: boolean;
   level?: Level;
 }
 
-interface CleanupPlan {
-  files: string[];
-  maxFiles: number;
+// Silent by default until init() is called — nothing goes to stdout/stderr before then
+let rootLogger: pino.Logger = pino({ level: 'silent' });
+const loggers = new Map<string, Logger>();
+
+export async function init(options: Options): Promise<void> {
+  const level = pinoLevel[options.level ?? 'INFO'];
+
+  loggers.clear();
+
+  await fs.mkdir(PATHS.logDir, { recursive: true });
+
+  const fileBase = path.join(PATHS.logDir, options.dev ? 'dev' : 'app');
+
+  rootLogger = pino(
+    { level },
+    pino.transport({
+      target: 'pino-roll',
+      options: {
+        file: fileBase,
+        extension: '.log',
+        frequency: 'daily',
+        dateFormat: 'yyyy-MM-dd',
+        mkdir: true,
+        limit: { count: 9 },
+        // SonicBoom flushes synchronously on process exit — no lost entries on crash
+        sync: false,
+      },
+    }),
+  );
 }
 
-let logpath = '';
-let logStream: ReturnType<typeof createWriteStream> | null = null;
-let logOptions: Options | null = null;
-let rotationPromise: Promise<void> | null = null;
-const CLEANUP_THRESHOLD = 5;
-const MAX_LOG_FILES = 10;
-let nextRotationAt = Number.POSITIVE_INFINITY;
-let rotationTimer: ReturnType<typeof setTimeout> | null = null;
-let write: (msg: string) => number | Promise<number> = (msg: string) => {
-  process.stderr.write(msg);
-  return msg.length;
-};
+// Matches pino-roll's "Extension Last" filename format: <name>.<date>.<count>.log
+// e.g. app.2025-08-19.1.log or dev.2025-08-19.1.log
+const LOG_FILE_PATTERN = /^.+\.\d{4}-\d{2}-\d{2}\.\d+\.log$/;
 
-function getLogFilename(options: Options, now = new Date()): string {
-  return options.dev ? 'dev.log' : `${now.toISOString().slice(0, 10)}.log`;
-}
-
-function getNextRotationAt(now = new Date()): number {
-  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1);
-}
-
-function isProductionFileLogging(options: Options | null): options is Options {
-  return Boolean(options && !options.dev && !options.print);
-}
-
-function getLogPath(options: Options, now = new Date()): string {
-  return path.join(PATHS.logDir, getLogFilename(options, now));
-}
-
-function shouldRotate(options: Options, now: Date): boolean {
-  if (!logStream) return true;
-  if (options.dev) return !logpath;
-  return now.getTime() >= nextRotationAt;
-}
-
-function resetLogState(): void {
-  clearRotationTimer();
-  logpath = '';
-  nextRotationAt = Number.POSITIVE_INFINITY;
-}
-
-function createCleanupPlan(files: string[], dir: string): CleanupPlan {
-  const preservedFilename =
-    dir === PATHS.logDir && isProductionFileLogging(logOptions) ? getLogFilename(logOptions) : null;
-
-  if (!preservedFilename) {
-    return { files, maxFiles: MAX_LOG_FILES };
-  }
-
-  return {
-    files: files.filter((file) => path.basename(file) !== preservedFilename),
-    maxFiles: MAX_LOG_FILES - 1,
-  };
-}
-
-function clearRotationTimer(): void {
-  if (!rotationTimer) return;
-  clearTimeout(rotationTimer);
-  rotationTimer = null;
-}
-
-function scheduleRotation(options: Options): void {
-  clearRotationTimer();
-  if (options.dev || options.print || !Number.isFinite(nextRotationAt)) return;
-
-  const delayMs = Math.max(0, nextRotationAt - Date.now());
-  rotationTimer = setTimeout(() => {
-    rotationTimer = null;
-    if (!logOptions || logOptions.dev || logOptions.print) return;
-    ensureLogStream(logOptions).catch(() => {});
-  }, delayMs);
-}
-
-async function closeLogStream(): Promise<void> {
-  const stream = logStream;
-  logStream = null;
-  if (!stream) return;
-
-  await new Promise<void>((resolve) => {
-    stream.end(() => resolve());
-  });
-}
-
-async function ensureLogStream(options: Options): Promise<void> {
-  const now = new Date();
-  if (!shouldRotate(options, now)) {
+export async function cleanup(dir = PATHS.logDir): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
     return;
   }
 
-  const nextLogpath = getLogPath(options, now);
-  if (nextLogpath === logpath && logStream) return;
+  const logFiles = entries.filter((f) => LOG_FILE_PATTERN.test(f)).sort();
 
-  if (rotationPromise) {
-    await rotationPromise;
-  }
-  if (nextLogpath === logpath && logStream) return;
+  if (logFiles.length <= 10) return;
 
-  rotationPromise = (async () => {
-    const rotationNow = new Date();
-    const resolvedLogpath = getLogPath(options, rotationNow);
-    if (resolvedLogpath === logpath && logStream) return;
-
-    await fs.mkdir(PATHS.logDir, { recursive: true });
-    if (options.dev) {
-      await fs.writeFile(resolvedLogpath, '');
-    } else {
-      await fs.writeFile(resolvedLogpath, '', { flag: 'a' });
-    }
-
-    const nextStream = createWriteStream(resolvedLogpath, { flags: 'a' });
-    await closeLogStream();
-    logStream = nextStream;
-    logpath = resolvedLogpath;
-    nextRotationAt = options.dev ? Number.POSITIVE_INFINITY : getNextRotationAt(rotationNow);
-    scheduleRotation(options);
-  })().finally(() => {
-    rotationPromise = null;
-  });
-
-  await rotationPromise;
+  const toDelete = logFiles.slice(0, logFiles.length - 10);
+  await Promise.all(toDelete.map((f) => fs.unlink(path.join(dir, f)).catch(() => {})));
 }
 
-export async function init(options: Options) {
-  if (options.level) level = options.level;
-  logOptions = options;
-  await closeLogStream();
-  resetLogState();
-  await cleanup();
-  if (options.print) return;
-  await ensureLogStream(options);
-  write = async (msg: string) => {
-    if (logOptions) {
-      await ensureLogStream(logOptions);
-    }
-
-    const stream = logStream;
-    if (!stream) {
-      process.stderr.write(msg);
-      return msg.length;
-    }
-
-    return new Promise((resolve, reject) => {
-      stream.write(msg, (err) => {
-        if (err) reject(err);
-        else resolve(msg.length);
-      });
-    });
-  };
-}
-
-export async function cleanup(dir = PATHS.logDir) {
-  const files = await Glob.scan('{????-??-??.log,????-??-??T??????.log}', {
-    cwd: dir,
-    absolute: true,
-    include: 'file',
-  });
-
-  const plan = createCleanupPlan(files, dir);
-
-  if (plan.files.length <= CLEANUP_THRESHOLD) return;
-
-  const filesToDelete = plan.files.sort().slice(0, -plan.maxFiles);
-  await Promise.all(filesToDelete.map((file) => fs.unlink(file).catch(() => {})));
-}
-
-function serializeError(error: Error, depth = 0): Record<string, any> {
-  const result: Record<string, any> = {
-    type: error.name,
-    message: error.message,
-    stack: error.stack,
-  };
-  if (error.cause instanceof Error && depth < 10) {
-    result.cause = serializeError(error.cause, depth + 1);
-  }
-  return result;
-}
-
-function serializeValue(value: unknown): unknown {
-  if (value instanceof Error) return serializeError(value);
-  return value;
-}
-
-export function create(tags?: Record<string, unknown>) {
-  tags = tags || {};
+export function create(tags?: Record<string, unknown>, { skipCache = false } = {}): Logger {
+  tags = tags ?? {};
 
   const service = tags['service'];
-  if (service && typeof service === 'string') {
+  if (!skipCache && service && typeof service === 'string') {
     const cached = loggers.get(service);
     if (cached) return cached;
   }
 
-  function emit(lvl: Level, extraOrMessage: Record<string, unknown> | string, message?: string) {
-    if (!shouldLog(lvl)) return;
+  let child = rootLogger.child(tags);
 
-    const [extra, msg] =
-      typeof extraOrMessage === 'string' ? [{}, extraOrMessage] : [extraOrMessage, message!];
-
-    const entry: Record<string, unknown> = {
-      level: lvl.toLowerCase(),
-      time: new Date().toISOString(),
-      msg,
-    };
-
-    for (const [key, value] of Object.entries({ ...tags, ...extra })) {
-      if (value !== undefined && value !== null) {
-        entry[key] = serializeValue(value);
-      }
+  function emit(
+    lvl: pino.Level,
+    extraOrMessage: Record<string, unknown> | string,
+    message?: string,
+  ) {
+    if (typeof extraOrMessage === 'string') {
+      child[lvl](extraOrMessage);
+    } else {
+      child[lvl](extraOrMessage, message ?? '');
     }
-
-    void write(JSON.stringify(entry) + '\n');
   }
 
   const result: Logger = {
-    debug(extraOrMessage: Record<string, unknown> | string, message?: string) {
-      emit('DEBUG', extraOrMessage, message);
+    debug(extraOrMessage, message?) {
+      emit('debug', extraOrMessage, message as string | undefined);
     },
-    info(extraOrMessage: Record<string, unknown> | string, message?: string) {
-      emit('INFO', extraOrMessage, message);
+    info(extraOrMessage, message?) {
+      emit('info', extraOrMessage, message as string | undefined);
     },
-    warn(extraOrMessage: Record<string, unknown> | string, message?: string) {
-      emit('WARN', extraOrMessage, message);
+    warn(extraOrMessage, message?) {
+      emit('warn', extraOrMessage, message as string | undefined);
     },
-    error(extraOrMessage: Record<string, unknown> | string, message?: string) {
-      emit('ERROR', extraOrMessage, message);
+    error(extraOrMessage, message?) {
+      emit('error', extraOrMessage, message as string | undefined);
     },
     tag(key: string, value: string) {
-      if (tags) tags[key] = value;
+      tags = { ...tags, [key]: value };
+      child = rootLogger.child(tags);
       return result;
     },
     clone() {
-      return create({ ...tags });
+      return create({ ...tags }, { skipCache: true });
     },
     time(message: string, extra?: Record<string, unknown>) {
       const now = Date.now();


### PR DESCRIPTION
## Change Summary

Replaces the hand-rolled file logging system with [Pino](https://github.com/pinojs/pino) + [pino-roll](https://github.com/mcollina/pino-roll) to fix persistent reliability issues: files being deleted unexpectedly, rotation not working consistently, and log entries lost on server crashes.

### Bug Fixes
- **Crash safety**: SonicBoom (pino-roll's underlying stream) calls \lushSync()\ on process exit — buffered entries are no longer lost when the server crashes or is killed
- **File-only output**: Removed all stdout/stderr output; logs go exclusively to the rotating file. Default logger is silent until \init()\ is called, so nothing leaks before startup
- **Rotation**: Daily rotation and 10-file retention are handled natively by pino-roll — no more custom glob-based cleanup races or missing files
- **Event loop blocking**: Log I/O now runs in a dedicated worker thread via \pino.transport()\; the main event loop is never blocked by file writes
- **Unhandled stream errors**: SonicBoom handles stream errors internally — no more unhandled \rror\ events that could crash the process
- **clone() bug**: Fixed \clone()\ returning the cached service logger instead of a new independent instance

### Improvements
- Removed unused \print\ option from \Options\ interface
- Updated tests to cover the new \cleanup()\ regex (matching pino-roll's \
ame.date.count.log\ format) and \create()\ API contract