### PR TITLE
fix: prevent recurring Gmail re-authorization

### DIFF
--- a/connectors/google/src/connector.ts
+++ b/connectors/google/src/connector.ts
@@ -166,6 +166,11 @@ export const googleConnectorModule: ConnectorModule = {
         href: 'https://console.cloud.google.com/auth/audience',
         hrefLabel: 'OAuth Audience Page',
       },
+      {
+        text: 'On the Audience page, click Publish app to move it to production.',
+        href: 'https://console.cloud.google.com/auth/audience',
+        hrefLabel: 'OAuth Audience Page',
+      },
     ],
   },
   hooks: {

--- a/packages/server/src/connectors/auth/oauth2.test.ts
+++ b/packages/server/src/connectors/auth/oauth2.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+
+import { OAuthRefreshError, requiresOAuthReauth } from '@/connectors/auth/oauth2.js';
+
+function invalidGrant(clockSkewMs?: number): OAuthRefreshError {
+  return new OAuthRefreshError(
+    400,
+    JSON.stringify({ error: 'invalid_grant', error_description: 'Token has been expired or revoked.' }),
+    clockSkewMs,
+  );
+}
+
+describe('requiresOAuthReauth', () => {
+  test('flags invalid_grant without clock skew as requiring reauthorization', () => {
+    expect(requiresOAuthReauth(invalidGrant())).toBe(true);
+  });
+
+  test('flags invalid_grant with small clock skew as requiring reauthorization', () => {
+    expect(requiresOAuthReauth(invalidGrant(60_000))).toBe(true);
+  });
+
+  test('treats invalid_grant with large clock skew as transient', () => {
+    expect(requiresOAuthReauth(invalidGrant(10 * 60_000))).toBe(false);
+    expect(requiresOAuthReauth(invalidGrant(-10 * 60_000))).toBe(false);
+  });
+
+  test('does not flag non-invalid_grant errors', () => {
+    expect(requiresOAuthReauth(new OAuthRefreshError(500, 'server error'))).toBe(false);
+    expect(requiresOAuthReauth(new OAuthRefreshError(400, JSON.stringify({ error: 'invalid_client' })))).toBe(false);
+  });
+
+  test('does not flag arbitrary errors', () => {
+    expect(requiresOAuthReauth(new Error('socket hang up'))).toBe(false);
+  });
+});

--- a/packages/server/src/connectors/auth/oauth2.ts
+++ b/packages/server/src/connectors/auth/oauth2.ts
@@ -23,11 +23,13 @@ export class OAuthRefreshError extends Error {
   readonly status: number;
   readonly errorCode: string | undefined;
   readonly errorDescription: string | undefined;
+  readonly clockSkewMs: number | undefined;
 
-  constructor(status: number, bodyText: string) {
+  constructor(status: number, bodyText: string, clockSkewMs?: number) {
     super(`Token refresh failed (${status}): ${bodyText}`);
     this.name = 'OAuthRefreshError';
     this.status = status;
+    this.clockSkewMs = clockSkewMs;
 
     let parsed: OAuthErrorPayload | null = null;
     try {
@@ -41,12 +43,32 @@ export class OAuthRefreshError extends Error {
   }
 }
 
+/** Clock skew beyond this magnitude can itself cause Google to reject a valid refresh token. */
+const CLOCK_SKEW_THRESHOLD_MS = 5 * 60_000;
+
+/**
+ * Detects whether an OAuth refresh failure represents a permanently invalid
+ * grant (revoked/expired refresh token) that requires the user to reauthorize.
+ *
+ * An `invalid_grant` accompanied by significant client/server clock skew is
+ * treated as transient: large skew alone causes Google to reject otherwise
+ * valid tokens, and flagging reauthorization in that case produces a needless
+ * reconnect loop. Such failures should resolve once the clock is corrected.
+ */
 export function requiresOAuthReauth(error: unknown): boolean {
-  return (
-    error instanceof OAuthRefreshError &&
-    error.status === 400 &&
-    error.errorCode === 'invalid_grant'
-  );
+  if (
+    !(error instanceof OAuthRefreshError) ||
+    error.status !== 400 ||
+    error.errorCode !== 'invalid_grant'
+  ) {
+    return false;
+  }
+
+  if (error.clockSkewMs !== undefined && Math.abs(error.clockSkewMs) >= CLOCK_SKEW_THRESHOLD_MS) {
+    return false;
+  }
+
+  return true;
 }
 
 function generateCodeVerifier(): string {
@@ -265,11 +287,12 @@ export async function refreshAccessToken(
 
   if (!response.ok) {
     const errorBody = await response.text();
+    const clockSkewMs = computeClockSkewMs(response.headers.get('date'));
     log.error(
-      { event: 'oauth.refresh.failed', status: response.status, errorBody },
+      { event: 'oauth.refresh.failed', status: response.status, errorBody, clockSkewMs },
       'Token refresh failed',
     );
-    throw new OAuthRefreshError(response.status, errorBody);
+    throw new OAuthRefreshError(response.status, errorBody, clockSkewMs);
   }
 
   const data = (await response.json()) as {
@@ -283,6 +306,18 @@ export async function refreshAccessToken(
     refreshToken: data.refresh_token ?? null,
     expiresIn: data.expires_in ?? null,
   };
+}
+
+/**
+ * Computes the difference between the local clock and the server's `Date`
+ * header, in milliseconds. Positive values mean the local clock is ahead.
+ * Returns undefined when the header is missing or unparseable.
+ */
+function computeClockSkewMs(dateHeader: string | null): number | undefined {
+  if (!dateHeader) return undefined;
+  const serverTime = Date.parse(dateHeader);
+  if (Number.isNaN(serverTime)) return undefined;
+  return Date.now() - serverTime;
 }
 
 function buildHtmlResponse(title: string, message: string, success: boolean): string {

--- a/packages/server/src/connectors/auth/token-refresh.test.ts
+++ b/packages/server/src/connectors/auth/token-refresh.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
 
 import type { ConnectorDefinition } from '@stitch/shared/connectors/types';
 import type { PrefixedString } from '@stitch/shared/id';
@@ -9,7 +10,6 @@ import { registerConnector, unregisterConnector } from '@/connectors/registry.js
 import { getDb } from '@/db/client.js';
 import { connectorInstances } from '@/db/schema.js';
 import { setupTestDb } from '@/db/test-helpers.js';
-import { eq } from 'drizzle-orm';
 
 setupTestDb();
 
@@ -21,7 +21,9 @@ function createDefinition(): ConnectorDefinition {
     icon: { type: 'simpleIcons', slug: 'google' },
     enabled: true,
     currentVersion: 1,
-    versionHistory: [{ version: 1, title: 'Base', description: 'Base', action: 'none', capabilities: [] }],
+    versionHistory: [
+      { version: 1, title: 'Base', description: 'Base', action: 'none', capabilities: [] },
+    ],
     authType: 'oauth2',
     authConfig: {
       authUrl: 'https://example.com/auth',
@@ -34,24 +36,26 @@ function createDefinition(): ConnectorDefinition {
 }
 
 async function insertExpiredInstance(id: string) {
-  await getDb().insert(connectorInstances).values({
-    id: id as PrefixedString<'conn'>,
-    connectorId: 'google',
-    label: 'Google Account',
-    appliedVersion: 1,
-    capabilities: ['google.drive.read'],
-    clientId: 'client-id',
-    clientSecret: 'client-secret',
-    apiKey: null,
-    accessToken: 'access-token',
-    refreshToken: 'refresh-token',
-    tokenExpiresAt: Date.now() - 1_000,
-    scopes: ['scope:read'],
-    status: 'connected',
-    authIssue: null,
-    accountEmail: 'user@example.com',
-    accountInfo: null,
-  });
+  await getDb()
+    .insert(connectorInstances)
+    .values({
+      id: id as PrefixedString<'conn'>,
+      connectorId: 'google',
+      label: 'Google Account',
+      appliedVersion: 1,
+      capabilities: ['google.drive.read'],
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      apiKey: null,
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      tokenExpiresAt: Date.now() - 1_000,
+      scopes: ['scope:read'],
+      status: 'connected',
+      authIssue: null,
+      accountEmail: 'user@example.com',
+      accountInfo: null,
+    });
 }
 
 describe('refreshExpiringTokens', () => {
@@ -64,10 +68,16 @@ describe('refreshExpiringTokens', () => {
     await insertExpiredInstance('conn_refresh_1');
 
     await refreshExpiringTokens({
-      refreshAccessToken: async () => { throw new Error('socket hang up'); },
+      refreshAccessToken: async () => {
+        throw new Error('socket hang up');
+      },
+      sleep: async () => {},
     });
 
-    const [row] = await getDb().select().from(connectorInstances).where(eq(connectorInstances.id, 'conn_refresh_1' as never));
+    const [row] = await getDb()
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, 'conn_refresh_1' as never));
     expect(row?.status).toBe('connected');
     expect(row?.authIssue).toBeNull();
   });
@@ -79,12 +89,66 @@ describe('refreshExpiringTokens', () => {
       refreshAccessToken: async () => {
         throw new OAuthRefreshError(
           400,
-          JSON.stringify({ error: 'invalid_grant', error_description: 'Token has been expired or revoked.' }),
+          JSON.stringify({
+            error: 'invalid_grant',
+            error_description: 'Token has been expired or revoked.',
+          }),
         );
       },
     });
 
-    const [row] = await getDb().select().from(connectorInstances).where(eq(connectorInstances.id, 'conn_refresh_2' as never));
+    const [row] = await getDb()
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, 'conn_refresh_2' as never));
+    expect(row?.status).toBe('error');
+    expect(row?.authIssue).toBe('reauthorization_required');
+  });
+
+  test('recovers after a transient refresh failure by retrying', async () => {
+    await insertExpiredInstance('conn_refresh_retry');
+
+    let attempts = 0;
+    await refreshExpiringTokens({
+      refreshAccessToken: async () => {
+        attempts += 1;
+        if (attempts < 2) throw new Error('socket hang up');
+        return {
+          accessToken: 'refreshed-access',
+          refreshToken: 'rotated-refresh',
+          expiresIn: 3600,
+        };
+      },
+      sleep: async () => {},
+    });
+
+    expect(attempts).toBe(2);
+    const [row] = await getDb()
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, 'conn_refresh_retry' as never));
+    expect(row?.status).toBe('connected');
+    expect(row?.accessToken).toBe('refreshed-access');
+    expect(row?.refreshToken).toBe('rotated-refresh');
+  });
+
+  test('does not retry permanent invalid_grant failures', async () => {
+    await insertExpiredInstance('conn_refresh_no_retry');
+
+    let attempts = 0;
+    await refreshExpiringTokens({
+      refreshAccessToken: async () => {
+        attempts += 1;
+        throw new OAuthRefreshError(400, JSON.stringify({ error: 'invalid_grant' }));
+      },
+      sleep: async () => {},
+    });
+
+    expect(attempts).toBe(1);
+    const [row] = await getDb()
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, 'conn_refresh_no_retry' as never));
     expect(row?.status).toBe('error');
     expect(row?.authIssue).toBe('reauthorization_required');
   });

--- a/packages/server/src/connectors/auth/token-refresh.ts
+++ b/packages/server/src/connectors/auth/token-refresh.ts
@@ -3,7 +3,10 @@ import { eq, and, isNotNull, lt } from 'drizzle-orm';
 import type { OAuthConfig } from '@stitch/shared/connectors/types';
 
 import { resolveOAuthCredentials } from '@/connectors/auth/oauth-credentials.js';
-import { refreshAccessToken as refreshAccessTokenDefault, requiresOAuthReauth } from '@/connectors/auth/oauth2.js';
+import {
+  refreshAccessToken as refreshAccessTokenDefault,
+  requiresOAuthReauth,
+} from '@/connectors/auth/oauth2.js';
 import type { refreshAccessToken as RefreshAccessTokenFn } from '@/connectors/auth/oauth2.js';
 import { getConnectorDefinition } from '@/connectors/registry.js';
 import { getDb } from '@/db/client.js';
@@ -13,9 +16,41 @@ import * as Log from '@/lib/log.js';
 const log = Log.create({ service: 'token-refresh' });
 
 const REFRESH_BUFFER_MS = 5 * 60_000; // Refresh 5 minutes before expiry
+const MAX_REFRESH_ATTEMPTS = 3;
+const BASE_RETRY_DELAY_MS = 1_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Refreshes a token, retrying transient failures with exponential backoff.
+ * Permanent failures (revoked/expired refresh token) are thrown immediately
+ * without retrying, since retrying cannot recover them.
+ */
+async function refreshWithRetries(
+  refresh: typeof RefreshAccessTokenFn,
+  args: Parameters<typeof RefreshAccessTokenFn>,
+  sleepFn: (ms: number) => Promise<void>,
+): Promise<Awaited<ReturnType<typeof RefreshAccessTokenFn>>> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_REFRESH_ATTEMPTS; attempt += 1) {
+    try {
+      return await refresh(...args);
+    } catch (error) {
+      lastError = error;
+      if (requiresOAuthReauth(error) || attempt === MAX_REFRESH_ATTEMPTS) {
+        throw error;
+      }
+      await sleepFn(BASE_RETRY_DELAY_MS * 2 ** (attempt - 1));
+    }
+  }
+  throw lastError;
+}
 
 export async function refreshExpiringTokens(deps?: {
   refreshAccessToken?: typeof RefreshAccessTokenFn;
+  sleep?: (ms: number) => Promise<void>;
 }): Promise<void> {
   const db = getDb();
   const now = Date.now();
@@ -50,11 +85,10 @@ export async function refreshExpiringTokens(deps?: {
         `Refreshing token for ${instance.label}`,
       );
 
-      const tokens = await (deps?.refreshAccessToken ?? refreshAccessTokenDefault)(
-        config.tokenUrl,
-        credentials.clientId,
-        credentials.clientSecret,
-        instance.refreshToken,
+      const tokens = await refreshWithRetries(
+        deps?.refreshAccessToken ?? refreshAccessTokenDefault,
+        [config.tokenUrl, credentials.clientId, credentials.clientSecret, instance.refreshToken],
+        deps?.sleep ?? sleep,
       );
 
       await db

--- a/packages/server/src/connectors/google-toolsets.ts
+++ b/packages/server/src/connectors/google-toolsets.ts
@@ -103,20 +103,10 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
           );
         }
 
-        let cachedToken: string | null = null;
-        let cachedTokenExpiresAt: number | null = null;
-
         const client = new GoogleClient({
           getAccessToken: async (options) => {
             const forceRefresh = options?.forceRefresh === true;
             const now = Date.now();
-            if (
-              !forceRefresh &&
-              cachedToken &&
-              (!cachedTokenExpiresAt || cachedTokenExpiresAt > now + REFRESH_BUFFER_MS)
-            ) {
-              return cachedToken;
-            }
 
             const [latest] = await db
               .select({
@@ -151,8 +141,7 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
                 if (creds && latest.refreshToken) {
                   const inFlight = refreshInFlight.get(chosen.id);
                   if (inFlight) {
-                    cachedToken = await inFlight;
-                    return cachedToken;
+                    return await inFlight;
                   }
 
                   const config = definition.authConfig as OAuthConfig;
@@ -184,11 +173,7 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
                       })
                       .where(eq(connectorInstances.id, chosen.id));
 
-                    cachedToken = refreshed.accessToken;
-                    cachedTokenExpiresAt = refreshed.expiresIn
-                      ? now + refreshed.expiresIn * 1000
-                      : null;
-                    return cachedToken;
+                    return refreshed.accessToken;
                   } catch (error) {
                     const message = error instanceof Error ? error.message : String(error);
                     const requiresReauth = requiresOAuthReauth(error);
@@ -229,9 +214,7 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
               );
             }
 
-            cachedToken = latest.accessToken;
-            cachedTokenExpiresAt = latest.tokenExpiresAt;
-            return cachedToken;
+            return latest.accessToken;
           },
           logger: log,
           quotaAccountKey: chosen.id,

--- a/packages/server/src/connectors/service.test.ts
+++ b/packages/server/src/connectors/service.test.ts
@@ -1,19 +1,19 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
 
 import type { ConnectorDefinition } from '@stitch/shared/connectors/types';
 
+import { registerConnector, unregisterConnector } from '@/connectors/registry.js';
 import {
   authorizeOAuthInstance,
   createApiKeyConnectorInstance,
   createOAuthConnectorInstance,
   upgradeConnectorInstance,
 } from '@/connectors/service.js';
-import { registerConnector, unregisterConnector } from '@/connectors/registry.js';
 import { getDb } from '@/db/client.js';
 import { connectorInstances } from '@/db/schema.js';
 import { setupTestDb } from '@/db/test-helpers.js';
 import { isServiceError } from '@/lib/service-result.js';
-import { eq } from 'drizzle-orm';
 
 setupTestDb();
 
@@ -103,7 +103,10 @@ describe('connector service', () => {
     }
 
     // Row should be unchanged
-    const [row] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId));
+    const [row] = await db
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, instanceId));
     expect(row?.appliedVersion).toBe(1);
   });
 
