### PR TITLE
fix: remove flaky same-millisecond timestamp test

### DIFF
--- a/packages/shared/src/id/index.test.ts
+++ b/packages/shared/src/id/index.test.ts
@@ -81,13 +81,6 @@ describe('extractTimestamp', () => {
     expect(extracted).toBeGreaterThan(0);
   });
 
-  test('same-millisecond ids produce the same extracted timestamp', () => {
-    // Generate two ids quickly — they'll share the same ms
-    const a = createPartId();
-    const b = createPartId();
-    expect(extractTimestamp(a)).toBe(extractTimestamp(b));
-  });
-
   test('ids created later have equal or greater timestamps', async () => {
     const first = createPartId();
     // Wait 2ms to guarantee a new timestamp bucket


### PR DESCRIPTION
## 🐛 Bug Fixes

- **Remove flaky timestamp test**: The \same-millisecond ids produce the same extracted timestamp\ test in \packages/shared/src/id/index.test.ts\ assumed two rapid sequential ID creations would always share the same millisecond — but on CI (Windows) the calls can straddle a millisecond boundary, causing intermittent failures (e.g. expected \61836596313\, received \61836596311\). This was blocking the release pipeline ([run #43](https://github.com/UseStitch/stitch/actions/runs/26469970184/job/77940561061)).