### PR TITLE
fix: align tool call stop button

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+apps/web/src/routeTree.gen.ts text eol=lf

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -254,11 +254,11 @@ function ToolCallRowStopButton({ onAbort }: { onAbort: () => void }) {
       variant="ghost"
       size="xs"
       onClick={onAbort}
-      className="h-5 px-1.5 text-[11px] text-destructive hover:text-destructive"
+      className="h-5 pr-0 pl-1.5 text-[11px] leading-none text-destructive hover:text-destructive"
       title="Stop running response"
     >
       <SquareIcon className="size-2.5" />
-      Stop
+      <span className="leading-none">Stop</span>
     </Button>
   );
 }


### PR DESCRIPTION
## 🚀 Change Summary

Fixes the active tool call Stop button alignment so it lines up with the Running status text and sits flush with completed statuses in the row.

### 🐛 Bug Fixes
- Align the Stop button label with the Running status baseline.
- Remove extra right inset so Stop reaches the same row edge as Done.

### 🛠 Improvements & Refactors
- Normalize generated route tree line endings with a targeted Git attribute to prevent phantom modifications.