### PR TITLE
fix: sidebar not updating chat title until navigation

### DIFF
--- a/apps/web/src/components/navigation/app-sidebar.tsx
+++ b/apps/web/src/components/navigation/app-sidebar.tsx
@@ -7,8 +7,11 @@ import {
 } from 'lucide-react';
 import * as React from 'react';
 
+import type { InfiniteData } from '@tanstack/react-query';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { Link, useParams, useRouterState } from '@tanstack/react-router';
+
+import type { SessionsPage } from '@stitch/shared/chat/messages';
 
 import { AgendaSidebarContent } from '@/components/agenda/agenda-sidebar';
 import { AnimatedTitle } from '@/components/animated-title';
@@ -30,6 +33,22 @@ import { useSessionTitleUpdates } from '@/hooks/sse/use-session-title-updates';
 import { useStreamingSessionIds } from '@/hooks/use-session-stream-state';
 import { sessionsInfiniteQueryOptions } from '@/lib/queries/chat';
 import { cn } from '@/lib/utils';
+
+type SidebarSession = {
+  id: string;
+  title: string | null;
+  isUnread: boolean;
+};
+
+const selectSidebarSessions = (data: InfiniteData<SessionsPage>) => ({
+  ...data,
+  pages: data.pages.map((page) => ({
+    ...page,
+    sessions: page.sessions.map(
+      ({ id, title, isUnread }) => ({ id, title, isUnread }) as SidebarSession,
+    ),
+  })),
+});
 
 const SessionStatusIcon = React.memo(function SessionStatusIcon({
   isStreaming,
@@ -61,9 +80,10 @@ function ChatSidebarContent() {
   const [search, setSearch] = React.useState('');
   const deferredSearch = React.useDeferredValue(search.trim());
   const loadMoreRef = React.useRef<HTMLDivElement>(null);
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
-    sessionsInfiniteQueryOptions(deferredSearch),
-  );
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+    ...sessionsInfiniteQueryOptions(deferredSearch),
+    select: selectSidebarSessions,
+  });
   useSessionTitleUpdates();
   const streamingIds = useStreamingSessionIds();
   const streamingIdSet = React.useMemo(() => new Set(streamingIds), [streamingIds]);

--- a/apps/web/src/hooks/sse/use-session-title-updates.ts
+++ b/apps/web/src/hooks/sse/use-session-title-updates.ts
@@ -1,6 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
+import type { InfiniteData } from '@tanstack/react-query';
 
-import type { Session } from '@stitch/shared/chat/messages';
+import type { Session, SessionsPage } from '@stitch/shared/chat/messages';
 
 import { useSSE } from '@/hooks/sse/sse-context';
 import { sessionKeys } from '@/lib/queries/chat';
@@ -14,9 +15,19 @@ export function useSessionTitleUpdates(
     'session-title-update': (data) => {
       const { sessionId, title } = data;
 
-      // Update the session list cache
-      queryClient.setQueryData<Session[]>(sessionKeys.list(), (prev) =>
-        prev?.map((s) => (s.id === sessionId ? { ...s, title } : s)),
+      // Update all session list caches (including infinite queries used by sidebar)
+      queryClient.setQueriesData<InfiniteData<SessionsPage>>(
+        { queryKey: sessionKeys.list() },
+        (prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            pages: prev.pages.map((page) => ({
+              ...page,
+              sessions: page.sessions.map((s) => (s.id === sessionId ? { ...s, title } : s)),
+            })),
+          };
+        },
       );
 
       // Update the session detail cache if present


### PR DESCRIPTION
## 🚀 Change Summary

Fixes sidebar not reflecting chat title updates until navigating away and back.

### 🐛 Bug Fixes
- **SSE title sync**: The SSE handler for \session-title-update\ was calling \setQueryData\ on \sessionKeys.list()\ (\['sessions', 'list']\), but the sidebar uses an **infinite query** with key \['sessions', 'list', 'infinite', search]\. Switched to \setQueriesData\ with the list prefix so all child keys (including infinite queries) are updated.
- **Sidebar performance**: Added a Tanstack Query \select\ to the sidebar's infinite query to subscribe only to the three fields it renders (\id\, \	itle\, \isUnread\), preventing re-renders when unrelated session fields change.