### PR TITLE
fix: prevent currency dollars rendering as math

### DIFF
--- a/apps/web/src/components/chat/chat-markdown.test.tsx
+++ b/apps/web/src/components/chat/chat-markdown.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import ChatMarkdown from './chat-markdown.js';
+
+describe('ChatMarkdown', () => {
+  test('renders dollar amounts as text instead of inline math', () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown text="* **$10 Billion Private Placement:** Warren agreed to buy $5 billion." />,
+    );
+
+    expect(html).toContain('$10 Billion Private Placement:');
+    expect(html).toContain('$5 billion');
+    expect(html).not.toContain('katex');
+  });
+
+  test('still renders double-dollar inline math', () => {
+    const html = renderToStaticMarkup(<ChatMarkdown text="Inline math: $$x + y$$" />);
+
+    expect(html).toContain('katex');
+  });
+});

--- a/apps/web/src/components/chat/chat-markdown.tsx
+++ b/apps/web/src/components/chat/chat-markdown.tsx
@@ -289,10 +289,15 @@ function ChatMarkdown({ text, className, isStreaming = false }: ChatMarkdownProp
   }, [isStreaming]);
 
   // During streaming: use remarkGfm only — skip remark-math + rehype-katex (heavy)
-  const remarkPlugins = useMemo(
-    () => (isStreaming ? [remarkGfm] : [remarkGfm, remarkMath]),
-    [isStreaming],
-  );
+  const remarkPlugins = useMemo(() => {
+    if (isStreaming) return [remarkGfm];
+
+    const remarkMathWithoutSingleDollar = [remarkMath, { singleDollarTextMath: false }] as [
+      typeof remarkMath,
+      { singleDollarTextMath: false },
+    ];
+    return [remarkGfm, remarkMathWithoutSingleDollar];
+  }, [isStreaming]);
   const rehypePlugins = useMemo(() => (isStreaming ? [] : [rehypeKatex]), [isStreaming]);
 
   return (


### PR DESCRIPTION
## 🚀 Change Summary

Prevents chat markdown from treating currency amounts like $10 ...  as inline KaTeX math by disabling single-dollar text math parsing while preserving double-dollar math rendering.

### 🐛 Bug Fixes
- Currency amounts in assistant messages now render as normal text instead of malformed math output.
- Added regression coverage for dollar amounts and double-dollar math rendering.