### PR TITLE
fix(ci): pin runner images in release check job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
       fail-fast: true
       matrix:
         os:
-          - windows-latest
-          - macos-latest
+          - windows-2022
+          - macos-14
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/bun.lock
+++ b/bun.lock
@@ -191,6 +191,9 @@
     "registries/embeddings": {
       "name": "@stitch/registry-embeddings",
     },
+    "registries/live-transcription": {
+      "name": "@stitch/registry-live-transcription",
+    },
     "registries/mcp": {
       "name": "@stitch/registry-mcp",
     },
@@ -904,6 +907,8 @@
     "@stitch/desktop": ["@stitch/desktop@workspace:apps/desktop"],
 
     "@stitch/registry-embeddings": ["@stitch/registry-embeddings@workspace:registries/embeddings"],
+
+    "@stitch/registry-live-transcription": ["@stitch/registry-live-transcription@workspace:registries/live-transcription"],
 
     "@stitch/registry-mcp": ["@stitch/registry-mcp@workspace:registries/mcp"],
 


### PR DESCRIPTION
## 🐛 Bug Fixes

- **Pin CI runner images**: Pin \windows-2022\ and \macos-14\ in the release workflow's check job instead of using \*-latest\ tags. The \windows-latest\ redirect to \windows-2025-vs2026\ was causing Bun setup to fail (see [run #47](https://github.com/UseStitch/stitch/actions/runs/26574646406)). This aligns the check job with the build job which already uses pinned runners.