### PR TITLE
refactor(server): add human interaction broker

### DIFF
--- a/packages/server/__test__/interactions/broker.test.ts
+++ b/packages/server/__test__/interactions/broker.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { InteractionBroker } from '@/interactions/broker.js';
+
+describe('InteractionBroker', () => {
+  let broker: InteractionBroker;
+
+  beforeEach(() => {
+    broker = new InteractionBroker();
+  });
+
+  afterEach(() => {
+    broker.clear();
+    vi.useRealTimers();
+  });
+
+  test('resolves a pending interaction', async () => {
+    const promise = broker.wait<string>({
+      id: 'permres_1',
+      kind: 'permission',
+      sessionId: 'ses_1',
+    });
+
+    expect(broker.resolve('permres_1', 'allow')).toBe(true);
+    await expect(promise).resolves.toBe('allow');
+  });
+
+  test('rejects a pending interaction', async () => {
+    const promise = broker.wait<string>({
+      id: 'quest_1',
+      kind: 'question',
+      sessionId: 'ses_1',
+    });
+
+    expect(broker.reject('quest_1', new Error('No'))).toBe(true);
+    await expect(promise).rejects.toThrow('No');
+  });
+
+  test('abort signal rejects and cleans up', async () => {
+    const controller = new AbortController();
+    const promise = broker.wait<string>({
+      id: 'quest_2',
+      kind: 'question',
+      sessionId: 'ses_1',
+      abortSignal: controller.signal,
+      abortError: () => new Error('Aborted'),
+    });
+
+    controller.abort();
+
+    await expect(promise).rejects.toThrow('Aborted');
+    expect(broker.resolve('quest_2', 'answer')).toBe(false);
+  });
+
+  test('aborts only matching session interactions', async () => {
+    const first = broker.wait<string>({ id: 'a', kind: 'question', sessionId: 'ses_1' });
+    const second = broker.wait<string>({ id: 'b', kind: 'question', sessionId: 'ses_2' });
+
+    const aborted = broker.abortSession({
+      sessionId: 'ses_1',
+      error: new Error('Session aborted'),
+    });
+
+    expect(aborted.map((entry) => entry.id)).toEqual(['a']);
+    await expect(first).rejects.toThrow('Session aborted');
+
+    expect(broker.resolve('b', 'ok')).toBe(true);
+    await expect(second).resolves.toBe('ok');
+  });
+
+  test('timeout resolves with configured decision', async () => {
+    vi.useFakeTimers();
+
+    const promise = broker.wait<string>({
+      id: 'doom_loop:ses_1',
+      kind: 'doom_loop',
+      sessionId: 'ses_1',
+      timeoutMs: 100,
+      onTimeout: () => 'stop',
+    });
+
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(promise).resolves.toBe('stop');
+  });
+
+  test('duplicate wait resolves previous interaction with configured decision', async () => {
+    const first = broker.wait<string>({
+      id: 'doom_loop:ses_1',
+      kind: 'doom_loop',
+      sessionId: 'ses_1',
+      onDuplicate: () => 'stop',
+    });
+    const second = broker.wait<string>({
+      id: 'doom_loop:ses_1',
+      kind: 'doom_loop',
+      sessionId: 'ses_1',
+      onDuplicate: () => 'stop',
+    });
+
+    await expect(first).resolves.toBe('stop');
+    expect(broker.resolve('doom_loop:ses_1', 'continue')).toBe(true);
+    await expect(second).resolves.toBe('continue');
+  });
+});

