### PR TITLE
fix(ci): fix cloudflare deploy workflow step ordering and tooling

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Build MCP registry artifact
-        run: node scripts/build-mcp-registry.mjs
+        run: node scripts/build-website-registries.mjs
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Build MCP registry artifact
-        run: node scripts/build-website-registries.mjs
-
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
+
+      - name: Build website registry artifacts
+        run: bun run scripts/build-website-registries.mjs
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## 🚀 Change Summary

Fixes three issues in the Cloudflare deploy workflow.

### 🐛 Bug Fixes
- **Wrong script name**: Updated step to call \uild-website-registries.mjs\ instead of the now-deleted \uild-mcp-registry.mjs\
- **Wrong runner**: Changed from \
ode\ to \un\ to stay consistent with the rest of the project
- **Wrong step order**: Moved \Setup Bun\ before the build step so bun is available when the script runs