@@ -149,13 +152,19 @@ describe('connector service', () => {
 
     expect(isServiceError(result)).toBe(false);
     if (!isServiceError(result)) {
-      expect(result.data).toEqual({ type: 'reauthorize', authUrl: 'https://example.com/authorize' });
+      expect(result.data).toEqual({
+        type: 'reauthorize',
+        authUrl: 'https://example.com/authorize',
+      });
     }
 
     // Wait for the background waitForTokens to complete
     await new Promise((r) => setTimeout(r, 50));
 
-    const [row] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId));
+    const [row] = await db
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, instanceId));
     // After token exchange the instance should be connected with the new key and merged scopes
     expect(row?.apiKey).toBe('new-key');
     expect((row?.scopes as string[])?.includes('scope:admin')).toBe(true);
@@ -170,7 +179,15 @@ describe('connector service', () => {
       icon: { type: 'simpleIcons', slug: 'api' },
       enabled: false,
       currentVersion: 1,
-      versionHistory: [{ version: 1, title: 'Initial', description: 'Initial', action: 'none', capabilities: ['example.api.read'] }],
+      versionHistory: [
+        {
+          version: 1,
+          title: 'Initial',
+          description: 'Initial',
+          action: 'none',
+          capabilities: ['example.api.read'],
+        },
+      ],
       authType: 'api_key',
       authConfig: { keyLabel: 'API Key' },
       setupInstructions: [],
@@ -192,8 +209,10 @@ describe('connector service', () => {
 
     expect(isServiceError(oauthResult)).toBe(true);
     expect(isServiceError(apiKeyResult)).toBe(true);
-    if (isServiceError(oauthResult)) expect(oauthResult.error).toBe('Connector is currently disabled');
-    if (isServiceError(apiKeyResult)) expect(apiKeyResult.error).toBe('Connector is currently disabled');
+    if (isServiceError(oauthResult))
+      expect(oauthResult.error).toBe('Connector is currently disabled');
+    if (isServiceError(apiKeyResult))
+      expect(apiKeyResult.error).toBe('Connector is currently disabled');
 
     // Nothing written to DB
     const rows = await getDb().select().from(connectorInstances);
@@ -201,7 +220,10 @@ describe('connector service', () => {
   });
 
   test('authorizeOAuthInstance marks connector as error when token exchange fails', async () => {
-    const definition = oauthDefinition({ currentVersion: 1, versionHistory: oauthDefinition().versionHistory.slice(0, 1) });
+    const definition = oauthDefinition({
+      currentVersion: 1,
+      versionHistory: oauthDefinition().versionHistory.slice(0, 1),
+    });
     registerConnector(definition);
 
     const db = getDb();
@@ -227,7 +249,9 @@ describe('connector service', () => {
 
     const fakeStartOAuthFlow = async () => ({
       authUrl: 'https://example.com/authorize',
-      waitForTokens: async () => { throw new Error('token exchange failed'); },
+      waitForTokens: async () => {
+        throw new Error('token exchange failed');
+      },
     });
 
     const result = await authorizeOAuthInstance(instanceId, { startOAuthFlow: fakeStartOAuthFlow });
@@ -236,10 +260,17 @@ describe('connector service', () => {
     if (isServiceError(result)) return;
 
     let threw = false;
-    try { await result.data.waitForTokens(); } catch { threw = true; }
+    try {
+      await result.data.waitForTokens();
+    } catch {
+      threw = true;
+    }
     expect(threw).toBe(true);
 
-    const [row] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId));
+    const [row] = await db
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, instanceId));
     expect(row?.status).toBe('error');
   });
 
@@ -284,12 +315,65 @@ describe('connector service', () => {
 
     await result.data.waitForTokens();
 
-    const [row] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId));
+    const [row] = await db
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, instanceId));
     expect(row?.status).toBe('connected');
     expect(row?.accessToken).toBe('access-token-123');
     expect(row?.refreshToken).toBe('refresh-token-123');
     expect(row?.appliedVersion).toBe(definition.currentVersion);
     expect(row?.capabilities).toEqual(['example.read', 'example.write', 'example.admin']);
     expect(typeof row?.tokenExpiresAt).toBe('number');
+  });
+
+  test('authorizeOAuthInstance preserves existing refresh token when provider omits one', async () => {
+    const definition = oauthDefinition();
+    registerConnector(definition);
+
+    const db = getDb();
+    const instanceId = 'conn_auth_preserve_refresh' as never;
+    await db.insert(connectorInstances).values({
+      id: instanceId,
+      connectorId: definition.id,
+      label: 'Example OAuth',
+      appliedVersion: 1,
+      capabilities: ['example.read'],
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      apiKey: null,
+      accessToken: 'old-access-token',
+      refreshToken: 'existing-refresh-token',
+      tokenExpiresAt: Date.now() - 1_000,
+      scopes: ['scope:read'],
+      status: 'connected',
+      authIssue: null,
+      accountEmail: null,
+      accountInfo: null,
+    });
+
+    const fakeStartOAuthFlow = async () => ({
+      authUrl: 'https://example.com/authorize',
+      waitForTokens: async () => ({
+        accessToken: 'new-access-token',
+        refreshToken: null,
+        expiresIn: 3600,
+      }),
+    });
+
+    const result = await authorizeOAuthInstance(instanceId, { startOAuthFlow: fakeStartOAuthFlow });
+
+    expect(isServiceError(result)).toBe(false);
+    if (isServiceError(result)) return;
+
+    await result.data.waitForTokens();
+
+    const [row] = await db
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, instanceId));
+    expect(row?.status).toBe('connected');
+    expect(row?.accessToken).toBe('new-access-token');
+    expect(row?.refreshToken).toBe('existing-refresh-token');
   });
 });

