### PR TITLE
Add icons to tool settings

### DIFF
--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -1,5 +1,6 @@
 import {
   BrainIcon,
+  CalendarCheckIcon,
   CheckIcon,
   ChevronDownIcon,
   ClockIcon,
@@ -8,8 +9,11 @@ import {
   FileTextIcon,
   GlobeIcon,
   HelpCircleIcon,
+  HistoryIcon,
   ListTodoIcon,
   LoaderIcon,
+  MicIcon,
+  PanelTopIcon,
   PencilIcon,
   SearchIcon,
   SquareIcon,
@@ -46,6 +50,10 @@ type ToolSummaryKind =
   | 'skill'
   | 'memory'
   | 'todo'
+  | 'agenda'
+  | 'browser'
+  | 'recordings'
+  | 'session-history'
   | 'mcp'
   | 'generic';
 
@@ -205,12 +213,16 @@ function getToolKind(toolName: string): ToolSummaryKind {
   if (toolName === 'edit') return 'edit';
   if (toolName === 'write') return 'write';
   if (SEARCH_TOOLS.has(toolName)) return 'search';
-  if (toolName === 'webfetch' || toolName.startsWith('browser_')) return 'web';
+  if (toolName === 'webfetch') return 'web';
   if (toolName === 'task') return 'task';
   if (toolName === 'question') return 'question';
   if (toolName === 'skill') return 'skill';
   if (toolName === 'memory') return 'memory';
   if (toolName === 'todo') return 'todo';
+  if (toolName.startsWith('agenda_')) return 'agenda';
+  if (toolName === 'browser' || toolName.startsWith('browser_')) return 'browser';
+  if (toolName.startsWith('recordings_')) return 'recordings';
+  if (toolName.startsWith('session_history_')) return 'session-history';
   if (parseMcpToolName(toolName)) return 'mcp';
   return 'generic';
 }
@@ -268,6 +280,14 @@ function getToolPreview(call: ToolCallDisplayItem, kind: ToolSummaryKind): strin
       return getStringArg(call.args, ['action', 'content']) ?? 'Using memory';
     case 'todo':
       return getStringArg(call.args, ['action']) ?? 'Updating todos';
+    case 'agenda':
+      return getBestGenericPreview(call.args, call.result) ?? 'Using agenda';
+    case 'browser':
+      return getStringArg(call.args, ['url', 'action', 'ref']) ?? 'Using browser';
+    case 'recordings':
+      return getBestGenericPreview(call.args, call.result) ?? 'Using recordings';
+    case 'session-history':
+      return getBestGenericPreview(call.args, call.result) ?? 'Searching sessions';
     case 'mcp':
     case 'generic':
       return getBestGenericPreview(call.args, call.result) ?? 'Using tool';
@@ -452,6 +472,14 @@ function ToolKindIcon({ kind, className }: { kind: ToolSummaryKind; className?: 
       return <BrainIcon className={className} />;
     case 'todo':
       return <ListTodoIcon className={className} />;
+    case 'agenda':
+      return <CalendarCheckIcon className={className} />;
+    case 'browser':
+      return <PanelTopIcon className={className} />;
+    case 'recordings':
+      return <MicIcon className={className} />;
+    case 'session-history':
+      return <HistoryIcon className={className} />;
     case 'mcp':
       return <WrenchIcon className={className} />;
     case 'generic':

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -1,25 +1,4 @@
-import {
-  BrainIcon,
-  CalendarCheckIcon,
-  CheckIcon,
-  ChevronDownIcon,
-  ClockIcon,
-  FilePenIcon,
-  FilePlusIcon,
-  FileTextIcon,
-  GlobeIcon,
-  HelpCircleIcon,
-  HistoryIcon,
-  ListTodoIcon,
-  LoaderIcon,
-  MicIcon,
-  PanelTopIcon,
-  PencilIcon,
-  SearchIcon,
-  SquareIcon,
-  TerminalIcon,
-  WrenchIcon,
-} from 'lucide-react';
+import { ChevronDownIcon, ClockIcon, LoaderIcon, SquareIcon } from 'lucide-react';
 import * as React from 'react';
 
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
@@ -33,29 +12,13 @@ import {
 
 import { ConnectorIcon } from '@/components/connectors/connector-icon';
 import { McpServerLogo } from '@/components/mcp/mcp-server-logo';
+import { getToolIconKind, ToolKindIcon, type ToolIconKind } from '@/components/tools/tool-icons';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 const VISIBLE_TOOL_COUNT = 4;
 
-type ToolSummaryKind =
-  | 'bash'
-  | 'read'
-  | 'edit'
-  | 'write'
-  | 'search'
-  | 'web'
-  | 'task'
-  | 'question'
-  | 'skill'
-  | 'memory'
-  | 'todo'
-  | 'agenda'
-  | 'browser'
-  | 'recordings'
-  | 'session-history'
-  | 'mcp'
-  | 'generic';
+type ToolSummaryKind = ToolIconKind;
 
 type ToolCallDisplayItem = {
   id: string;
@@ -85,7 +48,6 @@ const STATUS_LABEL: Record<ToolCallStatus, string> = {
   error: 'Error',
 };
 
-const SEARCH_TOOLS = new Set(['gmail_search', 'drive_search', 'grep', 'glob']);
 const GOOGLE_SERVICE_ICON_SLUGS = {
   gmail: 'gmail',
   drive: 'googledrive',
@@ -208,23 +170,8 @@ function getToolSummary(call: ToolCallDisplayItem, displayName: string) {
 }
 
 function getToolKind(toolName: string): ToolSummaryKind {
-  if (toolName === 'bash' || toolName === 'execute_typescript') return 'bash';
-  if (toolName === 'read') return 'read';
-  if (toolName === 'edit') return 'edit';
-  if (toolName === 'write') return 'write';
-  if (SEARCH_TOOLS.has(toolName)) return 'search';
-  if (toolName === 'webfetch') return 'web';
-  if (toolName === 'task') return 'task';
-  if (toolName === 'question') return 'question';
-  if (toolName === 'skill') return 'skill';
-  if (toolName === 'memory') return 'memory';
-  if (toolName === 'todo') return 'todo';
-  if (toolName.startsWith('agenda_')) return 'agenda';
-  if (toolName === 'browser' || toolName.startsWith('browser_')) return 'browser';
-  if (toolName.startsWith('recordings_')) return 'recordings';
-  if (toolName.startsWith('session_history_')) return 'session-history';
   if (parseMcpToolName(toolName)) return 'mcp';
-  return 'generic';
+  return getToolIconKind(toolName);
 }
 
 function getToolLabel(toolName: string, displayName: string, kind: ToolSummaryKind): string {
@@ -446,45 +393,6 @@ function ToolStatusIcon({
   }
 
   return <ToolKindIcon kind={kind} className="size-3.5 shrink-0 text-success" />;
-}
-
-function ToolKindIcon({ kind, className }: { kind: ToolSummaryKind; className?: string }) {
-  switch (kind) {
-    case 'bash':
-      return <TerminalIcon className={className} />;
-    case 'read':
-      return <FileTextIcon className={className} />;
-    case 'edit':
-      return <PencilIcon className={className} />;
-    case 'write':
-      return <FilePlusIcon className={className} />;
-    case 'search':
-      return <SearchIcon className={className} />;
-    case 'web':
-      return <GlobeIcon className={className} />;
-    case 'task':
-      return <WrenchIcon className={className} />;
-    case 'question':
-      return <HelpCircleIcon className={className} />;
-    case 'skill':
-      return <CheckIcon className={className} />;
-    case 'memory':
-      return <BrainIcon className={className} />;
-    case 'todo':
-      return <ListTodoIcon className={className} />;
-    case 'agenda':
-      return <CalendarCheckIcon className={className} />;
-    case 'browser':
-      return <PanelTopIcon className={className} />;
-    case 'recordings':
-      return <MicIcon className={className} />;
-    case 'session-history':
-      return <HistoryIcon className={className} />;
-    case 'mcp':
-      return <WrenchIcon className={className} />;
-    case 'generic':
-      return <FilePenIcon className={className} />;
-  }
 }
 
 function usePrevious(value: number) {

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -1,12 +1,16 @@
 import {
+  BrainIcon,
   CheckIcon,
   ChevronDownIcon,
   ClockIcon,
   FilePenIcon,
+  FilePlusIcon,
   FileTextIcon,
   GlobeIcon,
   HelpCircleIcon,
+  ListTodoIcon,
   LoaderIcon,
+  PencilIcon,
   SearchIcon,
   SquareIcon,
   TerminalIcon,
@@ -32,12 +36,16 @@ const VISIBLE_TOOL_COUNT = 4;
 
 type ToolSummaryKind =
   | 'bash'
-  | 'file'
+  | 'read'
+  | 'edit'
+  | 'write'
   | 'search'
   | 'web'
   | 'task'
   | 'question'
   | 'skill'
+  | 'memory'
+  | 'todo'
   | 'mcp'
   | 'generic';
 
@@ -70,8 +78,6 @@ const STATUS_LABEL: Record<ToolCallStatus, string> = {
 };
 
 const SEARCH_TOOLS = new Set(['gmail_search', 'drive_search', 'grep', 'glob']);
-const FILE_TOOLS = new Set(['read', 'write', 'edit']);
-
 const GOOGLE_SERVICE_ICON_SLUGS = {
   gmail: 'gmail',
   drive: 'googledrive',
@@ -195,12 +201,16 @@ function getToolSummary(call: ToolCallDisplayItem, displayName: string) {
 
 function getToolKind(toolName: string): ToolSummaryKind {
   if (toolName === 'bash' || toolName === 'execute_typescript') return 'bash';
-  if (FILE_TOOLS.has(toolName)) return 'file';
+  if (toolName === 'read') return 'read';
+  if (toolName === 'edit') return 'edit';
+  if (toolName === 'write') return 'write';
   if (SEARCH_TOOLS.has(toolName)) return 'search';
   if (toolName === 'webfetch' || toolName.startsWith('browser_')) return 'web';
   if (toolName === 'task') return 'task';
   if (toolName === 'question') return 'question';
   if (toolName === 'skill') return 'skill';
+  if (toolName === 'memory') return 'memory';
+  if (toolName === 'todo') return 'todo';
   if (parseMcpToolName(toolName)) return 'mcp';
   return 'generic';
 }
@@ -238,8 +248,12 @@ function getToolPreview(call: ToolCallDisplayItem, kind: ToolSummaryKind): strin
   switch (kind) {
     case 'bash':
       return getStringArg(call.args, ['description', 'command', 'code']) ?? 'Running command';
-    case 'file':
+    case 'read':
       return getStringArg(call.args, ['filePath', 'path']) ?? 'Waiting for path';
+    case 'edit':
+      return getStringArg(call.args, ['filePath', 'path']) ?? 'Editing file';
+    case 'write':
+      return getStringArg(call.args, ['filePath', 'path']) ?? 'Writing file';
     case 'search':
       return getStringArg(call.args, ['query', 'pattern', 'q']) ?? 'Searching';
     case 'web':
@@ -250,6 +264,10 @@ function getToolPreview(call: ToolCallDisplayItem, kind: ToolSummaryKind): strin
       return getStringArg(call.args, ['question', 'header']) ?? 'Waiting for response';
     case 'skill':
       return 'Loading skill';
+    case 'memory':
+      return getStringArg(call.args, ['action', 'content']) ?? 'Using memory';
+    case 'todo':
+      return getStringArg(call.args, ['action']) ?? 'Updating todos';
     case 'mcp':
     case 'generic':
       return getBestGenericPreview(call.args, call.result) ?? 'Using tool';
@@ -414,8 +432,12 @@ function ToolKindIcon({ kind, className }: { kind: ToolSummaryKind; className?: 
   switch (kind) {
     case 'bash':
       return <TerminalIcon className={className} />;
-    case 'file':
+    case 'read':
       return <FileTextIcon className={className} />;
+    case 'edit':
+      return <PencilIcon className={className} />;
+    case 'write':
+      return <FilePlusIcon className={className} />;
     case 'search':
       return <SearchIcon className={className} />;
     case 'web':
@@ -426,6 +448,10 @@ function ToolKindIcon({ kind, className }: { kind: ToolSummaryKind; className?: 
       return <HelpCircleIcon className={className} />;
     case 'skill':
       return <CheckIcon className={className} />;
+    case 'memory':
+      return <BrainIcon className={className} />;
+    case 'todo':
+      return <ListTodoIcon className={className} />;
     case 'mcp':
       return <WrenchIcon className={className} />;
     case 'generic':

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -1,9 +1,13 @@
 import {
+  BrainIcon,
   CheckIcon,
   FilePenIcon,
+  FilePlusIcon,
   FileTextIcon,
   GlobeIcon,
   HelpCircleIcon,
+  ListTodoIcon,
+  PencilIcon,
   SearchIcon,
   ServerIcon,
   Settings2Icon,
@@ -203,9 +207,9 @@ function CoreToolIcon({ toolName }: { toolName: string }) {
     return <TerminalIcon className={className} />;
   }
 
-  if (toolName === 'read' || toolName === 'write' || toolName === 'edit') {
-    return <FileTextIcon className={className} />;
-  }
+  if (toolName === 'read') return <FileTextIcon className={className} />;
+  if (toolName === 'edit') return <PencilIcon className={className} />;
+  if (toolName === 'write') return <FilePlusIcon className={className} />;
 
   if (toolName === 'grep' || toolName === 'glob') {
     return <SearchIcon className={className} />;
@@ -218,6 +222,8 @@ function CoreToolIcon({ toolName }: { toolName: string }) {
   if (toolName === 'task') return <WrenchIcon className={className} />;
   if (toolName === 'question') return <HelpCircleIcon className={className} />;
   if (toolName === 'skill') return <CheckIcon className={className} />;
+  if (toolName === 'memory') return <BrainIcon className={className} />;
+  if (toolName === 'todo') return <ListTodoIcon className={className} />;
 
   return <FilePenIcon className={className} />;
 }

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -1,23 +1,4 @@
-import {
-  BrainIcon,
-  CalendarCheckIcon,
-  CheckIcon,
-  FilePenIcon,
-  FilePlusIcon,
-  FileTextIcon,
-  GlobeIcon,
-  HelpCircleIcon,
-  HistoryIcon,
-  ListTodoIcon,
-  MicIcon,
-  PanelTopIcon,
-  PencilIcon,
-  SearchIcon,
-  ServerIcon,
-  Settings2Icon,
-  TerminalIcon,
-  WrenchIcon,
-} from 'lucide-react';
+import { SearchIcon, ServerIcon, Settings2Icon, WrenchIcon } from 'lucide-react';
 import * as React from 'react';
 import { toast } from 'sonner';
 
@@ -32,6 +13,7 @@ import {
   filterCoreTools,
   filterToolsetsByQuery,
 } from '@/components/settings/permissions/filtering';
+import { NativeToolsetIcon, ToolNameIcon } from '@/components/tools/tool-icons';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
@@ -202,45 +184,6 @@ function SectionCard({
       {children}
     </section>
   );
-}
-
-function CoreToolIcon({ toolName }: { toolName: string }) {
-  const className = 'size-4 shrink-0 text-muted-foreground';
-
-  if (toolName === 'bash' || toolName === 'execute_typescript') {
-    return <TerminalIcon className={className} />;
-  }
-
-  if (toolName === 'read') return <FileTextIcon className={className} />;
-  if (toolName === 'edit') return <PencilIcon className={className} />;
-  if (toolName === 'write') return <FilePlusIcon className={className} />;
-
-  if (toolName === 'grep' || toolName === 'glob') {
-    return <SearchIcon className={className} />;
-  }
-
-  if (toolName === 'webfetch' || toolName.startsWith('browser_')) {
-    return <GlobeIcon className={className} />;
-  }
-
-  if (toolName === 'task') return <WrenchIcon className={className} />;
-  if (toolName === 'question') return <HelpCircleIcon className={className} />;
-  if (toolName === 'skill') return <CheckIcon className={className} />;
-  if (toolName === 'memory') return <BrainIcon className={className} />;
-  if (toolName === 'todo') return <ListTodoIcon className={className} />;
-
-  return <FilePenIcon className={className} />;
-}
-
-function NativeToolsetIcon({ toolsetId }: { toolsetId: string }) {
-  const className = 'size-4 shrink-0 text-muted-foreground';
-
-  if (toolsetId === 'agenda') return <CalendarCheckIcon className={className} />;
-  if (toolsetId === 'browser') return <PanelTopIcon className={className} />;
-  if (toolsetId === 'recordings') return <MicIcon className={className} />;
-  if (toolsetId === 'session-history') return <HistoryIcon className={className} />;
-
-  return <ServerIcon className={className} />;
 }
 
 function ToolsContent() {
@@ -472,7 +415,12 @@ function ToolsContent() {
               <ToolRow
                 key={tool.toolName}
                 name={tool.displayName}
-                icon={<CoreToolIcon toolName={tool.toolName} />}
+                icon={
+                  <ToolNameIcon
+                    toolName={tool.toolName}
+                    className="size-4 shrink-0 text-muted-foreground"
+                  />
+                }
                 technicalName={tool.toolName}
                 enabled={getEnabled('tool', tool.toolName)}
                 onConfigure={() =>
@@ -503,7 +451,12 @@ function ToolsContent() {
                 key={toolset.id}
                 name={toolset.name}
                 description={toolset.description}
-                icon={<NativeToolsetIcon toolsetId={toolset.id} />}
+                icon={
+                  <NativeToolsetIcon
+                    toolsetId={toolset.id}
+                    className="size-4 shrink-0 text-muted-foreground"
+                  />
+                }
                 enabled={getEnabled('toolset', toolset.id)}
                 settingsAlign="end"
                 onConfigure={() =>

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -1,12 +1,16 @@
 import {
   BrainIcon,
+  CalendarCheckIcon,
   CheckIcon,
   FilePenIcon,
   FilePlusIcon,
   FileTextIcon,
   GlobeIcon,
   HelpCircleIcon,
+  HistoryIcon,
   ListTodoIcon,
+  MicIcon,
+  PanelTopIcon,
   PencilIcon,
   SearchIcon,
   ServerIcon,
@@ -226,6 +230,17 @@ function CoreToolIcon({ toolName }: { toolName: string }) {
   if (toolName === 'todo') return <ListTodoIcon className={className} />;
 
   return <FilePenIcon className={className} />;
+}
+
+function NativeToolsetIcon({ toolsetId }: { toolsetId: string }) {
+  const className = 'size-4 shrink-0 text-muted-foreground';
+
+  if (toolsetId === 'agenda') return <CalendarCheckIcon className={className} />;
+  if (toolsetId === 'browser') return <PanelTopIcon className={className} />;
+  if (toolsetId === 'recordings') return <MicIcon className={className} />;
+  if (toolsetId === 'session-history') return <HistoryIcon className={className} />;
+
+  return <ServerIcon className={className} />;
 }
 
 function ToolsContent() {
@@ -488,6 +503,7 @@ function ToolsContent() {
                 key={toolset.id}
                 name={toolset.name}
                 description={toolset.description}
+                icon={<NativeToolsetIcon toolsetId={toolset.id} />}
                 enabled={getEnabled('toolset', toolset.id)}
                 settingsAlign="end"
                 onConfigure={() =>

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -1,4 +1,15 @@
-import { SearchIcon, ServerIcon, Settings2Icon, WrenchIcon } from 'lucide-react';
+import {
+  CheckIcon,
+  FilePenIcon,
+  FileTextIcon,
+  GlobeIcon,
+  HelpCircleIcon,
+  SearchIcon,
+  ServerIcon,
+  Settings2Icon,
+  TerminalIcon,
+  WrenchIcon,
+} from 'lucide-react';
 import * as React from 'react';
 import { toast } from 'sonner';
 
@@ -8,6 +19,7 @@ import { PermissionPolicyEditor } from './permissions/permission-policy-editor';
 
 import { ConnectorIcon } from '@/components/connectors/connector-icon';
 import { RemoteImageIcon } from '@/components/icons/remote-icon';
+import { McpServerLogo } from '@/components/mcp/mcp-server-logo';
 import {
   filterCoreTools,
   filterToolsetsByQuery,
@@ -44,6 +56,7 @@ type ScopeFilter = 'stitch' | 'native' | 'connectors' | 'mcp';
 
 type ToolRowProps = {
   name: string;
+  icon?: React.ReactNode;
   subtitle?: string;
   iconPath?: string;
   technicalName?: string;
@@ -68,6 +81,7 @@ type ToolsetRowProps = {
 
 function ToolRow({
   name,
+  icon,
   iconPath,
   enabled,
   onConfigure,
@@ -87,14 +101,15 @@ function ToolRow({
       )}
     >
       <div className="flex min-w-0 items-center gap-2.5">
-        {iconPath && (
-          <RemoteImageIcon
-            path={iconPath}
-            label={`${name} icon`}
-            className="size-4"
-            fallback={null}
-          />
-        )}
+        {icon ??
+          (iconPath && (
+            <RemoteImageIcon
+              path={iconPath}
+              label={`${name} icon`}
+              className="size-4"
+              fallback={null}
+            />
+          ))}
         <div className="min-w-0">
           <p className="truncate text-sm font-medium">{name}</p>
         </div>
@@ -179,6 +194,32 @@ function SectionCard({
       {children}
     </section>
   );
+}
+
+function CoreToolIcon({ toolName }: { toolName: string }) {
+  const className = 'size-4 shrink-0 text-muted-foreground';
+
+  if (toolName === 'bash' || toolName === 'execute_typescript') {
+    return <TerminalIcon className={className} />;
+  }
+
+  if (toolName === 'read' || toolName === 'write' || toolName === 'edit') {
+    return <FileTextIcon className={className} />;
+  }
+
+  if (toolName === 'grep' || toolName === 'glob') {
+    return <SearchIcon className={className} />;
+  }
+
+  if (toolName === 'webfetch' || toolName.startsWith('browser_')) {
+    return <GlobeIcon className={className} />;
+  }
+
+  if (toolName === 'task') return <WrenchIcon className={className} />;
+  if (toolName === 'question') return <HelpCircleIcon className={className} />;
+  if (toolName === 'skill') return <CheckIcon className={className} />;
+
+  return <FilePenIcon className={className} />;
 }
 
 function ToolsContent() {
@@ -410,6 +451,7 @@ function ToolsContent() {
               <ToolRow
                 key={tool.toolName}
                 name={tool.displayName}
+                icon={<CoreToolIcon toolName={tool.toolName} />}
                 technicalName={tool.toolName}
                 enabled={getEnabled('tool', tool.toolName)}
                 onConfigure={() =>
@@ -510,16 +552,11 @@ function ToolsContent() {
                 <div key={group.serverId} className="flex flex-col">
                   <div className="grid grid-cols-[minmax(0,1fr)_5rem_2.5rem] items-center gap-3 px-3 py-2.5 sm:px-4">
                     <div className="flex min-w-0 items-center gap-2.5">
-                      {group.serverIconPath ? (
-                        <img
-                          src={group.serverIconPath}
-                          alt=""
-                          className="size-4 shrink-0 rounded-sm"
-                          loading="lazy"
-                        />
-                      ) : (
-                        <ServerIcon className="size-4 shrink-0 text-muted-foreground" />
-                      )}
+                      <McpServerLogo
+                        serverId={group.serverId}
+                        name={group.serverName}
+                        className="size-4 shrink-0"
+                      />
                       <div className="min-w-0">
                         <p className="truncate text-sm font-medium">{group.serverName}</p>
                         <p className="text-xs text-muted-foreground">

--- a/apps/web/src/components/tools/tool-icons.tsx
+++ b/apps/web/src/components/tools/tool-icons.tsx
@@ -1,0 +1,117 @@
+import {
+  BrainIcon,
+  CalendarCheckIcon,
+  CheckIcon,
+  FilePenIcon,
+  FilePlusIcon,
+  FileTextIcon,
+  GlobeIcon,
+  HelpCircleIcon,
+  HistoryIcon,
+  ListTodoIcon,
+  MicIcon,
+  PanelTopIcon,
+  PencilIcon,
+  SearchIcon,
+  ServerIcon,
+  TerminalIcon,
+  WrenchIcon,
+} from 'lucide-react';
+
+export type ToolIconKind =
+  | 'bash'
+  | 'read'
+  | 'edit'
+  | 'write'
+  | 'search'
+  | 'web'
+  | 'task'
+  | 'question'
+  | 'skill'
+  | 'memory'
+  | 'todo'
+  | 'agenda'
+  | 'browser'
+  | 'recordings'
+  | 'session-history'
+  | 'mcp'
+  | 'generic';
+
+const SEARCH_TOOLS = new Set(['gmail_search', 'drive_search', 'grep', 'glob']);
+
+export function getToolIconKind(toolName: string): ToolIconKind {
+  if (toolName === 'bash' || toolName === 'execute_typescript') return 'bash';
+  if (toolName === 'read') return 'read';
+  if (toolName === 'edit') return 'edit';
+  if (toolName === 'write') return 'write';
+  if (SEARCH_TOOLS.has(toolName)) return 'search';
+  if (toolName === 'webfetch') return 'web';
+  if (toolName === 'task') return 'task';
+  if (toolName === 'question') return 'question';
+  if (toolName === 'skill') return 'skill';
+  if (toolName === 'memory') return 'memory';
+  if (toolName === 'todo') return 'todo';
+  if (toolName.startsWith('agenda_')) return 'agenda';
+  if (toolName === 'browser' || toolName.startsWith('browser_')) return 'browser';
+  if (toolName.startsWith('recordings_')) return 'recordings';
+  if (toolName.startsWith('session_history_')) return 'session-history';
+  return 'generic';
+}
+
+export function ToolKindIcon({ kind, className }: { kind: ToolIconKind; className?: string }) {
+  switch (kind) {
+    case 'bash':
+      return <TerminalIcon className={className} />;
+    case 'read':
+      return <FileTextIcon className={className} />;
+    case 'edit':
+      return <PencilIcon className={className} />;
+    case 'write':
+      return <FilePlusIcon className={className} />;
+    case 'search':
+      return <SearchIcon className={className} />;
+    case 'web':
+      return <GlobeIcon className={className} />;
+    case 'task':
+      return <WrenchIcon className={className} />;
+    case 'question':
+      return <HelpCircleIcon className={className} />;
+    case 'skill':
+      return <CheckIcon className={className} />;
+    case 'memory':
+      return <BrainIcon className={className} />;
+    case 'todo':
+      return <ListTodoIcon className={className} />;
+    case 'agenda':
+      return <CalendarCheckIcon className={className} />;
+    case 'browser':
+      return <PanelTopIcon className={className} />;
+    case 'recordings':
+      return <MicIcon className={className} />;
+    case 'session-history':
+      return <HistoryIcon className={className} />;
+    case 'mcp':
+      return <WrenchIcon className={className} />;
+    case 'generic':
+      return <FilePenIcon className={className} />;
+  }
+}
+
+export function ToolNameIcon({ toolName, className }: { toolName: string; className?: string }) {
+  return <ToolKindIcon kind={getToolIconKind(toolName)} className={className} />;
+}
+
+export function NativeToolsetIcon({
+  toolsetId,
+  className,
+}: {
+  toolsetId: string;
+  className?: string;
+}) {
+  if (toolsetId === 'agenda') return <CalendarCheckIcon className={className} />;
+  if (toolsetId === 'browser') return <PanelTopIcon className={className} />;
+  if (toolsetId === 'recordings') return <MicIcon className={className} />;
+  if (toolsetId === 'session-history') return <HistoryIcon className={className} />;
+
+  return <ServerIcon className={className} />;
+}


### PR DESCRIPTION
## 🚀 Change Summary

Adds consistent icons across the tools settings UI and chat tool-call rows so core tools, native toolsets, connectors, and MCP servers are easier to visually scan. The icon mapping is centralized in a shared frontend module to keep settings and chat rendering aligned.

### ✨ New Features
- **Tool Settings Icons**: Adds row-level icons for core tools, native toolsets, connector toolsets, and MCP servers in the tool settings panel.
- **Tool Call Icons**: Adds matching icons for read, edit, write, memory, todo, agenda, browser, recordings, and session history tool calls.

### 🛠 Improvements & Refactors
- Centralizes frontend tool icon classification and rendering in a shared 	ool-icons module to avoid duplicate mappings.