--- a/packages/server/__test__/permission/service.test.ts
+++ b/packages/server/__test__/permission/service.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { PrefixedString } from '@stitch/shared/id';
+
+const mocks = vi.hoisted(() => {
+  const insertReturning: unknown[][] = [];
+  const updateReturning: unknown[][] = [];
+  const selectWhere: unknown[][] = [];
+  const broadcastMock = vi.fn();
+  const createPermissionResponseIdMock = vi.fn();
+  const createPermissionRuleIdMock = vi.fn(() => 'perm_rule');
+
+  const db = {
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(async () => insertReturning.shift() ?? []),
+        onConflictDoUpdate: vi.fn(async () => undefined),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(async () => updateReturning.shift() ?? []),
+        })),
+      })),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => selectWhere.shift() ?? []),
+      })),
+    })),
+  };
+
+  return {
+    broadcastMock,
+    createPermissionResponseIdMock,
+    createPermissionRuleIdMock,
+    db,
+    insertReturning,
+    updateReturning,
+    selectWhere,
+  };
+});
+
+vi.mock('@/db/client.js', () => ({
+  getDb: () => mocks.db,
+}));
+
+vi.mock('@stitch/shared/id', () => ({
+  createPermissionResponseId: mocks.createPermissionResponseIdMock,
+  createPermissionRuleId: mocks.createPermissionRuleIdMock,
+}));
+
+vi.mock('@/lib/sse.js', () => ({
+  broadcast: mocks.broadcastMock,
+}));
+
+describe('permission service interactions', () => {
+  const sessionId = 'ses_permission' as PrefixedString<'ses'>;
+  const messageId = 'msg_permission' as PrefixedString<'msg'>;
+
+  beforeEach(() => {
+    mocks.broadcastMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    const { interactionBroker } = await import('@/interactions/broker.js');
+    interactionBroker.clear();
+    vi.clearAllMocks();
+    mocks.insertReturning.length = 0;
+    mocks.updateReturning.length = 0;
+    mocks.selectWhere.length = 0;
+  });
+
+  test('requestPermissionResponse broadcasts and resolves through allowPermissionResponse', async () => {
+    const { requestPermissionResponse, allowPermissionResponse } = await import(
+      '@/permission/service.js'
+    );
+    const permissionResponseId = 'permres_allow' as PrefixedString<'permres'>;
+    mocks.createPermissionResponseIdMock.mockReturnValueOnce(permissionResponseId);
+    const row = {
+      id: permissionResponseId,
+      sessionId,
+      messageId,
+      toolCallId: 'call_permission',
+      toolName: 'bash',
+      toolInput: { command: 'pwd' },
+      systemReminder: 'Tool execution requires user approval',
+      suggestion: null,
+      status: 'pending',
+      createdAt: 1,
+      resolvedAt: null,
+      entry: null,
+    };
+    mocks.insertReturning.push([row]);
+    mocks.selectWhere.push([row]);
+    mocks.updateReturning.push([{ ...row, status: 'allowed', resolvedAt: 2 }]);
+
+    const promise = requestPermissionResponse({
+      sessionId,
+      messageId,
+      streamRunId: 'run_permission',
+      toolCallId: 'call_permission',
+      toolName: 'bash',
+      toolInput: { command: 'pwd' },
+      systemReminder: 'Tool execution requires user approval',
+    });
+
+    await Promise.resolve();
+    expect(mocks.broadcastMock).toHaveBeenCalledWith('permission-response-requested', {
+      permissionResponse: { ...row, resolvedAt: undefined },
+    });
+
+    await expect(allowPermissionResponse(permissionResponseId)).resolves.toEqual({ data: null });
+    await expect(promise).resolves.toEqual({ decision: 'allow' });
+    expect(mocks.broadcastMock).toHaveBeenCalledWith('permission-response-resolved', {
+      permissionResponseId,
+      sessionId,
+    });
+  });
+
+  test('alternativePermissionResponse resolves with alternative entry', async () => {
+    const { requestPermissionResponse, alternativePermissionResponse } = await import(
+      '@/permission/service.js'
+    );
+    const permissionResponseId = 'permres_alt' as PrefixedString<'permres'>;
+    mocks.createPermissionResponseIdMock.mockReturnValueOnce(permissionResponseId);
+    const row = {
+      id: permissionResponseId,
+      sessionId,
+      messageId,
+      toolCallId: 'call_permission',
+      toolName: 'write',
+      toolInput: { path: 'a.txt' },
+      systemReminder: 'Tool execution requires user approval',
+      suggestion: null,
+      status: 'pending',
+      createdAt: 1,
+      resolvedAt: null,
+      entry: null,
+    };
+    mocks.insertReturning.push([row]);
+    mocks.selectWhere.push([row]);
+    mocks.updateReturning.push([{ ...row, status: 'alternative', entry: 'Use read instead' }]);
+
+    const promise = requestPermissionResponse({
+      sessionId,
+      messageId,
+      toolCallId: 'call_permission',
+      toolName: 'write',
+      toolInput: { path: 'a.txt' },
+      systemReminder: 'Tool execution requires user approval',
+    });
+
+    await Promise.resolve();
+    await expect(alternativePermissionResponse(permissionResponseId, 'Use read instead')).resolves.toEqual({
+      data: null,
+    });
+    await expect(promise).resolves.toEqual({
+      decision: 'alternative',
+      entry: 'Use read instead',
+    });
+  });
+
+  test('abortPermissionResponses rejects pending permissions for the session', async () => {
+    const { requestPermissionResponse, abortPermissionResponses, rejectPermissionResponse } =
+      await import('@/permission/service.js');
+    const firstId = 'permres_abort_1' as PrefixedString<'permres'>;
+    const secondId = 'permres_abort_2' as PrefixedString<'permres'>;
+    mocks.createPermissionResponseIdMock.mockReturnValueOnce(firstId).mockReturnValueOnce(secondId);
+    const otherSessionId = 'ses_other' as PrefixedString<'ses'>;
+    const firstRow = {
+      id: firstId,
+      sessionId,
+      messageId,
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      toolInput: {},
+      systemReminder: 'Tool execution requires user approval',
+      suggestion: null,
+      status: 'pending',
+      createdAt: 1,
+      resolvedAt: null,
+      entry: null,
+    };
+    const secondRow = {
+      ...firstRow,
+      id: secondId,
+      sessionId: otherSessionId,
+      toolCallId: 'call_2',
+    };
+    mocks.insertReturning.push([firstRow], [secondRow]);
+    mocks.selectWhere.push([firstRow]);
+
+    const first = requestPermissionResponse({
+      sessionId,
+      messageId,
+      streamRunId: 'run_first',
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      toolInput: {},
+      systemReminder: 'Tool execution requires user approval',
+    });
+    const second = requestPermissionResponse({
+      sessionId: otherSessionId,
+      messageId,
+      streamRunId: 'run_second',
+      toolCallId: 'call_2',
+      toolName: 'bash',
+      toolInput: {},
+      systemReminder: 'Tool execution requires user approval',
+    });
+
+    await Promise.resolve();
+    await abortPermissionResponses(sessionId);
+
+    await expect(first).rejects.toThrow('Permission response aborted by session abort');
+    expect(mocks.broadcastMock).toHaveBeenCalledWith('permission-response-resolved', {
+      permissionResponseId: firstId,
+      sessionId,
+    });
+
+    mocks.selectWhere.push([secondRow]);
+    mocks.updateReturning.push([{ ...secondRow, status: 'rejected', resolvedAt: 2 }]);
+    await rejectPermissionResponse(secondId);
+    await expect(second).resolves.toEqual({ decision: 'reject' });
+  });
+});

