### PR TITLE
fix: prevent page refresh when opening Skills settings tab

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -28,6 +28,7 @@ import { useActions } from '@/lib/actions';
 import { providersQueryOptions } from '@/lib/queries/providers';
 import { settingsQueryOptions } from '@/lib/queries/settings';
 import { shortcutsQueryOptions } from '@/lib/queries/shortcuts';
+import { skillsQueryOptions } from '@/lib/queries/skills';
 import { knownToolsQueryOptions } from '@/lib/queries/tools';
 import { useGlobalHotkeys } from '@/lib/use-global-hotkeys';
 
@@ -65,6 +66,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       context.queryClient.ensureQueryData(providersQueryOptions),
       context.queryClient.ensureQueryData(settingsQueryOptions),
       context.queryClient.ensureQueryData(knownToolsQueryOptions),
+      context.queryClient.ensureQueryData(skillsQueryOptions),
     ]),
 });
 


### PR DESCRIPTION
## Change Summary

Opening the Skills settings tab caused a visible background page refresh that did not occur on any other tab.

### Bug Fixes
- **Skills tab page refresh**: The skillsQueryOptions query was missing from the root route loader prefetch list. When SkillsSettings mounted with useSuspenseQuery, the skills data was not pre-cached, causing the component to suspend mid-render. This Suspense waterfall during navigation produced the visible refresh. Adding skillsQueryOptions to the root loader ensures data is ready before the component mounts, matching the behaviour of all other settings tabs.