### PR TITLE
Move meeting detection to desktop

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'electron-vite';
 
 export default defineConfig({
-  main: {},
+  main: {
+    build: {
+      externalizeDeps: {
+        exclude: ['@stitch/audio-capture'],
+      },
+    },
+  },
   preload: {},
 });

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@stitch/audio-capture": "workspace:*",
+    "@stitch/shared": "workspace:*",
     "electron-updater": "^6.8.3",
     "tree-kill": "1.2.2"
   },

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -12,6 +12,11 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import {
+  configureMeetingDetectionEnv,
+  startMeetingDetection,
+  stopMeetingDetection,
+} from './meeting-detection';
 import { resolveResourcePath } from './resources';
 import { findAvailablePort, killServer, spawnServer } from './sidecar';
 import { destroyTray, initTray } from './tray';
@@ -90,6 +95,7 @@ async function shutdownRuntime(): Promise<void> {
   if (isShuttingDown) return;
   isShuttingDown = true;
   destroyTray();
+  stopMeetingDetection();
   await killServer();
 }
 
@@ -299,6 +305,7 @@ void app.whenReady().then(async () => {
     // Register launch at startup for packaged builds only.
     if (app.isPackaged) {
       app.setLoginItemSettings({ openAtLogin: true });
+      configureMeetingDetectionEnv();
     }
 
     // When a second instance attempts to launch, focus the existing window.
@@ -316,6 +323,7 @@ void app.whenReady().then(async () => {
     const permissionsWereReset = await resetTccPermissionsIfVersionChanged();
 
     await createWindow();
+    startMeetingDetection(() => mainWindow);
 
     if (permissionsWereReset && mainWindow) {
       void dialog.showMessageBox(mainWindow, {

--- a/apps/desktop/src/main/meeting-detection.ts
+++ b/apps/desktop/src/main/meeting-detection.ts
@@ -1,35 +1,50 @@
-import { createMeetingDetector } from '@stitch/audio-capture';
+import type { BrowserWindow } from 'electron';
 
-import * as Events from '@/lib/events.js';
-import * as Log from '@/lib/log.js';
+import { createMeetingDetector, resolveMeetingWatcherBinaryPath } from '@stitch/audio-capture';
 
-const log = Log.create({ service: 'meeting-detection' });
+import type {
+  MeetingCallDetectedPayload,
+  MeetingCallEndedPayload,
+} from '@stitch/shared/chat/realtime';
 
 const detector = createMeetingDetector(process.platform, {
   activationThresholdMs: 5_000,
   cooldownMs: 10 * 60_000,
-  logger: log,
 });
 
 let unsubscribe: (() => void) | null = null;
 let started = false;
 
-export function startMeetingDetection(): void {
+export function configureMeetingDetectionEnv(): void {
+  if (process.env.STITCH_MEETING_WATCH_BIN) {
+    return;
+  }
+
+  process.env.STITCH_MEETING_WATCH_BIN = resolveMeetingWatcherBinaryPath();
+}
+
+export function startMeetingDetection(getWindow: () => BrowserWindow | null): void {
   if (started) {
     return;
   }
 
   started = true;
   unsubscribe = detector.subscribe((event) => {
-    if (event.type === 'ended') {
-      Events.emit('meeting-call-ended', {
-        key: event.key,
-        endedAt: event.endedAt,
-      });
+    const webContents = getWindow()?.webContents;
+    if (!webContents || webContents.isDestroyed()) {
       return;
     }
 
-    Events.emit('meeting-call-detected', {
+    if (event.type === 'ended') {
+      const payload: MeetingCallEndedPayload = {
+        key: event.key,
+        endedAt: event.endedAt,
+      };
+      webContents.send('meeting:call-ended', payload);
+      return;
+    }
+
+    const payload: MeetingCallDetectedPayload = {
       key: event.detection.key,
       platform: event.detection.platform,
       kind: event.detection.kind,
@@ -37,17 +52,8 @@ export function startMeetingDetection(): void {
       processNames: event.detection.processNames,
       windowTitle: event.detection.windowTitle,
       detectedAt: event.detectedAt,
-    });
-
-    log.info(
-      {
-        key: event.detection.key,
-        platform: event.detection.platform,
-        kind: event.detection.kind,
-        processNames: event.detection.processNames,
-      },
-      'meeting call detected',
-    );
+    };
+    webContents.send('meeting:call-detected', payload);
   });
 
   detector.start();

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -4,7 +4,7 @@ import { createServer } from 'node:net';
 import { join, resolve } from 'node:path';
 import treeKill from 'tree-kill';
 
-import { resolveMeetingWatcherBinaryPath, resolveNativeBinaryPath } from '@stitch/audio-capture';
+import { resolveNativeBinaryPath } from '@stitch/audio-capture';
 
 const HEALTH_POLL_INTERVAL_MS = 100;
 const HEALTH_TIMEOUT_MS = 30_000;
@@ -132,7 +132,6 @@ export async function spawnServer(port: number): Promise<string> {
     const suffix = process.platform === 'win32' ? '.exe' : '';
     const sandboxBin = join(process.resourcesPath, `stitch-sandbox${suffix}`);
     sidecarEnv.STITCH_AUDIO_CAPTURE_BIN = resolveNativeBinaryPath();
-    sidecarEnv.STITCH_MEETING_WATCH_BIN = resolveMeetingWatcherBinaryPath();
     sidecarEnv.SANDBOX_EXEC_PATH = sandboxBin;
   } else {
     const root = getMonorepoRoot();

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,16 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+import type {
+  MeetingCallDetectedPayload,
+  MeetingCallEndedPayload,
+} from '@stitch/shared/chat/realtime';
+
+function onIpc<TPayload>(channel: string, callback: (payload: TPayload) => void): () => void {
+  const subscription = (_event: Electron.IpcRendererEvent, payload: TPayload) => callback(payload);
+  ipcRenderer.on(channel, subscription);
+  return () => ipcRenderer.removeListener(channel, subscription);
+}
+
 contextBridge.exposeInMainWorld('electron', {
   platform: process.platform,
   send: (channel: string, data?: unknown) => ipcRenderer.send(channel, data),
@@ -60,5 +71,11 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke('permissions:getScreenCaptureStatus') as Promise<string>,
     openScreenCaptureSettings: () =>
       ipcRenderer.invoke('permissions:openScreenCaptureSettings') as Promise<void>,
+  },
+  meeting: {
+    onCallDetected: (callback: (payload: MeetingCallDetectedPayload) => void) =>
+      onIpc('meeting:call-detected', callback),
+    onCallEnded: (callback: (payload: MeetingCallEndedPayload) => void) =>
+      onIpc('meeting:call-ended', callback),
   },
 });

--- a/apps/web/src/components/recordings/meeting-recording-banner.tsx
+++ b/apps/web/src/components/recordings/meeting-recording-banner.tsx
@@ -43,8 +43,8 @@ export function MeetingRecordingBanner() {
   const activeRecordingIdRef = React.useRef(data?.activeRecordingId ?? null);
   activeRecordingIdRef.current = data?.activeRecordingId ?? null;
 
-  useSSE({
-    'meeting-call-detected': (payload) => {
+  React.useEffect(() => {
+    const unsubscribeDetected = window.api?.meeting?.onCallDetected((payload) => {
       if (activeRecordingIdRef.current) {
         return;
       }
@@ -56,8 +56,8 @@ export function MeetingRecordingBanner() {
 
         return payload;
       });
-    },
-    'meeting-call-ended': ({ key }) => {
+    });
+    const unsubscribeEnded = window.api?.meeting?.onCallEnded(({ key }) => {
       setDetection((current) => {
         if (!current || current.key !== key) {
           return current;
@@ -74,8 +74,13 @@ export function MeetingRecordingBanner() {
         next.delete(key);
         return next;
       });
-    },
-  });
+    });
+
+    return () => {
+      unsubscribeDetected?.();
+      unsubscribeEnded?.();
+    };
+  }, [dismissedKeys]);
 
   React.useEffect(() => {
     if (data?.activeRecordingId) {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,3 +1,8 @@
+import type {
+  MeetingCallDetectedPayload,
+  MeetingCallEndedPayload,
+} from '@stitch/shared/chat/realtime';
+
 export type ContextMenuParams = {
   x: number;
   y: number;
@@ -69,6 +74,10 @@ declare global {
         requestMicrophone: () => Promise<boolean>;
         getScreenCaptureStatus: () => Promise<string>;
         openScreenCaptureSettings: () => Promise<void>;
+      };
+      meeting?: {
+        onCallDetected: (callback: (payload: MeetingCallDetectedPayload) => void) => () => void;
+        onCallEnded: (callback: (payload: MeetingCallEndedPayload) => void) => () => void;
       };
     };
   }

--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
       "version": "0.4.6",
       "dependencies": {
         "@stitch/audio-capture": "workspace:*",
+        "@stitch/shared": "workspace:*",
         "electron-updater": "^6.8.3",
         "tree-kill": "1.2.2",
       },

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -7,7 +7,6 @@ import * as Log from '@/lib/log.js';
 import { initSseBridge } from '@/lib/sse.js';
 import { refreshMcpToolsets } from '@/mcp/tool-executor.js';
 import { syncDefaultPermissions } from '@/permission/default-permissions.js';
-import { startMeetingDetection } from '@/recordings/meeting-detection.js';
 import { startScheduler } from '@/scheduler/runtime.js';
 import { loadBuiltInSkills } from '@/skills/built-in-skills.js';
 import { syncBuiltInSkills } from '@/skills/service.js';
@@ -36,7 +35,6 @@ export async function init() {
   await initConnectorRuntime();
 
   await startScheduler();
-  startMeetingDetection();
   await syncAllAutomationSchedules();
 
   log.info('server initialized');

--- a/packages/server/src/shutdown.ts
+++ b/packages/server/src/shutdown.ts
@@ -1,7 +1,6 @@
 import { shutdownConnectorRuntime } from '@/connectors/runtime.js';
 import { closeDb } from '@/db/client.js';
 import * as Log from '@/lib/log.js';
-import { stopMeetingDetection } from '@/recordings/meeting-detection.js';
 import { stopRecording } from '@/recordings/service.js';
 import { stopScheduler } from '@/scheduler/runtime.js';
 
@@ -10,7 +9,6 @@ const log = Log.create({ service: 'shutdown' });
 async function shutdown(signal: string) {
   log.info({ signal }, 'shutting down');
   await stopScheduler();
-  stopMeetingDetection();
   await stopRecording().catch((error) => {
     log.warn({ error }, 'failed to stop recording during shutdown');
   });

--- a/packages/shared/src/chat/realtime.ts
+++ b/packages/shared/src/chat/realtime.ts
@@ -205,8 +205,6 @@ export const SSE_EVENT_NAMES = [
   'permission-response-requested',
   'permission-response-resolved',
   'session-todos-updated',
-  'meeting-call-detected',
-  'meeting-call-ended',
   'recording-analysis-updated',
   'recording-warning',
   'recording-device-changed',
@@ -237,8 +235,6 @@ export type SseEventPayloadMap = {
   'permission-response-requested': PermissionResponseRequestedPayload;
   'permission-response-resolved': PermissionResponseResolvedPayload;
   'session-todos-updated': SessionTodosUpdatedPayload;
-  'meeting-call-detected': MeetingCallDetectedPayload;
-  'meeting-call-ended': MeetingCallEndedPayload;
   'recording-analysis-updated': RecordingAnalysisUpdatedPayload;
   'recording-warning': RecordingWarningPayload;
   'recording-device-changed': RecordingDeviceChangedPayload;


### PR DESCRIPTION
## 🚀 Change Summary

Moves meeting detection out of the server sidecar and into the Electron main process, forwarding call lifecycle events to the web app through preload-backed IPC.

Closes #235

### ✨ New Features
- **Desktop Meeting Detection**: Starts and stops meeting detection from Electron main and sends call detected/ended events over IPC.
- **Renderer Meeting IPC API**: Adds window.api.meeting.onCallDetected and window.api.meeting.onCallEnded for the web app.

### 🛠 Improvements & Refactors
- Replaces meeting banner SSE listeners with Electron IPC subscriptions while keeping existing banner state behavior.
- Removes server-owned meeting detection startup/shutdown and meeting events from the SSE event registry.
- Moves packaged meeting watcher binary env ownership to Electron main and bundles @stitch/audio-capture into main to avoid runtime source import failures.