### PR TITLE
chore: upgrade bun to 1.3.14

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: '1.3.8'
+        bun-version: '1.3.14'
 
     - name: Cache bun global install cache (Windows)
       id: cache-bun-global

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "oxlint-tsgolint": "^0.16.0",
     "turbo": "latest"
   },
-  "packageManager": "bun@1.3.8",
+  "packageManager": "bun@1.3.14",
   "catalog": {
     "typescript": "latest",
     "@types/bun": "latest",


### PR DESCRIPTION
## 🚀 Change Summary

Upgrades Bun from 1.3.8 to 1.3.14 to fix Worker entrypoint resolution in compiled standalone binaries.

### 🛠 Improvements & Refactors
- **Bun 1.3.14**: Includes oven-sh/bun#29150 which fixes \ModuleNotFound\ errors when using \
ew Worker(new URL(..., import.meta.url))\ inside compiled binaries on Windows (\B:/~BUN/\ path resolution)