### PR TITLE
Add Gmail attachment downloads

### DIFF
--- a/connectors/google/src/__test__/gmail-api.test.ts
+++ b/connectors/google/src/__test__/gmail-api.test.ts
@@ -1,0 +1,69 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { downloadAttachments } from '../gmail/api.js';
+
+import type { GoogleClient } from '../client.js';
+
+function base64Url(value: string): string {
+  return Buffer.from(value, 'utf8').toString('base64url');
+}
+
+describe('gmail api', () => {
+  let tempRoot: string | null = null;
+
+  afterEach(async () => {
+    if (tempRoot) {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+      tempRoot = null;
+    }
+  });
+
+  it('downloads message attachments to the configured temp path', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'gmail-attachments-test-'));
+    tempRoot = root;
+    const request = vi.fn(async (url: string) => {
+      if (url.includes('/messages/msg-1?format=FULL')) {
+        return {
+          id: 'msg-1',
+          threadId: 'thread-1',
+          snippet: '',
+          payload: {
+            mimeType: 'multipart/mixed',
+            parts: [
+              {
+                mimeType: 'application/pdf',
+                headers: [{ name: 'Content-Disposition', value: 'attachment; filename="report.pdf"' }],
+                body: { size: 11, attachmentId: 'att-1' },
+              },
+            ],
+          },
+        };
+      }
+
+      if (url.includes('/messages/msg-1/attachments/att-1')) {
+        return { size: 11, data: base64Url('hello world') };
+      }
+
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const client = { request } as unknown as GoogleClient;
+
+    const result = await downloadAttachments(client, 'msg-1', root);
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0]).toMatchObject({
+      attachmentId: 'att-1',
+      filename: 'report.pdf',
+      mimeType: 'application/pdf',
+      size: 11,
+    });
+    expect(result.attachments[0]?.path).toBe(
+      path.join(root, 'gmail-attachments', 'msg-1', 'report.pdf'),
+    );
+    await expect(fs.readFile(result.attachments[0]?.path ?? '', 'utf8')).resolves.toBe('hello world');
+  });
+});

