### PR TITLE
Fix tool call error display

### DIFF
--- a/apps/web/src/components/chat/message-bubble/assistant-message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble/assistant-message-bubble.tsx
@@ -9,6 +9,7 @@ import ChatMarkdown from '@/components/chat/chat-markdown';
 import { ErrorPanel } from '@/components/chat/error-panel';
 import { ReasoningBlock } from '@/components/chat/message-bubble/reasoning-block.js';
 import { SourceChip } from '@/components/chat/message-bubble/source-chip.js';
+import { buildStoredToolCallDisplayItems } from '@/components/chat/message-bubble/tool-call-display.js';
 import { ToolCallGroup } from '@/components/chat/message-bubble/tool-call-group.js';
 
 type AssistantMessageBubbleProps = {
@@ -62,30 +63,7 @@ export function AssistantMessageBubble({
             return (
               <ToolCallGroup
                 key={segment.key}
-                calls={segment.parts.filter(isVisibleToolCallPart).map((part) => {
-                  const result = resultsByCallId.get(part.toolCallId);
-                  const output = result && 'output' in result ? result.output : undefined;
-                  const isError = isToolResultError(output);
-                  const missingResult = !result;
-                  const status = missingResult || isError ? 'error' : 'completed';
-
-                  let toolError: string | undefined;
-                  if (isError) {
-                    const rawError = (output as { error?: unknown }).error;
-                    toolError = typeof rawError === 'string' ? rawError : String(rawError);
-                  } else if (missingResult) {
-                    toolError = wasAborted ? 'Interrupted' : 'Blocked or failed before completion';
-                  }
-
-                  return {
-                    id: part.toolCallId,
-                    toolName: part.toolName,
-                    status,
-                    args: part.input,
-                    result: output,
-                    error: toolError,
-                  };
-                })}
+                calls={buildStoredToolCallDisplayItems(segment.parts, resultsByCallId, wasAborted)}
                 onAbort={onAbortTool}
               />
             );
@@ -111,22 +89,4 @@ export function AssistantMessageBubble({
       {wasAborted && <InterruptedLabel />}
     </AssistantBubbleWrapper>
   );
-}
-
-function isToolResultError(output: unknown): boolean {
-  return (
-    output !== null &&
-    output !== undefined &&
-    typeof output === 'object' &&
-    ('error' in output || (output as { failed?: unknown }).failed === true)
-  );
-}
-
-function isVisibleToolCallPart(part: StoredPart): part is StoredPart & {
-  type: 'tool-call';
-  toolCallId: string;
-  toolName: string;
-  input: unknown;
-} {
-  return part.type === 'tool-call' && part.toolName !== 'todo';
 }

--- a/apps/web/src/components/chat/message-bubble/streaming-message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble/streaming-message-bubble.tsx
@@ -6,6 +6,7 @@ import { AssistantBubbleWrapper, FileBlock } from './shared-components';
 import ChatMarkdown from '@/components/chat/chat-markdown';
 import { ReasoningBlock } from '@/components/chat/message-bubble/reasoning-block.js';
 import { SourceChip } from '@/components/chat/message-bubble/source-chip.js';
+import { buildStreamingToolCallDisplayItems } from '@/components/chat/message-bubble/tool-call-display.js';
 import { ToolCallGroup } from '@/components/chat/message-bubble/tool-call-group.js';
 import type { StreamingPart } from '@/stores/stream-store';
 
@@ -51,20 +52,7 @@ export const StreamingMessageBubble = React.memo(function StreamingMessageBubble
     nodes.push(
       <ToolCallGroup
         key={group.key}
-        calls={group.partIds.flatMap((partId) => {
-          const part = parts[partId];
-          if (!part || part.type !== 'tool-call' || part.toolName === 'todo') return [];
-          return [
-            {
-              id: part.toolCallId,
-              toolName: part.toolName,
-              status: part.status,
-              args: part.input,
-              result: part.output,
-              error: part.error ?? undefined,
-            },
-          ];
-        })}
+        calls={buildStreamingToolCallDisplayItems(group.partIds, parts)}
         onAbort={onAbortTool}
       />,
     );

--- a/apps/web/src/components/chat/message-bubble/tool-call-display.ts
+++ b/apps/web/src/components/chat/message-bubble/tool-call-display.ts
@@ -1,0 +1,322 @@
+import type { StoredPart } from '@stitch/shared/chat/messages';
+import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
+import { parseMcpToolName } from '@stitch/shared/mcp/types';
+
+import { formatToolDisplayName, truncateText } from './tool-call/card-primitives';
+
+import { getToolIconKind, type ToolIconKind } from '@/components/tools/tool-icons';
+import type { StreamingPart } from '@/stores/stream-store';
+
+const GOOGLE_SERVICE_ICON_SLUGS = {
+  gmail: 'gmail',
+  drive: 'googledrive',
+  docs: 'googledocs',
+  sheets: 'googlesheets',
+  calendar: 'googlecalendar',
+} as const;
+
+type ToolSummaryKind = ToolIconKind;
+
+export type ToolCallDisplayItem = {
+  id: string;
+  toolName: string;
+  status: ToolCallStatus;
+  args?: unknown;
+  result?: unknown;
+  error?: string;
+};
+
+export type ToolCallSummary = {
+  kind: ToolSummaryKind;
+  label: string;
+  preview: string;
+  meta?: string;
+  connectorIconSlug: string | null;
+  mcpServerId: string | null;
+};
+
+export type ToolCallAction = { type: 'open-child-session'; sessionId: string };
+
+type StoredToolResult = StoredPart & { type: 'tool-result' };
+
+export function buildStoredToolCallDisplayItems(
+  parts: StoredPart[],
+  resultsByCallId: Map<string, StoredToolResult>,
+  wasAborted: boolean,
+): ToolCallDisplayItem[] {
+  return parts.filter(isVisibleStoredToolCallPart).map((part) => {
+    const result = resultsByCallId.get(part.toolCallId);
+    const output = result && 'output' in result ? result.output : undefined;
+    const isError = isToolResultError(output);
+    const missingResult = !result;
+    const status = missingResult || isError ? 'error' : 'completed';
+
+    let toolError: string | undefined;
+    if (isError) {
+      const rawError = (output as { error?: unknown }).error;
+      toolError = typeof rawError === 'string' ? rawError : String(rawError);
+    } else if (missingResult) {
+      toolError = wasAborted ? 'Interrupted' : 'Blocked or failed before completion';
+    }
+
+    return {
+      id: part.toolCallId,
+      toolName: part.toolName,
+      status,
+      args: part.input,
+      result: output,
+      error: toolError,
+    };
+  });
+}
+
+export function buildStreamingToolCallDisplayItems(
+  partIds: string[],
+  parts: Record<string, StreamingPart>,
+): ToolCallDisplayItem[] {
+  return partIds.flatMap((partId) => {
+    const part = parts[partId];
+    if (!part || part.type !== 'tool-call' || part.toolName === 'todo') return [];
+
+    return [
+      {
+        id: part.toolCallId,
+        toolName: part.toolName,
+        status: part.status,
+        args: part.input,
+        result: part.output,
+        error: part.error ?? undefined,
+      },
+    ];
+  });
+}
+
+export function getToolSummary(
+  call: ToolCallDisplayItem,
+  displayName: string,
+): ToolCallSummary {
+  const kind = getToolKind(call.toolName);
+  const label = getToolLabel(call.toolName, displayName, kind);
+  const preview = getToolPreview(call, kind);
+  const meta = getToolMeta(call);
+  const connectorIconSlug = getConnectorIconSlug(call.toolName);
+  const mcpServerId = parseMcpToolName(call.toolName)?.serverId ?? null;
+
+  return { kind, label, preview, meta, connectorIconSlug, mcpServerId };
+}
+
+export function getToolCallActions(call: ToolCallDisplayItem): ToolCallAction[] {
+  const childSessionId = getChildSessionId(call.result);
+  return childSessionId ? [{ type: 'open-child-session', sessionId: childSessionId }] : [];
+}
+
+function isVisibleStoredToolCallPart(part: StoredPart): part is StoredPart & {
+  type: 'tool-call';
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+} {
+  return part.type === 'tool-call' && part.toolName !== 'todo';
+}
+
+function isToolResultError(output: unknown): boolean {
+  return (
+    output !== null &&
+    output !== undefined &&
+    typeof output === 'object' &&
+    ('error' in output || (output as { failed?: unknown }).failed === true)
+  );
+}
+
+function getChildSessionId(result: unknown): string | null {
+  if (!result || typeof result !== 'object') return null;
+  const id = (result as Record<string, unknown>).childSessionId;
+  return typeof id === 'string' ? id : null;
+}
+
+function getToolKind(toolName: string): ToolSummaryKind {
+  if (parseMcpToolName(toolName)) return 'mcp';
+  return getToolIconKind(toolName);
+}
+
+function getToolLabel(toolName: string, displayName: string, kind: ToolSummaryKind): string {
+  if (toolName === 'gmail_download_attachments') return 'Gmail Attachments';
+
+  if (kind === 'mcp') {
+    const parsed = parseMcpToolName(toolName);
+    return parsed ? formatToolDisplayName(parsed.toolName) : displayName;
+  }
+
+  if (toolName === 'execute_typescript') return 'Code';
+  return displayName;
+}
+
+function getConnectorIconSlug(toolName: string): string | null {
+  const service = toolName.split('_', 1)[0];
+  if (!service) return null;
+  return GOOGLE_SERVICE_ICON_SLUGS[service as keyof typeof GOOGLE_SERVICE_ICON_SLUGS] ?? null;
+}
+
+function getToolPreview(call: ToolCallDisplayItem, kind: ToolSummaryKind): string {
+  if (call.error) return truncateText(call.error, 96);
+
+  for (const getPreview of [getToolsetPreview, getGmailPreview, getSkillPreview]) {
+    const preview = getPreview(call);
+    if (preview) return preview;
+  }
+
+  switch (kind) {
+    case 'bash':
+      return getStringArg(call.args, ['description', 'command', 'code']) ?? 'Running command';
+    case 'read':
+      return getStringArg(call.args, ['filePath', 'path']) ?? 'Waiting for path';
+    case 'edit':
+      return getStringArg(call.args, ['filePath', 'path']) ?? 'Editing file';
+    case 'write':
+      return getStringArg(call.args, ['filePath', 'path']) ?? 'Writing file';
+    case 'search':
+      return getStringArg(call.args, ['query', 'pattern', 'q']) ?? 'Searching';
+    case 'web':
+      return getStringArg(call.args, ['url', 'target', 'action']) ?? 'Using browser';
+    case 'task':
+      return getStringArg(call.args, ['description', 'prompt', 'command']) ?? 'Running subagent';
+    case 'question':
+      return getStringArg(call.args, ['question', 'header']) ?? 'Waiting for response';
+    case 'skill':
+      return 'Loading skill';
+    case 'memory':
+      return getStringArg(call.args, ['action', 'content']) ?? 'Using memory';
+    case 'todo':
+      return getStringArg(call.args, ['action']) ?? 'Updating todos';
+    case 'agenda':
+      return getBestGenericPreview(call.args, call.result) ?? 'Using agenda';
+    case 'browser':
+      return getStringArg(call.args, ['url', 'action', 'ref']) ?? 'Using browser';
+    case 'recordings':
+      return getBestGenericPreview(call.args, call.result) ?? 'Using recordings';
+    case 'session-history':
+      return getBestGenericPreview(call.args, call.result) ?? 'Searching sessions';
+    case 'inspect-image':
+      return getStringArg(call.args, ['prompt', 'imagePath']) ?? 'Inspecting image';
+    case 'mcp':
+    case 'generic':
+      return getBestGenericPreview(call.args, call.result) ?? 'Using tool';
+  }
+}
+
+function getSkillPreview(call: ToolCallDisplayItem): string | null {
+  if (call.toolName !== 'skill') return null;
+
+  if (call.status === 'pending' || call.status === 'in-progress') {
+    return 'Loading skill';
+  }
+
+  return 'Reading skill';
+}
+
+function getToolsetPreview(call: ToolCallDisplayItem): string | null {
+  if (!isToolsetTool(call.toolName)) return null;
+
+  const toolsetName =
+    getStringArg(call.result, ['toolsetName', 'name']) ?? getStringArg(call.args, ['toolsetId']);
+  const normalizedName = toolsetName ?? 'toolset';
+
+  if (call.toolName === 'list_toolsets') {
+    const toolsets = getArrayLength(call.result, 'toolsets');
+    if (toolsets !== null) return `${toolsets} available toolsets`;
+
+    const query = getStringArg(call.args, ['query']);
+    return query ? `Find toolsets matching ${query}` : 'Review available toolsets';
+  }
+
+  if (call.toolName === 'activate_toolset') {
+    if (call.status === 'pending' || call.status === 'in-progress') {
+      return `Activating ${normalizedName}`;
+    }
+
+    const tools = getArrayLength(call.result, 'tools');
+    const suffix = tools !== null ? ` with ${tools} tools` : '';
+    return `Activated ${normalizedName}${suffix}`;
+  }
+
+  if (call.toolName === 'deactivate_toolset') {
+    if (call.status === 'pending' || call.status === 'in-progress') {
+      return `Deactivating ${normalizedName}`;
+    }
+    return `Removed ${normalizedName} tools`;
+  }
+
+  return null;
+}
+
+function getGmailPreview(call: ToolCallDisplayItem): string | null {
+  if (call.toolName === 'gmail_download_attachments') {
+    const attachments = getArrayLength(call.result, 'attachments');
+    if (attachments !== null) {
+      return attachments === 0
+        ? 'No attachments found'
+        : `Downloaded ${attachments} attachment${attachments === 1 ? '' : 's'}`;
+    }
+
+    const messageId = getStringArg(call.args, ['messageId']);
+    return messageId ? `Download attachments from message ${messageId}` : 'Download attachments';
+  }
+
+  if (call.toolName === 'gmail_read') {
+    const subject = getStringArg(call.result, ['subject']);
+    if (subject) return subject;
+
+    const messageId = getStringArg(call.args, ['messageId']);
+    return messageId ? `Read message ${messageId}` : 'Read message';
+  }
+
+  return null;
+}
+
+function isToolsetTool(toolName: string): boolean {
+  return (
+    toolName === 'list_toolsets' ||
+    toolName === 'activate_toolset' ||
+    toolName === 'deactivate_toolset'
+  );
+}
+
+function getArrayLength(value: unknown, key: string): number | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = (value as Record<string, unknown>)[key];
+  return Array.isArray(raw) ? raw.length : null;
+}
+
+function getToolMeta(call: ToolCallDisplayItem): string | undefined {
+  if (call.status === 'error') return undefined;
+
+  if (call.toolName === 'skill') {
+    return getStringArg(call.args, ['name', 'skill']) ?? undefined;
+  }
+
+  const exitCode = (call.result as { metadata?: { exit?: unknown } } | undefined)?.metadata?.exit;
+  if (typeof exitCode === 'number' && exitCode !== 0) return `exit ${exitCode}`;
+
+  const usedAccount =
+    getStringArg(call.args, ['account']) ?? getStringArg(call.result, ['usedAccount', 'account']);
+  return usedAccount ?? undefined;
+}
+
+function getBestGenericPreview(args: unknown, result: unknown): string | null {
+  return (
+    getStringArg(args, ['description', 'query', 'title', 'name', 'id']) ??
+    getStringArg(result, ['title', 'name', 'id'])
+  );
+}
+
+function getStringArg(value: unknown, keys: string[]): string | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+
+  for (const key of keys) {
+    const raw = record[key];
+    if (typeof raw === 'string' && raw.trim().length > 0) return truncateText(raw.trim(), 120);
+  }
+
+  return null;
+}

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -4,34 +4,25 @@ import * as React from 'react';
 import { Link } from '@tanstack/react-router';
 
 import type { ToolCallStatus } from '@stitch/shared/chat/realtime';
-import { parseMcpToolName } from '@stitch/shared/mcp/types';
 
 import {
-  formatToolDisplayName,
-  truncateText,
-  useStitchToolDisplayName,
-} from './tool-call/card-primitives';
+  getToolCallActions,
+  getToolSummary,
+  type ToolCallAction,
+  type ToolCallDisplayItem,
+  type ToolCallSummary,
+} from './tool-call-display';
+import { useStitchToolDisplayName } from './tool-call/card-primitives';
 
 import { ConnectorIcon } from '@/components/connectors/connector-icon';
 import { McpServerLogo } from '@/components/mcp/mcp-server-logo';
-import { getToolIconKind, ToolKindIcon, type ToolIconKind } from '@/components/tools/tool-icons';
+import { ToolKindIcon } from '@/components/tools/tool-icons';
 import { Button } from '@/components/ui/button';
 import { CopyButton } from '@/components/ui/copy-button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
 const VISIBLE_TOOL_COUNT = 4;
-
-type ToolSummaryKind = ToolIconKind;
-
-type ToolCallDisplayItem = {
-  id: string;
-  toolName: string;
-  status: ToolCallStatus;
-  args?: unknown;
-  result?: unknown;
-  error?: string;
-};
 
 type ToolCallGroupProps = {
   calls: ToolCallDisplayItem[];
@@ -58,13 +49,14 @@ const STATUS_LABEL: Record<ToolCallStatus, string> = {
   error: 'Error',
 };
 
-const GOOGLE_SERVICE_ICON_SLUGS = {
-  gmail: 'gmail',
-  drive: 'googledrive',
-  docs: 'googledocs',
-  sheets: 'googlesheets',
-  calendar: 'googlecalendar',
-} as const;
+type ToolCallRowContextValue = {
+  call: ToolCallDisplayItem;
+  summary: ToolCallSummary;
+  errorDetails: ToolErrorDetails | null;
+  onViewErrorDetails: (details: ToolErrorDetails) => void;
+};
+
+const ToolCallRowContext = React.createContext<ToolCallRowContextValue | null>(null);
 
 export function ToolCallGroup({ calls, onAbort }: ToolCallGroupProps) {
   const [expanded, setExpanded] = React.useState(false);
@@ -100,7 +92,7 @@ export function ToolCallGroup({ calls, onAbort }: ToolCallGroupProps) {
 
       <div className="space-y-0.5">
         {visibleCalls.map((call, index) => (
-          <ToolCallRow
+          <ToolCallDisplayRow
             key={call.id}
             call={call}
             onAbort={onAbort}
@@ -115,19 +107,7 @@ export function ToolCallGroup({ calls, onAbort }: ToolCallGroupProps) {
   );
 }
 
-const CHILD_SESSION_TOOLS = new Set(['task', 'inspect_image']);
-
-function isChildSessionTool(toolName: string): boolean {
-  return CHILD_SESSION_TOOLS.has(toolName);
-}
-
-function getChildSessionId(result: unknown): string | null {
-  if (!result || typeof result !== 'object') return null;
-  const id = (result as Record<string, unknown>).childSessionId;
-  return typeof id === 'string' ? id : null;
-}
-
-function ToolCallRow({
+function ToolCallDisplayRow({
   call,
   onAbort,
   onViewErrorDetails,
@@ -137,97 +117,6 @@ function ToolCallRow({
   onAbort?: () => void;
   onViewErrorDetails: (details: ToolErrorDetails) => void;
   animateIn: boolean;
-}) {
-  if (isChildSessionTool(call.toolName)) {
-    return (
-      <ChildSessionToolCallRow
-        call={call}
-        onAbort={onAbort}
-        onViewErrorDetails={onViewErrorDetails}
-        animateIn={animateIn}
-      />
-    );
-  }
-
-  return (
-    <DefaultToolCallRow
-      call={call}
-      onAbort={onAbort}
-      onViewErrorDetails={onViewErrorDetails}
-      animateIn={animateIn}
-    />
-  );
-}
-
-function DefaultToolCallRow({
-  call,
-  onAbort,
-  onViewErrorDetails,
-  animateIn,
-}: {
-  call: ToolCallDisplayItem;
-  onAbort?: () => void;
-  onViewErrorDetails: (details: ToolErrorDetails) => void;
-  animateIn: boolean;
-}) {
-  return (
-    <ToolCallRowBase
-      call={call}
-      onAbort={onAbort}
-      onViewErrorDetails={onViewErrorDetails}
-      animateIn={animateIn}
-    />
-  );
-}
-
-function ChildSessionToolCallRow({
-  call,
-  onAbort,
-  onViewErrorDetails,
-  animateIn,
-}: {
-  call: ToolCallDisplayItem;
-  onAbort?: () => void;
-  onViewErrorDetails: (details: ToolErrorDetails) => void;
-  animateIn: boolean;
-}) {
-  const childSessionId = getChildSessionId(call.result);
-
-  return (
-    <ToolCallRowBase
-      call={call}
-      onAbort={onAbort}
-      onViewErrorDetails={onViewErrorDetails}
-      animateIn={animateIn}
-    >
-      {childSessionId ? (
-        <Button
-          variant="ghost"
-          size="xs"
-          className="h-5 px-1.5 text-[11px] text-muted-foreground"
-          title="Open child session"
-          render={<Link to="/session/$id" params={{ id: childSessionId }} />}
-        >
-          <ExternalLinkIcon className="size-2.5" />
-          Open
-        </Button>
-      ) : null}
-    </ToolCallRowBase>
-  );
-}
-
-function ToolCallRowBase({
-  call,
-  onAbort,
-  onViewErrorDetails,
-  animateIn,
-  children,
-}: {
-  call: ToolCallDisplayItem;
-  onAbort?: () => void;
-  onViewErrorDetails: (details: ToolErrorDetails) => void;
-  animateIn: boolean;
-  children?: React.ReactNode;
 }) {
   const displayName = useStitchToolDisplayName(call.toolName);
   const summary = getToolSummary(call, displayName);
@@ -236,79 +125,169 @@ function ToolCallRowBase({
     call.status === 'error' && call.error
       ? { toolName: call.toolName, label: summary.label, error: call.error }
       : null;
-  const viewErrorDetails = () => {
-    if (!errorDetails) return;
-    onViewErrorDetails(errorDetails);
-  };
+  const actions = getToolCallActions(call);
 
   return (
-    <div
-      className={cn(
-        'group flex min-h-7 min-w-0 items-center gap-2 rounded-md px-1.5 text-xs transition-colors hover:bg-muted/40',
-        animateIn && isActive && 'animate-in fade-in slide-in-from-top-1 duration-200',
-      )}
+    <ToolCallRow.Root
+      call={call}
+      summary={summary}
+      errorDetails={errorDetails}
+      onViewErrorDetails={onViewErrorDetails}
+      animateIn={animateIn && isActive}
     >
-      <ToolStatusIcon
-        status={call.status}
-        kind={summary.kind}
-        connectorIconSlug={summary.connectorIconSlug}
-        mcpServerId={summary.mcpServerId}
-        label={summary.label}
-      />
-      <span className="shrink-0 font-medium text-foreground">{summary.label}</span>
-      {errorDetails ? (
-        <button
-          type="button"
-          onClick={viewErrorDetails}
-          className="min-w-0 flex-1 cursor-pointer truncate text-left text-muted-foreground hover:text-destructive"
-          title="View full error"
-        >
-          {summary.preview}
-        </button>
-      ) : (
-        <span className="min-w-0 flex-1 truncate text-muted-foreground">{summary.preview}</span>
-      )}
-      <span className="hidden h-5 w-44 shrink-0 items-center justify-end truncate text-right text-[11px] leading-none text-muted-foreground/80 sm:flex">
-        {summary.meta}
-      </span>
-      {errorDetails ? (
-        <button
-          type="button"
-          onClick={viewErrorDetails}
-          className={cn(
-            'flex h-5 w-12 shrink-0 cursor-pointer items-center justify-end text-right text-[11px] leading-none font-medium hover:underline',
-            STATUS_CLASS[call.status],
-          )}
-          title="View full error"
-        >
-          {STATUS_LABEL[call.status]}
-        </button>
-      ) : (
-        <span
-          className={cn(
-            'flex h-5 w-12 shrink-0 items-center justify-end text-right text-[11px] leading-none font-medium',
-            STATUS_CLASS[call.status],
-          )}
-        >
-          {STATUS_LABEL[call.status]}
-        </span>
-      )}
-      {isActive && onAbort ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="xs"
-          onClick={onAbort}
-          className="h-5 px-1.5 text-[11px] text-destructive hover:text-destructive"
-          title="Stop running tool"
-        >
-          <SquareIcon className="size-2.5" />
-          Stop
-        </Button>
-      ) : null}
-      {children}
-    </div>
+      <ToolCallRow.Icon />
+      <ToolCallRow.Label />
+      <ToolCallRow.Preview />
+      <ToolCallRow.Meta />
+      <ToolCallRow.Status />
+      {isActive && onAbort ? <ToolCallRow.StopButton onAbort={onAbort} /> : null}
+      <ToolCallRow.Actions actions={actions} />
+    </ToolCallRow.Root>
   );
+}
+
+const ToolCallRow = {
+  Root: ToolCallRowRoot,
+  Icon: ToolCallRowIcon,
+  Label: ToolCallRowLabel,
+  Preview: ToolCallRowPreview,
+  Meta: ToolCallRowMeta,
+  Status: ToolCallRowStatus,
+  StopButton: ToolCallRowStopButton,
+  Actions: ToolCallRowActions,
+};
+
+function ToolCallRowRoot({
+  call,
+  summary,
+  errorDetails,
+  onViewErrorDetails,
+  animateIn,
+  children,
+}: {
+  call: ToolCallDisplayItem;
+  summary: ToolCallSummary;
+  errorDetails: ToolErrorDetails | null;
+  onViewErrorDetails: (details: ToolErrorDetails) => void;
+  animateIn: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <ToolCallRowContext.Provider value={{ call, summary, errorDetails, onViewErrorDetails }}>
+      <div
+        className={cn(
+          'group flex min-h-7 min-w-0 items-center gap-2 rounded-md px-1.5 text-xs transition-colors hover:bg-muted/40',
+          animateIn && 'animate-in fade-in slide-in-from-top-1 duration-200',
+        )}
+      >
+        {children}
+      </div>
+    </ToolCallRowContext.Provider>
+  );
+}
+
+function ToolCallRowIcon() {
+  const { call, summary } = useToolCallRow();
+  return <ToolStatusIcon status={call.status} summary={summary} />;
+}
+
+function ToolCallRowLabel() {
+  const { summary } = useToolCallRow();
+  return <span className="shrink-0 font-medium text-foreground">{summary.label}</span>;
+}
+
+function ToolCallRowPreview() {
+  const { summary, errorDetails, onViewErrorDetails } = useToolCallRow();
+
+  if (!errorDetails) {
+    return <span className="min-w-0 flex-1 truncate text-muted-foreground">{summary.preview}</span>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onViewErrorDetails(errorDetails)}
+      className="min-w-0 flex-1 cursor-pointer truncate text-left text-muted-foreground hover:text-destructive"
+      title="View full error"
+    >
+      {summary.preview}
+    </button>
+  );
+}
+
+function ToolCallRowMeta() {
+  const { summary } = useToolCallRow();
+  return (
+    <span className="hidden h-5 w-44 shrink-0 items-center justify-end truncate text-right text-[11px] leading-none text-muted-foreground/80 sm:flex">
+      {summary.meta}
+    </span>
+  );
+}
+
+function ToolCallRowStatus() {
+  const { call, errorDetails, onViewErrorDetails } = useToolCallRow();
+  const className = cn(
+    'flex h-5 w-12 shrink-0 items-center justify-end text-right text-[11px] leading-none font-medium',
+    STATUS_CLASS[call.status],
+  );
+
+  if (!errorDetails) {
+    return <span className={className}>{STATUS_LABEL[call.status]}</span>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onViewErrorDetails(errorDetails)}
+      className={cn(className, 'cursor-pointer hover:underline')}
+      title="View full error"
+    >
+      {STATUS_LABEL[call.status]}
+    </button>
+  );
+}
+
+function ToolCallRowStopButton({ onAbort }: { onAbort: () => void }) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="xs"
+      onClick={onAbort}
+      className="h-5 px-1.5 text-[11px] text-destructive hover:text-destructive"
+      title="Stop running response"
+    >
+      <SquareIcon className="size-2.5" />
+      Stop
+    </Button>
+  );
+}
+
+function ToolCallRowActions({ actions }: { actions: ToolCallAction[] }) {
+  return actions.map((action) => {
+    switch (action.type) {
+      case 'open-child-session':
+        return (
+          <Button
+            key={`${action.type}-${action.sessionId}`}
+            variant="ghost"
+            size="xs"
+            className="h-5 px-1.5 text-[11px] leading-3 text-muted-foreground"
+            title="Open child session"
+            render={<Link to="/session/$id" params={{ id: action.sessionId }} />}
+          >
+            <ExternalLinkIcon className="size-3" />
+            <span className="leading-3">Open</span>
+          </Button>
+        );
+    }
+  });
+}
+
+function useToolCallRow() {
+  const context = React.useContext(ToolCallRowContext);
+  if (!context) throw new Error('ToolCallRow components must be rendered inside ToolCallRow.Root');
+  return context;
 }
 
 function ToolErrorDetailsDialog({
@@ -342,221 +321,7 @@ function ToolErrorDetailsDialog({
   );
 }
 
-function getToolSummary(call: ToolCallDisplayItem, displayName: string) {
-  const kind = getToolKind(call.toolName);
-  const label = getToolLabel(call.toolName, displayName, kind);
-  const preview = getToolPreview(call, kind);
-  const meta = getToolMeta(call);
-  const connectorIconSlug = getConnectorIconSlug(call.toolName);
-  const mcpServerId = parseMcpToolName(call.toolName)?.serverId ?? null;
-
-  return { kind, label, preview, meta, connectorIconSlug, mcpServerId };
-}
-
-function getToolKind(toolName: string): ToolSummaryKind {
-  if (parseMcpToolName(toolName)) return 'mcp';
-  return getToolIconKind(toolName);
-}
-
-function getToolLabel(toolName: string, displayName: string, kind: ToolSummaryKind): string {
-  if (toolName === 'gmail_download_attachments') return 'Gmail Attachments';
-
-  if (kind === 'mcp') {
-    const parsed = parseMcpToolName(toolName);
-    return parsed ? formatToolDisplayName(parsed.toolName) : displayName;
-  }
-
-  if (toolName === 'execute_typescript') return 'Code';
-  return displayName;
-}
-
-function getConnectorIconSlug(toolName: string): string | null {
-  const service = toolName.split('_', 1)[0];
-  if (!service) return null;
-  return GOOGLE_SERVICE_ICON_SLUGS[service as keyof typeof GOOGLE_SERVICE_ICON_SLUGS] ?? null;
-}
-
-function getToolPreview(call: ToolCallDisplayItem, kind: ToolSummaryKind): string {
-  if (call.error) return truncateText(call.error, 96);
-
-  const toolsetPreview = getToolsetPreview(call);
-  if (toolsetPreview) return toolsetPreview;
-
-  const gmailPreview = getGmailPreview(call);
-  if (gmailPreview) return gmailPreview;
-
-  const skillPreview = getSkillPreview(call);
-  if (skillPreview) return skillPreview;
-
-  switch (kind) {
-    case 'bash':
-      return getStringArg(call.args, ['description', 'command', 'code']) ?? 'Running command';
-    case 'read':
-      return getStringArg(call.args, ['filePath', 'path']) ?? 'Waiting for path';
-    case 'edit':
-      return getStringArg(call.args, ['filePath', 'path']) ?? 'Editing file';
-    case 'write':
-      return getStringArg(call.args, ['filePath', 'path']) ?? 'Writing file';
-    case 'search':
-      return getStringArg(call.args, ['query', 'pattern', 'q']) ?? 'Searching';
-    case 'web':
-      return getStringArg(call.args, ['url', 'target', 'action']) ?? 'Using browser';
-    case 'task':
-      return getStringArg(call.args, ['description', 'prompt', 'command']) ?? 'Running subagent';
-    case 'question':
-      return getStringArg(call.args, ['question', 'header']) ?? 'Waiting for response';
-    case 'skill':
-      return 'Loading skill';
-    case 'memory':
-      return getStringArg(call.args, ['action', 'content']) ?? 'Using memory';
-    case 'todo':
-      return getStringArg(call.args, ['action']) ?? 'Updating todos';
-    case 'agenda':
-      return getBestGenericPreview(call.args, call.result) ?? 'Using agenda';
-    case 'browser':
-      return getStringArg(call.args, ['url', 'action', 'ref']) ?? 'Using browser';
-    case 'recordings':
-      return getBestGenericPreview(call.args, call.result) ?? 'Using recordings';
-    case 'session-history':
-      return getBestGenericPreview(call.args, call.result) ?? 'Searching sessions';
-    case 'inspect-image':
-      return getStringArg(call.args, ['prompt', 'imagePath']) ?? 'Inspecting image';
-    case 'mcp':
-    case 'generic':
-      return getBestGenericPreview(call.args, call.result) ?? 'Using tool';
-  }
-}
-
-function getSkillPreview(call: ToolCallDisplayItem): string | null {
-  if (call.toolName !== 'skill') return null;
-
-  if (call.status === 'pending' || call.status === 'in-progress') {
-    return 'Loading skill';
-  }
-
-  return 'Reading skill';
-}
-
-function getToolsetPreview(call: ToolCallDisplayItem): string | null {
-  if (!isToolsetTool(call.toolName)) return null;
-
-  const toolsetName =
-    getStringArg(call.result, ['toolsetName', 'name']) ?? getStringArg(call.args, ['toolsetId']);
-  const normalizedName = toolsetName ?? 'toolset';
-
-  if (call.toolName === 'list_toolsets') {
-    const toolsets = getArrayLength(call.result, 'toolsets');
-    if (toolsets !== null) return `${toolsets} available toolsets`;
-
-    const query = getStringArg(call.args, ['query']);
-    return query ? `Find toolsets matching ${query}` : 'Review available toolsets';
-  }
-
-  if (call.toolName === 'activate_toolset') {
-    if (call.status === 'pending' || call.status === 'in-progress') {
-      return `Activating ${normalizedName}`;
-    }
-
-    const tools = getArrayLength(call.result, 'tools');
-    const suffix = tools !== null ? ` with ${tools} tools` : '';
-    return `Activated ${normalizedName}${suffix}`;
-  }
-
-  if (call.toolName === 'deactivate_toolset') {
-    if (call.status === 'pending' || call.status === 'in-progress') {
-      return `Deactivating ${normalizedName}`;
-    }
-    return `Removed ${normalizedName} tools`;
-  }
-
-  return null;
-}
-
-function getGmailPreview(call: ToolCallDisplayItem): string | null {
-  if (call.toolName === 'gmail_download_attachments') {
-    const attachments = getArrayLength(call.result, 'attachments');
-    if (attachments !== null) {
-      return attachments === 0
-        ? 'No attachments found'
-        : `Downloaded ${attachments} attachment${attachments === 1 ? '' : 's'}`;
-    }
-
-    const messageId = getStringArg(call.args, ['messageId']);
-    return messageId ? `Download attachments from message ${messageId}` : 'Download attachments';
-  }
-
-  if (call.toolName === 'gmail_read') {
-    const subject = getStringArg(call.result, ['subject']);
-    if (subject) return subject;
-
-    const messageId = getStringArg(call.args, ['messageId']);
-    return messageId ? `Read message ${messageId}` : 'Read message';
-  }
-
-  return null;
-}
-
-function isToolsetTool(toolName: string): boolean {
-  return (
-    toolName === 'list_toolsets' ||
-    toolName === 'activate_toolset' ||
-    toolName === 'deactivate_toolset'
-  );
-}
-
-function getArrayLength(value: unknown, key: string): number | null {
-  if (!value || typeof value !== 'object') return null;
-  const raw = (value as Record<string, unknown>)[key];
-  return Array.isArray(raw) ? raw.length : null;
-}
-
-function getToolMeta(call: ToolCallDisplayItem): string | undefined {
-  if (call.status === 'error') return undefined;
-
-  if (call.toolName === 'skill') {
-    return getStringArg(call.args, ['name', 'skill']) ?? undefined;
-  }
-
-  const exitCode = (call.result as { metadata?: { exit?: unknown } } | undefined)?.metadata?.exit;
-  if (typeof exitCode === 'number' && exitCode !== 0) return `exit ${exitCode}`;
-
-  const usedAccount =
-    getStringArg(call.args, ['account']) ?? getStringArg(call.result, ['usedAccount', 'account']);
-  return usedAccount ?? undefined;
-}
-
-function getBestGenericPreview(args: unknown, result: unknown): string | null {
-  return (
-    getStringArg(args, ['description', 'query', 'title', 'name', 'id']) ??
-    getStringArg(result, ['title', 'name', 'id'])
-  );
-}
-
-function getStringArg(value: unknown, keys: string[]): string | null {
-  if (!value || typeof value !== 'object') return null;
-  const record = value as Record<string, unknown>;
-
-  for (const key of keys) {
-    const raw = record[key];
-    if (typeof raw === 'string' && raw.trim().length > 0) return truncateText(raw.trim(), 120);
-  }
-
-  return null;
-}
-
-function ToolStatusIcon({
-  status,
-  kind,
-  connectorIconSlug,
-  mcpServerId,
-  label,
-}: {
-  status: ToolCallStatus;
-  kind: ToolSummaryKind;
-  connectorIconSlug: string | null;
-  mcpServerId: string | null;
-  label: string;
-}) {
+function ToolStatusIcon({ status, summary }: { status: ToolCallStatus; summary: ToolCallSummary }) {
   if (status === 'pending') {
     return <ClockIcon className="size-3.5 shrink-0 text-muted-foreground" />;
   }
@@ -565,20 +330,27 @@ function ToolStatusIcon({
     return <LoaderIcon className="size-3.5 shrink-0 animate-spin text-info" />;
   }
 
-  if (connectorIconSlug) {
+  if (summary.connectorIconSlug) {
     return (
       <ConnectorIcon
-        icon={{ type: 'simpleIcons', slug: connectorIconSlug }}
-        className="size-3.5 shrink-0 bg-success"
+        icon={{ type: 'simpleIcons', slug: summary.connectorIconSlug }}
+        className={cn('size-3.5 shrink-0', status === 'error' ? 'bg-destructive' : 'bg-success')}
       />
     );
   }
 
-  if (mcpServerId) {
-    return <McpServerLogo serverId={mcpServerId} name={label} className="size-3.5" />;
+  if (summary.mcpServerId) {
+    return (
+      <McpServerLogo serverId={summary.mcpServerId} name={summary.label} className="size-3.5" />
+    );
   }
 
-  return <ToolKindIcon kind={kind} className="size-3.5 shrink-0 text-success" />;
+  return (
+    <ToolKindIcon
+      kind={summary.kind}
+      className={cn('size-3.5 shrink-0', status === 'error' ? 'text-destructive' : 'text-success')}
+    />
+  );
 }
 
 function usePrevious(value: number) {

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -16,6 +16,8 @@ import { ConnectorIcon } from '@/components/connectors/connector-icon';
 import { McpServerLogo } from '@/components/mcp/mcp-server-logo';
 import { getToolIconKind, ToolKindIcon, type ToolIconKind } from '@/components/tools/tool-icons';
 import { Button } from '@/components/ui/button';
+import { CopyButton } from '@/components/ui/copy-button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 
 const VISIBLE_TOOL_COUNT = 4;
@@ -34,6 +36,12 @@ type ToolCallDisplayItem = {
 type ToolCallGroupProps = {
   calls: ToolCallDisplayItem[];
   onAbort?: () => void;
+};
+
+type ToolErrorDetails = {
+  toolName: string;
+  label: string;
+  error: string;
 };
 
 const STATUS_CLASS: Record<ToolCallStatus, string> = {
@@ -60,6 +68,7 @@ const GOOGLE_SERVICE_ICON_SLUGS = {
 
 export function ToolCallGroup({ calls, onAbort }: ToolCallGroupProps) {
   const [expanded, setExpanded] = React.useState(false);
+  const [errorDetails, setErrorDetails] = React.useState<ToolErrorDetails | null>(null);
   const hiddenCount = Math.max(0, calls.length - VISIBLE_TOOL_COUNT);
   const visibleCalls = expanded ? calls : calls.slice(hiddenCount);
   const previousHiddenCount = usePrevious(hiddenCount);
@@ -95,10 +104,13 @@ export function ToolCallGroup({ calls, onAbort }: ToolCallGroupProps) {
             key={call.id}
             call={call}
             onAbort={onAbort}
+            onViewErrorDetails={setErrorDetails}
             animateIn={index === visibleCalls.length - 1}
           />
         ))}
       </div>
+
+      <ToolErrorDetailsDialog details={errorDetails} onOpenChange={setErrorDetails} />
     </div>
   );
 }
@@ -118,44 +130,76 @@ function getChildSessionId(result: unknown): string | null {
 function ToolCallRow({
   call,
   onAbort,
+  onViewErrorDetails,
   animateIn,
 }: {
   call: ToolCallDisplayItem;
   onAbort?: () => void;
+  onViewErrorDetails: (details: ToolErrorDetails) => void;
   animateIn: boolean;
 }) {
   if (isChildSessionTool(call.toolName)) {
-    return <ChildSessionToolCallRow call={call} onAbort={onAbort} animateIn={animateIn} />;
+    return (
+      <ChildSessionToolCallRow
+        call={call}
+        onAbort={onAbort}
+        onViewErrorDetails={onViewErrorDetails}
+        animateIn={animateIn}
+      />
+    );
   }
 
-  return <DefaultToolCallRow call={call} onAbort={onAbort} animateIn={animateIn} />;
+  return (
+    <DefaultToolCallRow
+      call={call}
+      onAbort={onAbort}
+      onViewErrorDetails={onViewErrorDetails}
+      animateIn={animateIn}
+    />
+  );
 }
 
 function DefaultToolCallRow({
   call,
   onAbort,
+  onViewErrorDetails,
   animateIn,
 }: {
   call: ToolCallDisplayItem;
   onAbort?: () => void;
+  onViewErrorDetails: (details: ToolErrorDetails) => void;
   animateIn: boolean;
 }) {
-  return <ToolCallRowBase call={call} onAbort={onAbort} animateIn={animateIn} />;
+  return (
+    <ToolCallRowBase
+      call={call}
+      onAbort={onAbort}
+      onViewErrorDetails={onViewErrorDetails}
+      animateIn={animateIn}
+    />
+  );
 }
 
 function ChildSessionToolCallRow({
   call,
   onAbort,
+  onViewErrorDetails,
   animateIn,
 }: {
   call: ToolCallDisplayItem;
   onAbort?: () => void;
+  onViewErrorDetails: (details: ToolErrorDetails) => void;
   animateIn: boolean;
 }) {
   const childSessionId = getChildSessionId(call.result);
 
   return (
-    <ToolCallRowBase call={call} onAbort={onAbort} animateIn={animateIn}>
+    <ToolCallRowBase
+      call={call}
+      onAbort={onAbort}
+      onViewErrorDetails={onViewErrorDetails}
+      animateIn={animateIn}
+    >
       {childSessionId ? (
         <Button
           variant="ghost"
@@ -175,17 +219,27 @@ function ChildSessionToolCallRow({
 function ToolCallRowBase({
   call,
   onAbort,
+  onViewErrorDetails,
   animateIn,
   children,
 }: {
   call: ToolCallDisplayItem;
   onAbort?: () => void;
+  onViewErrorDetails: (details: ToolErrorDetails) => void;
   animateIn: boolean;
   children?: React.ReactNode;
 }) {
   const displayName = useStitchToolDisplayName(call.toolName);
   const summary = getToolSummary(call, displayName);
   const isActive = call.status === 'pending' || call.status === 'in-progress';
+  const errorDetails =
+    call.status === 'error' && call.error
+      ? { toolName: call.toolName, label: summary.label, error: call.error }
+      : null;
+  const viewErrorDetails = () => {
+    if (!errorDetails) return;
+    onViewErrorDetails(errorDetails);
+  };
 
   return (
     <div
@@ -202,18 +256,43 @@ function ToolCallRowBase({
         label={summary.label}
       />
       <span className="shrink-0 font-medium text-foreground">{summary.label}</span>
-      <span className="min-w-0 flex-1 truncate text-muted-foreground">{summary.preview}</span>
+      {errorDetails ? (
+        <button
+          type="button"
+          onClick={viewErrorDetails}
+          className="min-w-0 flex-1 cursor-pointer truncate text-left text-muted-foreground hover:text-destructive"
+          title="View full error"
+        >
+          {summary.preview}
+        </button>
+      ) : (
+        <span className="min-w-0 flex-1 truncate text-muted-foreground">{summary.preview}</span>
+      )}
       <span className="hidden h-5 w-44 shrink-0 items-center justify-end truncate text-right text-[11px] leading-none text-muted-foreground/80 sm:flex">
         {summary.meta}
       </span>
-      <span
-        className={cn(
-          'flex h-5 w-12 shrink-0 items-center justify-end text-right text-[11px] leading-none font-medium',
-          STATUS_CLASS[call.status],
-        )}
-      >
-        {STATUS_LABEL[call.status]}
-      </span>
+      {errorDetails ? (
+        <button
+          type="button"
+          onClick={viewErrorDetails}
+          className={cn(
+            'flex h-5 w-12 shrink-0 cursor-pointer items-center justify-end text-right text-[11px] leading-none font-medium hover:underline',
+            STATUS_CLASS[call.status],
+          )}
+          title="View full error"
+        >
+          {STATUS_LABEL[call.status]}
+        </button>
+      ) : (
+        <span
+          className={cn(
+            'flex h-5 w-12 shrink-0 items-center justify-end text-right text-[11px] leading-none font-medium',
+            STATUS_CLASS[call.status],
+          )}
+        >
+          {STATUS_LABEL[call.status]}
+        </span>
+      )}
       {isActive && onAbort ? (
         <Button
           type="button"
@@ -229,6 +308,37 @@ function ToolCallRowBase({
       ) : null}
       {children}
     </div>
+  );
+}
+
+function ToolErrorDetailsDialog({
+  details,
+  onOpenChange,
+}: {
+  details: ToolErrorDetails | null;
+  onOpenChange: (details: ToolErrorDetails | null) => void;
+}) {
+  return (
+    <Dialog open={details !== null} onOpenChange={(open) => !open && onOpenChange(null)}>
+      <DialogContent className="max-h-[calc(100vh-2rem)] max-w-[calc(100vw-2rem)] gap-3 overflow-hidden sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="pr-16">Tool error</DialogTitle>
+        </DialogHeader>
+        {details ? (
+          <CopyButton
+            value={details.error}
+            copyLabel="Copy full error"
+            copiedLabel="Copied error"
+            variant="ghost"
+            size="icon-sm"
+            className="absolute top-2 right-9"
+          />
+        ) : null}
+        <pre className="max-h-[min(28rem,60vh)] overflow-auto rounded-lg border bg-muted/30 p-3 text-xs whitespace-pre-wrap text-foreground">
+          {details?.error}
+        </pre>
+      </DialogContent>
+    </Dialog>
   );
 }
 


### PR DESCRIPTION
## 🚀 Change Summary

Improves tool call error presentation in chat by exposing full tool error details, preserving recognizable tool icons in error states, and simplifying the tool-call UI rendering path so stored and streaming messages share the same display model.

### ✨ New Features
- **Full Tool Error Details**: Adds an error details dialog with copy support for failed tool calls.

### 🛠 Improvements & Refactors
- **Tool Call Display Model**: Centralizes stored and streaming tool-call normalization in a shared display module.
- **Compound Row Rendering**: Refactors tool-call rows into compound components for clearer rendering structure and easier extension.
- **Consistent Error Icons**: Keeps each tool's normal icon or fallback icon when a call errors instead of replacing it with a generic alert icon.

### 🐛 Bug Fixes
- **Child Session Action Alignment**: Aligns the Open action icon and label for child-session tool calls.