### PR TITLE
feat: add inspect_image tool and child session navigation

### DIFF
--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -147,7 +147,7 @@ function ToolCallRow({
           variant="ghost"
           size="xs"
           onClick={onAbort}
-          className="h-5 px-1.5 text-[11px] text-muted-foreground"
+          className="h-5 px-1.5 text-[11px] text-destructive hover:text-destructive"
           title="Stop running tool"
         >
           <SquareIcon className="size-2.5" />

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -1,5 +1,7 @@
-import { ChevronDownIcon, ClockIcon, LoaderIcon, SquareIcon } from 'lucide-react';
+import { ChevronDownIcon, ClockIcon, ExternalLinkIcon, LoaderIcon, SquareIcon } from 'lucide-react';
 import * as React from 'react';
+
+import { Link } from '@tanstack/react-router';
 
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
 import { parseMcpToolName } from '@stitch/shared/mcp/types';
@@ -101,6 +103,18 @@ export function ToolCallGroup({ calls, onAbort }: ToolCallGroupProps) {
   );
 }
 
+const CHILD_SESSION_TOOLS = new Set(['task', 'inspect_image']);
+
+function isChildSessionTool(toolName: string): boolean {
+  return CHILD_SESSION_TOOLS.has(toolName);
+}
+
+function getChildSessionId(result: unknown): string | null {
+  if (!result || typeof result !== 'object') return null;
+  const id = (result as Record<string, unknown>).childSessionId;
+  return typeof id === 'string' ? id : null;
+}
+
 function ToolCallRow({
   call,
   onAbort,
@@ -109,6 +123,65 @@ function ToolCallRow({
   call: ToolCallDisplayItem;
   onAbort?: () => void;
   animateIn: boolean;
+}) {
+  if (isChildSessionTool(call.toolName)) {
+    return <ChildSessionToolCallRow call={call} onAbort={onAbort} animateIn={animateIn} />;
+  }
+
+  return <DefaultToolCallRow call={call} onAbort={onAbort} animateIn={animateIn} />;
+}
+
+function DefaultToolCallRow({
+  call,
+  onAbort,
+  animateIn,
+}: {
+  call: ToolCallDisplayItem;
+  onAbort?: () => void;
+  animateIn: boolean;
+}) {
+  return <ToolCallRowBase call={call} onAbort={onAbort} animateIn={animateIn} />;
+}
+
+function ChildSessionToolCallRow({
+  call,
+  onAbort,
+  animateIn,
+}: {
+  call: ToolCallDisplayItem;
+  onAbort?: () => void;
+  animateIn: boolean;
+}) {
+  const childSessionId = getChildSessionId(call.result);
+
+  return (
+    <ToolCallRowBase call={call} onAbort={onAbort} animateIn={animateIn}>
+      {childSessionId ? (
+        <Button
+          variant="ghost"
+          size="xs"
+          className="h-5 px-1.5 text-[11px] text-muted-foreground"
+          title="Open child session"
+          render={<Link to="/session/$id" params={{ id: childSessionId }} />}
+        >
+          <ExternalLinkIcon className="size-2.5" />
+          Open
+        </Button>
+      ) : null}
+    </ToolCallRowBase>
+  );
+}
+
+function ToolCallRowBase({
+  call,
+  onAbort,
+  animateIn,
+  children,
+}: {
+  call: ToolCallDisplayItem;
+  onAbort?: () => void;
+  animateIn: boolean;
+  children?: React.ReactNode;
 }) {
   const displayName = useStitchToolDisplayName(call.toolName);
   const summary = getToolSummary(call, displayName);
@@ -154,6 +227,7 @@ function ToolCallRow({
           Stop
         </Button>
       ) : null}
+      {children}
     </div>
   );
 }

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -235,6 +235,8 @@ function getToolPreview(call: ToolCallDisplayItem, kind: ToolSummaryKind): strin
       return getBestGenericPreview(call.args, call.result) ?? 'Using recordings';
     case 'session-history':
       return getBestGenericPreview(call.args, call.result) ?? 'Searching sessions';
+    case 'inspect-image':
+      return getStringArg(call.args, ['prompt', 'imagePath']) ?? 'Inspecting image';
     case 'mcp':
     case 'generic':
       return getBestGenericPreview(call.args, call.result) ?? 'Using tool';

--- a/apps/web/src/components/tools/tool-icons.tsx
+++ b/apps/web/src/components/tools/tool-icons.tsx
@@ -8,6 +8,7 @@ import {
   GlobeIcon,
   HelpCircleIcon,
   HistoryIcon,
+  ImageIcon,
   ListTodoIcon,
   MicIcon,
   PanelTopIcon,
@@ -34,6 +35,7 @@ export type ToolIconKind =
   | 'browser'
   | 'recordings'
   | 'session-history'
+  | 'inspect-image'
   | 'mcp'
   | 'generic';
 
@@ -51,6 +53,7 @@ export function getToolIconKind(toolName: string): ToolIconKind {
   if (toolName === 'skill') return 'skill';
   if (toolName === 'memory') return 'memory';
   if (toolName === 'todo') return 'todo';
+  if (toolName === 'inspect_image') return 'inspect-image';
   if (toolName.startsWith('agenda_')) return 'agenda';
   if (toolName === 'browser' || toolName.startsWith('browser_')) return 'browser';
   if (toolName.startsWith('recordings_')) return 'recordings';
@@ -88,6 +91,8 @@ export function ToolKindIcon({ kind, className }: { kind: ToolIconKind; classNam
       return <PanelTopIcon className={className} />;
     case 'recordings':
       return <MicIcon className={className} />;
+    case 'inspect-image':
+      return <ImageIcon className={className} />;
     case 'session-history':
       return <HistoryIcon className={className} />;
     case 'mcp':

--- a/packages/server/src/llm/stream/tool-assembler.ts
+++ b/packages/server/src/llm/stream/tool-assembler.ts
@@ -5,6 +5,7 @@ import * as Log from '@/lib/log.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { getSessionActiveToolsetIds } from '@/llm/stream/session-toolsets.js';
 import { buildSkillsSystemPrompt } from '@/skills/service.js';
+import { createInspectImageTool } from '@/tools/core/inspect-image.js';
 import { createTaskTool } from '@/tools/core/task.js';
 import { createToolsetTools } from '@/tools/core/toolset-management.js';
 import { resultNormalizationMiddleware } from '@/tools/runtime/middleware.js';
@@ -75,18 +76,21 @@ export class ToolAssembler {
   }
 
   async assemble(): Promise<AssembledTools> {
-    const persistedToolsetIds = this.opts.activeToolsetIds ?? getSessionActiveToolsetIds(this.opts.sessionId);
+    const persistedToolsetIds =
+      this.opts.activeToolsetIds ?? getSessionActiveToolsetIds(this.opts.sessionId);
     const toolsetManager = new ToolsetManager(this.toolContext, persistedToolsetIds);
     await this.restoreToolsets(toolsetManager, persistedToolsetIds);
 
     const coreTools = await createTools(this.toolContext);
     const metaTools = this.buildToolsetMetaTools(toolsetManager);
     const taskTool = this.buildTaskTool(toolsetManager);
+    const inspectImageTool = this.buildInspectImageTool();
     const codeModeResult = createCodeModeTool({
       getTools: () =>
         this.mergeTools({
           staticTools: { ...coreTools, ...metaTools },
           taskTool,
+          inspectImageTool,
           dynamicTools: toolsetManager.getActiveTools(),
         }),
       abortSignal: this.opts.abortSignal,
@@ -99,12 +103,15 @@ export class ToolAssembler {
         ...this.mergeTools({
           staticTools: { ...coreTools, ...metaTools },
           taskTool,
+          inspectImageTool,
           dynamicTools: {},
         }),
         execute_typescript: codeModeResult.tool,
       },
       toolsetManager,
-      promptAdditions: [codeModeResult.getSystemPrompt(), toolsetsPrompt, skillsPrompt].filter(Boolean),
+      promptAdditions: [codeModeResult.getSystemPrompt(), toolsetsPrompt, skillsPrompt].filter(
+        Boolean,
+      ),
     };
   }
 
@@ -152,14 +159,31 @@ export class ToolAssembler {
     );
   }
 
+  private buildInspectImageTool(): Tool {
+    const runtime = createToolRuntime(this.toolContext).use(resultNormalizationMiddleware());
+    return runtime.wrapTool(
+      'inspect_image',
+      createInspectImageTool(this.toolContext, {
+        parentSessionId: this.opts.sessionId,
+        parentAbortSignal: this.opts.abortSignal,
+        credentials: this.opts.credentials,
+        modelId: this.opts.modelId,
+        providerId: this.opts.credentials.providerId,
+      }),
+      { source: 'core' },
+    );
+  }
+
   private mergeTools(parts: {
     staticTools: Record<string, Tool>;
     taskTool: Tool | null;
+    inspectImageTool: Tool;
     dynamicTools: Record<string, Tool>;
   }): Record<string, Tool> {
     return {
       ...parts.staticTools,
       ...(parts.taskTool ? { task: parts.taskTool } : {}),
+      inspect_image: parts.inspectImageTool,
       ...parts.dynamicTools,
     };
   }

--- a/packages/server/src/skills/built-ins/pdf/SKILL.md
+++ b/packages/server/src/skills/built-ins/pdf/SKILL.md
@@ -10,6 +10,10 @@ license: Proprietary. LICENSE.txt has complete terms
 
 Use `@libpdf/core` (available as the `libpdf` global in code mode) for all PDF operations. It handles parsing, generation, merge, split, forms, and encryption in a single TypeScript-first library.
 
+Some PDFs, especially ticketing or receipt PDFs, are image-only: each page paints an embedded image and has no extractable text layer. In those cases, `extractText()` can correctly return an empty string even though the page visibly contains text. Do not stop there; inspect and extract page images for vision/OCR processing.
+
+`@libpdf/core` does not currently expose a high-level "extract images" API. Use the low-level PDF object API for image extraction: page resources contain `/XObject` dictionaries, image XObjects are `PdfStream` objects with `/Subtype /Image`, and indirect objects must be resolved with `pdf.getObject(ref)`.
+
 ## Quick Start
 
 ```typescript
@@ -46,12 +50,89 @@ for (let i = 0; i < pdf.getPageCount(); i++) {
 }
 ```
 
+If the combined text is empty or only whitespace, treat the PDF as possibly image-only and use the image fallback below.
+
 ### Extract Text from a Specific Page
 
 ```typescript
 const page = pdf.getPage(0); // 0-indexed
 const text = page.extractText().text; // .text gives the string
 ```
+
+## Image-Only PDF Fallback
+
+When text extraction returns empty text, check page content and resources for image XObjects. A common pattern is a page content stream containing only a `Do` operator for an `/XObject` image, with no fonts in the resources.
+
+### Detect Embedded Page Images
+
+```typescript
+const fs = await import('node:fs/promises');
+const bytes = new Uint8Array(await fs.readFile('document.pdf'));
+const pdf = await libpdf.PDF.load(bytes);
+
+for (let pageIndex = 0; pageIndex < pdf.getPageCount(); pageIndex++) {
+  const page = pdf.getPage(pageIndex);
+  const text = page.extractText().text.trim();
+  const content = Buffer.from(page.getContentBytes()).toString('latin1');
+
+  console.log({
+    pageIndex,
+    textLength: text.length,
+    paintsXObject: /\/[^\s]+\s+Do/.test(content),
+  });
+}
+```
+
+### Extract JPEG Image XObjects
+
+Many image-only PDFs embed JPEG streams using `/Filter /DCTDecode`. Those streams can be written directly as `.jpg` files. For extraction, write `stream.data` because it is the raw stream data from the PDF. Do not use `getEncodedData()` for extraction; that method is for encoding decoded stream content after modification. Do not use `getDecodedData()` for JPEG extraction unless you explicitly need decoded pixel data instead of a JPEG file.
+
+```typescript
+const fs = await import('node:fs/promises');
+const path = await import('node:path');
+
+const pdfPath = 'document.pdf';
+const outputDir = 'pdf-images';
+await fs.mkdir(outputDir, { recursive: true });
+
+const bytes = new Uint8Array(await fs.readFile(pdfPath));
+const pdf = await libpdf.PDF.load(bytes);
+const { PdfName, PdfRef } = libpdf;
+
+const extractedImages = [];
+
+for (let pageIndex = 0; pageIndex < pdf.getPageCount(); pageIndex++) {
+  const page = pdf.getPage(pageIndex);
+  const resources = page.getResources();
+  const xObjects = resources?.getDict(PdfName.of('XObject'));
+
+  if (!xObjects) continue;
+
+  for (const [name, value] of xObjects) {
+    const stream = value instanceof PdfRef ? pdf.getObject(value) : value;
+    if (stream?.getName?.(PdfName.of('Subtype')) !== 'Image') continue;
+
+    const filter = stream.getName(PdfName.of('Filter'));
+    if (filter !== 'DCTDecode') continue;
+
+    const filename = `page-${pageIndex + 1}-${name.value}.jpg`;
+    const filePath = path.join(outputDir, filename);
+    await fs.writeFile(filePath, stream.data);
+
+    extractedImages.push({
+      pageIndex,
+      filePath,
+      width: stream.getNumber(PdfName.of('Width')),
+      height: stream.getNumber(PdfName.of('Height')),
+      filter,
+    });
+  }
+}
+
+return extractedImages;
+```
+
+Use the extracted images with any available vision or OCR capability to read visible text. If no vision/OCR capability is available, report that the PDF is image-only and provide the extracted image paths instead of claiming the PDF has no content.
 
 ### Extract Metadata
 

--- a/packages/server/src/tools/core/inspect-image.ts
+++ b/packages/server/src/tools/core/inspect-image.ts
@@ -1,0 +1,251 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { tool } from 'ai';
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+import type { StoredPart } from '@stitch/shared/chat/messages';
+import { createMessageId, createPartId } from '@stitch/shared/id';
+import type { PrefixedString } from '@stitch/shared/id';
+
+import { createSession } from '@/chat/service.js';
+import { getDb } from '@/db/client.js';
+import { messages } from '@/db/schema.js';
+import * as AbortRegistry from '@/lib/abort-registry.js';
+import * as Events from '@/lib/events.js';
+import * as Log from '@/lib/log.js';
+import { isServiceError } from '@/lib/service-result.js';
+import { buildCompactedHistory } from '@/llm/compaction.js';
+import type { ProviderCredentials } from '@/llm/provider/provider.js';
+import { runStream } from '@/llm/stream/runner.js';
+import type { ToolContext } from '@/tools/runtime/runtime.js';
+
+const log = Log.create({ service: 'inspect-image-tool' });
+
+const SUPPORTED_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp']);
+
+const MIME_MAP: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.bmp': 'image/bmp',
+};
+
+const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
+
+const DESCRIPTION = `Inspect an image using vision capabilities. Reads a local image file and sends it to the LLM with a prompt describing what to analyze.
+
+Use this tool when you need to:
+- Understand the contents of a screenshot, diagram, or photo
+- Extract text or data from an image (OCR)
+- Analyze UI mockups, charts, or visual layouts
+- Compare visual elements or identify patterns
+
+The image is sent to a child session with vision capabilities. Returns the LLM's analysis as a summary.
+
+Supported formats: PNG, JPG, JPEG, GIF, WEBP, SVG, BMP.`;
+
+type InspectImageToolDeps = {
+  parentSessionId: PrefixedString<'ses'>;
+  parentAbortSignal: AbortSignal;
+  credentials: ProviderCredentials;
+  modelId: string;
+  providerId: string;
+};
+
+export function createInspectImageTool(context: ToolContext, deps: InspectImageToolDeps) {
+  return tool({
+    description: DESCRIPTION,
+    inputSchema: z.object({
+      imagePath: z.string().describe('Absolute path to the image file to inspect'),
+      prompt: z.string().describe('What to analyze or look for in the image'),
+    }),
+    execute: async ({ imagePath, prompt }, { toolCallId }) => {
+      const ext = path.extname(imagePath).toLowerCase();
+      if (!SUPPORTED_EXTENSIONS.has(ext)) {
+        return {
+          childSessionId: null,
+          childSessionName: null,
+          summary: `Unsupported image format "${ext}". Supported: ${[...SUPPORTED_EXTENSIONS].join(', ')}`,
+        };
+      }
+
+      let stat;
+      try {
+        stat = await fs.stat(imagePath);
+      } catch {
+        return {
+          childSessionId: null,
+          childSessionName: null,
+          summary: `Image file not found: ${imagePath}`,
+        };
+      }
+
+      if (stat.size > MAX_FILE_SIZE) {
+        return {
+          childSessionId: null,
+          childSessionName: null,
+          summary: `Image file too large (${(stat.size / 1024 / 1024).toFixed(1)}MB). Maximum supported size is 20MB.`,
+        };
+      }
+
+      const mime = MIME_MAP[ext] ?? 'application/octet-stream';
+      const buffer = await fs.readFile(imagePath);
+      const base64 = buffer.toString('base64');
+      const dataUrl = `data:${mime};base64,${base64}`;
+
+      const filename = path.basename(imagePath);
+      const sessionTitle = `Inspect: ${filename}`.slice(0, 50);
+
+      const sessionResult = await createSession({
+        title: sessionTitle,
+        parentSessionId: deps.parentSessionId,
+      });
+      if (isServiceError(sessionResult)) {
+        return {
+          childSessionId: null,
+          childSessionName: null,
+          summary: `Failed to create inspection session: ${sessionResult.error}`,
+        };
+      }
+      const childSession = sessionResult.data;
+      const childSessionId = childSession.id;
+
+      Events.emit('stream-tool-state', {
+        sessionId: context.sessionId,
+        messageId: context.messageId,
+        toolCallId,
+        toolName: 'inspect_image',
+        status: 'in-progress',
+        output: {
+          childSessionId,
+          childSessionName: childSession.title,
+        },
+      });
+
+      log.info(
+        {
+          event: 'inspect_image.child_session.created',
+          parentSessionId: deps.parentSessionId,
+          childSessionId,
+          imagePath,
+          promptPreview: prompt.slice(0, 200),
+        },
+        'child session created for image inspection',
+      );
+
+      const now = Date.now();
+      const userMessageId = createMessageId();
+
+      const parts: StoredPart[] = [
+        {
+          type: 'text-delta',
+          id: createPartId(),
+          text: prompt,
+          startedAt: now,
+          endedAt: now,
+        },
+        {
+          type: 'user-image',
+          id: createPartId(),
+          dataUrl,
+          mime,
+          filename,
+          startedAt: now,
+          endedAt: now,
+        },
+      ];
+
+      const db = getDb();
+      await db.insert(messages).values({
+        id: userMessageId,
+        sessionId: childSessionId,
+        role: 'user',
+        parts,
+        modelId: deps.modelId,
+        providerId: deps.providerId,
+        costUsd: 0,
+        createdAt: now,
+        updatedAt: now,
+        startedAt: now,
+        duration: null,
+      });
+
+      const llmMessages = await buildCompactedHistory(childSessionId);
+      const assistantMessageId = createMessageId();
+
+      const childAbortSignal = AbortRegistry.register(childSessionId);
+      const onParentAbort = () => {
+        AbortRegistry.abort(childSessionId);
+      };
+      deps.parentAbortSignal.addEventListener('abort', onParentAbort, { once: true });
+
+      try {
+        await runStream({
+          sessionId: childSessionId,
+          assistantMessageId,
+          modelId: deps.modelId,
+          llmMessages,
+          credentials: deps.credentials,
+          abortSignal: childAbortSignal,
+          activeToolsetIds: [],
+          allowTaskTool: false,
+        });
+
+        log.info(
+          {
+            event: 'inspect_image.child_session.completed',
+            parentSessionId: deps.parentSessionId,
+            childSessionId,
+          },
+          'image inspection completed',
+        );
+
+        const childMessages = await db
+          .select()
+          .from(messages)
+          .where(and(eq(messages.sessionId, childSessionId), eq(messages.id, assistantMessageId)));
+
+        const assistantMessage = childMessages[0];
+        let summary = 'Image inspection completed.';
+
+        if (assistantMessage?.parts) {
+          const textParts = assistantMessage.parts
+            .filter(
+              (p: StoredPart): p is StoredPart & { type: 'text-delta'; text: string } =>
+                p.type === 'text-delta' && typeof (p as { text?: unknown }).text === 'string',
+            )
+            .map((p: { text: string }) => p.text);
+          if (textParts.length > 0) {
+            summary = textParts.join('');
+          }
+        }
+
+        return { childSessionId, childSessionName: childSession.title, summary };
+      } catch (error) {
+        log.error(
+          {
+            event: 'inspect_image.child_session.failed',
+            parentSessionId: deps.parentSessionId,
+            childSessionId,
+            error,
+          },
+          'image inspection failed',
+        );
+
+        return {
+          childSessionId,
+          childSessionName: childSession.title,
+          summary: `Image inspection failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        };
+      } finally {
+        deps.parentAbortSignal.removeEventListener('abort', onParentAbort);
+        AbortRegistry.cleanup(childSessionId);
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Change Summary

Adds a vision-based image inspection tool that spawns child sessions, and improves the tool call UI to support navigating into child sessions.

### New Features
- **inspect_image tool**: Reads a local image file and sends it to a child session with vision capabilities for analysis (OCR, diagram understanding, UI mockup inspection, etc.). Supports PNG, JPG, GIF, WEBP, SVG, BMP up to 20MB.
- **Child session navigation**: Tool call rows for task and inspect_image now show an "Open" button that links directly to the child session once created.

### Improvements & Refactors
- Refactored ToolCallRow into a composable ToolCallRowBase with a children slot, dispatching to DefaultToolCallRow and ChildSessionToolCallRow variants to eliminate layout duplication.
- Stop button in tool call UI now uses destructive (red) styling for better visibility.

### Documentation
- Extended the built-in PDF skill with guidance for handling image-only PDFs (detection, JPEG extraction from XObjects, vision/OCR fallback).
