### PR TITLE
Refactor LLM and embedding registry caches into shared utility

### DIFF
--- a/packages/server/src/lib/registry-cache.test.ts
+++ b/packages/server/src/lib/registry-cache.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createRegistryCache, type FetchLike } from '@/lib/registry-cache.js';
+
+const tempDirs: string[] = [];
+
+async function createTempCacheFilePath(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'stitch-registry-cache-test-'));
+  tempDirs.push(dir);
+  return path.join(dir, 'registry.json');
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+const PAYLOAD = { version: 1, items: ['a', 'b'] };
+const parse = (raw: unknown) => raw as typeof PAYLOAD;
+
+function okFetch(payload: unknown): FetchLike {
+  return async () =>
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+}
+
+function failFetch(): FetchLike {
+  return async () => {
+    throw new Error('network unavailable');
+  };
+}
+
+function errorFetch(status: number): FetchLike {
+  return async () => new Response(null, { status });
+}
+
+describe('createRegistryCache', () => {
+  test('fetches from network and writes disk cache on first get', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    const cache = createRegistryCache({ cacheFilePath, url: 'https://example.com', parse });
+
+    const result = await cache.get(okFetch(PAYLOAD));
+
+    expect(result).toEqual(PAYLOAD);
+    const written = JSON.parse(await fs.readFile(cacheFilePath, 'utf8'));
+    expect(written).toEqual(PAYLOAD);
+  });
+
+  test('returns in-memory cache on second get without fetching', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    const cache = createRegistryCache({ cacheFilePath, url: 'https://example.com', parse });
+
+    await cache.get(okFetch(PAYLOAD));
+
+    let fetchCalled = false;
+    const neverFetch: FetchLike = async () => {
+      fetchCalled = true;
+      throw new Error('should not be called');
+    };
+
+    const result = await cache.get(neverFetch);
+    expect(result).toEqual(PAYLOAD);
+    expect(fetchCalled).toBe(false);
+  });
+
+  test('reads from disk cache and skips network', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    await fs.mkdir(path.dirname(cacheFilePath), { recursive: true });
+    await fs.writeFile(cacheFilePath, JSON.stringify(PAYLOAD), 'utf8');
+
+    const cache = createRegistryCache({ cacheFilePath, url: 'https://example.com', parse });
+
+    let fetchCalled = false;
+    const neverFetch: FetchLike = async () => {
+      fetchCalled = true;
+      throw new Error('should not be called');
+    };
+
+    const result = await cache.get(neverFetch);
+    expect(result).toEqual(PAYLOAD);
+    expect(fetchCalled).toBe(false);
+  });
+
+  test('ignores invalid disk cache and fetches from network', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    await fs.mkdir(path.dirname(cacheFilePath), { recursive: true });
+    await fs.writeFile(cacheFilePath, 'not valid json', 'utf8');
+
+    const throwingParse = (raw: unknown) => {
+      if ((raw as Record<string, unknown>)['version'] === undefined) {
+        throw new Error('invalid');
+      }
+      return raw as typeof PAYLOAD;
+    };
+
+    const cache = createRegistryCache({
+      cacheFilePath,
+      url: 'https://example.com',
+      parse: throwingParse,
+    });
+
+    const result = await cache.get(okFetch(PAYLOAD));
+    expect(result).toEqual(PAYLOAD);
+  });
+
+  test('returns fallback when network fails and no disk cache exists', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    const fallback = { version: 0, items: ['fallback'] };
+    const cache = createRegistryCache({
+      cacheFilePath,
+      url: 'https://example.com',
+      parse,
+      fallback,
+    });
+
+    const result = await cache.get(failFetch());
+    expect(result).toEqual(fallback);
+  });
+
+  test('throws when network fails and no fallback is configured', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    const cache = createRegistryCache({ cacheFilePath, url: 'https://example.com', parse });
+
+    expect(cache.get(failFetch())).rejects.toThrow();
+  });
+
+  test('throws when server returns non-ok status and no fallback', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    const cache = createRegistryCache({ cacheFilePath, url: 'https://example.com', parse });
+
+    expect(cache.get(errorFetch(503))).rejects.toThrow('HTTP 503');
+  });
+
+  test('refresh fetches and writes disk cache, clears in-memory cache', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    const cache = createRegistryCache({ cacheFilePath, url: 'https://example.com', parse });
+
+    await cache.get(okFetch(PAYLOAD));
+
+    const updated = { version: 2, items: ['c'] };
+    await cache.refresh(okFetch(updated));
+
+    const written = JSON.parse(await fs.readFile(cacheFilePath, 'utf8'));
+    expect(written).toEqual(updated);
+
+    // After refresh the in-memory cache is cleared so next get re-reads from disk.
+    const result = await cache.get(failFetch());
+    expect(result).toEqual(updated);
+  });
+
+  test('refresh silently ignores network failures', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    const cache = createRegistryCache({ cacheFilePath, url: 'https://example.com', parse });
+
+    expect(cache.refresh(failFetch())).resolves.toBeUndefined();
+  });
+
+  test('reset clears in-memory cache so disk is re-read on next get', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    const cache = createRegistryCache({ cacheFilePath, url: 'https://example.com', parse });
+
+    await cache.get(okFetch(PAYLOAD));
+    cache.reset();
+
+    const updated = { version: 3, items: ['x'] };
+    await fs.writeFile(cacheFilePath, JSON.stringify(updated), 'utf8');
+
+    const result = await cache.get(failFetch());
+    expect(result).toEqual(updated);
+  });
+});

