### PR TITLE
feat(sidebar): infinite scroll and search for chat sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,17 @@ Stitch is a ai based tool to help users do work locally.
 | ------------- | ------------------------ |
 | `bun install` | Install all dependencies |
 
+## Think Before Coding
+
+Before implementing anything:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
 ## General Workflow
 
 After completing any task, you **must** run the following checks and fix all issues until the output is fully clean:
@@ -25,6 +36,22 @@ Do not consider a task done until all three commands pass with zero errors.
 - Write a reproducible test case wherever possible before fixing the bug
 - Fix the bug while ensuring the test passes
 - This ensures the bug is well-understood and prevents regressions
+
+Transform bug tasks into verifiable goals:
+
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+
+### Surgical Changes
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting that isn't broken
+- Don't refactor things outside the scope of the task
+- Match existing style, even if you'd do it differently
+- If you notice unrelated dead code, mention it — don't delete it
+
+Every changed line should trace directly to the user's request.
 
 ### Managing Packages
 
@@ -69,6 +96,16 @@ Do not consider a task done until all three commands pass with zero errors.
 
 - Prefer low cyclomatic complexity code - keep functions simple with minimal branching
 - Prefer absolute imports over relative (ie. import x from '@stitch/lib/...' instead of import x from '../../lib/...')
+
+#### Simplicity First
+
+- No features beyond what was asked
+- No abstractions for single-use code
+- No "flexibility" or "configurability" that wasn't requested
+- No error handling for impossible scenarios
+- If you write 200 lines and it could be 50, rewrite it
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
 
 Naming Conventions
 

--- a/apps/web/src/components/navigation/app-sidebar.tsx
+++ b/apps/web/src/components/navigation/app-sidebar.tsx
@@ -1,7 +1,13 @@
-import { PlusIcon, MessageSquareIcon, MessageCircleIcon } from 'lucide-react';
+import {
+  Loader2Icon,
+  MessageCircleIcon,
+  MessageSquareIcon,
+  PlusIcon,
+  SearchIcon,
+} from 'lucide-react';
 import * as React from 'react';
 
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { Link, useParams, useRouterState } from '@tanstack/react-router';
 
 import { AgendaSidebarContent } from '@/components/agenda/agenda-sidebar';
@@ -18,10 +24,11 @@ import {
   SidebarMenuItem,
   SidebarMenuButton,
   SidebarHeader,
+  SidebarInput,
 } from '@/components/ui/sidebar';
 import { useSessionTitleUpdates } from '@/hooks/sse/use-session-title-updates';
 import { useStreamingSessionIds } from '@/hooks/use-session-stream-state';
