### PR TITLE
Share audio capture with desktop

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@stitch/audio-capture": "workspace:*",
     "electron-updater": "^6.8.3",
     "tree-kill": "1.2.2"
   },

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -4,6 +4,8 @@ import { createServer } from 'node:net';
 import { join, resolve } from 'node:path';
 import treeKill from 'tree-kill';
 
+import { resolveMeetingWatcherBinaryPath, resolveNativeBinaryPath } from '@stitch/audio-capture';
+
 const HEALTH_POLL_INTERVAL_MS = 100;
 const HEALTH_TIMEOUT_MS = 30_000;
 const HOSTNAME = '127.0.0.1';
@@ -128,19 +130,9 @@ export async function spawnServer(port: number): Promise<string> {
 
   if (app.isPackaged) {
     const suffix = process.platform === 'win32' ? '.exe' : '';
-    const audioCaptureBin = join(
-      process.resourcesPath,
-      'audio-capture',
-      `stitch-audio-capture${suffix}`,
-    );
-    const meetingWatchBin = join(
-      process.resourcesPath,
-      'audio-capture',
-      `stitch-meeting-watch${suffix}`,
-    );
     const sandboxBin = join(process.resourcesPath, `stitch-sandbox${suffix}`);
-    sidecarEnv.STITCH_AUDIO_CAPTURE_BIN = audioCaptureBin;
-    sidecarEnv.STITCH_MEETING_WATCH_BIN = meetingWatchBin;
+    sidecarEnv.STITCH_AUDIO_CAPTURE_BIN = resolveNativeBinaryPath();
+    sidecarEnv.STITCH_MEETING_WATCH_BIN = resolveMeetingWatcherBinaryPath();
     sidecarEnv.SANDBOX_EXEC_PATH = sandboxBin;
   } else {
     const root = getMonorepoRoot();

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "lib": ["ESNext"],
     "esModuleInterop": true,
     "strict": true,

--- a/bun.lock
+++ b/bun.lock
@@ -14,8 +14,9 @@
     },
     "apps/desktop": {
       "name": "@stitch/desktop",
-      "version": "0.4.4",
+      "version": "0.4.6",
       "dependencies": {
+        "@stitch/audio-capture": "workspace:*",
         "electron-updater": "^6.8.3",
         "tree-kill": "1.2.2",
       },
@@ -29,7 +30,7 @@
     },
     "apps/web": {
       "name": "@stitch/web",
-      "version": "0.4.4",
+      "version": "0.4.6",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@stitch/shared": "workspace:*",

--- a/packages/audio-capture/package.json
+++ b/packages/audio-capture/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/packages/audio-capture/src/index.ts
+++ b/packages/audio-capture/src/index.ts
@@ -1,6 +1,7 @@
 import { createMacosMeetingDetector } from './meeting-detection/macos.js';
 import { createWindowsMeetingDetector } from './meeting-detection/windows.js';
 import { createNativeDriver } from './native-driver.js';
+export { resolveMeetingWatcherBinaryPath, resolveNativeBinaryPath } from './native-binary.js';
 
 const macosDriver = createNativeDriver('darwin');
 const windowsDriver = createNativeDriver('win32');
@@ -14,7 +15,12 @@ import type {
   StartCaptureInput,
   StopCaptureResult,
 } from './types.js';
-import type { MeetingDetection, MeetingDetectionListener, MeetingDetectionOptions, MeetingDetector } from './types.js';
+import type {
+  MeetingDetection,
+  MeetingDetectionListener,
+  MeetingDetectionOptions,
+  MeetingDetector,
+} from './types.js';
 
 const DRIVERS: Partial<Record<NodeJS.Platform, AudioCaptureDriver>> = {
   darwin: macosDriver,

--- a/packages/audio-capture/src/native-binary.ts
+++ b/packages/audio-capture/src/native-binary.ts
@@ -19,6 +19,10 @@ function getRepoCandidatePaths(binary: NativeBinary): string[] {
   return [
     path.join(sourceDir, '../../../native/target/release', binaryName),
     path.join(sourceDir, '../../../native/target/debug', binaryName),
+    path.join(sourceDir, '../../../../native/target/release', binaryName),
+    path.join(sourceDir, '../../../../native/target/debug', binaryName),
+    path.resolve(process.cwd(), '../../native/target/release', binaryName),
+    path.resolve(process.cwd(), '../../native/target/debug', binaryName),
   ];
 }
 


### PR DESCRIPTION
## 🚀 Change Summary

Enables the Electron desktop main process to consume the shared audio capture package as the first phase of isolating local transport concerns from the server.

Closes #234

### ✨ New Features
- **Desktop Audio Capture Dependency**: Adds @stitch/audio-capture to the desktop app workspace so Electron main can import shared capture utilities.

### 🛠 Improvements & Refactors
- Exposes native audio and meeting watcher binary resolvers from @stitch/audio-capture.
- Routes packaged desktop audio binary environment wiring through the shared resolver functions instead of duplicating paths in sidecar.ts.
- Extends native binary lookup candidates for bundled Electron main output and aligns desktop typechecking with workspace ESM package imports.