### PR TITLE
Add hosted embedding registry

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun run ../../scripts/build-mcp-registry.mjs"
+    "build": "bun run ../../scripts/build-website-registries.mjs"
   }
 }

--- a/registries/embeddings/models/google.json
+++ b/registries/embeddings/models/google.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://usestitch.ai/schemas/embedding-provider.schema.json",
+  "providerId": "google",
+  "providerName": "Google",
+  "npm": "@ai-sdk/google",
+  "env": ["GOOGLE_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"],
+  "models": [
+    {
+      "id": "gemini-embedding-001",
+      "name": "Gemini Embedding 001",
+      "family": "gemini",
+      "dimensions": 1,
+      "release_date": "2025-05-20",
+      "context": 2048,
+      "cost": {
+        "input": 0.15,
+        "output": 0
+      }
+    }
+  ]
+}

--- a/registries/embeddings/models/google.json
+++ b/registries/embeddings/models/google.json
@@ -15,7 +15,10 @@
       "inputModalities": ["text", "image", "video", "audio", "pdf"],
       "outputModalities": ["text"],
       "cost": {
-        "input": 0.15,
+        "input": 0.2,
+        "inputImage": 0.45,
+        "inputAudio": 6.5,
+        "inputVideo": 12,
         "output": 0
       }
     },

--- a/registries/embeddings/models/google.json
+++ b/registries/embeddings/models/google.json
@@ -6,12 +6,28 @@
   "env": ["GOOGLE_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"],
   "models": [
     {
+      "id": "gemini-embedding-2",
+      "name": "Gemini Embedding 2",
+      "family": "gemini",
+      "dimensions": 3072,
+      "release_date": "2026-04-01",
+      "context": 8192,
+      "inputModalities": ["text", "image", "video", "audio", "pdf"],
+      "outputModalities": ["text"],
+      "cost": {
+        "input": 0.15,
+        "output": 0
+      }
+    },
+    {
       "id": "gemini-embedding-001",
       "name": "Gemini Embedding 001",
       "family": "gemini",
-      "dimensions": 1,
-      "release_date": "2025-05-20",
+      "dimensions": 3072,
+      "release_date": "2025-06-01",
       "context": 2048,
+      "inputModalities": ["text"],
+      "outputModalities": ["text"],
       "cost": {
         "input": 0.15,
         "output": 0

--- a/registries/embeddings/models/openai.json
+++ b/registries/embeddings/models/openai.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://usestitch.ai/schemas/embedding-provider.schema.json",
+  "providerId": "openai",
+  "providerName": "OpenAI",
+  "npm": "@ai-sdk/openai",
+  "env": ["OPENAI_API_KEY"],
+  "models": [
+    {
+      "id": "text-embedding-3-large",
+      "name": "text-embedding-3-large",
+      "family": "text-embedding",
+      "dimensions": 3072,
+      "release_date": "2024-01-25",
+      "context": 8191,
+      "cost": {
+        "input": 0.13,
+        "output": 0
+      }
+    },
+    {
+      "id": "text-embedding-3-small",
+      "name": "text-embedding-3-small",
+      "family": "text-embedding",
+      "dimensions": 1536,
+      "release_date": "2024-01-25",
+      "context": 8191,
+      "cost": {
+        "input": 0.02,
+        "output": 0
+      }
+    },
+    {
+      "id": "text-embedding-ada-002",
+      "name": "text-embedding-ada-002",
+      "family": "text-embedding",
+      "dimensions": 1536,
+      "release_date": "2022-12-15",
+      "context": 8192,
+      "cost": {
+        "input": 0.1,
+        "output": 0
+      }
+    }
+  ]
+}

--- a/registries/embeddings/package.json
+++ b/registries/embeddings/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@stitch/registry-embeddings",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./models/google.json": "./models/google.json",
+    "./models/openai.json": "./models/openai.json"
+  }
+}

--- a/registries/embeddings/schema/embedding-provider.schema.json
+++ b/registries/embeddings/schema/embedding-provider.schema.json
@@ -88,6 +88,18 @@
               "input": {
                 "type": "number"
               },
+              "inputImage": {
+                "type": "number",
+                "description": "Image input price in USD per image."
+              },
+              "inputAudio": {
+                "type": "number",
+                "description": "Audio input price in USD per second."
+              },
+              "inputVideo": {
+                "type": "number",
+                "description": "Video input price in USD per frame."
+              },
               "output": {
                 "type": "number"
               }

--- a/registries/embeddings/schema/embedding-provider.schema.json
+++ b/registries/embeddings/schema/embedding-provider.schema.json
@@ -62,6 +62,24 @@
             "type": "integer",
             "minimum": 1
           },
