### PR TITLE
Refactor icon fetching and rendering

### DIFF
--- a/apps/web/src/components/connectors/connector-icon.tsx
+++ b/apps/web/src/components/connectors/connector-icon.tsx
@@ -2,6 +2,7 @@ import { BoxIcon } from 'lucide-react';
 
 import type { ConnectorIconSource } from '@stitch/shared/connectors/types';
 
+import { MaskedIcon } from '@/components/icons/masked-icon';
 import { SimpleIcon } from '@/components/ui/simple-icon';
 import { cn } from '@/lib/utils';
 
@@ -24,14 +25,6 @@ export function ConnectorIcon({ icon, className }: ConnectorIconProps) {
   const logoUrl = `data:image/svg+xml;utf8,${encodeURIComponent(icon.svgString)}`;
 
   return (
-    <div
-      role="img"
-      aria-label="connector icon"
-      className={cn('bg-foreground', className)}
-      style={{
-        WebkitMask: `url(${logoUrl}) no-repeat center / contain`,
-        mask: `url(${logoUrl}) no-repeat center / contain`,
-      }}
-    />
+    <MaskedIcon src={logoUrl} label="connector icon" className={cn('bg-foreground', className)} />
   );
 }

--- a/apps/web/src/components/icons/masked-icon.tsx
+++ b/apps/web/src/components/icons/masked-icon.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils';
+
+type MaskedIconProps = {
+  src: string;
+  label: string;
+  className?: string;
+};
+
+export function MaskedIcon({ src, label, className }: MaskedIconProps) {
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      className={cn('bg-foreground', className)}
+      style={{
+        WebkitMask: `url(${src}) no-repeat center / contain`,
+        mask: `url(${src}) no-repeat center / contain`,
+      }}
+    />
+  );
+}