--- a/packages/server/src/lib/registry-cache.ts
+++ b/packages/server/src/lib/registry-cache.ts
@@ -1,0 +1,114 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import * as Log from '@/lib/log.js';
+
+const log = Log.create({ service: 'registry-cache' });
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+type RegistryCacheOptions<T> = {
+  /** Absolute path to the disk cache file. */
+  cacheFilePath: string;
+  /** Remote URL to fetch when no cache is available. */
+  url: string;
+  /** Parse and validate a raw JSON value into domain type T. Throws on invalid input. */
+  parse: (raw: unknown) => T;
+  /** Fallback value to use if both network and disk cache are unavailable. */
+  fallback?: T;
+  /** Fetch timeout in milliseconds. Defaults to 10 000. */
+  timeoutMs?: number;
+  /** Inject a custom fetch implementation (useful for tests). */
+  fetchImpl?: FetchLike;
+};
+
+/**
+ * Generic registry cache.
+ *
+ * Resolution order:
+ *   1. In-memory singleton (fastest path, cleared by `refresh`)
+ *   2. Disk cache (survives restarts, re-validated via `parse` on read)
+ *   3. Remote fetch (result written to disk)
+ *   4. `fallback` value if provided
+ *
+ * Deliberately knows nothing about LLM models or embeddings.
+ */
+export function createRegistryCache<T>(options: RegistryCacheOptions<T>) {
+  const { cacheFilePath, url, parse, fallback, fetchImpl: defaultFetch = fetch } = options;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  let memory: T | null = null;
+
+  async function readFromDisk(): Promise<T | null> {
+    const text = await fs.readFile(cacheFilePath, 'utf8').catch(() => null);
+    if (!text) return null;
+
+    try {
+      return parse(JSON.parse(text));
+    } catch (error) {
+      log.warn({ error, cacheFilePath }, 'failed to parse registry disk cache, ignoring');
+      return null;
+    }
+  }
+
+  async function writeToDisk(value: T): Promise<void> {
+    await fs.mkdir(path.dirname(cacheFilePath), { recursive: true });
+    await fs.writeFile(cacheFilePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+  }
+
+  async function fetchFromNetwork(fetchImpl: FetchLike): Promise<T> {
+    const response = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return parse(await response.json());
+  }
+
+  /**
+   * Returns the cached registry. Populates and writes disk cache on first fetch.
+   * Uses `fallback` if network is unreachable and no disk cache exists.
+   */
+  async function get(fetchImpl: FetchLike = defaultFetch): Promise<T> {
+    if (memory) return memory;
+
+    const fromDisk = await readFromDisk();
+    if (fromDisk) {
+      memory = fromDisk;
+      return fromDisk;
+    }
+
+    try {
+      const fetched = await fetchFromNetwork(fetchImpl);
+      await writeToDisk(fetched);
+      memory = fetched;
+      return fetched;
+    } catch (error) {
+      log.warn({ error, url }, 'failed to fetch registry from network');
+      if (fallback !== undefined) {
+        memory = fallback;
+        return fallback;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Forces a network refresh and writes the result to disk.
+   * Clears the in-memory cache on success so the next `get` returns fresh data.
+   */
+  async function refresh(fetchImpl: FetchLike = defaultFetch): Promise<void> {
+    try {
+      const fetched = await fetchFromNetwork(fetchImpl);
+      await writeToDisk(fetched);
+      memory = null;
+    } catch (error) {
+      log.error({ error, url }, 'failed to refresh registry');
+    }
+  }
+
+  /** Clears the in-memory singleton (primarily useful in tests). */
+  function reset(): void {
+    memory = null;
+  }
+
+  return { get, refresh, reset };
+}

--- a/packages/server/src/llm/provider/embedding-registry.ts
+++ b/packages/server/src/llm/provider/embedding-registry.ts
@@ -1,11 +1,8 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
-
 import googleRegistry from '@stitch/registry-embeddings/models/google.json';
 import openaiRegistry from '@stitch/registry-embeddings/models/openai.json';
 
-import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
+import { createRegistryCache } from '@/lib/registry-cache.js';
 import {
   EmbeddingProviderSchema,
   EmbeddingRegistryPayloadSchema,
@@ -15,14 +12,9 @@ import {
 } from '@/llm/provider/embedding-schema.js';
 import type { RawModel, RawProvider } from '@/llm/provider/models.js';
 
-const log = Log.create({ service: 'embedding-registry' });
 const DEFAULT_EMBEDDING_REGISTRY_URL = 'https://usestitch.ai/embedding-models.json';
-const FETCH_TIMEOUT_MS = 10_000;
 
 const registries = [googleRegistry, openaiRegistry] as const;
-let inMemoryRegistry: EmbeddingRegistryPayload | null = null;
-
-type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 function toRawModel(model: EmbeddingModel): RawModel {
   return {
@@ -70,10 +62,6 @@ function getRegistryUrl(): string {
   return process.env['STITCH_EMBEDDING_REGISTRY_URL']?.trim() || DEFAULT_EMBEDDING_REGISTRY_URL;
 }
 
-function parseRegistryPayload(raw: unknown): EmbeddingRegistryPayload {
-  return EmbeddingRegistryPayloadSchema.parse(raw);
-}
-
 function getBundledRegistryPayload(): EmbeddingRegistryPayload {
   return {
     version: 1,
@@ -82,57 +70,18 @@ function getBundledRegistryPayload(): EmbeddingRegistryPayload {
   };
 }
 
-async function readRegistryFromDisk(): Promise<EmbeddingRegistryPayload | null> {
-  const text = await fs.readFile(PATHS.filePaths.embeddingModelsRegistry, 'utf8').catch(() => null);
-  if (!text) return null;
-
-  try {
-    return parseRegistryPayload(JSON.parse(text));
-  } catch (error) {
-    log.warn({ error }, 'failed to read embedding registry cache');
-    return null;
-  }
-}
-
-async function writeRegistryToDisk(payload: EmbeddingRegistryPayload): Promise<void> {
-  await fs.mkdir(path.dirname(PATHS.filePaths.embeddingModelsRegistry), { recursive: true });
-  await fs.writeFile(
-    PATHS.filePaths.embeddingModelsRegistry,
-    `${JSON.stringify(payload, null, 2)}\n`,
-    'utf8',
-  );
-}
-
-async function fetchRegistryPayload(fetchImpl: FetchLike): Promise<EmbeddingRegistryPayload> {
-  const response = await fetchImpl(getRegistryUrl(), {
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-  });
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`);
-  }
-  return parseRegistryPayload(await response.json());
-}
+const embeddingRegistryCache = createRegistryCache<EmbeddingRegistryPayload>({
+  cacheFilePath: PATHS.filePaths.embeddingModelsRegistry,
+  get url() {
+    return getRegistryUrl();
+  },
+  parse: (raw) => EmbeddingRegistryPayloadSchema.parse(raw),
+  fallback: getBundledRegistryPayload(),
+});
 
 export async function getEmbeddingModelsFromRegistry(
-  fetchImpl: FetchLike = fetch,
+  fetchImpl = fetch,
 ): Promise<Record<string, RawProvider>> {
-  if (inMemoryRegistry) return toRawProviders(inMemoryRegistry.providers);
-
-  const cached = await readRegistryFromDisk();
-  if (cached) {
-    inMemoryRegistry = cached;
-    return toRawProviders(cached.providers);
-  }
-
-  try {
-    const payload = await fetchRegistryPayload(fetchImpl);
-    await writeRegistryToDisk(payload);
-    inMemoryRegistry = payload;
-    return toRawProviders(payload.providers);
-  } catch (error) {
-    log.warn({ error }, 'failed to fetch embedding registry, using bundled registry');
-    const bundled = getBundledRegistryPayload();
-    inMemoryRegistry = bundled;
-    return toRawProviders(bundled.providers);
-  }
+  const payload = await embeddingRegistryCache.get(fetchImpl);
+  return toRawProviders(payload.providers);
 }

--- a/packages/server/src/llm/provider/models.ts
+++ b/packages/server/src/llm/provider/models.ts
@@ -1,13 +1,13 @@
-import fs from 'node:fs/promises';
 import z from 'zod';
 
 import { PROVIDER_IDS, type ProviderId } from '@stitch/shared/providers/types';
 
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
+import { createRegistryCache } from '@/lib/registry-cache.js';
 
 const log = Log.create({ service: 'models.dev' });
-const URL = 'https://models.dev';
+const MODELS_DEV_URL = 'https://models.dev/api.json';
 
 const ALLOWERD_PROVIDER_IDS = PROVIDER_IDS satisfies readonly ProviderId[];
 
@@ -20,10 +20,10 @@ export const ModelSchema = z.object({
   name: z.string(),
   family: z.string().optional(),
   release_date: z.string(),
-  attachment: z.boolean(),
-  reasoning: z.boolean(),
-  temperature: z.boolean(),
-  tool_call: z.boolean(),
+  attachment: z.boolean().optional().default(false),
+  reasoning: z.boolean().optional().default(false),
+  temperature: z.boolean().optional().default(false),
+  tool_call: z.boolean().optional().default(false),
   interleaved: z
     .union([
       z.literal(true),
@@ -61,9 +61,9 @@ export const ModelSchema = z.object({
       output: z.array(z.enum(['text', 'audio', 'image', 'video', 'pdf'])),
     })
     .optional(),
-  experimental: z.boolean().optional(),
+  experimental: z.unknown().optional(),
   status: z.enum(['alpha', 'beta', 'deprecated']).optional(),
-  options: z.record(z.string(), z.any()),
+  options: z.record(z.string(), z.any()).optional().default({}),
   headers: z.record(z.string(), z.string()).optional(),
   provider: z.object({ npm: z.string().optional(), api: z.string().optional() }).optional(),
   variants: z.record(z.string(), z.record(z.string(), z.any())).optional(),
@@ -77,10 +77,10 @@ export const ProviderSchema = z.object({
   models: z.record(z.string(), ModelSchema),
 });
 
+const RegistrySchema = z.record(z.string(), ProviderSchema);
+
 export type RawModel = z.infer<typeof ModelSchema>;
 export type RawProvider = z.infer<typeof ProviderSchema>;
-
-let data: Record<string, RawProvider> | undefined;
 
 function filterModels(models: Record<string, RawModel>): Record<string, RawModel> {
   return Object.fromEntries(
@@ -114,19 +114,14 @@ function filterProviders(raw: Record<string, RawProvider>): Record<string, RawPr
   );
 }
 
+const registryCache = createRegistryCache<Record<string, RawProvider>>({
+  cacheFilePath: PATHS.filePaths.models,
+  url: MODELS_DEV_URL,
+  parse: (raw) => RegistrySchema.parse(raw),
+});
+
 export async function get(): Promise<Record<string, RawProvider>> {
-  if (data) return data;
-  const cached = await fs.readFile(PATHS.filePaths.models, 'utf8').catch(() => undefined);
-
-  if (cached) {
-    data = filterProviders(JSON.parse(cached) as Record<string, RawProvider>);
-    return data;
-  }
-
-  const json = await fetch(`${URL}/api.json`).then((x) => x.text());
-  data = filterProviders(JSON.parse(json) as Record<string, RawProvider>);
-
-  return data;
+  return filterProviders(await registryCache.get());
 }
 
 export async function getAudioModels(): Promise<Record<string, RawProvider>> {
@@ -151,16 +146,7 @@ export async function getAudioModels(): Promise<Record<string, RawProvider>> {
   return audioProviders;
 }
 
-export async function refresh() {
-  const result = await fetch(`${URL}/api.json`, {
-    signal: AbortSignal.timeout(10 * 1000),
-  }).catch((e) => {
-    log.error({ error: e }, 'failed to fetch models.dev');
-  });
-  if (result && result.ok) {
-    const text = await result.text();
-    await fs.mkdir(PATHS.cacheDir, { recursive: true });
-    await fs.writeFile(PATHS.filePaths.models, text, 'utf8');
-    data = undefined;
-  }
+export async function refresh(): Promise<void> {
+  log.info('refreshing models.dev registry');
+  await registryCache.refresh();
 }


### PR DESCRIPTION
## 🚀 Change Summary

Eliminates duplicated cache-aside mechanics shared between the LLM model registry (\models.dev\) and the embedding model registry. Both registries previously maintained their own in-memory singleton, disk read/write, network fetch, timeout, and logging logic independently and with inconsistent behaviour.

### ✨ New Features
- **\lib/registry-cache.ts\**: Generic cache factory (\createRegistryCache\) that handles the full cache-aside lifecycle — in-memory → disk → network → optional fallback. Accepts injected \etchImpl\ for clean testing.

### 🛠 Improvements & Refactors
- **\models.ts\**: Replaced hand-rolled cache mechanics with \createRegistryCache\. Added \RegistrySchema\ so the models.dev payload is now schema-validated on read rather than cast with \s\. Hardened field optionality to match real-world models.dev data (\options\, boolean capability fields, \xperimental\).
- **\mbedding-registry.ts\**: Replaced \eadRegistryFromDisk\, \writeRegistryToDisk\, \etchRegistryPayload\, and the module-level \inMemoryRegistry\ singleton with \createRegistryCache\. Bundled fallback and \STITCH_EMBEDDING_REGISTRY_URL\ env override are preserved. Domain conversion functions (\	oRawModel\, \	oRawProvider\) are unchanged.
- Both registries now behave consistently: first successful fetch writes disk cache, invalid disk cache is logged and bypassed rather than poisoning startup, and \efresh()\ clears the in-memory cache so the next \get()\ picks up the fresh data.

### 🐛 Bug Fixes
- \models.ts\ \get()\ previously never wrote the disk cache on a fresh fetch — only the scheduled \efresh()\ job did. Both paths now write cache consistently.