### PR TITLE
Replace worker threads with process-based sandbox isolation

### DIFF
--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -40,7 +40,7 @@ const config: Configuration = {
     {
       from: '../../packages/server/dist',
       to: '',
-      filter: ['stitch-server*'],
+      filter: ['stitch-server*', 'stitch-sandbox*'],
     },
     {
       from: '../../packages/server/drizzle',
@@ -82,6 +82,7 @@ const config: Configuration = {
     entitlementsInherit: 'resources/entitlements.mac.inherit.plist',
     binaries: [
       'Contents/Resources/stitch-server',
+      'Contents/Resources/stitch-sandbox',
       'Contents/Resources/audio-capture/stitch-audio-capture',
       'Contents/Resources/audio-capture/stitch-meeting-watch',
     ],

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -138,8 +138,14 @@ export async function spawnServer(port: number): Promise<string> {
       'audio-capture',
       `stitch-meeting-watch${suffix}`,
     );
+    const sandboxBin = join(process.resourcesPath, `stitch-sandbox${suffix}`);
     sidecarEnv.STITCH_AUDIO_CAPTURE_BIN = audioCaptureBin;
     sidecarEnv.STITCH_MEETING_WATCH_BIN = meetingWatchBin;
+    sidecarEnv.SANDBOX_EXEC_PATH = sandboxBin;
+  } else {
+    const root = getMonorepoRoot();
+    const sandboxEntry = join(root, 'packages/server/src/code-mode/sandbox-process.ts');
+    sidecarEnv.SANDBOX_EXEC_PATH = sandboxEntry;
   }
 
   serverProcess = spawn(cmd, args, {

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -25,7 +25,7 @@ const config: KnipConfig = {
       project: ['src/**/*.{ts,tsx}'],
     },
     'packages/server': {
-      entry: ['src/index.{ts,tsx}', 'src/**/*.test.{ts,tsx}'],
+      entry: ['src/index.{ts,tsx}', 'src/code-mode/sandbox-process.ts', 'src/**/*.test.{ts,tsx}'],
       project: ['src/**/*.{ts,tsx}'],
     },
     'packages/audio-capture': {

--- a/packages/sandbox/src/errors.ts
+++ b/packages/sandbox/src/errors.ts
@@ -1,3 +1,7 @@
+export function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export class SandboxError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/sandbox/src/errors.ts
+++ b/packages/sandbox/src/errors.ts
@@ -60,3 +60,10 @@ export class SandboxUnknownToolError extends SandboxError {
     this.name = 'SandboxUnknownToolError';
   }
 }
+
+export class SandboxMemoryError extends SandboxError {
+  constructor(limitMB: number) {
+    super(`Sandbox memory limit exceeded (${limitMB}MB)`);
+    this.name = 'SandboxMemoryError';
+  }
+}

--- a/packages/sandbox/src/fixtures/sample-library.ts
+++ b/packages/sandbox/src/fixtures/sample-library.ts
@@ -9,5 +9,5 @@ export function canReadFunctionPrototype(): boolean {
 }
 
 export function hasGlobalSampleWorker(): boolean {
-  return typeof (globalThis as { sampleWorker?: unknown }).sampleWorker === 'object';
+  return typeof (globalThis as { sampleGlobal?: unknown }).sampleGlobal === 'object';
 }

--- a/packages/sandbox/src/hardening.ts
+++ b/packages/sandbox/src/hardening.ts
@@ -1,6 +1,6 @@
 import { SandboxSecurityError } from './errors.js';
 
-const DANGEROUS_GLOBALS = [
+export const DANGEROUS_GLOBALS = [
   'Bun',
   'process',
   'require',

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,3 +1,3 @@
-export { createWorkerSandbox } from './driver.js';
-export { startWorkerRuntime } from './worker-runtime.js';
+export { createProcessSandbox } from './process-driver.js';
+export { startProcessRuntime } from './process-runtime.js';
 export type { IsolateDriver, IsolateOptions, ToolBinding } from './types.js';

--- a/packages/sandbox/src/process-driver.ts
+++ b/packages/sandbox/src/process-driver.ts
@@ -1,4 +1,5 @@
 import {
+  SandboxMemoryError,
   SandboxMessageTooLargeError,
   SandboxSecurityError,
   SandboxTimeoutError,
@@ -22,6 +23,8 @@ import type {
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_TOOL_CALLS = 100;
 const DEFAULT_MAX_MESSAGE_BYTES = 512 * 1024;
+const DEFAULT_MEMORY_LIMIT_MB = 512;
+const MEMORY_REPORT_INTERVAL_MS = 500;
 const TOOL_TIMEOUT_BUFFER_MS = 5_000;
 const IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/;
 const RESERVED_LIBRARY_NAMES = new Set([
@@ -46,6 +49,7 @@ type ProcessInitMessage = {
   type: 'init';
   toolNames: string[];
   libraries: IsolateOptions['libraries'];
+  memoryReportIntervalMs: number;
 };
 
 function toErrorMessage(error: unknown): string {
@@ -101,8 +105,10 @@ function validateLibraryNames(libraries: IsolateOptions['libraries']): void {
  */
 export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions): IsolateDriver {
   const execPath = driverOptions.execPath;
+  const memoryLimitMB = driverOptions.memoryLimit ?? DEFAULT_MEMORY_LIMIT_MB;
+  const memoryLimitBytes = memoryLimitMB * 1024 * 1024;
   const isScript = /\.[mc]?[jt]sx?$/.test(execPath);
-  const cmd = isScript ? [process.execPath, execPath] : [execPath];
+  const cmd = isScript ? [process.execPath, '--smol', execPath] : [execPath];
 
   return {
     async createContext(
@@ -124,7 +130,7 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
       let messageHandler: ((message: unknown) => void) | null = null;
 
       const proc = Bun.spawn(cmd, {
-        env: {},
+        env: { BUN_JSC_forceRAMSize: String(memoryLimitBytes) },
         ipc(message) {
           messageHandler?.(message);
         },
@@ -142,7 +148,12 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
       };
 
       // Send initialization data via IPC
-      sendToProcess(proc, { type: 'init', toolNames, libraries });
+      sendToProcess(proc, {
+        type: 'init',
+        toolNames,
+        libraries,
+        memoryReportIntervalMs: MEMORY_REPORT_INTERVAL_MS,
+      });
 
       return {
         async execute(code: string): Promise<IsolateExecuteResult> {
@@ -218,6 +229,18 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
 
             const onMessage = (message: unknown) => {
               if (!isWorkerMessage(message)) return;
+
+              if (message.type === 'memory_report') {
+                if (message.rss > memoryLimitBytes) {
+                  cleanup();
+                  terminate();
+                  resolve({
+                    result: { error: new SandboxMemoryError(memoryLimitMB).message },
+                    logs: [],
+                  });
+                }
+                return;
+              }
 
               if (message.type === 'complete') {
                 cleanup();

--- a/packages/sandbox/src/process-driver.ts
+++ b/packages/sandbox/src/process-driver.ts
@@ -1,5 +1,3 @@
-import { Worker } from 'node:worker_threads';
-
 import {
   SandboxMessageTooLargeError,
   SandboxSecurityError,
@@ -17,11 +15,10 @@ import type {
   IsolateDriver,
   IsolateExecuteResult,
   IsolateOptions,
-  SandboxDriverOptions,
+  SandboxProcessDriverOptions,
   ToolBinding,
 } from './types.js';
 
-const DEFAULT_MEMORY_LIMIT_MB = 128;
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_TOOL_CALLS = 100;
 const DEFAULT_MAX_MESSAGE_BYTES = 512 * 1024;
@@ -45,8 +42,10 @@ const RESERVED_LIBRARY_NAMES = new Set([
   'Function',
 ]);
 
-type WorkerWithBunOptions = ConstructorParameters<typeof Worker>[1] & {
-  smol?: boolean;
+type ProcessInitMessage = {
+  type: 'init';
+  toolNames: string[];
+  libraries: IsolateOptions['libraries'];
 };
 
 function toErrorMessage(error: unknown): string {
@@ -68,8 +67,11 @@ function assertMessageSize(message: unknown, maxMessageBytes: number): void {
   }
 }
 
-function postToWorker(worker: Worker, message: HostMessage): void {
-  worker.postMessage(message);
+function sendToProcess(
+  proc: { send(message: unknown): void },
+  message: HostMessage | ProcessInitMessage,
+): void {
+  proc.send(message);
 }
 
 function validateLibraryNames(libraries: IsolateOptions['libraries']): void {
@@ -87,15 +89,26 @@ function validateLibraryNames(libraries: IsolateOptions['libraries']): void {
   }
 }
 
-export function createWorkerSandbox(driverOptions?: SandboxDriverOptions): IsolateDriver {
-  const workerUrl = driverOptions?.workerUrl ?? new URL('./worker-entry.ts', import.meta.url);
+/**
+ * Creates a process-based sandbox driver that spawns a separate Bun process for isolation.
+ * Communicates via Bun's IPC channel (structured clone serialization).
+ *
+ * This provides stronger isolation than Worker threads:
+ * - Completely separate address space (OS process boundary)
+ * - No shared memory or prototype chain
+ * - Reliable kill semantics via process.kill()
+ * - Works consistently across platforms (no import.meta.url resolution issues)
+ */
+export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions): IsolateDriver {
+  const execPath = driverOptions.execPath;
+  const isScript = /\.[mc]?[jt]sx?$/.test(execPath);
+  const cmd = isScript ? [process.execPath, execPath] : [execPath];
 
   return {
     async createContext(
       bindings: Record<string, ToolBinding>,
       options: IsolateOptions = {},
     ): Promise<IsolateContext> {
-      const memoryLimitMb = options.memoryLimit ?? DEFAULT_MEMORY_LIMIT_MB;
       const timeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
       const maxToolCalls = options.maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS;
       const maxMessageBytes = options.maxMessageBytes ?? DEFAULT_MAX_MESSAGE_BYTES;
@@ -104,27 +117,32 @@ export function createWorkerSandbox(driverOptions?: SandboxDriverOptions): Isola
       const toolTimeoutMs = Math.max(1_000, timeoutMs - TOOL_TIMEOUT_BUFFER_MS);
       const toolNames = Object.keys(bindings);
       validateLibraryNames(libraries);
-      const workerOptions: WorkerWithBunOptions = {
-        env: {},
-        resourceLimits: {
-          maxOldGenerationSizeMb: memoryLimitMb,
-          maxYoungGenerationSizeMb: Math.max(1, Math.ceil(memoryLimitMb / 4)),
-          stackSizeMb: 1,
-        },
-        smol: true,
-        workerData: { toolNames, libraries },
-      };
 
-      const worker = new Worker(workerUrl, workerOptions);
       let disposed = false;
       let toolCallCount = 0;
       const timer = createPausableTimer();
+      let messageHandler: ((message: unknown) => void) | null = null;
+
+      const proc = Bun.spawn(cmd, {
+        env: {},
+        ipc(message) {
+          messageHandler?.(message);
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
 
       const terminate = () => {
         if (disposed) return;
         disposed = true;
-        void worker.terminate();
+        try {
+          proc.kill();
+        } catch {
+          // Process may have already exited.
+        }
       };
+
+      // Send initialization data via IPC
+      sendToProcess(proc, { type: 'init', toolNames, libraries });
 
       return {
         async execute(code: string): Promise<IsolateExecuteResult> {
@@ -136,13 +154,11 @@ export function createWorkerSandbox(driverOptions?: SandboxDriverOptions): Isola
 
           const executionPromise = new Promise<IsolateExecuteResult>((resolve, reject) => {
             const cleanup = () => {
-              worker.off('message', onMessage);
-              worker.off('error', onError);
-              worker.off('exit', onExit);
+              messageHandler = null;
             };
 
             const sendToolError = (id: string, error: string) => {
-              postToWorker(worker, { type: 'tool_error', id, error });
+              sendToProcess(proc, { type: 'tool_error', id, error });
             };
 
             const executeToolCall = async (
@@ -192,7 +208,7 @@ export function createWorkerSandbox(driverOptions?: SandboxDriverOptions): Isola
                 if (timeoutId !== null) clearTimeout(timeoutId);
                 const response: HostMessage = { type: 'tool_result', id: message.id, result };
                 assertMessageSize(response, maxMessageBytes);
-                postToWorker(worker, response);
+                sendToProcess(proc, response);
               } catch (err) {
                 sendToolError(message.id, toErrorMessage(err));
               } finally {
@@ -218,24 +234,18 @@ export function createWorkerSandbox(driverOptions?: SandboxDriverOptions): Isola
               void executeToolCall(message);
             };
 
-            const onError = (error: Error) => {
-              cleanup();
-              reject(error);
-            };
-
-            const onExit = (code: number) => {
+            const onExit = () => {
               cleanup();
               if (disposed) {
                 resolve({ result: { error: 'Sandbox execution terminated' }, logs: [] });
                 return;
               }
-              reject(new Error(`Sandbox worker exited with code ${code}`));
+              reject(new Error('Sandbox process exited unexpectedly'));
             };
 
-            worker.on('message', onMessage);
-            worker.on('error', onError);
-            worker.on('exit', onExit);
-            postToWorker(worker, { type: 'execute', code });
+            messageHandler = onMessage;
+            void proc.exited.then(onExit);
+            sendToProcess(proc, { type: 'execute', code });
           });
 
           try {

--- a/packages/sandbox/src/process-driver.ts
+++ b/packages/sandbox/src/process-driver.ts
@@ -6,7 +6,9 @@ import {
   SandboxToolError,
   SandboxToolLimitError,
   SandboxUnknownToolError,
+  toErrorMessage,
 } from './errors.js';
+import { DANGEROUS_GLOBALS } from './hardening.js';
 import { isWorkerMessage } from './protocol.js';
 import { createAbortRace, createExecutionTimeoutRace, createPausableTimer } from './timer.js';
 
@@ -27,23 +29,8 @@ const DEFAULT_MEMORY_LIMIT_MB = 512;
 const MEMORY_REPORT_INTERVAL_MS = 500;
 const TOOL_TIMEOUT_BUFFER_MS = 5_000;
 const IDENTIFIER_PATTERN = /^[A-Za-z_$][\w$]*$/;
-const RESERVED_LIBRARY_NAMES = new Set([
-  'console',
-  'Bun',
-  'process',
-  'require',
-  'fetch',
-  'WebSocket',
-  'Worker',
-  'SharedWorker',
-  'XMLHttpRequest',
-  'EventSource',
-  'importScripts',
-  'navigator',
-  'location',
-  'eval',
-  'Function',
-]);
+const RESERVED_LIBRARY_NAMES = new Set([...DANGEROUS_GLOBALS, 'console', 'Function']);
+const encoder = new TextEncoder();
 
 type ProcessInitMessage = {
   type: 'init';
@@ -52,13 +39,21 @@ type ProcessInitMessage = {
   memoryReportIntervalMs: number;
 };
 
-function toErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
+type ToolCallContext = {
+  bindings: Record<string, ToolBinding>;
+  maxToolCalls: number;
+  maxMessageBytes: number;
+  toolTimeoutMs: number;
+  abortSignal: AbortSignal | undefined;
+  proc: { send(message: unknown): void };
+  timer: ReturnType<typeof createPausableTimer>;
+  getToolCallCount: () => number;
+  incrementToolCallCount: () => number;
+};
 
 function getMessageSize(message: unknown): number {
   try {
-    return new TextEncoder().encode(JSON.stringify(message)).byteLength;
+    return encoder.encode(JSON.stringify(message)).byteLength;
   } catch {
     return Number.POSITIVE_INFINITY;
   }
@@ -90,6 +85,70 @@ function validateLibraryNames(libraries: IsolateOptions['libraries']): void {
     ) {
       throw new SandboxSecurityError(`Invalid sandbox library global name: ${library.globalName}`);
     }
+  }
+}
+
+async function dispatchToolCall(
+  message: Extract<WorkerMessage, { type: 'tool_call' }>,
+  ctx: ToolCallContext,
+): Promise<void> {
+  ctx.timer.pause();
+  try {
+    const count = ctx.incrementToolCallCount();
+    if (count > ctx.maxToolCalls) {
+      sendToProcess(ctx.proc, {
+        type: 'tool_error',
+        id: message.id,
+        error: new SandboxToolLimitError(ctx.maxToolCalls).message,
+      });
+      return;
+    }
+
+    assertMessageSize(message, ctx.maxMessageBytes);
+
+    const binding = ctx.bindings[message.name];
+    if (!binding) {
+      sendToProcess(ctx.proc, {
+        type: 'tool_error',
+        id: message.id,
+        error: new SandboxUnknownToolError(message.name).message,
+      });
+      return;
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const toolTimeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(
+        () => reject(new SandboxToolError(`Tool call timed out after ${ctx.toolTimeoutMs}ms`)),
+        ctx.toolTimeoutMs,
+      );
+      ctx.abortSignal?.addEventListener(
+        'abort',
+        () => {
+          if (timeoutId !== null) clearTimeout(timeoutId);
+        },
+        { once: true },
+      );
+    });
+
+    const toolAbort = createAbortRace(ctx.abortSignal, 'Tool call aborted');
+    const raceTargets: Promise<unknown>[] = [
+      binding.execute(message.args, ctx.abortSignal),
+      toolTimeout,
+    ];
+    if (toolAbort !== null) raceTargets.push(toolAbort.promise);
+
+    const result = await Promise.race(raceTargets);
+    if (timeoutId !== null) clearTimeout(timeoutId);
+    toolAbort?.cleanup();
+
+    const response: HostMessage = { type: 'tool_result', id: message.id, result };
+    assertMessageSize(response, ctx.maxMessageBytes);
+    sendToProcess(ctx.proc, response);
+  } catch (err) {
+    sendToProcess(ctx.proc, { type: 'tool_error', id: message.id, error: toErrorMessage(err) });
+  } finally {
+    ctx.timer.resume();
   }
 }
 
@@ -147,7 +206,6 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
         }
       };
 
-      // Send initialization data via IPC
       sendToProcess(proc, {
         type: 'init',
         toolNames,
@@ -155,76 +213,29 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
         memoryReportIntervalMs: MEMORY_REPORT_INTERVAL_MS,
       });
 
+      const toolCallCtx: ToolCallContext = {
+        bindings,
+        maxToolCalls,
+        maxMessageBytes,
+        toolTimeoutMs,
+        abortSignal,
+        proc,
+        timer,
+        getToolCallCount: () => toolCallCount,
+        incrementToolCallCount: () => (toolCallCount += 1),
+      };
+
       return {
         async execute(code: string): Promise<IsolateExecuteResult> {
           if (disposed) return { result: { error: 'Sandbox context is disposed' }, logs: [] };
 
           const startedAt = Date.now();
           const timeoutRace = createExecutionTimeoutRace(timer, startedAt, timeoutMs, terminate);
-          const abortPromise = createAbortRace(abortSignal, 'Sandbox execution aborted');
+          const abortRace = createAbortRace(abortSignal, 'Sandbox execution aborted');
 
           const executionPromise = new Promise<IsolateExecuteResult>((resolve, reject) => {
             const cleanup = () => {
               messageHandler = null;
-            };
-
-            const sendToolError = (id: string, error: string) => {
-              sendToProcess(proc, { type: 'tool_error', id, error });
-            };
-
-            const executeToolCall = async (
-              message: Extract<WorkerMessage, { type: 'tool_call' }>,
-            ) => {
-              timer.pause();
-              try {
-                toolCallCount += 1;
-                if (toolCallCount > maxToolCalls) {
-                  sendToolError(message.id, new SandboxToolLimitError(maxToolCalls).message);
-                  return;
-                }
-
-                assertMessageSize(message, maxMessageBytes);
-
-                const binding = bindings[message.name];
-                if (!binding) {
-                  sendToolError(message.id, new SandboxUnknownToolError(message.name).message);
-                  return;
-                }
-
-                let timeoutId: ReturnType<typeof setTimeout> | null = null;
-                const toolTimeout = new Promise<never>((_, rejectTool) => {
-                  timeoutId = setTimeout(
-                    () =>
-                      rejectTool(
-                        new SandboxToolError(`Tool call timed out after ${toolTimeoutMs}ms`),
-                      ),
-                    toolTimeoutMs,
-                  );
-                  abortSignal?.addEventListener(
-                    'abort',
-                    () => {
-                      if (timeoutId !== null) clearTimeout(timeoutId);
-                    },
-                    { once: true },
-                  );
-                });
-                const toolAbort = createAbortRace(abortSignal, 'Tool call aborted');
-                const raceTargets: Promise<unknown>[] = [
-                  binding.execute(message.args, abortSignal),
-                  toolTimeout,
-                ];
-                if (toolAbort !== null) raceTargets.push(toolAbort);
-
-                const result = await Promise.race(raceTargets);
-                if (timeoutId !== null) clearTimeout(timeoutId);
-                const response: HostMessage = { type: 'tool_result', id: message.id, result };
-                assertMessageSize(response, maxMessageBytes);
-                sendToProcess(proc, response);
-              } catch (err) {
-                sendToolError(message.id, toErrorMessage(err));
-              } finally {
-                timer.resume();
-              }
             };
 
             const onMessage = (message: unknown) => {
@@ -254,7 +265,7 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
                 return;
               }
 
-              void executeToolCall(message);
+              void dispatchToolCall(message, toolCallCtx);
             };
 
             const onExit = () => {
@@ -276,7 +287,7 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
               executionPromise,
               timeoutRace.promise,
             ];
-            if (abortPromise !== null) raceTargets.push(abortPromise);
+            if (abortRace !== null) raceTargets.push(abortRace.promise);
             return await Promise.race(raceTargets);
           } catch (err) {
             terminate();
@@ -290,6 +301,7 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
             };
           } finally {
             timeoutRace.cleanup();
+            abortRace?.cleanup();
           }
         },
 

--- a/packages/sandbox/src/process-entry.ts
+++ b/packages/sandbox/src/process-entry.ts
@@ -1,0 +1,6 @@
+import { startProcessRuntime } from './process-runtime.js';
+
+// Default process entry: no preloaded modules, relies on dynamic import for libraries.
+// For compiled binaries, use a custom process entry that statically imports libraries
+// and passes them to startProcessRuntime().
+startProcessRuntime();

--- a/packages/sandbox/src/process-runtime.ts
+++ b/packages/sandbox/src/process-runtime.ts
@@ -1,9 +1,14 @@
-import { SandboxError, SandboxToolError } from './errors.js';
-import { assertSafeCode, harden } from './hardening.js';
+import { SandboxError, SandboxToolError, toErrorMessage } from './errors.js';
+import { assertSafeCode, DANGEROUS_GLOBALS, harden } from './hardening.js';
+import { isHostMessage } from './protocol.js';
 import { ERROR_KEYS } from './types.js';
 
-import type { WorkerMessage } from './protocol.js';
+import type { HostMessage, WorkerMessage } from './protocol.js';
 import type { SandboxLibrary } from './types.js';
+
+/** Global names shadowed as `undefined` in sandbox function params (includes 'Function'). */
+const HIDDEN_GLOBAL_NAMES: readonly string[] = [...DANGEROUS_GLOBALS, 'Function'];
+const HIDDEN_GLOBAL_VALUES: readonly undefined[] = HIDDEN_GLOBAL_NAMES.map(() => undefined);
 
 type PendingCall = {
   resolve: (value: unknown) => void;
@@ -124,27 +129,11 @@ export function startProcessRuntime(
 
     try {
       assertSafeCode(code);
-      const hiddenGlobalNames = [
-        'Bun',
-        'process',
-        'require',
-        'fetch',
-        'WebSocket',
-        'Worker',
-        'SharedWorker',
-        'XMLHttpRequest',
-        'EventSource',
-        'importScripts',
-        'navigator',
-        'location',
-        'eval',
-        'Function',
-      ];
       const libraryNames = Object.keys(injectedLibraries);
       const libraryValues = libraryNames.map((n) => injectedLibraries[n]);
       const execute = new SandboxFunction(
         'console',
-        ...hiddenGlobalNames,
+        ...HIDDEN_GLOBAL_NAMES,
         ...libraryNames,
         `return (async () => {
         try {
@@ -158,11 +147,7 @@ export function startProcessRuntime(
       })();`,
       ) as (console: Console, ...args: unknown[]) => Promise<unknown>;
 
-      let result = await execute(
-        sandboxConsole,
-        ...hiddenGlobalNames.map(() => undefined),
-        ...libraryValues,
-      );
+      let result = await execute(sandboxConsole, ...HIDDEN_GLOBAL_VALUES, ...libraryValues);
       if (result !== null && typeof result === 'object' && ERROR_KEYS.CODE_ERROR in result) {
         result = {
           error: (result as { [ERROR_KEYS.CODE_ERROR]: unknown })[ERROR_KEYS.CODE_ERROR],
@@ -170,7 +155,7 @@ export function startProcessRuntime(
       }
       post({ type: 'complete', result, logs });
     } catch (err) {
-      post({ type: 'error', error: err instanceof Error ? err.message : String(err), logs });
+      post({ type: 'error', error: toErrorMessage(err), logs });
     }
   }
 
@@ -196,50 +181,54 @@ export function startProcessRuntime(
 
   let initialization: Promise<void> | null = null;
 
+  function handleInit(data: InitData): void {
+    initialization = initialize(data);
+    initialization.catch((err) => {
+      post({ type: 'error', error: toErrorMessage(err), logs });
+    });
+  }
+
+  function handleToolResult(msg: Extract<HostMessage, { type: 'tool_result' }>): void {
+    pendingCalls.get(msg.id)?.resolve(msg.result);
+    pendingCalls.delete(msg.id);
+  }
+
+  function handleToolError(msg: Extract<HostMessage, { type: 'tool_error' }>): void {
+    pendingCalls.get(msg.id)?.reject(new SandboxToolError(msg.error ?? 'Tool call failed'));
+    pendingCalls.delete(msg.id);
+  }
+
+  function handleExecute(msg: Extract<HostMessage, { type: 'execute' }>): void {
+    const ready = initialization ?? Promise.resolve();
+    void ready
+      .then(() => executeCode(msg.code))
+      .catch((err) => {
+        post({ type: 'error', error: toErrorMessage(err), logs });
+      });
+  }
+
   ipcOn('message', (message) => {
     if (message === null || typeof message !== 'object') return;
-    const msg = message as {
-      type?: string;
-      id?: string;
-      result?: unknown;
-      error?: string;
-      code?: string;
-      toolNames?: string[];
-      libraries?: Record<string, SandboxLibrary>;
-      memoryReportIntervalMs?: number;
-    };
+    const msg = message as { type?: string };
 
+    // Init message is not part of HostMessage protocol (sent only once before execution).
     if (msg.type === 'init') {
-      initialization = initialize({
-        toolNames: msg.toolNames,
-        libraries: msg.libraries,
-        memoryReportIntervalMs: msg.memoryReportIntervalMs,
-      });
-      initialization.catch((err) => {
-        post({ type: 'error', error: err instanceof Error ? err.message : String(err), logs });
-      });
+      handleInit(message as unknown as InitData);
       return;
     }
 
-    if (msg.type === 'tool_result' && typeof msg.id === 'string') {
-      pendingCalls.get(msg.id)?.resolve(msg.result);
-      pendingCalls.delete(msg.id);
-      return;
-    }
+    if (!isHostMessage(message)) return;
 
-    if (msg.type === 'tool_error' && typeof msg.id === 'string') {
-      pendingCalls.get(msg.id)?.reject(new SandboxToolError(msg.error ?? 'Tool call failed'));
-      pendingCalls.delete(msg.id);
-      return;
-    }
-
-    if (msg.type === 'execute' && typeof msg.code === 'string') {
-      const ready = initialization ?? Promise.resolve();
-      void ready
-        .then(() => executeCode(msg.code as string))
-        .catch((err) => {
-          post({ type: 'error', error: err instanceof Error ? err.message : String(err), logs });
-        });
+    switch (message.type) {
+      case 'tool_result':
+        handleToolResult(message);
+        break;
+      case 'tool_error':
+        handleToolError(message);
+        break;
+      case 'execute':
+        handleExecute(message);
+        break;
     }
   });
 }

--- a/packages/sandbox/src/process-runtime.ts
+++ b/packages/sandbox/src/process-runtime.ts
@@ -13,6 +13,7 @@ type PendingCall = {
 type InitData = {
   toolNames?: string[];
   libraries?: Record<string, SandboxLibrary>;
+  memoryReportIntervalMs?: number;
 };
 
 /**
@@ -36,6 +37,7 @@ export function startProcessRuntime(
     event: string,
     listener: (message: unknown) => void,
   ) => void;
+  const getMemoryUsage = process.memoryUsage.bind(process) as () => NodeJS.MemoryUsage;
 
   const pendingCalls = new Map<string, PendingCall>();
   let logs: string[] = [];
@@ -181,6 +183,15 @@ export function startProcessRuntime(
     await importLibrary('node:fs/promises');
     harden();
     registerToolProxies();
+
+    // Start periodic RSS reporting after hardening (uses pre-captured references).
+    const intervalMs = initData.memoryReportIntervalMs;
+    if (intervalMs && intervalMs > 0) {
+      setInterval(() => {
+        const { rss } = getMemoryUsage();
+        ipcSend({ type: 'memory_report', rss });
+      }, intervalMs);
+    }
   }
 
   let initialization: Promise<void> | null = null;
@@ -195,10 +206,15 @@ export function startProcessRuntime(
       code?: string;
       toolNames?: string[];
       libraries?: Record<string, SandboxLibrary>;
+      memoryReportIntervalMs?: number;
     };
 
     if (msg.type === 'init') {
-      initialization = initialize({ toolNames: msg.toolNames, libraries: msg.libraries });
+      initialization = initialize({
+        toolNames: msg.toolNames,
+        libraries: msg.libraries,
+        memoryReportIntervalMs: msg.memoryReportIntervalMs,
+      });
       initialization.catch((err) => {
         post({ type: 'error', error: err instanceof Error ? err.message : String(err), logs });
       });

--- a/packages/sandbox/src/process-runtime.ts
+++ b/packages/sandbox/src/process-runtime.ts
@@ -1,5 +1,3 @@
-import { parentPort, workerData } from 'node:worker_threads';
-
 import { SandboxError, SandboxToolError } from './errors.js';
 import { assertSafeCode, harden } from './hardening.js';
 import { ERROR_KEYS } from './types.js';
@@ -12,31 +10,33 @@ type PendingCall = {
   reject: (reason: Error) => void;
 };
 
-type WorkerData = {
+type InitData = {
   toolNames?: string[];
   libraries?: Record<string, SandboxLibrary>;
 };
 
 /**
- * Starts the sandbox worker runtime. Call this from a worker entry file.
+ * Starts the sandbox process runtime. Call this from a process entry file.
+ * Communicates with the host via Bun IPC (process.send / process.on("message")).
  *
  * @param preloadedModules - A map of library specifiers to already-imported module namespaces.
- *   When running inside a compiled binary, libraries are statically imported by the worker entry
+ *   When running inside a compiled binary, libraries are statically imported by the entry
  *   and passed here so no dynamic import is needed at runtime.
  */
-export function startWorkerRuntime(
+export function startProcessRuntime(
   preloadedModules: Record<string, Record<string, unknown>> = {},
 ): void {
-  function getParentPort() {
-    if (parentPort === null) throw new SandboxError('sandbox worker requires parentPort');
-    return parentPort;
+  if (typeof process.send !== 'function') {
+    throw new SandboxError('sandbox process requires IPC channel (process.send)');
   }
 
-  const port = getParentPort();
+  // Capture IPC primitives before harden() removes `process` from globalThis.
+  const ipcSend = process.send.bind(process) as (message: unknown) => void;
+  const ipcOn = process.on.bind(process) as (
+    event: string,
+    listener: (message: unknown) => void,
+  ) => void;
 
-  const data = workerData as WorkerData | undefined;
-  const toolNames = data?.toolNames ?? [];
-  const libraries = data?.libraries ?? {};
   const pendingCalls = new Map<string, PendingCall>();
   let logs: string[] = [];
   const SandboxFunction = Function;
@@ -44,6 +44,12 @@ export function startWorkerRuntime(
     specifier: string,
   ) => Promise<Record<string, unknown>>;
   let injectedLibraries: Record<string, unknown> = {};
+  let toolNames: string[] = [];
+  let libraries: Record<string, SandboxLibrary> = {};
+
+  function post(message: WorkerMessage): void {
+    ipcSend(message);
+  }
 
   function stringifyLogValue(value: unknown): string {
     if (typeof value === 'string') return value;
@@ -67,10 +73,6 @@ export function startWorkerRuntime(
       error: (...values: unknown[]) => write('error', values),
       debug: (...values: unknown[]) => write('debug', values),
     } as Console;
-  }
-
-  function post(message: WorkerMessage): void {
-    port.postMessage(message);
   }
 
   function createToolProxy(name: string): (args: unknown) => Promise<unknown> {
@@ -170,15 +172,20 @@ export function startWorkerRuntime(
     }
   }
 
-  async function initialize(): Promise<void> {
+  async function initialize(initData: InitData): Promise<void> {
+    toolNames = initData.toolNames ?? [];
+    libraries = initData.libraries ?? {};
     injectedLibraries = await loadLibraries();
+    // Pre-import allowed modules before hardening freezes globals.
+    await importLibrary('node:fs');
+    await importLibrary('node:fs/promises');
     harden();
     registerToolProxies();
   }
 
-  const initialization = initialize();
+  let initialization: Promise<void> | null = null;
 
-  port.on('message', (message) => {
+  ipcOn('message', (message) => {
     if (message === null || typeof message !== 'object') return;
     const msg = message as {
       type?: string;
@@ -186,7 +193,17 @@ export function startWorkerRuntime(
       result?: unknown;
       error?: string;
       code?: string;
+      toolNames?: string[];
+      libraries?: Record<string, SandboxLibrary>;
     };
+
+    if (msg.type === 'init') {
+      initialization = initialize({ toolNames: msg.toolNames, libraries: msg.libraries });
+      initialization.catch((err) => {
+        post({ type: 'error', error: err instanceof Error ? err.message : String(err), logs });
+      });
+      return;
+    }
 
     if (msg.type === 'tool_result' && typeof msg.id === 'string') {
       pendingCalls.get(msg.id)?.resolve(msg.result);
@@ -201,7 +218,8 @@ export function startWorkerRuntime(
     }
 
     if (msg.type === 'execute' && typeof msg.code === 'string') {
-      void initialization
+      const ready = initialization ?? Promise.resolve();
+      void ready
         .then(() => executeCode(msg.code as string))
         .catch((err) => {
           post({ type: 'error', error: err instanceof Error ? err.message : String(err), logs });

--- a/packages/sandbox/src/protocol.ts
+++ b/packages/sandbox/src/protocol.ts
@@ -36,10 +36,21 @@ export type SandboxErrorMessage = {
   logs: string[];
 };
 
-export type WorkerMessage = SandboxToolCallMessage | SandboxCompleteMessage | SandboxErrorMessage;
+export type SandboxMemoryReportMessage = {
+  type: 'memory_report';
+  rss: number;
+};
+
+export type WorkerMessage =
+  | SandboxToolCallMessage
+  | SandboxCompleteMessage
+  | SandboxErrorMessage
+  | SandboxMemoryReportMessage;
 
 export function isWorkerMessage(message: unknown): message is WorkerMessage {
   if (message === null || typeof message !== 'object') return false;
   const type = (message as { type?: unknown }).type;
-  return type === 'tool_call' || type === 'complete' || type === 'error';
+  return (
+    type === 'tool_call' || type === 'complete' || type === 'error' || type === 'memory_report'
+  );
 }

--- a/packages/sandbox/src/protocol.ts
+++ b/packages/sandbox/src/protocol.ts
@@ -54,3 +54,9 @@ export function isWorkerMessage(message: unknown): message is WorkerMessage {
     type === 'tool_call' || type === 'complete' || type === 'error' || type === 'memory_report'
   );
 }
+
+export function isHostMessage(message: unknown): message is HostMessage {
+  if (message === null || typeof message !== 'object') return false;
+  const type = (message as { type?: unknown }).type;
+  return type === 'execute' || type === 'tool_result' || type === 'tool_error';
+}

--- a/packages/sandbox/src/sandbox.test.ts
+++ b/packages/sandbox/src/sandbox.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
 
-import { createWorkerSandbox } from '../src/index.js';
+import { createProcessSandbox } from '../src/index.js';
 
 import type { ToolBinding } from '../src/types.js';
 
+const PROCESS_ENTRY = fileURLToPath(new URL('./process-entry.ts', import.meta.url));
+
+function createDriver() {
+  return createProcessSandbox({ execPath: PROCESS_ENTRY });
+}
+
 async function execute(code: string, bindings: Record<string, ToolBinding> = {}) {
-  const context = await createWorkerSandbox().createContext(bindings, { timeout: 2_000 });
+  const context = await createDriver().createContext(bindings, { timeout: 5_000 });
   try {
     return await context.execute(code);
   } finally {
@@ -13,7 +20,7 @@ async function execute(code: string, bindings: Record<string, ToolBinding> = {})
   }
 }
 
-describe('worker sandbox', () => {
+describe('process sandbox', () => {
   test('executes code and returns the result', async () => {
     const result = await execute('return [1, 2, 3].map((value) => value * 2);');
 
@@ -53,15 +60,15 @@ describe('worker sandbox', () => {
   });
 
   test('injects host-approved libraries', async () => {
-    const context = await createWorkerSandbox().createContext(
+    const context = await createDriver().createContext(
       {},
       {
-        timeout: 2_000,
+        timeout: 5_000,
         libraries: {
           sample: { specifier: new URL('./fixtures/sample-library.ts', import.meta.url).href },
-          sampleWorker: {
+          sampleGlobal: {
             specifier: new URL('./fixtures/sample-library.ts', import.meta.url).href,
-            globalName: 'sampleWorker',
+            globalName: 'sampleGlobal',
             inject: false,
           },
         },
@@ -76,7 +83,7 @@ describe('worker sandbox', () => {
           frozen: Object.isFrozen(sample),
           canReadFunctionPrototype: sample.canReadFunctionPrototype(),
           hasGlobalSampleWorker: sample.hasGlobalSampleWorker(),
-          sampleWorkerType: typeof sampleWorker,
+          sampleGlobalType: typeof sampleGlobal,
         };
       `);
 
@@ -86,7 +93,7 @@ describe('worker sandbox', () => {
         frozen: true,
         canReadFunctionPrototype: true,
         hasGlobalSampleWorker: true,
-        sampleWorkerType: 'object',
+        sampleGlobalType: 'object',
       });
     } finally {
       context.dispose();
@@ -94,10 +101,10 @@ describe('worker sandbox', () => {
   });
 
   test('terminates infinite loops', async () => {
-    const context = await createWorkerSandbox().createContext({}, { timeout: 100 });
+    const context = await createDriver().createContext({}, { timeout: 200 });
     try {
       const result = await context.execute('while (true) {}');
-      expect(result.result).toEqual({ error: 'Execution timed out after 100ms' });
+      expect(result.result).toEqual({ error: 'Execution timed out after 200ms' });
     } finally {
       context.dispose();
     }

--- a/packages/sandbox/src/sandbox.test.ts
+++ b/packages/sandbox/src/sandbox.test.ts
@@ -109,4 +109,23 @@ describe('process sandbox', () => {
       context.dispose();
     }
   });
+
+  test('kills process when memory limit is exceeded', async () => {
+    const driver = createProcessSandbox({ execPath: PROCESS_ENTRY, memoryLimit: 64 });
+    const context = await driver.createContext({}, { timeout: 15_000 });
+    try {
+      const result = await context.execute(`
+        const arrays = [];
+        for (let i = 0; i < 200; i++) {
+          const arr = new Uint8Array(1024 * 1024);
+          arr.fill(1);
+          arrays.push(arr);
+          if (i % 5 === 0) await new Promise(r => setTimeout(r, 10));
+        }
+      `);
+      expect(result.result).toEqual({ error: 'Sandbox memory limit exceeded (64MB)' });
+    } finally {
+      context.dispose();
+    }
+  });
 });

--- a/packages/sandbox/src/security.test.ts
+++ b/packages/sandbox/src/security.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
 
-import { createWorkerSandbox } from '../src/index.js';
+import { createProcessSandbox } from '../src/index.js';
+
+const PROCESS_ENTRY = fileURLToPath(new URL('./process-entry.ts', import.meta.url));
+
+function createDriver() {
+  return createProcessSandbox({ execPath: PROCESS_ENTRY });
+}
 
 async function run(code: string) {
-  const context = await createWorkerSandbox().createContext({}, { timeout: 1_000 });
+  const context = await createDriver().createContext({}, { timeout: 2_000 });
   try {
     return await context.execute(code);
   } finally {
@@ -87,7 +94,7 @@ describe('sandbox hardening', () => {
 
   test('rejects unsafe library names', () => {
     expect(
-      createWorkerSandbox().createContext(
+      createDriver().createContext(
         {},
         {
           libraries: {
@@ -100,7 +107,7 @@ describe('sandbox hardening', () => {
 
   test('rejects unsafe library global names', () => {
     expect(
-      createWorkerSandbox().createContext(
+      createDriver().createContext(
         {},
         {
           libraries: {

--- a/packages/sandbox/src/timer.ts
+++ b/packages/sandbox/src/timer.ts
@@ -35,20 +35,36 @@ type RaceGuard = {
   isTimedOut: () => boolean;
 };
 
+type AbortRace = {
+  promise: Promise<never>;
+  cleanup: () => void;
+};
+
 export function createAbortRace(
   abortSignal: AbortSignal | undefined,
   message: string,
-): Promise<never> | null {
+): AbortRace | null {
   if (abortSignal === undefined) return null;
-  return new Promise<never>((_, reject) => {
+
+  let onAbort: (() => void) | null = null;
+
+  const promise = new Promise<never>((_, reject) => {
     if (abortSignal.aborted) {
       reject(new SandboxAbortError(message));
       return;
     }
-    abortSignal.addEventListener('abort', () => reject(new SandboxAbortError(message)), {
-      once: true,
-    });
+    onAbort = () => reject(new SandboxAbortError(message));
+    abortSignal.addEventListener('abort', onAbort, { once: true });
   });
+
+  const cleanup = () => {
+    if (onAbort !== null) {
+      abortSignal.removeEventListener('abort', onAbort);
+      onAbort = null;
+    }
+  };
+
+  return { promise, cleanup };
 }
 
 export function createExecutionTimeoutRace(

--- a/packages/sandbox/src/tools.test.ts
+++ b/packages/sandbox/src/tools.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
 
-import { createWorkerSandbox } from '../src/index.js';
+import { createProcessSandbox } from '../src/index.js';
+
 import type { ToolBinding } from '../src/types.js';
+
+const PROCESS_ENTRY = fileURLToPath(new URL('./process-entry.ts', import.meta.url));
+
+function createDriver() {
+  return createProcessSandbox({ execPath: PROCESS_ENTRY });
+}
 
 const echoBinding: ToolBinding = {
   name: 'external_echo',
@@ -12,7 +20,7 @@ const echoBinding: ToolBinding = {
 
 describe('sandbox tools', () => {
   test('propagates tool errors into user code', async () => {
-    const context = await createWorkerSandbox().createContext({
+    const context = await createDriver().createContext({
       external_fail: {
         name: 'external_fail',
         description: 'fail',
@@ -39,7 +47,7 @@ describe('sandbox tools', () => {
   });
 
   test('limits tool call count', async () => {
-    const context = await createWorkerSandbox().createContext(
+    const context = await createDriver().createContext(
       { external_echo: echoBinding },
       { maxToolCalls: 1 },
     );

--- a/packages/sandbox/src/types.ts
+++ b/packages/sandbox/src/types.ts
@@ -21,9 +21,9 @@ export type SandboxLibrary = {
   inject?: boolean;
 };
 
-export type SandboxDriverOptions = {
-  /** Override the worker entry URL. Defaults to the built-in worker-entry.ts. */
-  workerUrl?: URL;
+export type SandboxProcessDriverOptions = {
+  /** Path to the compiled sandbox process binary. */
+  execPath: string;
 };
 
 export type IsolateOptions = {

--- a/packages/sandbox/src/types.ts
+++ b/packages/sandbox/src/types.ts
@@ -24,6 +24,8 @@ export type SandboxLibrary = {
 export type SandboxProcessDriverOptions = {
   /** Path to the compiled sandbox process binary. */
   execPath: string;
+  /** Memory limit in MB for the sandbox process (default: 512). */
+  memoryLimit?: number;
 };
 
 export type IsolateOptions = {

--- a/packages/sandbox/src/worker-entry.ts
+++ b/packages/sandbox/src/worker-entry.ts
@@ -1,6 +1,0 @@
-import { startWorkerRuntime } from './worker-runtime.js';
-
-// Default worker entry: no preloaded modules, relies on dynamic import for libraries.
-// For compiled binaries, use a custom worker entry that statically imports libraries
-// and passes them to startWorkerRuntime().
-startWorkerRuntime();

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "test": "bun test",
     "dev": "NODE_ENV=development bun --watch src/index.ts",
-    "build": "bun build src/index.ts src/code-mode/sandbox-worker.ts --compile --minify --outfile dist/stitch-server",
-    "build:x64": "bun build src/index.ts src/code-mode/sandbox-worker.ts --compile --minify --target=bun-darwin-x64 --outfile dist/stitch-server",
+    "build": "bun build src/index.ts --compile --minify --outfile dist/stitch-server && bun build src/code-mode/sandbox-process.ts --compile --minify --outfile dist/stitch-sandbox",
+    "build:x64": "bun build src/index.ts --compile --minify --target=bun-darwin-x64 --outfile dist/stitch-server && bun build src/code-mode/sandbox-process.ts --compile --minify --target=bun-darwin-x64 --outfile dist/stitch-sandbox",
     "typecheck": "tsc --noEmit",
     "lance:migration:new": "bun scripts/new-lance-migration.ts"
   },

--- a/packages/server/src/code-mode/sandbox-process.ts
+++ b/packages/server/src/code-mode/sandbox-process.ts
@@ -1,7 +1,8 @@
 import * as libpdfCore from '@libpdf/core';
-import { startWorkerRuntime } from '@stitch/sandbox';
+
+import { startProcessRuntime } from '@stitch/sandbox';
 
 // To add a new library: import it statically above, then add it to the map below.
-startWorkerRuntime({
+startProcessRuntime({
   '@libpdf/core': libpdfCore as Record<string, unknown>,
 });

--- a/packages/server/src/code-mode/tool.ts
+++ b/packages/server/src/code-mode/tool.ts
@@ -1,7 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 
-import { createWorkerSandbox } from '@stitch/sandbox';
+import { createProcessSandbox } from '@stitch/sandbox';
 import type { IsolateDriver, IsolateOptions } from '@stitch/sandbox';
 
 import { toolsToBindings, toolsToTypeInfo } from '@/code-mode/bindings/tool-binding.js';
@@ -14,7 +14,21 @@ import { truncateOutput } from '@/tools/runtime/truncation.js';
 import type { Tool } from 'ai';
 
 const log = Log.create({ service: 'code-mode' });
-const SANDBOX_WORKER_URL = new URL('./sandbox-worker.ts', import.meta.url);
+
+function getDefaultDriver(): IsolateDriver {
+  const sandboxExecPath = process.env['SANDBOX_EXEC_PATH'];
+  if (!sandboxExecPath) {
+    return {
+      async createContext() {
+        throw new Error(
+          'SANDBOX_EXEC_PATH environment variable is required. ' +
+            'Set it to the path of the compiled sandbox process binary.',
+        );
+      },
+    };
+  }
+  return createProcessSandbox({ execPath: sandboxExecPath });
+}
 
 type CodeModeOptions = {
   getTools: () => Record<string, Tool>;
@@ -30,7 +44,7 @@ type CodeModeToolResult = {
 };
 
 export function createCodeModeTool(options: CodeModeOptions): CodeModeToolResult {
-  const driver = options.driver ?? createWorkerSandbox({ workerUrl: SANDBOX_WORKER_URL });
+  const driver = options.driver ?? getDefaultDriver();
   const filter = options.filter ?? {};
   const isolateOptions = options.isolateOptions ?? {};
 


### PR DESCRIPTION
## 🚀 Change Summary

Replaces the Node.js worker thread sandbox with a fully process-isolated sandbox using Bun's IPC, providing stronger security guarantees and memory enforcement via OS-level process boundaries.

### ✨ New Features
- **Process-based isolation**: Sandbox code now runs in a completely separate OS process (via \Bun.spawn\), eliminating shared memory and prototype chain attack vectors
- **Memory limit enforcement**: Periodic RSS monitoring kills the sandbox process when it exceeds the configured memory limit (default 512MB)
- **Separate sandbox binary**: The sandbox process is compiled as its own standalone binary (\stitch-sandbox\), configured via \SANDBOX_EXEC_PATH\

### 🛠 Improvements & Refactors
- Extracted duplicated \DANGEROUS_GLOBALS\ list into a single shared constant
- Added shared \	oErrorMessage\ utility to eliminate repeated inline error formatting
- Extracted \dispatchToolCall\ from deeply nested closure into a top-level function with explicit \ToolCallContext\
- Hoisted \TextEncoder\, \HIDDEN_GLOBAL_NAMES\ to module scope to avoid per-call allocations
- Added \isHostMessage\ type guard and flattened the IPC message handler with a switch dispatch
- Fixed memory leak in \createAbortRace\ by adding a \cleanup\ method that removes the abort listener

### 🐛 Bug Fixes
- Fixed abort signal event listeners never being cleaned up after normal execution completes