### PR TITLE
improvement(agent): reduce redundant tool calls in toolset and code-mode flows

### DIFF
--- a/packages/server/src/code-mode/system-prompt.ts
+++ b/packages/server/src/code-mode/system-prompt.ts
@@ -50,6 +50,7 @@ Do not use \`execute_typescript\` for:
 - Straightforward search/read/modify flows you can complete directly
 - Simple batching that does not require substantial branching or transformation
 - Tasks that are already practical with normal tool calls in a few steps
+- Any task completable in 3 or fewer direct tool calls — the overhead and failure surface are not worth it
 
 ### How it works
 
@@ -73,6 +74,8 @@ ${typeSection}
 - Do not assume any global variables exist other than \`console\` and the \`external_*\` functions
 - External functions return \`Promise<unknown>\` — use type assertions if needed
 - If \`execute_typescript\` fails once in the current run, do not retry it for the same task unless the error clearly indicates a code mistake you can fix. Fall back to direct tool calls instead.
+- **Always return a structured object, not a plain string.** Include fields like \`found\`, \`processed\`, \`count\`, or \`ids\` so the result is unambiguous. A string like \`"No results found"\` is indistinguishable from a successful no-op — a structured return like \`{ found: 0, query: "...", processed: 0 }\` makes the outcome clear.
+- **Include the intermediate data that led to the outcome.** If a search returned zero results, include the query and the raw result count in the return object so you can diagnose whether the query was wrong, not just that nothing was processed.
 
 ### Async patterns
 

--- a/packages/server/src/llm/prompt/base-system-prompt.txt
+++ b/packages/server/src/llm/prompt/base-system-prompt.txt
@@ -59,7 +59,7 @@ Additional capabilities are organized into **toolsets** — groups of related to
 1. If the user names a domain directly (for example: Gmail, browser, calendar, knowledge base), start with `list_toolsets({ query: "<domain>" })` instead of the full catalog.
 2. Use `list_toolsets` with no arguments only when the needed domain is unclear and you genuinely need broad discovery.
 3. If you already know the exact toolset ID from this run or an earlier turn in the same session, activate it directly instead of rediscovering it.
-4. Use `list_toolsets({ toolsetId })` only when you need to inspect a specific toolset's tools or prompts before activation.
+4. Use `list_toolsets({ toolsetId })` only when you need to inspect a toolset's prompts or instructions before activation — `activate_toolset` already returns the full tool list, so never call `list_toolsets` just to preview tools you are about to activate.
 5. Use `activate_toolset` to load a toolset and make its tools callable for the current run.
 6. Set `persist=true` when the toolset will likely be needed again in future turns of the same session.
 7. Use `deactivate_toolset` to unload a toolset you no longer need, freeing up context.
@@ -88,7 +88,7 @@ Use the `task` tool to spawn a child session for:
 
 Do not use `task` for small searches, single-file reads, or short sequences you can complete directly.
 
-Use `execute_typescript` when you need deterministic orchestration over multiple tool calls, transformations, loops, or parallel work. Do not use it for a single simple tool call.
+Use `execute_typescript` when you need deterministic orchestration over multiple tool calls, transformations, loops, or parallel work. Do not use it for a single simple tool call. If the task can be completed in 3 or fewer direct tool calls, use direct tool calls — `execute_typescript` adds a failure surface and retry cost that is not worth it for simple flows.
 
 The child session inherits your active toolsets and permissions. Keep task descriptions detailed and specific — the child session starts fresh with only the task description as context. The child session can ask questions and request permissions from the user, just like you can.
 

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -22,7 +22,7 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
       .join(' ');
 
   const list_toolsets = tool({
-    description: `List toolsets and inspect toolset contents. Prefer a query string when you already know the domain (for example "gmail", "browser", or "calendar"). Call with no arguments only for broad discovery. Pass a toolsetId to inspect one specific toolset's exact callable tool names, descriptions, and prompts in detail.`,
+    description: `List toolsets and inspect toolset contents. Prefer a query string when you already know the domain (for example "gmail", "browser", or "calendar"). Call with no arguments only for broad discovery. Pass a toolsetId only when you need to inspect prompts or instructions before activation — activate_toolset already returns the full tool list, so do not call list_toolsets with a toolsetId just to preview tools you are about to activate.`,
     inputSchema: z.object({
       toolsetId: z
         .string()


### PR DESCRIPTION
## Change Summary

Analysis of a real session ('Mark GitHub emails as read') revealed the agent was making 12 tool calls for a task requiring 3. This PR addresses two root causes identified in that session.

### Improvements

- **Eliminate redundant list_toolsets pre-activation call**: Updated the list_toolsets description and base system prompt rule 4 to explicitly state that \ctivate_toolset\ already returns the full tool list — the agent should not call \list_toolsets\ with a \	oolsetId\ just to preview tools it is about to activate.

- **Raise the bar for xecute_typescript usage**: Updated both the base system prompt and code-mode system prompt to add a concrete threshold — tasks completable in 3 or fewer direct tool calls should use direct tool calls. The \xecute_typescript\ path adds failure surface and retry cost that is not justified for simple flows.

- **Require structured return values from generated code**: Added two rules to the code-mode system prompt instructing the agent to always return a structured object (not a plain string) and to include intermediate data (query used, raw result count) in the return value. This makes empty/zero outcomes diagnosable rather than silently indistinguishable from a logic error.