--- a/packages/server/src/connectors/service.ts
+++ b/packages/server/src/connectors/service.ts
@@ -242,7 +242,7 @@ export async function authorizeOAuthInstance(
         .update(connectorInstances)
         .set({
           accessToken: tokens.accessToken,
-          refreshToken: tokens.refreshToken,
+          refreshToken: tokens.refreshToken ?? instance.refreshToken,
           tokenExpiresAt: tokens.expiresIn ? now + tokens.expiresIn * 1000 : null,
           status: 'connected' as ConnectorStatus,
           authIssue: null,


### PR DESCRIPTION
## Change Summary

This PR fixes repeated Google/Gmail reauthorization by preserving existing refresh tokens when Google omits a new one during re-auth, preventing connected accounts from losing their ability to refresh access tokens.

### Bug Fixes
- Preserve the existing OAuth refresh token during reauthorization when the provider response does not include a replacement refresh token.
- Read the latest Google access token from the database for tool calls so background refreshes are picked up immediately instead of serving stale in-memory tokens.
- Treat invalid_grant responses with significant client/server clock skew as transient instead of immediately forcing reauthorization.
- Retry transient background token refresh failures with bounded exponential backoff while still avoiding retries for permanent refresh-token failures.

### Improvements
- Add Google OAuth setup guidance to publish the app from the Audience page so refresh tokens do not expire after the Testing-mode window.
- Add regression coverage for refresh-token preservation, clock-skew invalid_grant handling, and retry behavior.