-import { sessionsQueryOptions } from '@/lib/queries/chat';
+import { sessionsInfiniteQueryOptions } from '@/lib/queries/chat';
 import { cn } from '@/lib/utils';
 
 const SessionStatusIcon = React.memo(function SessionStatusIcon({
@@ -51,68 +58,105 @@ const SessionStatusIcon = React.memo(function SessionStatusIcon({
 });
 
 function ChatSidebarContent() {
-  const { data: sessions } = useQuery(sessionsQueryOptions);
+  const [search, setSearch] = React.useState('');
+  const deferredSearch = React.useDeferredValue(search.trim());
+  const loadMoreRef = React.useRef<HTMLDivElement>(null);
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
+    sessionsInfiniteQueryOptions(deferredSearch),
+  );
   useSessionTitleUpdates();
   const streamingIds = useStreamingSessionIds();
   const streamingIdSet = React.useMemo(() => new Set(streamingIds), [streamingIds]);
+  const sessions = data?.pages.flatMap((page) => page.sessions) ?? [];
 
   const params = useParams({ strict: false });
   const currentId = params.id;
 
+  React.useEffect(() => {
+    const node = loadMoreRef.current;
+    if (!node || !hasNextPage) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    });
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
   return (
     <>
-      <SidebarHeader className="pb-0">
+      <SidebarHeader>
         <SidebarMenuButton
           render={<Link to="/" className="flex items-center justify-center gap-2 font-medium" />}
         >
           <PlusIcon className="size-4" />
           New Chat
         </SidebarMenuButton>
+        <div className="relative">
+          <SearchIcon className="pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <SidebarInput
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search chats"
+            className="pl-8"
+          />
+        </div>
       </SidebarHeader>
 
       <SidebarContent>
-        {sessions && sessions.length > 0 ? (
+        {sessions.length > 0 ? (
           <SidebarGroup>
             <SidebarGroupLabel>Recent</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {[...sessions]
-                  .filter((session) => session.parentSessionId === null)
-                  .reverse()
-                  .map((session) => {
-                    const isStreaming = streamingIdSet.has(session.id);
-                    const isUnread = session.isUnread && session.id !== currentId && !isStreaming;
-                    return (
-                      <SidebarMenuItem key={session.id}>
-                        <SidebarMenuButton
-                          isActive={session.id === currentId}
-                          render={
-                            <Link
-                              to="/session/$id"
-                              params={{ id: session.id }}
-                              viewTransition
-                              className="flex items-center gap-2 truncate"
-                            />
-                          }
-                        >
-                          <SessionStatusIcon isStreaming={isStreaming} isUnread={isUnread} />
-                          <AnimatedTitle
-                            title={session.title ?? 'New conversation'}
-                            className={cn('truncate', isUnread && 'font-semibold')}
+                {sessions.map((session) => {
+                  const isStreaming = streamingIdSet.has(session.id);
+                  const isUnread = session.isUnread && session.id !== currentId && !isStreaming;
+                  return (
+                    <SidebarMenuItem key={session.id}>
+                      <SidebarMenuButton
+                        isActive={session.id === currentId}
+                        render={
+                          <Link
+                            to="/session/$id"
+                            params={{ id: session.id }}
+                            viewTransition
+                            className="flex items-center gap-2 truncate"
                           />
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                    );
-                  })}
+                        }
+                      >
+                        <SessionStatusIcon isStreaming={isStreaming} isUnread={isUnread} />
+                        <AnimatedTitle
+                          title={session.title ?? 'New conversation'}
+                          className={cn('truncate', isUnread && 'font-semibold')}
+                        />
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
               </SidebarMenu>
+              {hasNextPage ? (
+                <div ref={loadMoreRef} className="flex h-9 items-center justify-center">
+                  {isFetchingNextPage ? (
+                    <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+                  ) : null}
+                </div>
+              ) : null}
             </SidebarGroupContent>
           </SidebarGroup>
         ) : (
           <div className="flex flex-col items-center justify-center gap-3 px-4 py-12 text-center">
             <MessageCircleIcon className="size-8 text-muted-foreground/40" />
             <div className="space-y-1">
-              <p className="text-sm font-medium text-muted-foreground">No conversations yet</p>
-              <p className="text-xs text-muted-foreground/70">Start a new chat to get going</p>
+              <p className="text-sm font-medium text-muted-foreground">
+                {deferredSearch ? 'No matching conversations' : 'No conversations yet'}
+              </p>
+              <p className="text-xs text-muted-foreground/70">
+                {deferredSearch ? 'Try a different search' : 'Start a new chat to get going'}
+              </p>
             </div>
           </div>
         )}

--- a/apps/web/src/lib/queries/chat.ts
+++ b/apps/web/src/lib/queries/chat.ts
@@ -12,6 +12,7 @@ import type {
   Session,
   SessionStats,
   MessagesPage,
+  SessionsPage,
   LanguageModelUsage,
   StoredPart,
 } from '@stitch/shared/chat/messages';
@@ -35,20 +36,43 @@ const EMPTY_USAGE: LanguageModelUsage = {
 export const sessionKeys = {
   all: ['sessions'] as const,
   list: () => [...sessionKeys.all, 'list'] as const,
+  infiniteList: (search: string) => [...sessionKeys.list(), 'infinite', search] as const,
   detail: (id: string) => [...sessionKeys.all, 'detail', id] as const,
   messages: (id: string) => [...sessionKeys.all, 'messages', id] as const,
   stats: (id: string) => [...sessionKeys.all, 'stats', id] as const,
 };
 
-export const sessionsQueryOptions = queryOptions({
-  queryKey: sessionKeys.list(),
-  staleTime: Infinity,
-  queryFn: async (): Promise<Session[]> => {
-    const res = await serverFetch('/chat/sessions?type=chat');
-    if (!res.ok) throw new Error('Failed to fetch sessions');
-    return res.json() as Promise<Session[]>;
-  },
-});
+const SESSION_PAGE_SIZE = 30;
+
+export const sessionsInfiniteQueryOptions = (search: string) =>
+  infiniteQueryOptions({
+    queryKey: sessionKeys.infiniteList(search),
+    queryFn: async ({ pageParam }): Promise<SessionsPage> => {
+      const params = new URLSearchParams({
+        type: 'chat',
+        limit: String(SESSION_PAGE_SIZE),
+      });
+      if (search) {
+        params.set('q', search);
+      }
+      if (pageParam !== undefined) {
+        params.set('cursor', String(pageParam));
+      }
+
+      const res = await serverFetch(`/chat/sessions?${params.toString()}`);
+      if (!res.ok) throw new Error('Failed to fetch sessions');
+      return res.json() as Promise<SessionsPage>;
+    },
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+      if (!lastPage.hasMore || lastPage.sessions.length === 0) return undefined;
+      const oldest = lastPage.sessions.at(-1);
+      if (!oldest) return undefined;
+      if (lastPageParam !== undefined && oldest.createdAt === lastPageParam) return undefined;
+      return oldest.createdAt;
+    },
+    staleTime: Infinity,
+  });
 
 export const sessionQueryOptions = (id: string) =>
   queryOptions({

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, like, lt } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, like, lt } from 'drizzle-orm';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
@@ -28,6 +28,7 @@ import { calculateMessageCostUsd } from '@/utils/cost.js';
 const log = Log.create({ service: 'chat-service' });
 
 const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_SESSION_PAGE_SIZE = 30;
 
 type CreateSessionInput = {
   title?: string;
@@ -76,14 +77,34 @@ export async function createSession(
 
 export async function listSessions(
   type: 'chat' | 'automation' = 'chat',
-): Promise<ServiceResult<(typeof sessions.$inferSelect)[]>> {
+  options: { limit?: number; cursor?: number; search?: string } = {},
+): Promise<ServiceResult<{ sessions: (typeof sessions.$inferSelect)[]; hasMore: boolean }>> {
   const db = getDb();
+  const pageSize = options.limit
+    ? Math.min(Math.max(options.limit, 1), 100)
+    : DEFAULT_SESSION_PAGE_SIZE;
+
+  const conditions = [eq(sessions.type, type)];
+  if (options.cursor !== undefined) {
+    conditions.push(lt(sessions.createdAt, options.cursor));
+  }
+  if (options.search) {
+    conditions.push(like(sessions.title, `%${options.search}%`));
+  }
+  if (type === 'chat') {
+    conditions.push(isNull(sessions.parentSessionId));
+  }
+
   const rows = await db
     .select()
     .from(sessions)
-    .where(eq(sessions.type, type))
-    .orderBy(asc(sessions.createdAt));
-  return ok(rows);
+    .where(and(...conditions))
+    .orderBy(desc(sessions.createdAt))
+    .limit(pageSize + 1);
+
+  const hasMore = rows.length > pageSize;
+  const page = hasMore ? rows.slice(0, pageSize) : rows;
+  return ok({ sessions: page, hasMore });
 }
 
 export async function getSessionById(sessionId: PrefixedString<'ses'>) {

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -36,6 +36,9 @@ const createSessionSchema = z.object({
 
 const listSessionsQuerySchema = z.object({
   type: z.enum(['chat', 'automation']).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  cursor: z.coerce.number().int().optional(),
+  q: z.string().trim().optional(),
 });
 
 const listMessagesQuerySchema = z.object({
@@ -76,9 +79,9 @@ chatRouter.post('/sessions', zValidator('json', createSessionSchema), async (c) 
 });
 
 chatRouter.get('/sessions', zValidator('query', listSessionsQuerySchema), async (c) => {
-  const { type } = c.req.valid('query');
+  const { type, limit, cursor, q } = c.req.valid('query');
   const sessionType = type === 'automation' ? 'automation' : 'chat';
-  const result = await listSessions(sessionType);
+  const result = await listSessions(sessionType, { limit, cursor, search: q });
   return unwrapResult(c, result);
 });
 

--- a/packages/shared/src/chat/messages.ts
+++ b/packages/shared/src/chat/messages.ts
@@ -128,6 +128,11 @@ export type MessagesPage = {
   hasMore: boolean;
 };
 
+export type SessionsPage = {
+  sessions: Session[];
+  hasMore: boolean;
+};
+
 export type SessionStats = {
   sessionTitle: string;
   providerLabel: string;


### PR DESCRIPTION
## Change Summary

Upgrades the main chat sidebar from a flat all-sessions list to a paginated infinite-scroll list with a live search input.

### New Features
- **Infinite scroll**: Sidebar loads 30 sessions at a time and fetches the next page automatically when the user scrolls to the bottom via an IntersectionObserver.
- **Search**: A search input at the top of the sidebar filters sessions by title in real time (via useDeferredValue), sending the query to the server as ?q=.

### Improvements
- listSessions on the backend now paginates (cursor-based on createdAt), filters by title, and automatically scopes chat listings to root sessions (parentSessionId IS NULL), removing the need for client-side filtering and reversing.
- Replaced useQuery(sessionsQueryOptions) with useInfiniteQuery(sessionsInfiniteQueryOptions) in ChatSidebarContent.
- Added SessionsPage shared type alongside the existing MessagesPage.