### PR TITLE
Load codebase skills on startup

### DIFF
--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -62,6 +62,7 @@ const config: Configuration = {
       to: 'server-assets',
       filter: [
         'meeting/*.md',
+        'skills/built-ins/**/*.md',
         'lib/browser/instructions/*.md',
         'llm/prompt/base-system-prompt.txt',
       ],

--- a/packages/server/__test__/fixtures/skills/test-skill.md
+++ b/packages/server/__test__/fixtures/skills/test-skill.md
@@ -1,0 +1,6 @@
+---
+name: test-skill
+description: Use this test skill in loader tests.
+---
+
+These are test skill instructions.

--- a/packages/server/__test__/skills/built-in-skills.test.ts
+++ b/packages/server/__test__/skills/built-in-skills.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+
+import { getBuiltInSkillSource, loadBuiltInSkills } from '@/skills/built-in-skills.js';
+
+describe('loadBuiltInSkills', () => {
+  test('loads skills from markdown files', async () => {
+    const skills = await loadBuiltInSkills([
+      {
+        sourceUrl: new URL('../fixtures/skills/test-skill.md', import.meta.url),
+        bundledPath: 'unused-in-tests/test-skill.md',
+      },
+    ]);
+
+    expect(skills).toEqual([
+      {
+        name: 'test-skill',
+        description: 'Use this test skill in loader tests.',
+        content: 'These are test skill instructions.',
+      },
+    ]);
+  });
+
+  test('rejects duplicate skill names', async () => {
+    const file = {
+      sourceUrl: new URL('../fixtures/skills/test-skill.md', import.meta.url),
+      bundledPath: 'unused-in-tests/test-skill.md',
+    };
+
+    await expect(loadBuiltInSkills([file, file])).rejects.toThrow(
+      'Duplicate built-in skill name: test-skill',
+    );
+  });
+});
+
+describe('getBuiltInSkillSource', () => {
+  test('builds stable source keys', () => {
+    expect(getBuiltInSkillSource('test-skill')).toBe('builtin:test-skill');
+  });
+});

--- a/packages/server/__test__/skills/service-built-ins.test.ts
+++ b/packages/server/__test__/skills/service-built-ins.test.ts
@@ -1,0 +1,158 @@
+import { createHash } from 'node:crypto';
+
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+function skillHash(skill: { name: string; description: string; content: string }): string {
+  return createHash('sha256')
+    .update(
+      JSON.stringify({
+        name: skill.name,
+        description: skill.description,
+        content: skill.content,
+      }),
+      'utf8',
+    )
+    .digest('hex');
+}
+
+const mocks = vi.hoisted(() => {
+  const selectGetMock = vi.fn();
+  const insertValuesMock = vi.fn();
+  const updateWhereMock = vi.fn();
+  const updateSetMock = vi.fn(() => ({ where: updateWhereMock }));
+  const orderByMock = vi.fn();
+  const whereMock = vi.fn(() => ({ get: selectGetMock }));
+  const fromMock = vi.fn(() => ({ where: whereMock, orderBy: orderByMock }));
+  const selectMock = vi.fn(() => ({ from: fromMock }));
+  const insertMock = vi.fn(() => ({ values: insertValuesMock }));
+  const updateMock = vi.fn(() => ({ set: updateSetMock }));
+  const getDbMock = vi.fn(() => ({
+    insert: insertMock,
+    select: selectMock,
+    update: updateMock,
+  }));
+  const isDbInitializedMock = vi.fn(() => true);
+
+  return {
+    fromMock,
+    getDbMock,
+    insertValuesMock,
+    isDbInitializedMock,
+    orderByMock,
+    selectGetMock,
+    updateSetMock,
+    updateWhereMock,
+    whereMock,
+  };
+});
+
+vi.mock('@/db/client.js', () => ({
+  getDb: mocks.getDbMock,
+  isDbInitialized: mocks.isDbInitializedMock,
+}));
+
+describe('syncBuiltInSkills', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isDbInitializedMock.mockReturnValue(true);
+  });
+
+  test('inserts missing built-in skills', async () => {
+    const { syncBuiltInSkills } = await import('@/skills/service.js');
+    mocks.selectGetMock.mockReturnValue(undefined);
+
+    await syncBuiltInSkills([
+      {
+        name: 'test-skill',
+        description: 'Use this test skill.',
+        content: 'Test instructions.',
+      },
+    ]);
+
+    expect(mocks.insertValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'test-skill',
+        description: 'Use this test skill.',
+        content: 'Test instructions.',
+        isExternal: false,
+        source: 'builtin:test-skill',
+      }),
+    );
+  });
+
+  test('updates existing skills that match built-in names', async () => {
+    const { syncBuiltInSkills } = await import('@/skills/service.js');
+    mocks.selectGetMock.mockReturnValue({
+      id: 'skill_existing',
+      name: 'test-skill',
+      description: 'Old description.',
+      content: 'Old instructions.',
+      hash: 'old-hash',
+      isExternal: false,
+      source: null,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    await syncBuiltInSkills([
+      {
+        name: 'test-skill',
+        description: 'New description.',
+        content: 'New instructions.',
+      },
+    ]);
+
+    expect(mocks.updateSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'New description.',
+        content: 'New instructions.',
+        isExternal: false,
+        source: 'builtin:test-skill',
+      }),
+    );
+  });
+
+  test('does not update unchanged built-in skills', async () => {
+    const { syncBuiltInSkills } = await import('@/skills/service.js');
+    const skill = {
+      name: 'test-skill',
+      description: 'Use this test skill.',
+      content: 'Test instructions.',
+    };
+    mocks.selectGetMock.mockReturnValue({
+      id: 'skill_existing',
+      ...skill,
+      hash: skillHash(skill),
+      isExternal: false,
+      source: 'builtin:test-skill',
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    await syncBuiltInSkills([skill]);
+
+    expect(mocks.insertValuesMock).not.toHaveBeenCalled();
+    expect(mocks.updateSetMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildSkillsSystemPrompt', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isDbInitializedMock.mockReturnValue(true);
+  });
+
+  test('includes built-in skills from the database', async () => {
+    const { buildSkillsSystemPrompt } = await import('@/skills/service.js');
+    mocks.orderByMock.mockResolvedValue([
+      {
+        name: 'test-skill',
+        description: 'Use this test skill.',
+      },
+    ]);
+
+    await expect(buildSkillsSystemPrompt()).resolves.toContain(
+      '- test-skill: Use this test skill.',
+    );
+  });
+});

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -7,6 +7,7 @@ import * as Log from '@/lib/log.js';
 import { refreshMcpToolsets } from '@/mcp/tool-executor.js';
 import { startMeetingDetection } from '@/recordings/meeting-detection.js';
 import { startScheduler } from '@/scheduler/runtime.js';
+import { syncBuiltInSkills } from '@/skills/service.js';
 import { registerDefaultToolsets } from '@/tools/toolsets/register-default-toolsets.js';
 
 const log = Log.create({ service: 'init' });
@@ -16,6 +17,7 @@ export async function init() {
 
   await initDb();
   await runPendingMigrations(getDb());
+  await syncBuiltInSkills();
 
   // Register built-in toolsets, then refresh MCP toolsets
   registerDefaultToolsets();

--- a/packages/server/src/skills/built-in-skills.ts
+++ b/packages/server/src/skills/built-in-skills.ts
@@ -1,0 +1,43 @@
+import { readFile } from 'node:fs/promises';
+
+import { createSkillSchema } from '@stitch/shared/skills/types';
+import type { SkillCreateInput } from '@stitch/shared/skills/types';
+
+import { resolveRuntimeAssetPath } from '@/lib/runtime-assets.js';
+import { BUILT_IN_SKILL_FILES } from '@/skills/built-ins/manifest.js';
+import type { BuiltInSkillFile } from '@/skills/built-ins/manifest.js';
+import { parseSkillMarkdown } from '@/skills/parse-skill-markdown.js';
+
+export function getBuiltInSkillSource(name: string): string {
+  return `builtin:${name}`;
+}
+
+export async function loadBuiltInSkills(
+  files: BuiltInSkillFile[] = BUILT_IN_SKILL_FILES,
+): Promise<SkillCreateInput[]> {
+  const skills = await Promise.all(
+    files.map(async (file) => {
+      const path = resolveRuntimeAssetPath(file.sourceUrl, file.bundledPath);
+      const markdown = await readFile(path, 'utf8');
+      const parsed = parseSkillMarkdown(markdown);
+      if (!parsed) throw new Error(`Invalid built-in skill markdown: ${file.bundledPath}`);
+
+      const result = createSkillSchema.safeParse(parsed);
+      if (!result.success) {
+        throw new Error(
+          `Invalid built-in skill ${file.bundledPath}: ${result.error.issues[0]?.message ?? 'validation failed'}`,
+        );
+      }
+
+      return result.data;
+    }),
+  );
+
+  const names = new Set<string>();
+  for (const skill of skills) {
+    if (names.has(skill.name)) throw new Error(`Duplicate built-in skill name: ${skill.name}`);
+    names.add(skill.name);
+  }
+
+  return skills;
+}

--- a/packages/server/src/skills/built-ins/manifest.ts
+++ b/packages/server/src/skills/built-ins/manifest.ts
@@ -1,0 +1,6 @@
+export type BuiltInSkillFile = {
+  sourceUrl: URL;
+  bundledPath: string;
+};
+
+export const BUILT_IN_SKILL_FILES: BuiltInSkillFile[] = [];

--- a/packages/server/src/skills/service.ts
+++ b/packages/server/src/skills/service.ts
@@ -21,6 +21,7 @@ import { skills } from '@/db/schema.js';
 import * as Log from '@/lib/log.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
+import { getBuiltInSkillSource, loadBuiltInSkills } from '@/skills/built-in-skills.js';
 import { parseSkillMarkdown } from '@/skills/parse-skill-markdown.js';
 
 const log = Log.create({ service: 'skills' });
@@ -60,6 +61,20 @@ function computeSkillHash(input: SkillCreateInput): string {
       'utf8',
     )
     .digest('hex');
+}
+
+function buildSkillRow(input: SkillCreateInput, now: number, source: string | null): Skill {
+  return {
+    id: createSkillId(),
+    name: input.name,
+    description: input.description.trim(),
+    content: input.content.trim(),
+    hash: computeSkillHash(input),
+    isExternal: false,
+    source,
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 function toSourceKey(source: string, slug: string): string {
@@ -110,18 +125,7 @@ export async function createSkill(input: SkillCreateInput): Promise<ServiceResul
     return err(`Skill name "${value.name}" already exists`, 409);
   }
 
-  const now = Date.now();
-  const row = {
-    id: createSkillId(),
-    name: value.name,
-    description: value.description.trim(),
-    content: value.content.trim(),
-    hash: computeSkillHash(value),
-    isExternal: false,
-    source: null,
-    createdAt: now,
-    updatedAt: now,
-  } satisfies Skill;
+  const row = buildSkillRow(value, Date.now(), null);
 
   if (await skillHashExists(row.hash)) {
     return err('A skill with the same instructions already exists', 409);
@@ -129,6 +133,58 @@ export async function createSkill(input: SkillCreateInput): Promise<ServiceResul
 
   await getDb().insert(skills).values(row);
   return ok(row);
+}
+
+export async function syncBuiltInSkills(builtInSkills?: SkillCreateInput[]): Promise<void> {
+  const loadedSkills = builtInSkills ?? (await loadBuiltInSkills());
+  const parsedSkills = loadedSkills.map((skill) => {
+    const parsed = createSkillSchema.safeParse(skill);
+    if (!parsed.success) {
+      throw new Error(parsed.error.issues[0]?.message ?? 'Invalid built-in skill');
+    }
+    return parsed.data;
+  });
+
+  const names = new Set<string>();
+  for (const skill of parsedSkills) {
+    if (names.has(skill.name)) throw new Error(`Duplicate built-in skill name: ${skill.name}`);
+    names.add(skill.name);
+  }
+
+  for (const skill of parsedSkills) {
+    const source = getBuiltInSkillSource(skill.name);
+    const existing = getDb().select().from(skills).where(eq(skills.name, skill.name)).get();
+    const hash = computeSkillHash(skill);
+
+    if (!existing) {
+      await getDb()
+        .insert(skills)
+        .values(buildSkillRow(skill, Date.now(), source));
+      continue;
+    }
+
+    if (
+      existing.description === skill.description.trim() &&
+      existing.content === skill.content.trim() &&
+      existing.hash === hash &&
+      existing.source === source &&
+      existing.isExternal === false
+    ) {
+      continue;
+    }
+
+    await getDb()
+      .update(skills)
+      .set({
+        description: skill.description.trim(),
+        content: skill.content.trim(),
+        hash,
+        isExternal: false,
+        source,
+        updatedAt: Date.now(),
+      })
+      .where(eq(skills.id, existing.id));
+  }
 }
 
 export async function updateSkill(


### PR DESCRIPTION
## 🚀 Change Summary

Adds server support for codebase-maintained skills that are stored as markdown, loaded through the existing runtime asset path resolver, and synced into the skills database during app startup.

### ✨ New Features
- **Built-in Skill Sync**: Loads markdown-defined skills from a manifest and inserts or updates them in the skills table at startup.
- **Packaged Markdown Assets**: Includes built-in skill markdown files in Electron server assets so packaged apps can load them reliably.

### 🛠 Improvements & Refactors
- Reuses skill row construction for user-created and built-in skills.
- Adds validation for duplicate and invalid built-in skill definitions.

### 🐛 Bug Fixes
- None.

### 📚 Documentation
- None.