--- a/connectors/google/src/__test__/rate-limit.test.ts
+++ b/connectors/google/src/__test__/rate-limit.test.ts
@@ -22,6 +22,13 @@ describe('resolveGoogleQuotaOperation', () => {
 
     expect(
       resolveGoogleQuotaOperation(
+        'https://gmail.googleapis.com/gmail/v1/users/me/messages/abc/attachments/att-1',
+        'GET',
+      ),
+    ).toEqual({ service: 'gmail', quotaCost: 20 });
+
+    expect(
+      resolveGoogleQuotaOperation(
         'https://gmail.googleapis.com/gmail/v1/users/me/messages/send',
         'POST',
       ),

--- a/connectors/google/src/__test__/toolsets.test.ts
+++ b/connectors/google/src/__test__/toolsets.test.ts
@@ -12,6 +12,7 @@ describe('buildGoogleToolsets', () => {
     expect(gmail?.tools().map((tool) => tool.name)).toEqual([
       'gmail_search',
       'gmail_read',
+      'gmail_download_attachments',
       'gmail_list_labels',
       'gmail_get_label',
     ]);
@@ -31,6 +32,7 @@ describe('buildGoogleToolsets', () => {
     expect(sendOnly?.tools().map((tool) => tool.name)).toEqual([
       'gmail_search',
       'gmail_read',
+      'gmail_download_attachments',
       'gmail_send',
       'gmail_list_labels',
       'gmail_get_label',
@@ -39,6 +41,7 @@ describe('buildGoogleToolsets', () => {
     expect(modify?.tools().map((tool) => tool.name)).toEqual([
       'gmail_search',
       'gmail_read',
+      'gmail_download_attachments',
       'gmail_send',
       'gmail_list_labels',
       'gmail_get_label',
@@ -57,6 +60,7 @@ describe('buildGoogleToolsets', () => {
     expect(settingsOnly?.tools().map((tool) => tool.name)).toEqual([
       'gmail_search',
       'gmail_read',
+      'gmail_download_attachments',
       'gmail_list_labels',
       'gmail_get_label',
       'gmail_filters',

--- a/connectors/google/src/gmail/api.ts
+++ b/connectors/google/src/gmail/api.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
 import type { GoogleClient } from '../client.js';
 
 const GMAIL_API = 'https://gmail.googleapis.com/gmail/v1/users/me';
@@ -7,6 +10,7 @@ type GmailHeader = { name: string; value: string };
 type GmailMessagePartBody = {
   size: number;
   data?: string;
+  attachmentId?: string;
 };
 
 type GmailMessagePart = {
@@ -31,9 +35,43 @@ type GmailListResponse = {
   resultSizeEstimate?: number;
 };
 
+type GmailAttachmentResponse = {
+  data?: string;
+  size: number;
+};
+
 function decodeBase64Url(data: string): string {
   const base64 = data.replace(/-/g, '+').replace(/_/g, '/');
   return atob(base64);
+}
+
+function decodeBase64UrlBuffer(data: string): Buffer {
+  const base64 = data.replace(/-/g, '+').replace(/_/g, '/');
+  return Buffer.from(base64, 'base64');
+}
+
+function safeFilename(filename: string): string {
+  const parsed = Array.from(path.basename(filename))
+    .map((char) => (char.charCodeAt(0) < 32 || '<>:"/\\|?*'.includes(char) ? '_' : char))
+    .join('')
+    .trim();
+  return parsed && parsed !== '.' && parsed !== '..' ? parsed : 'attachment';
+}
+
+function uniquePath(dir: string, filename: string, used: Set<string>): string {
+  const safe = safeFilename(filename);
+  const ext = path.extname(safe);
+  const name = path.basename(safe, ext);
+  let candidate = safe;
+  let index = 1;
+
+  while (used.has(candidate)) {
+    candidate = `${name}-${index}${ext}`;
+    index += 1;
+  }
+
+  used.add(candidate);
+  return path.join(dir, candidate);
 }
 
 function extractHeader(headers: GmailHeader[] | undefined, name: string): string | undefined {
@@ -52,7 +90,12 @@ function extractAttachments(payload: GmailMessagePart | undefined): GmailAttachm
         ?.value.match(/name="?([^";]+)"?/i)?.[1];
 
     if (filename && part.body?.size) {
-      attachments.push({ filename, mimeType: part.mimeType, size: part.body.size });
+      attachments.push({
+        attachmentId: part.body.attachmentId,
+        filename,
+        mimeType: part.mimeType,
+        size: part.body.size,
+      });
     }
 
     // Recurse into nested multipart
@@ -88,9 +131,14 @@ function extractBody(payload: GmailMessagePart | undefined): string {
 }
 
 type GmailAttachment = {
+  attachmentId: string | undefined;
   filename: string;
   mimeType: string;
   size: number;
+};
+
+type GmailDownloadedAttachment = GmailAttachment & {
+  path: string;
 };
 
 type GmailMessage = {
@@ -283,6 +331,48 @@ export async function getMessage(client: GoogleClient, messageId: string): Promi
     labels: raw.labelIds ?? [],
     attachments: extractAttachments(raw.payload),
   };
+}
+
+export async function downloadAttachments(
+  client: GoogleClient,
+  messageId: string,
+  tempPath: string,
+): Promise<{ messageId: string; attachments: GmailDownloadedAttachment[] }> {
+  const raw = await client.request<GmailMessageRaw>(
+    `${GMAIL_API}/messages/${encodeURIComponent(messageId)}?format=FULL`,
+  );
+  const attachments = extractAttachments(raw.payload).filter(
+    (attachment) => attachment.attachmentId,
+  );
+
+  if (attachments.length === 0) {
+    return { messageId: raw.id, attachments: [] };
+  }
+
+  const outputDir = path.join(tempPath, 'gmail-attachments', raw.id);
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const usedFilenames = new Set<string>();
+  const downloaded: GmailDownloadedAttachment[] = [];
+
+  for (const attachment of attachments) {
+    const attachmentId = attachment.attachmentId;
+    if (!attachmentId) continue;
+
+    const response = await client.request<GmailAttachmentResponse>(
+      `${GMAIL_API}/messages/${encodeURIComponent(raw.id)}/attachments/${encodeURIComponent(attachmentId)}`,
+    );
+    if (!response.data) {
+      throw new Error(`Gmail attachment ${attachmentId} did not include download data`);
+    }
+
+    const filePath = uniquePath(outputDir, attachment.filename, usedFilenames);
+
+    await fs.writeFile(filePath, decodeBase64UrlBuffer(response.data));
+    downloaded.push({ ...attachment, path: filePath });
+  }
+
+  return { messageId: raw.id, attachments: downloaded };
 }
 
 export async function sendMessage(

--- a/connectors/google/src/gmail/tools.ts
+++ b/connectors/google/src/gmail/tools.ts
@@ -28,6 +28,14 @@ const gmailReadSchema = z.object({
   messageId: z.string().describe('The Gmail message ID to read'),
 });
 
+const gmailDownloadAttachmentsSchema = z.object({
+  account: z
+    .string()
+    .optional()
+    .describe('Optional account email or label when multiple Google accounts are connected'),
+  messageId: z.string().describe('The Gmail message ID whose attachments should be downloaded'),
+});
+
 const gmailSendSchema = z.object({
   account: z
     .string()
@@ -229,6 +237,7 @@ export function createGmailTools(
     account?: string,
   ) => Promise<{ client: GoogleClient; usedAccount: string | null }>,
   permissions: { canSend: boolean; canModify: boolean; canManageFilters: boolean },
+  config?: { tempPath?: string },
 ) {
   const { canSend, canModify, canManageFilters } = permissions;
   const tools: Record<string, Tool> = {
@@ -255,6 +264,20 @@ export function createGmailTools(
       execute: async (input: z.infer<typeof gmailReadSchema>) => {
         const { client, usedAccount } = await resolveClient(input.account);
         const result = await GmailApi.getMessage(client, input.messageId);
+        return { ...result, usedAccount };
+      },
+    }),
+    gmail_download_attachments: tool({
+      description:
+        'Download all attachments from a Gmail message by ID to a temporary local folder. Returns file paths for downloaded attachments.',
+      inputSchema: gmailDownloadAttachmentsSchema,
+      execute: async (input: z.infer<typeof gmailDownloadAttachmentsSchema>) => {
+        if (!config?.tempPath) {
+          throw new Error('Gmail attachment downloads require a configured temp path.');
+        }
+
+        const { client, usedAccount } = await resolveClient(input.account);
+        const result = await GmailApi.downloadAttachments(client, input.messageId, config.tempPath);
         return { ...result, usedAccount };
       },
     }),
@@ -366,6 +389,10 @@ export function createGmailTools(
 export const GMAIL_TOOL_SUMMARIES = [
   { name: 'gmail_search', description: 'Search Gmail messages using Gmail search syntax' },
   { name: 'gmail_read', description: 'Read the full content of a Gmail message by ID' },
+  {
+    name: 'gmail_download_attachments',
+    description: 'Download attachments from a Gmail message by ID to temporary local files',
+  },
   { name: 'gmail_send', description: 'Send an email or reply to a thread (requires write access)' },
   {
     name: 'gmail_list_labels',

--- a/connectors/google/src/rate-limit.ts
+++ b/connectors/google/src/rate-limit.ts
@@ -55,6 +55,7 @@ type GoogleQuotaOperation = {
 const GMAIL_METHOD_COSTS = {
   MESSAGES_LIST: 5,
   MESSAGES_GET: 5,
+  MESSAGES_ATTACHMENTS_GET: 20,
   MESSAGES_MODIFY: 5,
   MESSAGES_SEND: 100,
   LABELS_LIST: 1,
@@ -104,6 +105,10 @@ function resolveGmailQuotaCost(pathname: string, method: string): number {
 
   if (/\/messages\/[^/]+$/.test(withoutQuery) && method === 'GET') {
     return GMAIL_METHOD_COSTS.MESSAGES_GET;
+  }
+
+  if (/\/messages\/[^/]+\/attachments\/[^/]+$/.test(withoutQuery) && method === 'GET') {
+    return GMAIL_METHOD_COSTS.MESSAGES_ATTACHMENTS_GET;
   }
 
   if (withoutQuery.endsWith('/labels')) {

--- a/connectors/google/src/toolsets.ts
+++ b/connectors/google/src/toolsets.ts
@@ -65,6 +65,7 @@ type BuildGoogleToolsetsInput = {
   scopes: string[];
   capabilities?: string[];
   appliedVersion?: number;
+  tempPath?: string;
 };
 
 const EXACT_TOOL_NAME_INSTRUCTION =
@@ -103,7 +104,11 @@ export function canActivateToolset(
   return false;
 }
 
-function createGmailToolset(scopes: string[], capabilities: string[]): GoogleToolsetDefinition {
+function createGmailToolset(
+  scopes: string[],
+  capabilities: string[],
+  config?: { tempPath?: string },
+): GoogleToolsetDefinition {
   const canWriteCapability = hasCapability(capabilities, GOOGLE_CAPABILITY_GMAIL_WRITE);
   const canSend = hasGmailSendAccess(scopes) && canWriteCapability;
   const canModify = hasGmailModifyAccess(scopes) && canWriteCapability;
@@ -142,7 +147,7 @@ function createGmailToolset(scopes: string[], capabilities: string[]): GoogleToo
     ].join('\n'),
     tools: () => summaries,
     activate: (resolveClient) =>
-      createGmailTools(resolveClient, { canSend, canModify, canManageFilters }),
+      createGmailTools(resolveClient, { canSend, canModify, canManageFilters }, config),
   };
 }
 
@@ -246,16 +251,19 @@ function createDocsToolset(scopes: string[], capabilities: string[]): GoogleTool
 export function buildGoogleToolsets(
   input: string[] | BuildGoogleToolsetsInput,
 ): GoogleToolsetDefinition[] {
-  const normalizedInput = Array.isArray(input) ? { scopes: input } : input;
+  const normalizedInput: BuildGoogleToolsetsInput = Array.isArray(input)
+    ? { scopes: input }
+    : input;
   const scopes = normalizedInput.scopes;
   const capabilities = normalizedInput.capabilities ?? [...GOOGLE_DEFAULT_CAPABILITIES];
+  const tempPath = normalizedInput.tempPath;
   const toolsets: GoogleToolsetDefinition[] = [];
 
   if (
     hasServiceAccess(scopes, 'gmail') &&
     hasCapability(capabilities, GOOGLE_CAPABILITY_GMAIL_READ)
   ) {
-    toolsets.push(createGmailToolset(scopes, capabilities));
+    toolsets.push(createGmailToolset(scopes, capabilities, { tempPath }));
   }
 
   if (

--- a/connectors/google/tsconfig.json
+++ b/connectors/google/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ESNext", "DOM"],
+    "types": ["bun"],
     "strict": true,
     "skipLibCheck": true,
     "noEmit": true

--- a/packages/server/src/connectors/google-toolsets.ts
+++ b/packages/server/src/connectors/google-toolsets.ts
@@ -22,6 +22,7 @@ import { getConnectorDefinition } from '@/connectors/registry.js';
 import { getDb } from '@/db/client.js';
 import { connectorInstances } from '@/db/schema.js';
 import * as Log from '@/lib/log.js';
+import { PATHS } from '@/lib/paths.js';
 import { registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
 import type { Toolset } from '@/tools/toolsets/types.js';
 import type { Tool } from 'ai';
@@ -291,7 +292,12 @@ export async function registerGoogleToolsets(): Promise<void> {
     ),
   );
 
-  const toolsetDefs = buildGoogleToolsets({ scopes, capabilities, appliedVersion });
+  const toolsetDefs = buildGoogleToolsets({
+    scopes,
+    capabilities,
+    appliedVersion,
+    tempPath: PATHS.tempDir,
+  });
 
   for (const def of toolsetDefs) {
     registerToolset(toServerToolset(def));

--- a/packages/server/src/lib/paths.ts
+++ b/packages/server/src/lib/paths.ts
@@ -81,6 +81,7 @@ export const PATHS = {
   dataDir: paths.data,
   cacheDir: paths.cache,
   logDir: paths.log,
+  tempDir: paths.temp,
 
   filePaths: {
     db: path.join(paths.data, `${APP_NAME}.db`),


### PR DESCRIPTION
## 🚀 Change Summary

Adds a Gmail tool for downloading message attachments to the server-provided temp path and returning local file paths in the response.

### ✨ New Features
- **Gmail Attachment Downloads**: Adds gmail_download_attachments, which accepts a Gmail message ID, downloads available attachments to temporary local files, and returns attachment metadata plus file paths.

### 🛠 Improvements & Refactors
- Threads the server temp path into Google toolsets so the connector can create its own attachment download directory.
- Adds Gmail attachment quota mapping for messages.attachments.get at 20 quota units.
- Extends Gmail attachment metadata with attachment IDs for download support.