+          "inputModalities": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": ["text", "image", "video", "audio", "pdf"]
+            }
+          },
+          "outputModalities": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "enum": ["text"]
+            }
+          },
           "cost": {
             "type": "object",
             "additionalProperties": false,

--- a/registries/embeddings/schema/embedding-provider.schema.json
+++ b/registries/embeddings/schema/embedding-provider.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usestitch.ai/schemas/embedding-provider.schema.json",
+  "title": "Stitch Embedding Provider Registry Entry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["providerId", "providerName", "models"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON Schema reference for editor tooling"
+    },
+    "providerId": {
+      "type": "string",
+      "enum": ["google", "openai"]
+    },
+    "providerName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "api": {
+      "type": "string"
+    },
+    "npm": {
+      "type": "string"
+    },
+    "env": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "models": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name", "dimensions", "release_date", "context", "cost"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "family": {
+            "type": "string"
+          },
+          "dimensions": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "release_date": {
+            "type": "string",
+            "minLength": 1
+          },
+          "context": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "cost": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["input", "output"],
+            "properties": {
+              "input": {
+                "type": "number"
+              },
+              "output": {
+                "type": "number"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/build-website-registries.mjs
+++ b/scripts/build-website-registries.mjs
@@ -8,8 +8,12 @@ const rootDir = join(__dirname, '..');
 const registryDir = join(rootDir, 'registries', 'mcp');
 const serversDir = join(registryDir, 'servers');
 const schemaDir = join(registryDir, 'schema');
+const embeddingsRegistryDir = join(rootDir, 'registries', 'embeddings');
+const embeddingModelsDir = join(embeddingsRegistryDir, 'models');
+const embeddingSchemaDir = join(embeddingsRegistryDir, 'schema');
 const outputDir = join(rootDir, 'apps', 'website', 'dist');
 const outputFile = join(outputDir, 'mcp-registry.json');
+const embeddingOutputFile = join(outputDir, 'embedding-models.json');
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
@@ -108,6 +112,53 @@ function assertServerConfig(server, filePath) {
   }
 }
 
+function assertEmbeddingModel(model, filePath) {
+  assert(model && typeof model === 'object', `${filePath}: model must be an object`);
+  assert(typeof model.id === 'string' && model.id.length > 0, `${filePath}: model.id is required`);
+  assert(
+    typeof model.name === 'string' && model.name.length > 0,
+    `${filePath}: model.name is required`,
+  );
+  assert(
+    Number.isInteger(model.dimensions) && model.dimensions > 0,
+    `${filePath}: model.dimensions must be a positive integer`,
+  );
+  assert(
+    typeof model.release_date === 'string' && model.release_date.length > 0,
+    `${filePath}: model.release_date is required`,
+  );
+  assert(
+    Number.isInteger(model.context) && model.context > 0,
+    `${filePath}: model.context must be a positive integer`,
+  );
+  assert(model.cost && typeof model.cost === 'object', `${filePath}: model.cost is required`);
+  assert(typeof model.cost.input === 'number', `${filePath}: model.cost.input must be a number`);
+  assert(typeof model.cost.output === 'number', `${filePath}: model.cost.output must be a number`);
+}
+
+function assertEmbeddingProviderConfig(provider, filePath) {
+  assert(provider && typeof provider === 'object', `${filePath}: config must be an object`);
+  assert(
+    provider.providerId === 'google' || provider.providerId === 'openai',
+    `${filePath}: providerId must be google or openai`,
+  );
+  assert(
+    typeof provider.providerName === 'string' && provider.providerName.length > 0,
+    `${filePath}: providerName is required`,
+  );
+  assert(
+    Array.isArray(provider.models) && provider.models.length > 0,
+    `${filePath}: models must be a non-empty array`,
+  );
+
+  const ids = new Set();
+  for (const model of provider.models) {
+    assertEmbeddingModel(model, filePath);
+    assert(!ids.has(model.id), `${filePath}: duplicate model id ${model.id}`);
+    ids.add(model.id);
+  }
+}
+
 function loadServerConfigs() {
   const files = readdirSync(serversDir)
     .filter((name) => name.endsWith('.json'))
@@ -128,7 +179,30 @@ function loadServerConfigs() {
   return servers.toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
-function writeOutput(servers) {
+function loadEmbeddingProviderConfigs() {
+  const files = readdirSync(embeddingModelsDir)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => join(embeddingModelsDir, name));
+
+  const providers = files.map((filePath) => {
+    const parsed = readJson(filePath);
+    assertEmbeddingProviderConfig(parsed, filePath);
+    return parsed;
+  });
+
+  const ids = new Set();
+  for (const provider of providers) {
+    assert(
+      !ids.has(provider.providerId),
+      `Duplicate embedding provider id: ${provider.providerId}`,
+    );
+    ids.add(provider.providerId);
+  }
+
+  return providers.toSorted((a, b) => a.providerName.localeCompare(b.providerName));
+}
+
+function writeOutput(servers, embeddingProviders) {
   mkdirSync(outputDir, { recursive: true });
   mkdirSync(join(outputDir, 'schemas'), { recursive: true });
 
@@ -136,6 +210,10 @@ function writeOutput(servers) {
   cpSync(
     join(schemaDir, 'mcp-server.schema.json'),
     join(outputDir, 'schemas', 'mcp-server.schema.json'),
+  );
+  cpSync(
+    join(embeddingSchemaDir, 'embedding-provider.schema.json'),
+    join(outputDir, 'schemas', 'embedding-provider.schema.json'),
   );
 
   const payload = {
@@ -145,12 +223,24 @@ function writeOutput(servers) {
   };
 
   writeFileSync(outputFile, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+
+  const embeddingPayload = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    providers: embeddingProviders,
+  };
+
+  writeFileSync(embeddingOutputFile, `${JSON.stringify(embeddingPayload, null, 2)}\n`, 'utf8');
 }
 
 function main() {
   const servers = loadServerConfigs();
-  writeOutput(servers);
+  const embeddingProviders = loadEmbeddingProviderConfigs();
+  writeOutput(servers, embeddingProviders);
   console.log(`Built MCP registry with ${servers.length} server(s): ${outputFile}`);
+  console.log(
+    `Built embedding registry with ${embeddingProviders.length} provider(s): ${embeddingOutputFile}`,
+  );
 }
 
 main();

--- a/scripts/build-website-registries.mjs
+++ b/scripts/build-website-registries.mjs
@@ -145,6 +145,24 @@ function assertEmbeddingModel(model, filePath) {
   }
   assert(model.cost && typeof model.cost === 'object', `${filePath}: model.cost is required`);
   assert(typeof model.cost.input === 'number', `${filePath}: model.cost.input must be a number`);
+  if (model.cost.inputImage !== undefined) {
+    assert(
+      typeof model.cost.inputImage === 'number',
+      `${filePath}: model.cost.inputImage must be a number`,
+    );
+  }
+  if (model.cost.inputAudio !== undefined) {
+    assert(
+      typeof model.cost.inputAudio === 'number',
+      `${filePath}: model.cost.inputAudio must be a number`,
+    );
+  }
+  if (model.cost.inputVideo !== undefined) {
+    assert(
+      typeof model.cost.inputVideo === 'number',
+      `${filePath}: model.cost.inputVideo must be a number`,
+    );
+  }
   assert(typeof model.cost.output === 'number', `${filePath}: model.cost.output must be a number`);
 }
 

--- a/scripts/build-website-registries.mjs
+++ b/scripts/build-website-registries.mjs
@@ -131,6 +131,18 @@ function assertEmbeddingModel(model, filePath) {
     Number.isInteger(model.context) && model.context > 0,
     `${filePath}: model.context must be a positive integer`,
   );
+  if (model.inputModalities !== undefined) {
+    assert(
+      Array.isArray(model.inputModalities) && model.inputModalities.length > 0,
+      `${filePath}: model.inputModalities must be a non-empty array`,
+    );
+  }
+  if (model.outputModalities !== undefined) {
+    assert(
+      Array.isArray(model.outputModalities) && model.outputModalities.length > 0,
+      `${filePath}: model.outputModalities must be a non-empty array`,
+    );
+  }
   assert(model.cost && typeof model.cost === 'object', `${filePath}: model.cost is required`);
   assert(typeof model.cost.input === 'number', `${filePath}: model.cost.input must be a number`);
   assert(typeof model.cost.output === 'number', `${filePath}: model.cost.output must be a number`);


### PR DESCRIPTION
## 🚀 Change Summary

Adds a hosted embedding model registry to the website deployment so embedding model metadata can be served from Cloudflare Pages independently of the application runtime.

### ✨ New Features
- **Embedding Registry**: Adds a new @stitch/registry-embeddings workspace with OpenAI and Google embedding model metadata.
- **Hosted Registry Asset**: Publishes mbedding-models.json and its JSON schema from the website build output.

### 🛠 Improvements & Refactors
- Renames the website registry build script to uild-website-registries.mjs and expands it to validate and emit both MCP and embedding registries.
- Adds schema support for embedding modalities and multimodal Google pricing units.