### PR TITLE
feat: add NVIDIA provider with API key auth

### DIFF
--- a/packages/server/src/llm/cache-control.ts
+++ b/packages/server/src/llm/cache-control.ts
@@ -54,6 +54,8 @@ export function getCacheConfig(
     case 'vercel':
     // Ollama: local inference, no cache control support
     case 'ollama_local':
+    // NVIDIA: caching handled by API provider
+    case 'nvidia':
       return null;
   }
 }
@@ -152,6 +154,8 @@ export function getProviderOptions(
     // Google, Google Vertex: implicit caching, no session key mechanism
     case 'google':
     case 'google-vertex':
+    // NVIDIA: caching handled by API provider
+    case 'nvidia':
       return undefined;
 
     // Vercel (AI Gateway): automatic caching based on underlying provider

--- a/packages/server/src/llm/provider/provider.ts
+++ b/packages/server/src/llm/provider/provider.ts
@@ -73,6 +73,11 @@ const VercelCredentialsSchema = z.object({
   auth: z.object({ method: z.literal('api-key'), apiKey: z.string() }),
 });
 
+const NvidiaCredentialsSchema = z.object({
+  providerId: z.literal('nvidia'),
+  auth: z.object({ method: z.literal('api-key'), apiKey: z.string() }),
+});
+
 const OllamaCredentialsSchema = z.object({
   providerId: z.literal('ollama_local'),
   baseURL: z.string().optional(),
@@ -84,6 +89,7 @@ export const ProviderCredentialsSchema = z.discriminatedUnion('providerId', [
   AnthropicCredentialsSchema,
   GoogleCredentialsSchema,
   GoogleVertexCredentialsSchema,
+  NvidiaCredentialsSchema,
   OpenAICredentialsSchema,
   OpenRouterCredentialsSchema,
   VercelCredentialsSchema,
@@ -156,6 +162,13 @@ export const createProvider = (credentials: ProviderCredentials) => {
         apiKey: credentials.auth.apiKey,
         organization: credentials.organization,
         project: credentials.project,
+      });
+
+    case 'nvidia':
+      return createOpenAICompatible({
+        name: 'nvidia',
+        baseURL: 'https://integrate.api.nvidia.com/v1',
+        apiKey: credentials.auth.apiKey,
       });
 
     case 'openrouter':

--- a/packages/shared/src/providers/catalog.ts
+++ b/packages/shared/src/providers/catalog.ts
@@ -175,6 +175,27 @@ export const PROVIDER_META: Record<ProviderId, ProviderMeta> = {
       },
     ],
   },
+  nvidia: {
+    displayName: 'NVIDIA',
+    description: 'Access to NVIDIA NIM and foundation models',
+    extraFields: [],
+    authMethods: [
+      {
+        method: 'api-key',
+        label: 'API Key',
+        enabled: true,
+        fields: [
+          {
+            key: 'apiKey',
+            label: 'API Key',
+            placeholder: 'nvapi-...',
+            required: true,
+            secret: true,
+          },
+        ],
+      },
+    ],
+  },
   ollama_local: {
     displayName: 'Ollama',
     description: 'Run models locally with Ollama',

--- a/packages/shared/src/providers/types.ts
+++ b/packages/shared/src/providers/types.ts
@@ -58,6 +58,7 @@ export const PROVIDER_IDS = [
   'anthropic',
   'google',
   'google-vertex',
+  'nvidia',
   'ollama_local',
   'openai',
   'openrouter',


### PR DESCRIPTION
## 🚀 Change Summary

Adds NVIDIA as a supported LLM provider, configurable via API key in the provider settings UI.

### ✨ New Features
- **NVIDIA Provider**: Access to NVIDIA NIM and foundation models via \https://integrate.api.nvidia.com/v1\
- **API Key Auth**: Configure with \
vapi-\...\ keys through the providers settings panel
- **UI Integration**: Automatically appears in the provider configuration list with API key field