### PR TITLE
fix(tools): preserve raw truncated outputs and improve text file detection

### DIFF
--- a/packages/server/__test__/tools/read.test.ts
+++ b/packages/server/__test__/tools/read.test.ts
@@ -27,6 +27,16 @@ describe('read tool helpers', () => {
     expect(result.output).toBe('1: alpha\n2: beta\n3: gamma');
   });
 
+  test('reads UTF-16LE text files created by Windows tools', async () => {
+    const dir = await createTempDir();
+    const filePath = path.join(dir, 'windows-output.txt');
+    await fs.writeFile(filePath, Buffer.from('alpha\nbeta', 'utf16le'));
+
+    const result = await readPathContent({ filePath });
+
+    expect(result.output).toBe('1: alpha\n2: beta');
+  });
+
   test('supports offset and limit when reading file content', async () => {
     const dir = await createTempDir();
     const filePath = path.join(dir, 'example.txt');
@@ -79,6 +89,22 @@ describe('read tool helpers', () => {
     const dir = await createTempDir();
     const filePath = path.join(dir, 'image.png');
     await fs.writeFile(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02]));
+
+    await expect(readPathContent({ filePath })).rejects.toThrow('Only text files are supported');
+  });
+
+  test('rejects known binary file extensions', async () => {
+    const dir = await createTempDir();
+    const filePath = path.join(dir, 'module.wasm');
+    await fs.writeFile(filePath, 'plain bytes that would otherwise decode as utf8', 'utf8');
+
+    await expect(readPathContent({ filePath })).rejects.toThrow('Only text files are supported');
+  });
+
+  test('rejects files with too many non-printable characters', async () => {
+    const dir = await createTempDir();
+    const filePath = path.join(dir, 'control.txt');
+    await fs.writeFile(filePath, Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 65, 66]));
 
     await expect(readPathContent({ filePath })).rejects.toThrow('Only text files are supported');
   });