--- a/packages/server/__test__/question/service.test.ts
+++ b/packages/server/__test__/question/service.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { PrefixedString } from '@stitch/shared/id';
+
+const mocks = vi.hoisted(() => {
+  const insertReturning: unknown[][] = [];
+  const updateReturning: unknown[][] = [];
+  const selectWhere: unknown[][] = [];
+  const broadcastMock = vi.fn();
+  const createQuestionIdMock = vi.fn();
+
+  const db = {
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(async () => insertReturning.shift() ?? []),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(async () => updateReturning.shift() ?? []),
+        })),
+      })),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => selectWhere.shift() ?? []),
+      })),
+    })),
+  };
+
+  return {
+    broadcastMock,
+    createQuestionIdMock,
+    db,
+    insertReturning,
+    updateReturning,
+    selectWhere,
+  };
+});
+
+vi.mock('@/db/client.js', () => ({
+  getDb: () => mocks.db,
+}));
+
+vi.mock('@stitch/shared/id', () => ({
+  createQuestionId: mocks.createQuestionIdMock,
+}));
+
+vi.mock('@/lib/sse.js', () => ({
+  broadcast: mocks.broadcastMock,
+}));
+
+describe('question service interactions', () => {
+  const sessionId = 'ses_question' as PrefixedString<'ses'>;
+  const messageId = 'msg_question' as PrefixedString<'msg'>;
+
+  beforeEach(() => {
+    mocks.broadcastMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    const { interactionBroker } = await import('@/interactions/broker.js');
+    interactionBroker.clear();
+    vi.clearAllMocks();
+    mocks.insertReturning.length = 0;
+    mocks.updateReturning.length = 0;
+    mocks.selectWhere.length = 0;
+  });
+
+  test('askQuestion broadcasts and resolves through replyQuestion', async () => {
+    const { askQuestion, replyQuestion } = await import('@/question/service.js');
+    const questionId = 'quest_ask' as PrefixedString<'quest'>;
+    mocks.createQuestionIdMock.mockReturnValueOnce(questionId);
+    const row = {
+      id: questionId,
+      sessionId,
+      messageId,
+      toolCallId: 'call_question',
+      questions: [{ question: 'Pick one', header: 'Choice', options: [], multiple: false }],
+      answers: null,
+      status: 'pending',
+      createdAt: 1,
+      answeredAt: null,
+    };
+    mocks.insertReturning.push([row]);
+    mocks.updateReturning.push([{ ...row, status: 'answered', answers: [['A']], answeredAt: 2 }]);
+
+    const promise = askQuestion({
+      sessionId,
+      messageId,
+      streamRunId: 'run_question',
+      toolCallId: 'call_question',
+      questions: row.questions,
+    });
+
+    await Promise.resolve();
+    expect(mocks.broadcastMock).toHaveBeenCalledWith('question-asked', {
+      question: { ...row, answers: undefined, answeredAt: undefined },
+    });
+
+    await expect(replyQuestion(questionId, [['A']])).resolves.toEqual({ data: null });
+    await expect(promise).resolves.toEqual([['A']]);
+    expect(mocks.broadcastMock).toHaveBeenCalledWith('question-replied', {
+      questionId,
+      sessionId,
+      answers: [['A']],
+    });
+  });
+
+  test('rejectQuestion rejects a pending askQuestion promise', async () => {
+    const { askQuestion, rejectQuestion } = await import('@/question/service.js');
+    const questionId = 'quest_reject' as PrefixedString<'quest'>;
+    mocks.createQuestionIdMock.mockReturnValueOnce(questionId);
+    const row = {
+      id: questionId,
+      sessionId,
+      messageId,
+      toolCallId: 'call_question',
+      questions: [{ question: 'Continue?', header: 'Confirm', options: [], multiple: false }],
+      answers: null,
+      status: 'pending',
+      createdAt: 1,
+      answeredAt: null,
+    };
+    mocks.insertReturning.push([row]);
+    mocks.selectWhere.push([row]);
+
+    const promise = askQuestion({
+      sessionId,
+      messageId,
+      toolCallId: 'call_question',
+      questions: row.questions,
+    });
+
+    await Promise.resolve();
+    await expect(rejectQuestion(questionId)).resolves.toEqual({ data: null });
+    await expect(promise).rejects.toThrow('Question rejected by user');
+    expect(mocks.broadcastMock).toHaveBeenCalledWith('question-rejected', {
+      questionId,
+      sessionId,
+    });
+  });
+
+  test('abortQuestions rejects pending questions for the session', async () => {
+    const { askQuestion, abortQuestions } = await import('@/question/service.js');
+    const firstId = 'quest_abort_1' as PrefixedString<'quest'>;
+    const secondId = 'quest_abort_2' as PrefixedString<'quest'>;
+    mocks.createQuestionIdMock.mockReturnValueOnce(firstId).mockReturnValueOnce(secondId);
+    const otherSessionId = 'ses_other' as PrefixedString<'ses'>;
+    const firstRow = {
+      id: firstId,
+      sessionId,
+      messageId,
+      toolCallId: 'call_1',
+      questions: [{ question: 'First?', header: 'First', options: [], multiple: false }],
+      answers: null,
+      status: 'pending',
+      createdAt: 1,
+      answeredAt: null,
+    };
+    const secondRow = {
+      ...firstRow,
+      id: secondId,
+      sessionId: otherSessionId,
+      toolCallId: 'call_2',
+    };
+    mocks.insertReturning.push([firstRow], [secondRow]);
+    mocks.selectWhere.push([firstRow]);
+
+    const first = askQuestion({
+      sessionId,
+      messageId,
+      streamRunId: 'run_first',
+      toolCallId: 'call_1',
+      questions: firstRow.questions,
+    });
+    const second = askQuestion({
+      sessionId: otherSessionId,
+      messageId,
+      streamRunId: 'run_second',
+      toolCallId: 'call_2',
+      questions: secondRow.questions,
+    });
+
+    await Promise.resolve();
+    await abortQuestions(sessionId);
+
+    await expect(first).rejects.toThrow('Question aborted by session abort');
+    expect(mocks.broadcastMock).toHaveBeenCalledWith('question-rejected', {
+      questionId: firstId,
+      sessionId,
+    });
+
+    const { replyQuestion } = await import('@/question/service.js');
+    mocks.updateReturning.push([{ ...secondRow, status: 'answered', answers: [['ok']] }]);
+    await replyQuestion(secondId, [['ok']]);
+    await expect(second).resolves.toEqual([['ok']]);
+  });
+});

