### PR TITLE
improvement(agent): reduce toolset rediscovery and code-mode retries

### DIFF
--- a/connectors/google/src/gmail/tools.ts
+++ b/connectors/google/src/gmail/tools.ts
@@ -259,7 +259,8 @@ export function createGmailTools(
       },
     }),
     gmail_list_labels: tool({
-      description: 'List Gmail labels with visibility and message/thread counts.',
+      description:
+        'List Gmail labels with visibility and message/thread counts. Use this to discover exact label IDs before calling gmail_get_label or gmail_modify_messages.',
       inputSchema: gmailListLabelsSchema,
       execute: async (input: z.infer<typeof gmailListLabelsSchema>) => {
         const { client, usedAccount } = await resolveClient(input.account);
@@ -268,7 +269,7 @@ export function createGmailTools(
       },
     }),
     gmail_get_label: tool({
-      description: 'Get details for one Gmail label by label ID.',
+      description: 'Get details for one Gmail label by label ID, such as INBOX or a user label ID.',
       inputSchema: gmailGetLabelsSchema,
       execute: async (input: z.infer<typeof gmailGetLabelsSchema>) => {
         const { client, usedAccount } = await resolveClient(input.account);
@@ -300,7 +301,7 @@ export function createGmailTools(
   if (canModify) {
     tools['gmail_modify_labels'] = tool({
       description:
-        'Create, update, or delete Gmail labels using operation enum values: create, update, delete.',
+        'Create, update, or delete Gmail labels. Always include operation with one of: create, update, delete.',
       inputSchema: gmailModifyLabelsSchema,
       execute: async (input: z.infer<typeof gmailModifyLabelsSchema>) => {
         const { client, usedAccount } = await resolveClient(input.account);
@@ -310,7 +311,8 @@ export function createGmailTools(
     });
 
     tools['gmail_modify_messages'] = tool({
-      description: 'Add/remove Gmail labels on messages, or on threads when modifyThreads=true.',
+      description:
+        'Add or remove Gmail labels on messages, or on threads when modifyThreads=true. Provide at least one of addLabelIds or removeLabelIds. Do not add SPAM and TRASH in the same call.',
       inputSchema: gmailModifyMessagesSchema,
       execute: async (input: z.infer<typeof gmailModifyMessagesSchema>) => {
         const { client, usedAccount } = await resolveClient(input.account);
@@ -328,7 +330,7 @@ export function createGmailTools(
   if (canManageFilters) {
     tools['gmail_filters'] = tool({
       description:
-        'Manage Gmail filters that automatically label, archive, delete, or forward incoming messages. Operations: list (all filters), get (one filter by ID), create (new filter with criteria + action), delete (permanently remove a filter). Note: the Gmail API has no update endpoint — to modify a filter, delete it and create a new one.',
+        'Manage Gmail filters that automatically label, archive, delete, or forward incoming messages. Always include operation with one of: list, get, create, delete. Note: the Gmail API has no update endpoint, so to modify a filter you must delete it and recreate it.',
       inputSchema: gmailFiltersSchema,
       execute: async (input: z.infer<typeof gmailFiltersSchema>) => {
         const { client, usedAccount } = await resolveClient(input.account);
@@ -372,15 +374,16 @@ export const GMAIL_TOOL_SUMMARIES = [
   { name: 'gmail_get_label', description: 'Get details for a single Gmail label by ID' },
   {
     name: 'gmail_modify_labels',
-    description: 'Create, update, or delete Gmail labels using an operation enum',
+    description: 'Create, update, or delete Gmail labels; requires operation=create|update|delete',
   },
   {
     name: 'gmail_modify_messages',
-    description: 'Add or remove labels on messages (or threads with modifyThreads=true)',
+    description:
+      'Add or remove labels on messages or threads; requires addLabelIds/removeLabelIds and cannot add SPAM and TRASH together',
   },
   {
     name: 'gmail_filters',
     description:
-      'List, get, create, or delete Gmail filters that auto-label, archive, or forward incoming messages (requires settings access)',
+      'List, get, create, or delete Gmail filters; requires operation=list|get|create|delete (requires settings access)',
   },
 ];

--- a/connectors/google/src/toolsets.ts
+++ b/connectors/google/src/toolsets.ts
@@ -67,6 +67,9 @@ type BuildGoogleToolsetsInput = {
   appliedVersion?: number;
 };
 
+const EXACT_TOOL_NAME_INSTRUCTION =
+  'Use the exact callable tool names exactly as listed. Do not invent aliases, camelCase variants, or shortened names.';
+
 function hasCapability(capabilities: string[], capability: string): boolean {
   return capabilities.includes(capability);
 }
@@ -116,9 +119,13 @@ function createGmailToolset(scopes: string[], capabilities: string[]): GoogleToo
     id: 'google-gmail',
     name: 'Google Gmail',
     icon: { type: 'simpleIcons', slug: 'gmail' },
-    description:
-      'Search, read, and send emails via Gmail. Activate to access your inbox, search messages, and compose emails.',
+    description: canSend
+      ? 'Search, read, send, label, and manage Gmail messages and labels.'
+      : canModify
+        ? 'Search, read, label, and manage Gmail messages without send access.'
+        : 'Search and read Gmail messages and inspect Gmail labels.',
     instructions: [
+      EXACT_TOOL_NAME_INSTRUCTION,
       'Gmail tools use standard Gmail search syntax for queries.',
       'Common operators: from:, to:, subject:, is:unread, is:starred, has:attachment, newer_than:, older_than:, label:',
       'Example queries: "from:boss@company.com newer_than:7d", "subject:invoice is:unread", "has:attachment filename:pdf"',
@@ -126,11 +133,12 @@ function createGmailToolset(scopes: string[], capabilities: string[]): GoogleToo
         ? 'You have send access. Use gmail_send to compose or reply to emails.'
         : 'You do not have send access. Sending emails is not available.',
       canModify
-        ? 'You have label modify access. Use gmail_modify_labels and gmail_modify_messages to manage labels and archive messages.'
+        ? 'You have label modify access. Use gmail_modify_labels with an explicit operation field (create, update, or delete). Use gmail_modify_messages to add or remove labels on messages or threads.'
         : 'You have read-only label access. Use gmail_list_labels and gmail_get_label to inspect labels.',
       canManageFilters
-        ? 'You have settings access. Use gmail_filters to list, get, create, or delete inbox filters. To update a filter, delete it and recreate it.'
+        ? 'You have settings access. Use gmail_filters with an explicit operation field (list, get, create, or delete). To update a filter, delete it and recreate it.'
         : 'You do not have settings access. Managing Gmail filters is not available.',
+      'Do not add SPAM and TRASH in the same gmail_modify_messages call. Apply those actions in separate steps if needed.',
     ].join('\n'),
     tools: () => summaries,
     activate: (resolveClient) =>
@@ -149,9 +157,11 @@ function createDriveToolset(scopes: string[], capabilities: string[]): GoogleToo
     id: 'google-drive',
     name: 'Google Drive',
     icon: { type: 'simpleIcons', slug: 'googledrive' },
-    description:
-      'Search, read, and create files in Google Drive. Access Google Docs, Sheets, PDFs, and other documents.',
+    description: canWrite
+      ? 'Search, read, and create text files in Google Drive, including access to Docs, Sheets, PDFs, and other documents.'
+      : 'Search and read Google Drive files, including Docs, Sheets, PDFs, and other documents.',
     instructions: [
+      EXACT_TOOL_NAME_INSTRUCTION,
       'Drive search uses the Google Drive query syntax.',
       'Common queries: "name contains \'report\'", "mimeType=\'application/pdf\'", "modifiedTime > \'2024-01-01\'"',
       "Combine with: and, or, not. Example: \"name contains 'Q4' and mimeType='application/vnd.google-apps.spreadsheet'\"",
@@ -182,9 +192,11 @@ function createCalendarToolset(scopes: string[], capabilities: string[]): Google
     id: 'google-calendar',
     name: 'Google Calendar',
     icon: { type: 'simpleIcons', slug: 'googlecalendar' },
-    description:
-      'View and manage Google Calendar events. Check upcoming meetings, search events, and create new ones.',
+    description: canWrite
+      ? 'View and manage Google Calendar events, including creating, updating, and deleting events.'
+      : 'View Google Calendar events and inspect upcoming meetings without write access.',
     instructions: [
+      EXACT_TOOL_NAME_INSTRUCTION,
       'Calendar tools default to the primary calendar. Use calendarId parameter for other calendars.',
       'Time parameters use ISO 8601 format (e.g., "2025-06-15T10:00:00Z").',
       'Always pass the user\'s local IANA timezone (e.g. "America/New_York") so that "today" and time ranges are anchored to their local time, not UTC.',
@@ -211,9 +223,11 @@ function createDocsToolset(scopes: string[], capabilities: string[]): GoogleTool
     id: 'google-docs',
     name: 'Google Docs',
     icon: { type: 'simpleIcons', slug: 'googledocs' },
-    description:
-      'Search, read, create, and update Google Docs documents. Use Docs for structured notes, drafts, and collaborative writing.',
+    description: canWrite
+      ? 'Search, read, create, and update Google Docs documents for structured notes, drafts, and collaborative writing.'
+      : 'Search and read Google Docs documents without write access.',
     instructions: [
+      EXACT_TOOL_NAME_INSTRUCTION,
       'Google Docs search accepts optional Drive query filters (for example: "name contains \'Roadmap\'").',
       'docs_read returns flattened plain text extracted from the document body.',
       canWrite

--- a/packages/server/src/code-mode/system-prompt.ts
+++ b/packages/server/src/code-mode/system-prompt.ts
@@ -35,7 +35,7 @@ ${typeStubs}
 
 ## Code Mode: \`execute_typescript\`
 
-You have access to an \`execute_typescript\` tool that runs TypeScript code in a secure sandbox. Use it to orchestrate multiple tool calls, transform data, or implement logic that would otherwise require many sequential steps.
+You have access to an \`execute_typescript\` tool that runs TypeScript code in a secure sandbox. Use it sparingly to orchestrate multiple tool calls, transform data, or implement logic that would otherwise require many sequential steps.
 
 ### When to use \`execute_typescript\`
 
@@ -43,6 +43,13 @@ You have access to an \`execute_typescript\` tool that runs TypeScript code in a
 - When you need loops, conditionals, or data transformations across tool outputs
 - When you want to parallelize independent tool calls with \`Promise.all\`
 - When a single-step tool call is insufficient for the task
+
+Do not use \`execute_typescript\` for:
+
+- A small number of direct tool calls
+- Straightforward search/read/modify flows you can complete directly
+- Simple batching that does not require substantial branching or transformation
+- Tasks that are already practical with normal tool calls in a few steps
 
 ### How it works
 
@@ -65,6 +72,7 @@ ${typeSection}
 - If you define a helper \`async function\`, you **must \`await\`** the call at the top level — returning an un-awaited Promise silently discards the result
 - Do not assume any global variables exist other than \`console\` and the \`external_*\` functions
 - External functions return \`Promise<unknown>\` — use type assertions if needed
+- If \`execute_typescript\` fails once in the current run, do not retry it for the same task unless the error clearly indicates a code mistake you can fix. Fall back to direct tool calls instead.
 
 ### Async patterns
 

--- a/packages/server/src/llm/prompt/base-system-prompt.txt
+++ b/packages/server/src/llm/prompt/base-system-prompt.txt
@@ -55,23 +55,29 @@ Prefer the most specific tool for the job:
 
 Additional capabilities are organized into **toolsets** — groups of related tools that you can discover and load on demand.
 
-**Two-level discovery:**
-1. Use `list_toolsets` with no arguments to see the available toolset catalog and activation status.
-2. Use `list_toolsets` with a toolset ID to inspect what tools it contains before activating it.
-3. Use `activate_toolset` to load a toolset and make its tools callable for the current run.
-4. Set `persist=true` only when that toolset will likely be needed again in future turns of the same session.
-5. Use `deactivate_toolset` to unload a toolset you no longer need, freeing up context.
+**Toolset discovery:**
+1. If the user names a domain directly (for example: Gmail, browser, calendar, knowledge base), start with `list_toolsets({ query: "<domain>" })` instead of the full catalog.
+2. Use `list_toolsets` with no arguments only when the needed domain is unclear and you genuinely need broad discovery.
+3. If you already know the exact toolset ID from this run or an earlier turn in the same session, activate it directly instead of rediscovering it.
+4. Use `list_toolsets({ toolsetId })` only when you need to inspect a specific toolset's tools or prompts before activation.
+5. Use `activate_toolset` to load a toolset and make its tools callable for the current run.
+6. Set `persist=true` when the toolset will likely be needed again in future turns of the same session.
+7. Use `deactivate_toolset` to unload a toolset you no longer need, freeing up context.
 
 **Guidelines:**
 - Only activate toolsets you need for the current task.
-- Toolset activation is temporary by default. Persist a toolset only when keeping it across future turns is clearly useful.
-- After completing a task that required a toolset, deactivate it immediately with deactivate_toolset.
+- If a matching toolset is already active, call its tools directly. Do not re-list or re-activate it.
+- Toolset activation is temporary by default. Persist a toolset when keeping it across future turns is clearly useful, especially for ongoing multi-turn work in the same domain.
+- Do not deactivate a persisted toolset unless the task is clearly finished or the user has moved to a different domain.
+- Deactivate non-persisted toolsets when you no longer need them for the current task.
 - Do not activate all toolsets at once — this wastes context space.
+- Avoid repeated discovery loops inside one run. After one catalog or query result, either activate a matching toolset or conclude that the capability is unavailable.
 - If unsure whether a toolset has what you need, use `list_toolsets` first to check.
 - If the available toolset catalog clearly matches the task, activate that toolset directly instead of relying only on core tools.
 - For web search, current information, or external research tasks, prefer relevant web-search MCP toolsets when available.
 - For GitHub repository or codebase documentation questions, prefer relevant repository-knowledge MCP toolsets when available.
-- If the capability you need does not appear in the `list_toolsets` catalog, it is not available. Do not try alternative names, IDs, or queries — the catalog is the complete and filtered list of what you can use.
+- If the capability you need does not appear in the `list_toolsets` catalog, it is not available. Do not retry spelling variants, synonyms, IDs, or additional discovery queries — the catalog is the complete and filtered list of what you can use.
+- When a newly activated tool uses an operation-style schema, include the required discriminator field such as `operation`. Do not call such tools with an empty object.
 
 ## Delegating Work
 

--- a/packages/server/src/mcp/tool-executor.ts
+++ b/packages/server/src/mcp/tool-executor.ts
@@ -179,8 +179,10 @@ function buildToolsetDescription(
   liveInfo: McpServerLiveInfo | null,
   registryServer: McpRegistryServer | null,
 ): string {
+  const prefix = formatMcpToolName(server.id, '...');
+
   if (liveInfo?.description) {
-    return liveInfo.description;
+    return `${liveInfo.description} Activate this toolset to use its prefixed MCP tools (for example ${prefix}).`;
   }
 
   if (registryServer?.description) {
@@ -197,7 +199,27 @@ function buildToolsetDescription(
   }
 
   const toolCount = server.tools?.length ?? 0;
-  return `MCP server "${server.name}" - provides ${toolCount} tool(s).`;
+  return `MCP server "${server.name}" - provides ${toolCount} tool(s). Activate this toolset to use its prefixed MCP tools (for example ${prefix}).`;
+}
+
+function buildMcpInstructions(input: {
+  server: McpServerWithTools;
+  liveInfo: McpServerLiveInfo | null;
+  prompts: ToolsetPrompt[];
+}): string | undefined {
+  const exactNameRule = [
+    'Use the exact toolset ID and exact callable tool names exactly as listed.',
+    'Do not invent aliases, shortened names, camelCase variants, or unprefixed MCP tool names.',
+    `All callable tools from this server are prefixed with ${formatMcpToolName(input.server.id, '...')}.`,
+  ].join(' ');
+
+  const promptRule =
+    input.prompts.length > 0
+      ? 'This toolset also exposes MCP prompt templates. Inspect the listed prompt names and arguments before using them.'
+      : null;
+
+  const liveInstructions = input.liveInfo?.instructions?.trim();
+  return [exactNameRule, promptRule, liveInstructions].filter(Boolean).join('\n\n') || undefined;
 }
 
 function pickDisplayIcon(icons?: McpIcon[]): McpIcon | undefined {
@@ -236,12 +258,14 @@ function createMcpToolset(
     id: toolsetId,
     name: displayName,
     description,
-    instructions: liveInfo?.instructions ?? undefined,
+    instructions: buildMcpInstructions({ server, liveInfo, prompts }),
     prompts: prompts.length > 0 ? prompts : undefined,
     tools: () =>
       cachedTools.map((tool) => ({
         name: formatMcpToolName(server.id, tool.name),
-        description: tool.description ?? `Tool from MCP server "${displayName}"`,
+        description:
+          tool.description ??
+          `Tool from MCP server "${displayName}". Use this exact prefixed tool name; do not call the unprefixed MCP tool name.`,
       })),
     activate: (context) => getToolsForServer(server, context),
   };

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -22,7 +22,7 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
       .join(' ');
 
   const list_toolsets = tool({
-    description: `List toolsets and inspect toolset contents. Call with no arguments for the full catalog, pass a query string to filter by keyword (e.g. "database"), or pass a toolsetId to inspect a specific toolset's tools and prompts in detail.`,
+    description: `List toolsets and inspect toolset contents. Prefer a query string when you already know the domain (for example "gmail", "browser", or "calendar"). Call with no arguments only for broad discovery. Pass a toolsetId to inspect one specific toolset's exact callable tool names, descriptions, and prompts in detail.`,
     inputSchema: z.object({
       toolsetId: z
         .string()
@@ -92,7 +92,7 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
   });
 
   const activate_toolset = tool({
-    description: `Activate a toolset to make its tools callable. Activation applies to the current run by default. Set persist=true only when the toolset should stay active for future turns in this session. By default this returns a compact response; set verbose=true only when you need full toolset instructions and prompt metadata.`,
+    description: `Activate a toolset to make its tools callable. Use the exact toolset ID returned by list_toolsets. Activation applies to the current run by default. Set persist=true only when the toolset should stay active for future turns in this session. By default this returns a compact response; set verbose=true only when you need full toolset instructions and prompt metadata.`,
     inputSchema: z.object({
       toolsetId: z.string().describe('The toolset ID to activate (e.g. "browser")'),
       persist: z


### PR DESCRIPTION
## Change Summary

Tightens prompt and tool description guidance to reduce unnecessary toolset rediscovery loops and overuse of `execute_typescript` in the agent.

### Improvements & Refactors
- **Toolset discovery prompts**: Prefer targeted `list_toolsets({ query })` over full catalog when domain is known; skip re-listing already-active toolsets; avoid repeated discovery loops within a single run
- **Gmail/Drive/Calendar/Docs toolsets**: Add `EXACT_TOOL_NAME_INSTRUCTION` to all Google toolset instruction blocks; clarify operation-discriminator requirements for `gmail_modify_labels`, `gmail_modify_messages`, and `gmail_filters`; make toolset descriptions capability-aware
- **MCP toolsets**: Inject exact-name and prefix rules into MCP toolset instructions; hint prefixed tool name format in toolset descriptions
- **Code mode system prompt**: Add explicit do-not-use guidance for `execute_typescript` on simple flows; add fallback rule when it fails