### PR TITLE
feat: add live transcription provider registry

### DIFF
--- a/registries/live-transcription/models/google.json
+++ b/registries/live-transcription/models/google.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "../schema/live-transcription-provider.schema.json",
+  "providerId": "google",
+  "providerName": "Google",
+  "models": [
+    {
+      "id": "gemini-3.1-flash-live-preview",
+      "name": "Gemini 3.1 Flash Live",
+      "endpoint": "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent",
+      "supportedLanguages": ["en", "es", "fr", "de", "it", "pt", "ja", "ko", "zh", "hi", "ar"],
+      "audio": {
+        "sampleRate": 16000,
+        "channels": 1,
+        "encoding": "pcm_s16le"
+      },
+      "connection": {
+        "mode": "per-source",
+        "authMethod": "query-param",
+        "authParam": "key"
+      },
+      "features": {
+        "voiceActivityDetection": true,
+        "partialResults": true
+      },
+      "limits": {
+        "maxSessionDurationMs": 7200000,
+        "maxChunkDurationMs": 200
+      }
+    }
+  ]
+}

--- a/registries/live-transcription/models/openai.json
+++ b/registries/live-transcription/models/openai.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "../schema/live-transcription-provider.schema.json",
+  "providerId": "openai",
+  "providerName": "OpenAI",
+  "models": [
+    {
+      "id": "gpt-realtime-whisper",
+      "name": "GPT Realtime Whisper",
+      "endpoint": "wss://api.openai.com/v1/realtime",
+      "supportedLanguages": ["en", "es", "fr", "de", "it", "pt", "ja", "ko", "zh", "hi", "ar"],
+      "audio": {
+        "sampleRate": 24000,
+        "channels": 1,
+        "encoding": "pcm_s16le"
+      },
+      "connection": {
+        "mode": "per-source",
+        "authMethod": "header",
+        "authParam": "Authorization"
+      },
+      "features": {
+        "voiceActivityDetection": false,
+        "partialResults": true,
+        "delayLevels": ["minimal", "low", "medium", "high", "xhigh"]
+      },
+      "limits": {
+        "maxSessionDurationMs": 3600000,
+        "maxChunkDurationMs": 200
+      }
+    }
+  ]
+}

--- a/registries/live-transcription/package.json
+++ b/registries/live-transcription/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@stitch/registry-live-transcription",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./models/google.json": "./models/google.json",
+    "./models/openai.json": "./models/openai.json"
+  }
+}

--- a/registries/live-transcription/schema/live-transcription-provider.schema.json
+++ b/registries/live-transcription/schema/live-transcription-provider.schema.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usestitch.ai/schemas/live-transcription-provider.schema.json",
+  "title": "Stitch Live Transcription Provider Registry Entry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["providerId", "providerName", "models"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON Schema reference for editor tooling"
+    },
+    "providerId": {
+      "type": "string",
+      "enum": ["google", "openai"]
+    },
+    "providerName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "models": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name", "endpoint", "audio", "connection"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Model identifier used in API requests"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-readable model name"
+          },
+          "endpoint": {
+            "type": "string",
+            "format": "uri",
+            "description": "WebSocket endpoint URL for the provider"
+          },
+          "supportedLanguages": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 5
+            },
+            "description": "BCP-47 language codes supported by this model"
+          },
+          "audio": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["sampleRate", "channels", "encoding"],
+            "description": "Audio format the provider expects to receive",
+            "properties": {
+              "sampleRate": {
+                "type": "integer",
+                "minimum": 8000,
+                "maximum": 48000,
+                "description": "Sample rate in Hz"
+              },
+              "channels": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 2,
+                "description": "Number of audio channels"
+              },
+              "encoding": {
+                "type": "string",
+                "enum": ["pcm_s16le"],
+                "description": "Audio encoding format"
+              }
+            }
+          },
+          "connection": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["mode", "authMethod"],
+            "description": "How the server connects to this provider",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["per-source", "single"],
+                "description": "per-source opens one upstream WS per audio source (mic/speaker); single sends both through one session"
+              },
+              "authMethod": {
+                "type": "string",
+                "enum": ["query-param", "header"],
+                "description": "How authentication is passed to the WebSocket endpoint"
+              },
+              "authParam": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The query parameter name or header name used for auth"
+              }
+            }
+          },
+          "features": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Optional capabilities supported by this model",
+            "properties": {
+              "voiceActivityDetection": {
+                "type": "boolean",
+                "description": "Whether the provider handles VAD server-side"
+              },
+              "partialResults": {
+                "type": "boolean",
+                "description": "Whether the provider streams partial/delta transcripts"
+              },
+              "delayLevels": {
+                "type": "array",
+                "uniqueItems": true,
+                "items": {
+                  "type": "string"
+                },
+                "description": "Available latency/accuracy tradeoff levels"
+              }
+            }
+          },
+          "limits": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Operational limits for this model",
+            "properties": {
+              "maxSessionDurationMs": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum session duration in milliseconds"
+              },
+              "maxChunkDurationMs": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Recommended maximum duration per audio chunk in milliseconds"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/build-website-registries.mjs
+++ b/scripts/build-website-registries.mjs
@@ -11,9 +11,13 @@ const schemaDir = join(registryDir, 'schema');
 const embeddingsRegistryDir = join(rootDir, 'registries', 'embeddings');
 const embeddingModelsDir = join(embeddingsRegistryDir, 'models');
 const embeddingSchemaDir = join(embeddingsRegistryDir, 'schema');