--- a/apps/web/src/components/icons/remote-icon.tsx
+++ b/apps/web/src/components/icons/remote-icon.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+
+import { MaskedIcon } from '@/components/icons/masked-icon';
+import { useServerAssetUrl } from '@/components/icons/use-server-asset-url';
+import { cn } from '@/lib/utils';
+
+const resolvedImageCache = new Map<string, boolean>();
+
+function useResolvedImageUrl(url: string | null): string | null {
+  const [resolvedUrl, setResolvedUrl] = React.useState<string | null>(() => {
+    if (!url) return null;
+    return resolvedImageCache.get(url) === true ? url : null;
+  });
+  const [failed, setFailed] = React.useState(() => (url ? resolvedImageCache.get(url) === false : false));
+
+  React.useEffect(() => {
+    if (!url) {
+      setResolvedUrl(null);
+      setFailed(false);
+      return;
+    }
+
+    const cached = resolvedImageCache.get(url);
+    if (cached !== undefined) {
+      setResolvedUrl(cached ? url : null);
+      setFailed(!cached);
+      return;
+    }
+
+    let active = true;
+    const image = new Image();
+    image.onload = () => {
+      if (!active) return;
+      resolvedImageCache.set(url, true);
+      setResolvedUrl(url);
+      setFailed(false);
+    };
+    image.onerror = () => {
+      if (!active) return;
+      resolvedImageCache.set(url, false);
+      setResolvedUrl(null);
+      setFailed(true);
+    };
+    image.src = url;
+
+    return () => {
+      active = false;
+    };
+  }, [url]);
+
+  if (failed) return null;
+  return resolvedUrl;
+}
+
+type RemoteMaskedIconProps = {
+  path: string | null | undefined;
+  label: string;
+  className?: string;
+  fallback: React.ReactNode;
+};
+
+export function RemoteMaskedIcon({ path, label, className, fallback }: RemoteMaskedIconProps) {
+  const url = useServerAssetUrl(path);
+  const resolvedUrl = useResolvedImageUrl(url);
+
+  if (!resolvedUrl) return <>{fallback}</>;
+  return <MaskedIcon src={resolvedUrl} label={label} className={className} />;
+}
+
+type RemoteImageIconProps = {
+  path: string | null | undefined;
+  label: string;
+  className?: string;
+  fallback: React.ReactNode;
+};
+
+export function RemoteImageIcon({ path, label, className, fallback }: RemoteImageIconProps) {
+  const url = useServerAssetUrl(path);
+  const [failed, setFailed] = React.useState(false);
+
+  React.useEffect(() => {
+    setFailed(false);
+  }, [url]);
+
+  if (!url || failed) return <>{fallback}</>;
+
+  return (
+    <img
+      src={url}
+      alt=""
+      aria-label={label}
+      className={cn('shrink-0 rounded-sm object-contain', className)}
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/apps/web/src/components/icons/use-server-asset-url.ts
+++ b/apps/web/src/components/icons/use-server-asset-url.ts
@@ -1,0 +1,24 @@
+import * as React from 'react';
+
+import { getServerUrl, getServerUrlSync } from '@/lib/api';
+
+export function useServerAssetUrl(path: string | null | undefined): string | null {
+  const initialBaseUrl = getServerUrlSync();
+  const [baseUrl, setBaseUrl] = React.useState<string | null>(initialBaseUrl);
+
+  React.useEffect(() => {
+    if (baseUrl) return;
+
+    let active = true;
+    void getServerUrl().then((url) => {
+      if (active) setBaseUrl(url);
+    });
+
+    return () => {
+      active = false;
+    };
+  }, [baseUrl]);
+
+  if (!path || !baseUrl) return null;
+  return `${baseUrl}${path}`;
+}

--- a/apps/web/src/components/mcp/mcp-server-logo.tsx
+++ b/apps/web/src/components/mcp/mcp-server-logo.tsx
@@ -1,7 +1,6 @@
 import { WrenchIcon } from 'lucide-react';
-import * as React from 'react';
 
-import { getServerUrl } from '@/lib/api';
+import { RemoteImageIcon } from '@/components/icons/remote-icon';
 import { cn } from '@/lib/utils';
 
 type Props = {
@@ -10,39 +9,16 @@ type Props = {
 } & ({ registryId: string; serverId?: never } | { registryId?: never; serverId: string });
 
 export function McpServerLogo({ name, className = 'size-4.5', ...props }: Props) {
-  const [baseUrl, setBaseUrl] = React.useState<string | null>(null);
-  const [failed, setFailed] = React.useState(false);
-
-  React.useEffect(() => {
-    let active = true;
-    void getServerUrl().then((url) => {
-      if (active) setBaseUrl(url);
-    });
-    return () => {
-      active = false;
-    };
-  }, []);
-
   const logoPath =
-    'registryId' in props ? `/mcp/registry/${props.registryId}/logo` : `/mcp/${props.serverId}/logo`;
-  const logoUrl = baseUrl ? `${baseUrl}${logoPath}` : null;
-
-  React.useEffect(() => {
-    setFailed(false);
-  }, [logoUrl]);
-
-  if (logoUrl && !failed) {
-    return (
-      <img
-        src={logoUrl}
-        alt=""
-        aria-label={`${name} logo`}
-        className={cn('shrink-0 rounded-sm object-contain', className)}
-        loading="lazy"
-        onError={() => setFailed(true)}
-      />
-    );
-  }
-
-  return <WrenchIcon className={cn('shrink-0 text-primary', className)} />;
+    'registryId' in props
+      ? `/mcp/registry/${props.registryId}/logo`
+      : `/mcp/${props.serverId}/logo`;
+  return (
+    <RemoteImageIcon
+      path={logoPath}
+      label={`${name} logo`}
+      className={className}
+      fallback={<WrenchIcon className={cn('shrink-0 text-primary', className)} />}
+    />
+  );
 }

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -7,6 +7,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { PermissionPolicyEditor } from './permissions/permission-policy-editor';
 
 import { ConnectorIcon } from '@/components/connectors/connector-icon';
+import { RemoteImageIcon } from '@/components/icons/remote-icon';
 import {
   filterCoreTools,
   filterToolsetsByQuery,
@@ -87,7 +88,12 @@ function ToolRow({
     >
       <div className="flex min-w-0 items-center gap-2.5">
         {iconPath && (
-          <img src={iconPath} alt="" className="size-4 shrink-0 rounded-sm" loading="lazy" />
+          <RemoteImageIcon
+            path={iconPath}
+            label={`${name} icon`}
+            className="size-4"
+            fallback={null}
+          />
         )}
         <div className="min-w-0">
           <p className="truncate text-sm font-medium">{name}</p>

--- a/apps/web/src/components/settings/providers/provider-logo.tsx
+++ b/apps/web/src/components/settings/providers/provider-logo.tsx
@@ -1,7 +1,6 @@
 import { BoxIcon } from 'lucide-react';
-import * as React from 'react';
 
-import { getServerUrl } from '@/lib/api';
+import { RemoteMaskedIcon } from '@/components/icons/remote-icon';
 
 type Props = {
   providerId: string;
@@ -10,39 +9,12 @@ type Props = {
 };
 
 export function ProviderLogo({ providerId, providerName, className = 'size-4.5' }: Props) {
-  const [baseUrl, setBaseUrl] = React.useState<string | null>(null);
-  const [failed, setFailed] = React.useState(false);
-
-  React.useEffect(() => {
-    let active = true;
-    void getServerUrl().then((url) => {
-      if (active) setBaseUrl(url);
-    });
-    return () => {
-      active = false;
-    };
-  }, []);
-
-  React.useEffect(() => {
-    setFailed(false);
-  }, [providerId]);
-
-  const logoUrl = baseUrl ? `${baseUrl}/llm/provider/${providerId}/logo` : null;
-
-  if (logoUrl && !failed) {
-    return (
-      <div
-        role="img"
-        aria-label={`${providerName} logo`}
-        className={`bg-info ${className}`}
-        style={{
-          WebkitMask: `url(${logoUrl}) no-repeat center / contain`,
-          mask: `url(${logoUrl}) no-repeat center / contain`,
-        }}
-        onError={() => setFailed(true)}
-      />
-    );
-  }
-
-  return <BoxIcon className={`text-primary ${className}`} />;
+  return (
+    <RemoteMaskedIcon
+      path={`/llm/provider/${providerId}/logo`}
+      label={`${providerName} logo`}
+      className={`bg-info ${className}`}
+      fallback={<BoxIcon className={`text-primary ${className}`} />}
+    />
+  );
 }

--- a/apps/web/src/components/ui/simple-icon.tsx
+++ b/apps/web/src/components/ui/simple-icon.tsx
@@ -1,7 +1,7 @@
 import { BoxIcon } from 'lucide-react';
 import * as React from 'react';
 
-import { getServerUrl, getServerUrlSync } from '@/lib/api';
+import { RemoteMaskedIcon } from '@/components/icons/remote-icon';
 import { cn } from '@/lib/utils';
 
 type SimpleIconProps = {
@@ -10,82 +10,13 @@ type SimpleIconProps = {
   fallback?: React.ReactNode;
 };
 
-const resolvedCache = new Map<string, string | null>();
-
 export function SimpleIcon({ slug, className, fallback }: SimpleIconProps) {
-  const initialBaseUrl = getServerUrlSync();
-  const initialCacheKey = initialBaseUrl ? `${initialBaseUrl}:${slug}` : null;
-  const initialCached = initialCacheKey ? resolvedCache.get(initialCacheKey) : undefined;
-
-  const [baseUrl, setBaseUrl] = React.useState<string | null>(initialBaseUrl);
-  const [resolvedUrl, setResolvedUrl] = React.useState<string | null>(
-    initialCached !== undefined ? initialCached : null,
+  return (
+    <RemoteMaskedIcon
+      path={`/icons/simple-icons/${slug}`}
+      label={slug}
+      className={className}
+      fallback={fallback ?? <BoxIcon className={cn('text-muted-foreground', className)} />}
+    />
   );
-  const [failed, setFailed] = React.useState(initialCached === null);
-
-  React.useEffect(() => {
-    if (baseUrl) return;
-    let active = true;
-    void getServerUrl().then((url) => {
-      if (active) setBaseUrl(url);
-    });
-    return () => {
-      active = false;
-    };
-  }, [baseUrl]);
-
-  React.useEffect(() => {
-    if (!baseUrl) return;
-
-    const cacheKey = `${baseUrl}:${slug}`;
-    const logoUrl = `${baseUrl}/icons/simple-icons/${slug}`;
-
-    if (resolvedCache.has(cacheKey)) {
-      const cached = resolvedCache.get(cacheKey);
-      setResolvedUrl(cached ?? null);
-      setFailed(cached === null);
-      return;
-    }
-
-    let active = true;
-
-    const image = new Image();
-    image.onload = () => {
-      if (!active) return;
-      resolvedCache.set(cacheKey, logoUrl);
-      setResolvedUrl(logoUrl);
-      setFailed(false);
-    };
-    image.onerror = () => {
-      if (!active) return;
-      resolvedCache.set(cacheKey, null);
-      setResolvedUrl(null);
-      setFailed(true);
-    };
-    image.src = logoUrl;
-
-    return () => {
-      active = false;
-    };
-  }, [baseUrl, slug]);
-
-  if (resolvedUrl && !failed) {
-    return (
-      <div
-        role="img"
-        aria-label={slug}
-        className={cn('bg-foreground', className)}
-        style={{
-          WebkitMask: `url(${resolvedUrl}) no-repeat center / contain`,
-          mask: `url(${resolvedUrl}) no-repeat center / contain`,
-        }}
-      />
-    );
-  }
-
-  if (failed && fallback) {
-    return <>{fallback}</>;
-  }
-
-  return <BoxIcon className={cn('text-muted-foreground', className)} />;
 }

--- a/connectors/sdk/src/types.ts
+++ b/connectors/sdk/src/types.ts
@@ -1,6 +1,7 @@
 import type {
   ApiKeyConfig,
   ConnectorAuthType,
+  ConnectorIconSource,
   ConnectorSetupInstruction,
   ConnectorStatus,
   ConnectorUpgradeAction,
@@ -9,9 +10,7 @@ import type {
 } from '@stitch/shared/connectors/types';
 import type { StitchLogger } from '@stitch/shared/logger';
 
-export type ConnectorIconSource =
-  | { type: 'svgString'; svgString: string }
-  | { type: 'simpleIcons'; slug: string };
+export type { ConnectorIconSource } from '@stitch/shared/connectors/types';
 
 export type ConnectorDefinitionInput = {
   id: string;
@@ -60,7 +59,10 @@ export type ConnectorServiceHooks = {
     logger: StitchLogger;
   }) => Promise<{ accountEmail: string | null; accountInfo: Record<string, unknown> | null }>;
   onDeleted?: (input: { instance: ConnectorInstanceRecord; logger: StitchLogger }) => Promise<void>;
-  testConnection?: (input: { instance: ConnectorInstanceRecord; logger: StitchLogger }) => Promise<void>;
+  testConnection?: (input: {
+    instance: ConnectorInstanceRecord;
+    logger: StitchLogger;
+  }) => Promise<void>;
 };
 
 export type ConnectorModule = {

--- a/packages/server/src/lib/icon-cache.ts
+++ b/packages/server/src/lib/icon-cache.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export const ICON_CACHE_CONTROL = 'public, max-age=86400';
+export const SVG_CONTENT_TYPE = 'image/svg+xml; charset=utf-8';
+
+export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export async function readCachedText(filePath: string): Promise<string | undefined> {
+  return fs.readFile(filePath, 'utf8').catch(() => undefined);
+}
+
+export async function writeCachedText(filePath: string, value: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, value, 'utf8');
+}
+
+export function isSvgResponse(response: Response): boolean {
+  return response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() === 'image/svg+xml';
+}

--- a/packages/server/src/lib/simple-icons.ts
+++ b/packages/server/src/lib/simple-icons.ts
@@ -1,6 +1,6 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
 
+import { readCachedText, writeCachedText } from '@/lib/icon-cache.js';
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
 
@@ -13,7 +13,7 @@ export async function getSimpleIcon(slug: string): Promise<string | undefined> {
   const cacheDir = PATHS.dirPaths.simpleIcons;
   const filePath = path.join(cacheDir, `${slug}.svg`);
 
-  const cached = await fs.readFile(filePath, 'utf8').catch(() => undefined);
+  const cached = await readCachedText(filePath);
   if (cached) return cached;
 
   const result = await fetch(`${SIMPLE_ICONS_CDN}/${slug}`, {
@@ -25,7 +25,6 @@ export async function getSimpleIcon(slug: string): Promise<string | undefined> {
   if (!result || !result.ok) return undefined;
 
   const svg = await result.text();
-  await fs.mkdir(cacheDir, { recursive: true });
-  await fs.writeFile(filePath, svg, 'utf8');
+  await writeCachedText(filePath, svg);
   return svg;
 }

--- a/packages/server/src/llm/provider/logos.ts
+++ b/packages/server/src/llm/provider/logos.ts
@@ -1,6 +1,6 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
 
+import { readCachedText, writeCachedText } from '@/lib/icon-cache.js';
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
 import { isAllowedProvider } from '@/llm/provider/models.js';
@@ -30,7 +30,7 @@ export async function get(
   const cacheDir = options.cacheDir ?? PATHS.dirPaths.providerLogos;
   const filePath = getLogoPath(logoId, cacheDir);
 
-  const cached = await fs.readFile(filePath, 'utf8').catch(() => undefined);
+  const cached = await readCachedText(filePath);
   if (cached) return cached;
 
   const result = await fetch(`${LOGO_BASE_URL}/${logoId}.svg`, {
@@ -42,7 +42,6 @@ export async function get(
   if (!result || !result.ok) return undefined;
 
   const svg = await result.text();
-  await fs.mkdir(cacheDir, { recursive: true });
-  await fs.writeFile(filePath, svg, 'utf8');
+  await writeCachedText(filePath, svg);
   return svg;
 }

--- a/packages/server/src/mcp/presentation.ts
+++ b/packages/server/src/mcp/presentation.ts
@@ -1,0 +1,90 @@
+import type { McpIcon, McpRegistryServer } from '@stitch/shared/mcp/types';
+
+import { cacheMcpIcon } from '@/mcp/icons.js';
+import type { McpServerWithTools } from '@/mcp/service.js';
+
+export type McpServerLiveInfo = {
+  name?: string;
+  title?: string;
+  description?: string;
+  instructions?: string;
+  icons?: McpIcon[];
+};
+
+type McpToolPresentation = {
+  title?: string;
+  iconPath?: string;
+};
+
+export type McpServerPresentation = {
+  serverId: string;
+  name: string;
+  title?: string;
+  description?: string;
+  instructions?: string;
+  iconPath?: string;
+  tools: Record<string, McpToolPresentation>;
+};
+
+function pickDisplayIcon(icons?: McpIcon[]): McpIcon | undefined {
+  if (!icons || icons.length === 0) return undefined;
+  return icons[0];
+}
+
+async function resolveIconPath(input: {
+  server: McpServerWithTools;
+  scope: string;
+  icons?: McpIcon[];
+}): Promise<string | undefined> {
+  const icon = pickDisplayIcon(input.icons);
+  if (!icon) return undefined;
+  const cached = await cacheMcpIcon({
+    serverUrl: input.server.url,
+    scope: input.scope,
+    icon,
+  });
+  if (!cached) return undefined;
+  return `/mcp/icons/${cached.key}`;
+}
+
+export async function buildServerPresentation(
+  server: McpServerWithTools,
+  liveInfo: McpServerLiveInfo | null,
+  registryServer?: McpRegistryServer | null,
+): Promise<McpServerPresentation> {
+  const tools = server.tools ?? [];
+  const toolPresentations = await Promise.all(
+    tools.map(async (tool) => {
+      const iconPath = await resolveIconPath({
+        server,
+        scope: `tool:${server.id}:${tool.name}`,
+        icons: tool.icons,
+      });
+
+      return [
+        tool.name,
+        {
+          title: tool.title ?? tool.annotations?.title,
+          iconPath,
+        },
+      ] as const;
+    }),
+  );
+
+  const iconPath = await resolveIconPath({
+    server,
+    scope: `server:${server.id}`,
+    icons: liveInfo?.icons,
+  });
+  const registryIconPath = registryServer?.logoUrl ? `/mcp/${server.id}/logo` : undefined;
+
+  return {
+    serverId: server.id,
+    name: registryServer?.name ?? server.name ?? liveInfo?.name,
+    title: registryServer?.name ?? liveInfo?.title,
+    description: liveInfo?.description ?? registryServer?.description,
+    instructions: liveInfo?.instructions,
+    iconPath: iconPath ?? registryIconPath,
+    tools: Object.fromEntries(toolPresentations),
+  };
+}

--- a/packages/server/src/mcp/registry-logos.ts
+++ b/packages/server/src/mcp/registry-logos.ts
@@ -1,12 +1,13 @@
-import fs from 'node:fs/promises';
+import { eq } from 'drizzle-orm';
 import path from 'node:path';
 
 import type { PrefixedString } from '@stitch/shared/id';
 import type { McpRegistryServer } from '@stitch/shared/mcp/types';
-import { eq } from 'drizzle-orm';
 
 import { getDb } from '@/db/client.js';
 import { mcpServers } from '@/db/schema.js';
+import { isSvgResponse, readCachedText, writeCachedText } from '@/lib/icon-cache.js';
+import type { FetchLike } from '@/lib/icon-cache.js';
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
 import { isServiceError } from '@/lib/service-result.js';
@@ -14,8 +15,6 @@ import { findMcpRegistryServerForInstall, listMcpRegistryServers } from '@/mcp/r
 
 const log = Log.create({ service: 'mcp-registry-logos' });
 const REGISTRY_ID_REGEX = /^[a-z0-9][a-z0-9._-]*$/i;
-
-type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 type GetRegistryLogoOptions = {
   cacheDir?: string;
@@ -39,10 +38,6 @@ function isAllowedLogoUrl(logoUrl: string): boolean {
   }
 }
 
-function isSvgResponse(response: Response): boolean {
-  return response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() === 'image/svg+xml';
-}
-
 async function fetchAndCacheLogo(
   server: McpRegistryServer,
   filePath: string,
@@ -59,8 +54,7 @@ async function fetchAndCacheLogo(
   if (!response || !response.ok || !isSvgResponse(response)) return undefined;
 
   const svg = await response.text();
-  await fs.mkdir(cacheDir, { recursive: true });
-  await fs.writeFile(filePath, svg, 'utf8');
+  await writeCachedText(filePath, svg);
   return svg;
 }
 
@@ -72,7 +66,7 @@ export async function getMcpRegistryLogo(
 
   const cacheDir = options.cacheDir ?? PATHS.dirPaths.mcpRegistryLogos;
   const filePath = getLogoPath(registryId, cacheDir);
-  const cached = await fs.readFile(filePath, 'utf8').catch(() => undefined);
+  const cached = await readCachedText(filePath);
   if (cached) return cached;
 
   const result = await listMcpRegistryServers({ cacheFilePath: options.registryCacheFilePath });
@@ -84,7 +78,9 @@ export async function getMcpRegistryLogo(
   return fetchAndCacheLogo(server, filePath, cacheDir, options.fetchImpl ?? fetch);
 }
 
-export async function getMcpInstalledServerRegistryLogo(serverId: string): Promise<string | undefined> {
+export async function getMcpInstalledServerRegistryLogo(
+  serverId: string,
+): Promise<string | undefined> {
   const db = getDb();
   const [server] = await db
     .select()

--- a/packages/server/src/mcp/tool-executor.ts
+++ b/packages/server/src/mcp/tool-executor.ts
@@ -5,7 +5,8 @@ import * as Log from '@/lib/log.js';
 import { isServiceError } from '@/lib/service-result.js';
 import { buildAuthHeaders } from '@/mcp/auth.js';
 import { getMcpClient, withMcpClient } from '@/mcp/client.js';
-import { cacheMcpIcon } from '@/mcp/icons.js';
+import { buildServerPresentation } from '@/mcp/presentation.js';
+import type { McpServerLiveInfo, McpServerPresentation } from '@/mcp/presentation.js';
 import { findMcpRegistryServerForInstall } from '@/mcp/registry-service.js';
 import { fetchMcpTools, getMcpServersWithCachedTools } from '@/mcp/service.js';
 import type { McpServerWithTools } from '@/mcp/service.js';
@@ -19,21 +20,6 @@ import type { Tool } from 'ai';
 export { evictMcpClient } from '@/mcp/client.js';
 
 const log = Log.create({ service: 'mcp-tool-executor' });
-
-type McpToolPresentation = {
-  title?: string;
-  iconPath?: string;
-};
-
-type McpServerPresentation = {
-  serverId: string;
-  name: string;
-  title?: string;
-  description?: string;
-  instructions?: string;
-  iconPath?: string;
-  tools: Record<string, McpToolPresentation>;
-};
 
 const serverPresentationById = new Map<string, McpServerPresentation>();
 let refreshInFlight: Promise<void> | null = null;
@@ -76,14 +62,6 @@ async function getToolsForServer(
   }
   return prefixed;
 }
-
-type McpServerLiveInfo = {
-  name?: string;
-  title?: string;
-  description?: string;
-  instructions?: string;
-  icons?: McpIcon[];
-};
 
 async function fetchServerInfo(server: McpServerWithTools): Promise<McpServerLiveInfo | null> {
   try {
@@ -222,27 +200,6 @@ function buildMcpInstructions(input: {
   return [exactNameRule, promptRule, liveInstructions].filter(Boolean).join('\n\n') || undefined;
 }
 
-function pickDisplayIcon(icons?: McpIcon[]): McpIcon | undefined {
-  if (!icons || icons.length === 0) return undefined;
-  return icons[0];
-}
-
-async function resolveIconPath(input: {
-  server: McpServerWithTools;
-  scope: string;
-  icons?: McpIcon[];
-}): Promise<string | undefined> {
-  const icon = pickDisplayIcon(input.icons);
-  if (!icon) return undefined;
-  const cached = await cacheMcpIcon({
-    serverUrl: input.server.url,
-    scope: input.scope,
-    icon,
-  });
-  if (!cached) return undefined;
-  return `/mcp/icons/${cached.key}`;
-}
-
 function createMcpToolset(
   server: McpServerWithTools,
   liveInfo: McpServerLiveInfo | null,
@@ -268,48 +225,6 @@ function createMcpToolset(
           `Tool from MCP server "${displayName}". Use this exact prefixed tool name; do not call the unprefixed MCP tool name.`,
       })),
     activate: (context) => getToolsForServer(server, context),
-  };
-}
-
-async function buildServerPresentation(
-  server: McpServerWithTools,
-  liveInfo: McpServerLiveInfo | null,
-  registryServer?: McpRegistryServer | null,
-): Promise<McpServerPresentation> {
-  const tools = server.tools ?? [];
-  const toolPresentations = await Promise.all(
-    tools.map(async (tool) => {
-      const iconPath = await resolveIconPath({
-        server,
-        scope: `tool:${server.id}:${tool.name}`,
-        icons: tool.icons,
-      });
-
-      return [
-        tool.name,
-        {
-          title: tool.title ?? tool.annotations?.title,
-          iconPath,
-        },
-      ] as const;
-    }),
-  );
-
-  const iconPath = await resolveIconPath({
-    server,
-    scope: `server:${server.id}`,
-    icons: liveInfo?.icons,
-  });
-  const registryIconPath = registryServer?.logoUrl ? `/mcp/${server.id}/logo` : undefined;
-
-  return {
-    serverId: server.id,
-    name: registryServer?.name ?? server.name ?? liveInfo?.name,
-    title: registryServer?.name ?? liveInfo?.title,
-    description: liveInfo?.description ?? registryServer?.description,
-    instructions: liveInfo?.instructions,
-    iconPath: iconPath ?? registryIconPath,
-    tools: Object.fromEntries(toolPresentations),
   };
 }
 

--- a/packages/server/src/routes/icons.ts
+++ b/packages/server/src/routes/icons.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 
+import { ICON_CACHE_CONTROL, SVG_CONTENT_TYPE } from '@/lib/icon-cache.js';
 import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
 import { isServiceError } from '@/lib/service-result.js';
 import { getSimpleIcon } from '@/lib/simple-icons.js';
@@ -12,7 +13,7 @@ iconsRouter.get('/simple-icons/:slug', async (c) => {
   const result = requireFound(svg, 'Icon');
   if (isServiceError(result)) return unwrapResult(c, result);
 
-  c.header('Content-Type', 'image/svg+xml; charset=utf-8');
-  c.header('Cache-Control', 'public, max-age=86400');
+  c.header('Content-Type', SVG_CONTENT_TYPE);
+  c.header('Cache-Control', ICON_CACHE_CONTROL);
   return c.body(result.data, 200);
 });

--- a/packages/server/src/routes/llm-provider.ts
+++ b/packages/server/src/routes/llm-provider.ts
@@ -2,6 +2,9 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { z } from 'zod';
 
+import { PROVIDER_IDS } from '@stitch/shared/providers/types';
+
+import { ICON_CACHE_CONTROL, SVG_CONTENT_TYPE } from '@/lib/icon-cache.js';
 import * as Log from '@/lib/log.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
 import { isServiceError } from '@/lib/service-result.js';
@@ -17,7 +20,6 @@ import {
   listProviders,
   upsertProviderCredentials,
 } from '@/llm/provider/service.js';
-import { PROVIDER_IDS } from '@stitch/shared/providers/types';
 
 const log = Log.create({ service: 'provider-routes' });
 
@@ -42,19 +44,27 @@ providerRouter.get('/embedding-models', async (c) => {
   return unwrapResult(c, result);
 });
 
-providerRouter.get('/:providerId', zValidator('param', z.object({ providerId: providerIdSchema })), async (c) => {
-  const { providerId } = c.req.valid('param');
-  const result = await getProvider(providerId);
-  if (isServiceError(result)) log.warn({ providerId }, 'blocked access to provider');
-  return unwrapResult(c, result);
-});
+providerRouter.get(
+  '/:providerId',
+  zValidator('param', z.object({ providerId: providerIdSchema })),
+  async (c) => {
+    const { providerId } = c.req.valid('param');
+    const result = await getProvider(providerId);
+    if (isServiceError(result)) log.warn({ providerId }, 'blocked access to provider');
+    return unwrapResult(c, result);
+  },
+);
 
-providerRouter.get('/:providerId/models', zValidator('param', z.object({ providerId: providerIdSchema })), async (c) => {
-  const { providerId } = c.req.valid('param');
-  const result = await listProviderModels(providerId);
-  if (isServiceError(result)) log.warn({ providerId }, 'blocked access to provider models');
-  return unwrapResult(c, result);
-});
+providerRouter.get(
+  '/:providerId/models',
+  zValidator('param', z.object({ providerId: providerIdSchema })),
+  async (c) => {
+    const { providerId } = c.req.valid('param');
+    const result = await listProviderModels(providerId);
+    if (isServiceError(result)) log.warn({ providerId }, 'blocked access to provider models');
+    return unwrapResult(c, result);
+  },
+);
 
 providerRouter.get(
   '/:providerId/models/:modelId',
@@ -62,30 +72,39 @@ providerRouter.get(
   async (c) => {
     const { providerId, modelId } = c.req.valid('param');
     const result = await getProviderModel(providerId, modelId);
-    if (isServiceError(result)) log.warn({ providerId, modelId }, 'blocked access to provider model');
+    if (isServiceError(result))
+      log.warn({ providerId, modelId }, 'blocked access to provider model');
     return unwrapResult(c, result);
   },
 );
 
-providerRouter.get('/:providerId/logo', zValidator('param', z.object({ providerId: providerIdSchema })), async (c) => {
-  const { providerId } = c.req.valid('param');
-  const result = await getProviderLogo(providerId);
-  if (isServiceError(result)) {
-    log.warn({ providerId }, 'provider logo request failed');
+providerRouter.get(
+  '/:providerId/logo',
+  zValidator('param', z.object({ providerId: providerIdSchema })),
+  async (c) => {
+    const { providerId } = c.req.valid('param');
+    const result = await getProviderLogo(providerId);
+    if (isServiceError(result)) {
+      log.warn({ providerId }, 'provider logo request failed');
+      return unwrapResult(c, result);
+    }
+
+    c.header('Content-Type', SVG_CONTENT_TYPE);
+    c.header('Cache-Control', ICON_CACHE_CONTROL);
+    return c.body(result.data, 200);
+  },
+);
+
+providerRouter.get(
+  '/:providerId/config',
+  zValidator('param', z.object({ providerId: providerIdSchema })),
+  async (c) => {
+    const { providerId } = c.req.valid('param');
+    const result = await getProviderCredentials(providerId);
+    if (isServiceError(result)) log.warn({ providerId }, 'provider config request failed');
     return unwrapResult(c, result);
-  }
-
-  c.header('Content-Type', 'image/svg+xml; charset=utf-8');
-  c.header('Cache-Control', 'public, max-age=86400');
-  return c.body(result.data, 200);
-});
-
-providerRouter.get('/:providerId/config', zValidator('param', z.object({ providerId: providerIdSchema })), async (c) => {
-  const { providerId } = c.req.valid('param');
-  const result = await getProviderCredentials(providerId);
-  if (isServiceError(result)) log.warn({ providerId }, 'provider config request failed');
-  return unwrapResult(c, result);
-});
+  },
+);
 
 providerRouter.put(
   '/:providerId/config',

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import { MCP_TRANSPORT_TYPES } from '@stitch/shared/mcp/types';
 
+import { ICON_CACHE_CONTROL, SVG_CONTENT_TYPE } from '@/lib/icon-cache.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
 import { isServiceError } from '@/lib/service-result.js';
 import { getMcpIconByKey } from '@/mcp/icons.js';
@@ -68,8 +69,8 @@ mcpRouter.get('/registry/:registryId/logo', async (c) => {
     return c.json({ error: 'MCP registry logo not found' }, 404);
   }
 
-  c.header('Content-Type', 'image/svg+xml; charset=utf-8');
-  c.header('Cache-Control', 'public, max-age=86400');
+  c.header('Content-Type', SVG_CONTENT_TYPE);
+  c.header('Cache-Control', ICON_CACHE_CONTROL);
   return c.body(logo, 200);
 });
 
@@ -88,8 +89,8 @@ mcpRouter.get('/:id/logo', async (c) => {
     return c.json({ error: 'MCP server logo not found' }, 404);
   }
 
-  c.header('Content-Type', 'image/svg+xml; charset=utf-8');
-  c.header('Cache-Control', 'public, max-age=86400');
+  c.header('Content-Type', SVG_CONTENT_TYPE);
+  c.header('Cache-Control', ICON_CACHE_CONTROL);
   return c.body(logo, 200);
 });
 
@@ -112,7 +113,7 @@ mcpRouter.get('/icons/:key', async (c) => {
   }
 
   c.header('Content-Type', icon.mimeType);
-  c.header('Cache-Control', 'public, max-age=86400');
+  c.header('Cache-Control', ICON_CACHE_CONTROL);
   return c.body(Buffer.from(icon.body), 200);
 });
 


### PR DESCRIPTION
## 🚀 Change Summary

Refactors icon fetching, caching, serving, and frontend rendering paths while preserving separate server services and domain-specific frontend components.

### 🛠 Improvements & Refactors
- Added shared server icon cache/header helpers for SVG and icon responses without centralizing provider, MCP, or Simple Icons services.
- Moved MCP presentation icon resolution out of the tool executor into a dedicated MCP presentation module.
- Added reusable frontend icon primitives for server asset URLs, masked SVG icons, and remote image icons.
- Simplified connector, Simple Icons, provider logo, MCP logo, and permissions icon rendering through reusable components.
- Deduplicated the connector icon source type in the connector SDK.