### PR TITLE
fix: rebind pre-init loggers

### DIFF
--- a/packages/server/src/lib/log.test.ts
+++ b/packages/server/src/lib/log.test.ts
@@ -28,6 +28,26 @@ async function writeLogFiles(names: string[]) {
   );
 }
 
+async function readLogOutput(): Promise<string> {
+  const entries = await fs.readdir(PATHS.logDir).catch(() => []);
+  const logs = await Promise.all(
+    entries
+      .filter((name) => name.endsWith('.log'))
+      .map((name) => fs.readFile(path.join(PATHS.logDir, name), 'utf-8').catch(() => '')),
+  );
+  return logs.join('\n');
+}
+
+async function waitForLogOutput(message: string): Promise<string> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 1_000) {
+    const output = await readLogOutput();
+    if (output.includes(message)) return output;
+    await Bun.sleep(10);
+  }
+  return readLogOutput();
+}
+
 // Generates filenames matching log format: app.<date>.<count>.log
 function dailyLogNames(count: number, startDate = new Date('2020-01-01')): string[] {
   return Array.from({ length: count }, (_, i) => {
@@ -140,5 +160,21 @@ describe('Log.create', () => {
     expect(() => {
       using _t = log.time('block-op');
     }).not.toThrow();
+  });
+
+  test('loggers created before init write after init', async () => {
+    await fs.mkdir(PATHS.logDir, { recursive: true });
+    await clearLogDir();
+
+    const log = Log.create({ service: 'test-pre-init' });
+    await Log.init({});
+
+    log.info('pre-init logger is active');
+
+    const output = await waitForLogOutput('pre-init logger is active');
+    expect(output).toContain('pre-init logger is active');
+    expect(output).toContain('test-pre-init');
+
+    await clearLogDir();
   });
 });

--- a/packages/server/src/lib/log.ts
+++ b/packages/server/src/lib/log.ts
@@ -47,10 +47,15 @@ function formatDate(date: Date): string {
 let rootLogger: pino.Logger = pino({ level: 'silent' });
 const loggers = new Map<string, Logger>();
 
+type LoggerState = {
+  tags: Record<string, unknown>;
+  child: pino.Logger;
+};
+
+const loggerStates = new Set<LoggerState>();
+
 export async function init(options: Options): Promise<void> {
   const level = pinoLevel[options.level ?? 'INFO'];
-
-  loggers.clear();
 
   await fs.mkdir(PATHS.logDir, { recursive: true });
 
@@ -58,6 +63,9 @@ export async function init(options: Options): Promise<void> {
   const logFile = path.join(PATHS.logDir, `${prefix}.${formatDate(new Date())}.1.log`);
 
   rootLogger = pino({ level }, pino.destination({ dest: logFile, mkdir: true, sync: false }));
+  for (const state of loggerStates) {
+    state.child = rootLogger.child(state.tags);
+  }
 }
 
 // Log filename format: <prefix>.<date>.<count>.log
@@ -89,7 +97,11 @@ export function create(tags?: Record<string, unknown>, { skipCache = false } = {
     if (cached) return cached;
   }
 
-  let child = rootLogger.child(tags);
+  const state: LoggerState = {
+    tags,
+    child: rootLogger.child(tags),
+  };
+  loggerStates.add(state);
 
   function emit(
     lvl: pino.Level,
@@ -97,9 +109,9 @@ export function create(tags?: Record<string, unknown>, { skipCache = false } = {
     message?: string,
   ) {
     if (typeof extraOrMessage === 'string') {
-      child[lvl](extraOrMessage);
+      state.child[lvl](extraOrMessage);
     } else {
-      child[lvl](extraOrMessage, message ?? '');
+      state.child[lvl](extraOrMessage, message ?? '');
     }
   }
 
@@ -117,12 +129,12 @@ export function create(tags?: Record<string, unknown>, { skipCache = false } = {
       emit('error', extraOrMessage, message as string | undefined);
     },
     tag(key: string, value: string) {
-      tags = { ...tags, [key]: value };
-      child = rootLogger.child(tags);
+      state.tags = { ...state.tags, [key]: value };
+      state.child = rootLogger.child(state.tags);
       return result;
     },
     clone() {
-      return create({ ...tags }, { skipCache: true });
+      return create({ ...state.tags }, { skipCache: true });
     },
     time(message: string, extra?: Record<string, unknown>) {
       const now = Date.now();


### PR DESCRIPTION
## 🚀 Change Summary

Fixes file logging for server loggers that are created before logging initialization runs. Existing logger instances now rebind to the initialized root logger, so module-level services and connector flows write to the app log instead of staying attached to the initial silent logger.

### 🐛 Bug Fixes
- Restores log output for pre-init server loggers, including non-Google connector/runtime services.
- Adds a regression test covering logger creation before Log.init().