+const liveTranscriptionRegistryDir = join(rootDir, 'registries', 'live-transcription');
+const liveTranscriptionModelsDir = join(liveTranscriptionRegistryDir, 'models');
+const liveTranscriptionSchemaDir = join(liveTranscriptionRegistryDir, 'schema');
 const outputDir = join(rootDir, 'apps', 'website', 'dist');
 const outputFile = join(outputDir, 'mcp-registry.json');
 const embeddingOutputFile = join(outputDir, 'embedding-models.json');
+const liveTranscriptionOutputFile = join(outputDir, 'live-transcription-models.json');
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
@@ -189,6 +193,73 @@ function assertEmbeddingProviderConfig(provider, filePath) {
   }
 }
 
+function assertLiveTranscriptionModel(model, filePath) {
+  assert(model && typeof model === 'object', `${filePath}: model must be an object`);
+  assert(typeof model.id === 'string' && model.id.length > 0, `${filePath}: model.id is required`);
+  assert(
+    typeof model.name === 'string' && model.name.length > 0,
+    `${filePath}: model.name is required`,
+  );
+  assert(
+    typeof model.endpoint === 'string' && model.endpoint.startsWith('wss://'),
+    `${filePath}: model.endpoint must be a wss:// URL`,
+  );
+  assert(model.audio && typeof model.audio === 'object', `${filePath}: model.audio is required`);
+  assert(
+    Number.isInteger(model.audio.sampleRate) && model.audio.sampleRate >= 8000,
+    `${filePath}: model.audio.sampleRate must be an integer >= 8000`,
+  );
+  assert(
+    Number.isInteger(model.audio.channels) && model.audio.channels >= 1,
+    `${filePath}: model.audio.channels must be a positive integer`,
+  );
+  assert(
+    model.audio.encoding === 'pcm_s16le',
+    `${filePath}: model.audio.encoding must be pcm_s16le`,
+  );
+  assert(
+    model.connection && typeof model.connection === 'object',
+    `${filePath}: model.connection is required`,
+  );
+  assert(
+    model.connection.mode === 'per-source' || model.connection.mode === 'single',
+    `${filePath}: model.connection.mode must be per-source or single`,
+  );
+  assert(
+    model.connection.authMethod === 'query-param' || model.connection.authMethod === 'header',
+    `${filePath}: model.connection.authMethod must be query-param or header`,
+  );
+  if (model.supportedLanguages !== undefined) {
+    assert(
+      Array.isArray(model.supportedLanguages) && model.supportedLanguages.length > 0,
+      `${filePath}: model.supportedLanguages must be a non-empty array`,
+    );
+  }
+}
+
+function assertLiveTranscriptionProviderConfig(provider, filePath) {
+  assert(provider && typeof provider === 'object', `${filePath}: config must be an object`);
+  assert(
+    provider.providerId === 'google' || provider.providerId === 'openai',
+    `${filePath}: providerId must be google or openai`,
+  );
+  assert(
+    typeof provider.providerName === 'string' && provider.providerName.length > 0,
+    `${filePath}: providerName is required`,
+  );
+  assert(
+    Array.isArray(provider.models) && provider.models.length > 0,
+    `${filePath}: models must be a non-empty array`,
+  );
+
+  const ids = new Set();
+  for (const model of provider.models) {
+    assertLiveTranscriptionModel(model, filePath);
+    assert(!ids.has(model.id), `${filePath}: duplicate model id ${model.id}`);
+    ids.add(model.id);
+  }
+}
+
 function loadServerConfigs() {
   const files = readdirSync(serversDir)
     .filter((name) => name.endsWith('.json'))
@@ -232,7 +303,30 @@ function loadEmbeddingProviderConfigs() {
   return providers.toSorted((a, b) => a.providerName.localeCompare(b.providerName));
 }
 
-function writeOutput(servers, embeddingProviders) {
+function loadLiveTranscriptionProviderConfigs() {
+  const files = readdirSync(liveTranscriptionModelsDir)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => join(liveTranscriptionModelsDir, name));
+
+  const providers = files.map((filePath) => {
+    const parsed = readJson(filePath);
+    assertLiveTranscriptionProviderConfig(parsed, filePath);
+    return parsed;
+  });
+
+  const ids = new Set();
+  for (const provider of providers) {
+    assert(
+      !ids.has(provider.providerId),
+      `Duplicate live transcription provider id: ${provider.providerId}`,
+    );
+    ids.add(provider.providerId);
+  }
+
+  return providers.toSorted((a, b) => a.providerName.localeCompare(b.providerName));
+}
+
+function writeOutput(servers, embeddingProviders, liveTranscriptionProviders) {
   mkdirSync(outputDir, { recursive: true });
   mkdirSync(join(outputDir, 'schemas'), { recursive: true });
 
@@ -244,6 +338,10 @@ function writeOutput(servers, embeddingProviders) {
   cpSync(
     join(embeddingSchemaDir, 'embedding-provider.schema.json'),
     join(outputDir, 'schemas', 'embedding-provider.schema.json'),
+  );
+  cpSync(
+    join(liveTranscriptionSchemaDir, 'live-transcription-provider.schema.json'),
+    join(outputDir, 'schemas', 'live-transcription-provider.schema.json'),
   );
 
   const payload = {
@@ -261,15 +359,31 @@ function writeOutput(servers, embeddingProviders) {
   };
 
   writeFileSync(embeddingOutputFile, `${JSON.stringify(embeddingPayload, null, 2)}\n`, 'utf8');
+
+  const liveTranscriptionPayload = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    providers: liveTranscriptionProviders,
+  };
+
+  writeFileSync(
+    liveTranscriptionOutputFile,
+    `${JSON.stringify(liveTranscriptionPayload, null, 2)}\n`,
+    'utf8',
+  );
 }
 
 function main() {
   const servers = loadServerConfigs();
   const embeddingProviders = loadEmbeddingProviderConfigs();
-  writeOutput(servers, embeddingProviders);
+  const liveTranscriptionProviders = loadLiveTranscriptionProviderConfigs();
+  writeOutput(servers, embeddingProviders, liveTranscriptionProviders);
   console.log(`Built MCP registry with ${servers.length} server(s): ${outputFile}`);
   console.log(
     `Built embedding registry with ${embeddingProviders.length} provider(s): ${embeddingOutputFile}`,
+  );
+  console.log(
+    `Built live transcription registry with ${liveTranscriptionProviders.length} provider(s): ${liveTranscriptionOutputFile}`,
   );
 }
 


### PR DESCRIPTION
## Change Summary

Adds the \@stitch/registry-live-transcription\ workspace — a centralized configuration registry for live (streaming) transcription providers, supporting the upcoming real-time transcription feature.

### New Features
- **Live transcription registry**: JSON-based provider/model configurations for streaming STT services, following the same pattern as the existing embeddings and MCP registries
- **Google provider config**: Gemini 3.1 Flash Live (\gemini-3.1-flash-live-preview\) — 16kHz PCM, per-source WebSocket connections, server-side VAD
- **OpenAI provider config**: GPT Realtime Whisper (\gpt-realtime-whisper\) — 24kHz PCM, per-source WebSocket connections, configurable delay levels
- **JSON Schema**: Validates provider configs including audio format, connection mode, auth method, features, and operational limits

### Improvements & Refactors
- Extended \uild-website-registries.mjs\ to load, validate, and output the live transcription registry alongside MCP and embeddings registries