--- a/packages/server/__test__/tools/wrappers.test.ts
+++ b/packages/server/__test__/tools/wrappers.test.ts
@@ -8,12 +8,14 @@ import { withToolResultHandling, withTruncation } from '@/tools/runtime/wrappers
 
 describe('withTruncation', () => {
   test('returns compact result when truncation is triggered', async () => {
+    const largeOutput = 'big output\n'.repeat(300);
     const wrapped = withTruncation(
       tool({
         description: 'test tool',
         inputSchema: z.object({}),
         execute: async () => ({
-          output: 'big output',
+          output: largeOutput,
+          title: 'kept title',
           attachment: 'x'.repeat(20_000),
         }),
       }),
@@ -35,6 +37,10 @@ describe('withTruncation', () => {
     const outputPath = (result as { __stitchToolResultMeta: { outputPath: string } })
       .__stitchToolResultMeta.outputPath;
     await expect(fs.stat(outputPath)).resolves.toBeDefined();
+    await expect(fs.readFile(outputPath, 'utf8')).resolves.toBe(largeOutput);
+    expect(result).toMatchObject({ title: 'kept title' });
+    expect((result as { output: string }).output).toContain('Full raw output saved to:');
+    expect((result as { output: string }).output).toContain('prefer Grep first');
   });
 
   test('returns original result when truncation is not needed', async () => {

--- a/packages/server/src/tools/core/read.ts
+++ b/packages/server/src/tools/core/read.ts
@@ -7,7 +7,8 @@ import {
   getParentDirPermissionSuggestion,
 } from '@/tools/runtime/file-permissions.js';
 import {
-  isTextFileBuffer,
+  decodeTextFileBuffer,
+  isKnownBinaryFilePath,
   truncateLine,
   validateAbsoluteFilePath,
 } from '@/tools/runtime/shared.js';
@@ -95,14 +96,14 @@ export async function readPathContent(input: z.infer<typeof readInputSchema>): P
     throw new Error('Path must point to a file or directory');
   }
 
-  const buffer = await fs.readFile(targetPath);
-  if (!isTextFileBuffer(buffer)) {
+  if (isKnownBinaryFilePath(targetPath)) {
     throw new Error('Only text files are supported');
   }
 
+  const buffer = await fs.readFile(targetPath);
   const offset = normalizePositiveInteger(parsed.offset, 1);
   const limit = normalizePositiveInteger(parsed.limit, DEFAULT_LIMIT);
-  const content = new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+  const content = decodeTextFileBuffer(buffer);
 
   return {
     output: formatNumberedContent(content, offset, limit),

--- a/packages/server/src/tools/runtime/shared.ts
+++ b/packages/server/src/tools/runtime/shared.ts
@@ -2,17 +2,127 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 const MAX_LINE_LENGTH = 2000;
+const NON_PRINTABLE_RATIO_LIMIT = 0.3;
 
-export function isTextFileBuffer(buffer: Buffer): boolean {
-  if (buffer.length === 0) return true;
-  if (buffer.includes(0)) return false;
+const BINARY_EXTENSIONS = new Set([
+  '.7z',
+  '.a',
+  '.avi',
+  '.bin',
+  '.bmp',
+  '.class',
+  '.dll',
+  '.dmg',
+  '.doc',
+  '.docx',
+  '.dylib',
+  '.exe',
+  '.gif',
+  '.ico',
+  '.iso',
+  '.jar',
+  '.jpeg',
+  '.jpg',
+  '.mov',
+  '.mp3',
+  '.mp4',
+  '.o',
+  '.obj',
+  '.pdf',
+  '.png',
+  '.ppt',
+  '.pptx',
+  '.rar',
+  '.so',
+  '.wasm',
+  '.webm',
+  '.webp',
+  '.xls',
+  '.xlsx',
+  '.zip',
+]);
+
+type TextEncoding = 'utf-8' | 'utf-16le' | 'utf-16be';
+
+function isMostlyPrintableText(value: string): boolean {
+  if (value.length === 0) return true;
+
+  let nonPrintable = 0;
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0;
+    const isAllowedControl = code === 9 || code === 10 || code === 12 || code === 13;
+    if (!isAllowedControl && code < 32) {
+      nonPrintable++;
+    }
+  }
+
+  return nonPrintable / value.length <= NON_PRINTABLE_RATIO_LIMIT;
+}
+
+export function isKnownBinaryFilePath(filePath: string): boolean {
+  return BINARY_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+function detectTextEncoding(buffer: Buffer): TextEncoding | null {
+  if (buffer.length === 0) return 'utf-8';
+
+  if (buffer.length >= 2) {
+    if (buffer[0] === 0xff && buffer[1] === 0xfe) return 'utf-16le';
+    if (buffer[0] === 0xfe && buffer[1] === 0xff) return 'utf-16be';
+  }
+
+  let evenNulCount = 0;
+  let oddNulCount = 0;
+  const sampleLength = Math.min(buffer.length, 4096);
+
+  for (let i = 0; i < sampleLength; i++) {
+    if (buffer[i] !== 0) continue;
+    if (i % 2 === 0) {
+      evenNulCount++;
+    } else {
+      oddNulCount++;
+    }
+  }
+
+  const nulThreshold = Math.max(4, Math.floor(sampleLength / 8));
+  if (oddNulCount >= nulThreshold && evenNulCount === 0) return 'utf-16le';
+  if (evenNulCount >= nulThreshold && oddNulCount === 0) return 'utf-16be';
+
+  if (evenNulCount > 0 || oddNulCount > 0) return null;
 
   try {
-    new TextDecoder('utf-8', { fatal: true }).decode(buffer);
-    return true;
+    const content = new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+    if (!isMostlyPrintableText(content)) return null;
+    return 'utf-8';
   } catch {
-    return false;
+    return null;
   }
+}
+
+export function isTextFileBuffer(buffer: Buffer): boolean {
+  return detectTextEncoding(buffer) !== null;
+}
+
+export function decodeTextFileBuffer(buffer: Buffer): string {
+  const encoding = detectTextEncoding(buffer);
+  if (encoding === null) {
+    throw new Error('Only text files are supported');
+  }
+
+  if (encoding === 'utf-16be') {
+    const swapped = Buffer.alloc(buffer.length);
+    for (let i = 0; i < buffer.length; i += 2) {
+      swapped[i] = buffer[i + 1] ?? 0;
+      swapped[i + 1] = buffer[i];
+    }
+    const content = swapped.toString('utf16le');
+    if (!isMostlyPrintableText(content)) throw new Error('Only text files are supported');
+    return content;
+  }
+
+  const content = encoding === 'utf-16le' ? buffer.toString('utf16le') : buffer.toString('utf8');
+  if (!isMostlyPrintableText(content)) throw new Error('Only text files are supported');
+  return content;
 }
 
 export function validateAbsoluteFilePath(filePath: string): string {

--- a/packages/server/src/tools/runtime/truncation.ts
+++ b/packages/server/src/tools/runtime/truncation.ts
@@ -58,7 +58,7 @@ export async function truncateOutput(
   await fs.writeFile(outputPath, text, 'utf-8');
   log.info({ outputPath }, 'truncated output saved');
 
-  const hint = `The tool call succeeded but the output was truncated. Full output saved to: ${outputPath}\nUse Read with offset/limit to view specific sections or Grep to search the full content.`;
+  const hint = `The tool call succeeded but the output was truncated. Full raw output saved to: ${outputPath}\nUse Read with offset/limit to inspect ranges, or Grep to search the full content before reading. For very large single-line output, prefer Grep first.`;
   const content = `${preview}\n\n...${removed} ${unit} truncated...\n\n${hint}`;
 
   return { content, truncated: true, outputPath };

--- a/packages/server/src/tools/runtime/wrappers.ts
+++ b/packages/server/src/tools/runtime/wrappers.ts
@@ -23,6 +23,21 @@ type TruncationMeta = {
   };
 };
 
+function getTruncatableText(result: unknown): string {
+  if (typeof result === 'string') return result;
+
+  if (result !== null && typeof result === 'object') {
+    const output = (result as { output?: unknown }).output;
+    if (typeof output === 'string') return output;
+  }
+
+  try {
+    return JSON.stringify(result);
+  } catch {
+    return String(result);
+  }
+}
+
 type ToolPermissionBehavior = {
   getPatternTargets: (input: unknown) => string[];
   getSuggestion: (input: unknown) => PermissionSuggestion | null;
@@ -42,16 +57,7 @@ export function withTruncation<T extends Tool>(
     }
 
     const result = await originalExecute(...args);
-    const text =
-      typeof result === 'string'
-        ? result
-        : (() => {
-            try {
-              return JSON.stringify(result);
-            } catch {
-              return String(result);
-            }
-          })();
+    const text = getTruncatableText(result);
     const truncated = await truncateOutput(text, options);
     if (truncated.truncated) {
       const meta: TruncationMeta = {
@@ -60,6 +66,25 @@ export function withTruncation<T extends Tool>(
           outputPath: truncated.outputPath,
         },
       };
+
+      if (typeof result === 'string') {
+        return {
+          output: truncated.content,
+          ...meta,
+        };
+      }
+
+      if (
+        result !== null &&
+        typeof result === 'object' &&
+        typeof (result as { output?: unknown }).output === 'string'
+      ) {
+        return {
+          ...result,
+          output: truncated.content,
+          ...meta,
+        };
+      }
 
       return {
         output: truncated.content,


### PR DESCRIPTION
## Change Summary

Improves tool output handling: preserves structured tool result fields when truncating, adds robust multi-encoding text file detection, and improves truncation hint messages.

### Improvements & Refactors
- **Truncation**: When a tool returns a structured result with an `output` field, truncation now replaces only the `output` field and preserves all other fields (e.g. `title`, metadata). Previously all non-output fields were dropped
- **Text file decoding**: Replaces the naive null-byte check with proper UTF-16LE/BE BOM and heuristic detection; adds `isKnownBinaryFilePath` to reject binary extensions before reading; adds non-printable character ratio check to catch disguised binary content
- **Truncation hint**: Clarifies that Grep should be preferred over Read for very large single-line outputs