--- a/packages/server/src/interactions/broker.ts
+++ b/packages/server/src/interactions/broker.ts
@@ -1,0 +1,157 @@
+import type {
+  AbortSessionOptions,
+  InteractionWaitOptions,
+  PendingInteractionSnapshot,
+} from '@/interactions/types.js';
+
+type PendingInteraction = PendingInteractionSnapshot & {
+  resolve: (decision: unknown) => void;
+  reject: (error: Error) => void;
+  abortError: () => Error;
+  cleanup: () => void;
+};
+
+class InteractionAbortedError extends Error {
+  constructor(message = 'Interaction aborted') {
+    super(message);
+    this.name = 'InteractionAbortedError';
+  }
+}
+
+const defaultAbortError = () => new InteractionAbortedError();
+
+export class InteractionBroker {
+  private readonly pending = new Map<string, PendingInteraction>();
+
+  wait<TDecision>(opts: InteractionWaitOptions<TDecision>): Promise<TDecision> {
+    const existing = this.pending.get(opts.id);
+    if (existing) {
+      void this.resolveDuplicate(existing, opts.onDuplicate);
+    }
+
+    return new Promise<TDecision>((resolve, reject) => {
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const abortError = opts.abortError ?? defaultAbortError;
+      let pendingEntry: PendingInteraction;
+
+      const cleanup = () => {
+        if (timeout) clearTimeout(timeout);
+        opts.abortSignal?.removeEventListener('abort', abortHandler);
+        if (this.pending.get(opts.id) === pendingEntry) {
+          this.pending.delete(opts.id);
+        }
+      };
+
+      const settleResolve = (decision: unknown) => {
+        cleanup();
+        resolve(decision as TDecision);
+      };
+
+      const settleReject = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+
+      const abortHandler = () => {
+        settleReject(abortError());
+      };
+
+      if (opts.abortSignal) {
+        if (opts.abortSignal.aborted) {
+          reject(abortError());
+          return;
+        }
+        opts.abortSignal.addEventListener('abort', abortHandler, { once: true });
+      }
+
+      if (opts.timeoutMs !== undefined && opts.onTimeout) {
+        timeout = setTimeout(() => {
+          Promise.resolve(opts.onTimeout?.())
+            .then(settleResolve)
+            .catch((error: unknown) =>
+              settleReject(error instanceof Error ? error : new Error(String(error))),
+            );
+        }, opts.timeoutMs);
+      }
+
+      pendingEntry = {
+        id: opts.id,
+        kind: opts.kind,
+        sessionId: opts.sessionId,
+        streamRunId: opts.streamRunId,
+        resolve: settleResolve,
+        reject: settleReject,
+        abortError,
+        cleanup,
+      };
+      this.pending.set(opts.id, pendingEntry);
+    });
+  }
+
+  resolve<TDecision>(id: string, decision: TDecision): boolean {
+    const entry = this.pending.get(id);
+    if (!entry) return false;
+
+    entry.resolve(decision);
+    return true;
+  }
+
+  reject(id: string, error: Error): boolean {
+    const entry = this.pending.get(id);
+    if (!entry) return false;
+
+    entry.reject(error);
+    return true;
+  }
+
+  abortSession(opts: AbortSessionOptions): PendingInteractionSnapshot[] {
+    const aborted = [...this.pending.values()].filter(
+      (entry) => entry.sessionId === opts.sessionId && (!opts.kind || entry.kind === opts.kind),
+    );
+
+    for (const entry of aborted) {
+      entry.reject(opts.error ?? entry.abortError());
+    }
+
+    return aborted.map(toSnapshot);
+  }
+
+  get(id: string): PendingInteractionSnapshot | undefined {
+    const entry = this.pending.get(id);
+    return entry ? toSnapshot(entry) : undefined;
+  }
+
+  clear(): void {
+    for (const entry of this.pending.values()) {
+      entry.cleanup();
+    }
+    this.pending.clear();
+  }
+
+  private async resolveDuplicate<TDecision>(
+    entry: PendingInteraction,
+    onDuplicate: (() => TDecision | Promise<TDecision>) | undefined,
+  ): Promise<void> {
+    if (!onDuplicate) {
+      entry.reject(entry.abortError());
+      return;
+    }
+
+    try {
+      entry.resolve(await onDuplicate());
+    } catch (error) {
+      entry.reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+}
+
+export const interactionBroker = new InteractionBroker();
+
+function toSnapshot(entry: PendingInteraction): PendingInteractionSnapshot {
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    sessionId: entry.sessionId,
+    streamRunId: entry.streamRunId,
+  };
+}

--- a/packages/server/src/interactions/types.ts
+++ b/packages/server/src/interactions/types.ts
@@ -1,0 +1,28 @@
+import type { PrefixedString } from '@stitch/shared/id';
+
+export type InteractionKind = 'permission' | 'question' | 'doom_loop';
+
+export type PendingInteractionSnapshot = {
+  id: string;
+  kind: InteractionKind;
+  sessionId: PrefixedString<'ses'>;
+  streamRunId?: string;
+};
+
+export type InteractionWaitOptions<TDecision> = {
+  id: string;
+  kind: InteractionKind;
+  sessionId: PrefixedString<'ses'>;
+  streamRunId?: string;
+  abortSignal?: AbortSignal;
+  abortError?: () => Error;
+  timeoutMs?: number;
+  onTimeout?: () => TDecision | Promise<TDecision>;
+  onDuplicate?: () => TDecision | Promise<TDecision>;
+};
+
+export type AbortSessionOptions = {
+  sessionId: PrefixedString<'ses'>;
+  kind?: InteractionKind;
+  error?: Error;
+};

--- a/packages/server/src/llm/stream/doom-loop.ts
+++ b/packages/server/src/llm/stream/doom-loop.ts
@@ -2,6 +2,7 @@ import type { PrefixedString } from '@stitch/shared/id';
 
 import { executeStepWithRetry, type StepOptions } from './step-executor.js';
 
+import { interactionBroker } from '@/interactions/broker.js';
 import * as Log from '@/lib/log.js';
 import * as Sse from '@/lib/sse.js';
 import * as Usage from '@/utils/usage.js';
@@ -37,37 +38,21 @@ export function isDoomLoop(history: ToolCallRecord[]): boolean {
   return tail.every((r) => r.toolName === first.toolName && r.inputJson === first.inputJson);
 }
 
-// ─── Promise registry ─────────────────────────────────────────────────────────
-// One pending prompt per session at a time.
-
-type PendingDecision = {
-  resolve: (response: DoomLoopResponse) => void;
-  timer: ReturnType<typeof setTimeout>;
-};
-
-const pending = new Map<PrefixedString<'ses'>, PendingDecision>();
-
 /**
  * Pause execution until the user responds via the API endpoint.
  * Automatically resolves with `'stop'` after `DECISION_TIMEOUT_MS`.
  */
 export function waitForUserDecision(sessionId: PrefixedString<'ses'>): Promise<DoomLoopResponse> {
-  // If there is already a pending prompt for this session, resolve it first.
-  const existing = pending.get(sessionId);
-  if (existing) {
-    clearTimeout(existing.timer);
-    existing.resolve('stop');
-    pending.delete(sessionId);
-  }
-
-  return new Promise<DoomLoopResponse>((resolve) => {
-    const timer = setTimeout(() => {
+  return interactionBroker.wait<DoomLoopResponse>({
+    id: sessionId,
+    kind: 'doom_loop',
+    sessionId,
+    timeoutMs: DECISION_TIMEOUT_MS,
+    onTimeout: () => {
       log.warn({ sessionId }, 'doom loop decision timed out, auto-stopping');
-      pending.delete(sessionId);
-      resolve('stop');
-    }, DECISION_TIMEOUT_MS);
-
-    pending.set(sessionId, { resolve, timer });
+      return 'stop';
+    },
+    onDuplicate: () => 'stop',
   });
 }
 
@@ -79,13 +64,7 @@ export function resolveDecision(
   sessionId: PrefixedString<'ses'>,
   response: DoomLoopResponse,
 ): boolean {
-  const entry = pending.get(sessionId);
-  if (!entry) return false;
-
-  clearTimeout(entry.timer);
-  entry.resolve(response);
-  pending.delete(sessionId);
-  return true;
+  return interactionBroker.resolve(sessionId, response);
 }
 
 /**

--- a/packages/server/src/permission/service.ts
+++ b/packages/server/src/permission/service.ts
@@ -13,6 +13,7 @@ import type {
 
 import { getDb } from '@/db/client.js';
 import { permissionResponses, toolPermissions } from '@/db/schema.js';
+import { interactionBroker } from '@/interactions/broker.js';
 import * as Log from '@/lib/log.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
@@ -30,14 +31,6 @@ function toPermissionResponse(row: PermissionResponseRow): PermissionResponse {
     resolvedAt: row.resolvedAt ?? undefined,
   };
 }
-
-type PendingPermissionResponse = {
-  resolve: (decision: PermissionDecisionResult) => void;
-  reject: (error: Error) => void;
-  streamRunId?: string;
-};
-
-const pendingPermissionResponses = new Map<PrefixedString<'permres'>, PendingPermissionResponse>();
 
 type SetPermissionRule = {
   permission: ToolPermissionValue;
@@ -145,31 +138,13 @@ export async function requestPermissionResponse(opts: {
     'permission requested',
   );
 
-  return new Promise((resolve, reject) => {
-    const abortHandler = () => {
-      pendingPermissionResponses.delete(id);
-      reject(new PermissionResponseAbortedError());
-    };
-
-    if (opts.abortSignal) {
-      if (opts.abortSignal.aborted) {
-        reject(new PermissionResponseAbortedError());
-        return;
-      }
-      opts.abortSignal.addEventListener('abort', abortHandler, { once: true });
-    }
-
-    pendingPermissionResponses.set(id, {
-      streamRunId: opts.streamRunId,
-      resolve: (decision) => {
-        opts.abortSignal?.removeEventListener('abort', abortHandler);
-        resolve(decision);
-      },
-      reject: (error) => {
-        opts.abortSignal?.removeEventListener('abort', abortHandler);
-        reject(error);
-      },
-    });
+  return interactionBroker.wait<PermissionDecisionResult>({
+    id,
+    kind: 'permission',
+    sessionId: opts.sessionId,
+    streamRunId: opts.streamRunId,
+    abortSignal: opts.abortSignal,
+    abortError: () => new PermissionResponseAbortedError(),
   });
 }
 
@@ -215,7 +190,7 @@ async function resolvePermissionResponse(opts: {
     sessionId: permissionResponse?.sessionId ?? existing.sessionId,
   });
 
-  const pending = pendingPermissionResponses.get(opts.permissionResponseId);
+  const pending = interactionBroker.get(opts.permissionResponseId);
   log.info(
     {
       event: 'stream.permission.resolved',
@@ -227,10 +202,7 @@ async function resolvePermissionResponse(opts: {
     'permission resolved',
   );
 
-  if (pending) {
-    pending.resolve(opts.decision);
-    pendingPermissionResponses.delete(opts.permissionResponseId);
-  }
+  interactionBroker.resolve(opts.permissionResponseId, opts.decision);
 
   return ok(null);
 }
@@ -305,17 +277,17 @@ export async function abortPermissionResponses(sessionId: PrefixedString<'ses'>)
       and(eq(permissionResponses.sessionId, sessionId), eq(permissionResponses.status, 'pending')),
     );
 
+  const aborted = interactionBroker.abortSession({
+    sessionId,
+    kind: 'permission',
+    error: new PermissionResponseAbortedError('Permission response aborted by session abort'),
+  });
+  const streamRunIds = new Map(aborted.map((entry) => [entry.id, entry.streamRunId]));
+
   await Promise.all(
     pending.map(async (row) => {
       const id = row.id;
-      const entry = pendingPermissionResponses.get(id);
-      const streamRunId = entry?.streamRunId;
-      if (entry) {
-        entry.reject(
-          new PermissionResponseAbortedError('Permission response aborted by session abort'),
-        );
-        pendingPermissionResponses.delete(id);
-      }
+      const streamRunId = streamRunIds.get(id);
 
       await broadcast('permission-response-resolved', {
         permissionResponseId: row.id,

--- a/packages/server/src/question/service.ts
+++ b/packages/server/src/question/service.ts
@@ -6,6 +6,7 @@ import type { QuestionInfo, QuestionRequest } from '@stitch/shared/questions/typ
 
 import { getDb } from '@/db/client.js';
 import { questions } from '@/db/schema.js';
+import { interactionBroker } from '@/interactions/broker.js';
 import * as Log from '@/lib/log.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
@@ -49,14 +50,6 @@ export async function createQuestion(opts: {
 
   return toQuestionRequest(row);
 }
-
-type PendingQuestion = {
-  resolve: (answers: string[][]) => void;
-  reject: (error: Error) => void;
-  streamRunId?: string;
-};
-
-const pendingQuestions = new Map<PrefixedString<'quest'>, PendingQuestion>();
 
 export async function askQuestion(opts: {
   sessionId: PrefixedString<'ses'>;
@@ -104,25 +97,13 @@ export async function askQuestion(opts: {
     question: toQuestionRequest(row),
   });
 
-  return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      pendingQuestions.delete(id);
-    };
-
-    const abortHandler = () => {
-      cleanup();
-      reject(new QuestionAbortedError());
-    };
-
-    if (opts.abortSignal) {
-      if (opts.abortSignal.aborted) {
-        reject(new QuestionAbortedError());
-        return;
-      }
-      opts.abortSignal.addEventListener('abort', abortHandler, { once: true });
-    }
-
-    pendingQuestions.set(id, { resolve, reject, streamRunId: opts.streamRunId });
+  return interactionBroker.wait<string[][]>({
+    id,
+    kind: 'question',
+    sessionId: opts.sessionId,
+    streamRunId: opts.streamRunId,
+    abortSignal: opts.abortSignal,
+    abortError: () => new QuestionAbortedError(),
   });
 }
 
@@ -153,7 +134,7 @@ export async function replyQuestion(
     answers,
   });
 
-  const pending = pendingQuestions.get(questionId);
+  const pending = interactionBroker.get(questionId);
   log.info(
     {
       event: 'stream.question.resolved',
@@ -165,10 +146,7 @@ export async function replyQuestion(
     'question resolved',
   );
 
-  if (pending) {
-    pending.resolve(answers);
-    pendingQuestions.delete(questionId);
-  }
+  interactionBroker.resolve(questionId, answers);
 
   log.info({ questionId }, 'question replied');
   return ok(null);
@@ -198,7 +176,7 @@ export async function rejectQuestion(
     sessionId: question.sessionId,
   });
 
-  const pending = pendingQuestions.get(questionId);
+  const pending = interactionBroker.get(questionId);
   log.info(
     {
       event: 'stream.question.resolved',
@@ -210,10 +188,7 @@ export async function rejectQuestion(
     'question resolved',
   );
 
-  if (pending) {
-    pending.reject(new Error('Question rejected by user'));
-    pendingQuestions.delete(questionId);
-  }
+  interactionBroker.reject(questionId, new Error('Question rejected by user'));
 
   log.info({ questionId }, 'question rejected');
   return ok(null);
@@ -251,14 +226,16 @@ export async function abortQuestions(sessionId: PrefixedString<'ses'>): Promise<
     .set({ status: 'rejected', answeredAt: now })
     .where(and(eq(questions.sessionId, sessionId), eq(questions.status, 'pending')));
 
+  const aborted = interactionBroker.abortSession({
+    sessionId,
+    kind: 'question',
+    error: new QuestionAbortedError('Question aborted by session abort'),
+  });
+  const streamRunIds = new Map(aborted.map((entry) => [entry.id, entry.streamRunId]));
+
   await Promise.all(
     pendingRows.map(async (q) => {
-      const entry = pendingQuestions.get(q.id);
-      const streamRunId = entry?.streamRunId;
-      if (entry) {
-        entry.reject(new QuestionAbortedError('Question aborted by session abort'));
-        pendingQuestions.delete(q.id);
-      }
+      const streamRunId = streamRunIds.get(q.id);
       await broadcast('question-rejected', { questionId: q.id, sessionId });
 
       log.info(


### PR DESCRIPTION
## 🚀 Change Summary

Adds a shared server-side interaction broker for pending human-in-the-loop decisions, then migrates question prompts, permission prompts, and doom-loop decisions to use the same lifecycle primitive while preserving existing persistence and SSE contracts.

### 🛠 Improvements & Refactors
- Centralizes pending interaction wait, resolve, reject, abort, duplicate, and timeout behavior in a reusable broker.
- Migrates question, permission, and doom-loop pending promise registries to the shared broker.
- Adds focused coverage for broker behavior and service-level question/permission interaction flows.