### PR TITLE
feat: add recording ingest and desktop capture

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -12,11 +12,24 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import type {
+  StartRecordingInput,
+  StartRecordingResponse,
+  StopRecordingResponse,
+} from '@stitch/shared/recordings/types';
+
 import {
   configureMeetingDetectionEnv,
   startMeetingDetection,
   stopMeetingDetection,
 } from './meeting-detection';
+import {
+  checkRecordingPermissions,
+  configureRecordingCaptureEnv,
+  listRecordingDevices,
+  startRecordingCapture,
+  stopRecordingCapture,
+} from './recording-capture';
 import { resolveResourcePath } from './resources';
 import { findAvailablePort, killServer, spawnServer } from './sidecar';
 import { destroyTray, initTray } from './tray';
@@ -96,6 +109,7 @@ async function shutdownRuntime(): Promise<void> {
   isShuttingDown = true;
   destroyTray();
   stopMeetingDetection();
+  await stopRecordingCapture().catch(() => null);
   await killServer();
 }
 
@@ -207,6 +221,20 @@ async function createWindow() {
   }
 }
 
+async function serverJson<T>(path: string, init?: RequestInit): Promise<T> {
+  if (!serverUrl) {
+    throw new Error('Server is not ready');
+  }
+
+  const res = await fetch(`${serverUrl}${path}`, init);
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `Server request failed: ${path}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
 ipcMain.handle('window:minimize', () => {
   mainWindow?.minimize();
 });
@@ -288,6 +316,44 @@ ipcMain.handle('permissions:openScreenCaptureSettings', () => {
   }
 });
 
+ipcMain.handle('recording:start', async (_event, input: StartRecordingInput) => {
+  const startResponse = await serverJson<StartRecordingResponse>('/recordings/start', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+
+  try {
+    await startRecordingCapture({ ...startResponse, serverUrl: serverUrl! }, () => mainWindow);
+  } catch (error) {
+    await serverJson('/recordings/stop', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ durationMs: null, fileSizeBytes: null }),
+    }).catch(() => null);
+    throw error;
+  }
+
+  return startResponse;
+});
+
+ipcMain.handle('recording:stop', async () => {
+  const stopInput = await stopRecordingCapture();
+  return serverJson<StopRecordingResponse>('/recordings/stop', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(stopInput),
+  });
+});
+
+ipcMain.handle('recording:listDevices', () => {
+  return listRecordingDevices();
+});
+
+ipcMain.handle('recording:checkPermissions', () => {
+  return checkRecordingPermissions();
+});
+
 ipcMain.handle('updater:check', () => {
   return updater.checkForUpdates();
 });
@@ -306,6 +372,7 @@ void app.whenReady().then(async () => {
     if (app.isPackaged) {
       app.setLoginItemSettings({ openAtLogin: true });
       configureMeetingDetectionEnv();
+      configureRecordingCaptureEnv();
     }
 
     // When a second instance attempts to launch, focus the existing window.

--- a/apps/desktop/src/main/recording-capture.ts
+++ b/apps/desktop/src/main/recording-capture.ts
@@ -1,0 +1,159 @@
+import type { BrowserWindow } from 'electron';
+
+import { createAudioCaptureHandle, resolveNativeBinaryPath } from '@stitch/audio-capture';
+
+import type {
+  RecordingDeviceChangedPayload,
+  RecordingIngestMessage,
+  RecordingWarningPayload,
+} from '@stitch/shared/chat/realtime';
+import type { StartRecordingResponse, StopRecordingInput } from '@stitch/shared/recordings/types';
+
+type StartCaptureInput = Pick<
+  StartRecordingResponse,
+  | 'recordingId'
+  | 'outputPath'
+  | 'micDeviceId'
+  | 'speakerDeviceId'
+  | 'speakerGain'
+  | 'audioChunkConfig'
+> & {
+  serverUrl: string;
+};
+
+const capture = createAudioCaptureHandle();
+
+let activeSocket: WebSocket | null = null;
+let activeRecordingId: string | null = null;
+
+export function configureRecordingCaptureEnv(): void {
+  if (process.env.STITCH_AUDIO_CAPTURE_BIN) {
+    return;
+  }
+
+  process.env.STITCH_AUDIO_CAPTURE_BIN = resolveNativeBinaryPath();
+}
+
+function toIngestUrl(serverUrl: string): string {
+  const url = new URL('/recordings/ingest', serverUrl);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  return url.toString();
+}
+
+function waitForSocketOpen(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    ws.addEventListener('open', () => resolve(), { once: true });
+    ws.addEventListener('error', () => reject(new Error('Recording ingest socket failed to open')), {
+      once: true,
+    });
+  });
+}
+
+function sendIngestMessage(ws: WebSocket, message: RecordingIngestMessage): void {
+  if (ws.readyState !== WebSocket.OPEN) {
+    throw new Error('Recording ingest socket is not open');
+  }
+
+  ws.send(JSON.stringify(message));
+}
+
+export async function startRecordingCapture(
+  input: StartCaptureInput,
+  getWindow: () => BrowserWindow | null,
+): Promise<void> {
+  if (activeSocket || activeRecordingId || capture.getActive()) {
+    throw new Error('Recording capture is already running');
+  }
+
+  const ws = new WebSocket(toIngestUrl(input.serverUrl));
+  await waitForSocketOpen(ws);
+
+  try {
+    sendIngestMessage(ws, {
+      type: 'start',
+      recordingId: input.recordingId,
+      audioChunkConfig: input.audioChunkConfig,
+    });
+
+    await capture.start({
+      outputPath: input.outputPath,
+      channels: 1,
+      micDeviceId: input.micDeviceId,
+      speakerDeviceId: input.speakerDeviceId,
+      speakerGain: input.speakerGain,
+      audioChunkConfig: input.audioChunkConfig,
+    });
+
+    activeSocket = ws;
+    activeRecordingId = input.recordingId;
+    capture.onEvent((event) => {
+      if (event.type === 'audioChunk') {
+        sendIngestMessage(ws, {
+          type: 'chunk',
+          recordingId: input.recordingId,
+          source: event.source,
+          samplesB64: event.samplesB64,
+          sampleRateHz: event.sampleRateHz,
+          numSamples: event.numSamples,
+        });
+        return;
+      }
+
+      const webContents = getWindow()?.webContents;
+      if (!webContents || webContents.isDestroyed()) {
+        return;
+      }
+
+      if (event.type === 'warning') {
+        const payload: RecordingWarningPayload = { code: event.code, message: event.message };
+        webContents.send('recording:warning', payload);
+      } else if (event.type === 'deviceChanged') {
+        const payload: RecordingDeviceChangedPayload = {
+          kind: event.kind,
+          deviceName: event.deviceName,
+        };
+        webContents.send('recording:device-changed', payload);
+      }
+    });
+  } catch (error) {
+    ws.close();
+    activeSocket = null;
+    activeRecordingId = null;
+    throw error;
+  }
+}
+
+export async function stopRecordingCapture(): Promise<StopRecordingInput> {
+  const ws = activeSocket;
+  const recordingId = activeRecordingId;
+
+  activeSocket = null;
+  activeRecordingId = null;
+
+  try {
+    const result = await capture.stop();
+
+    if (ws && recordingId && ws.readyState === WebSocket.OPEN) {
+      sendIngestMessage(ws, { type: 'stop', recordingId });
+    }
+
+    return {
+      durationMs: result?.durationMs ?? null,
+      fileSizeBytes: result?.fileSizeBytes ?? null,
+    };
+  } finally {
+    ws?.close();
+  }
+}
+
+export function listRecordingDevices() {
+  return capture.listDevices();
+}
+
+export function checkRecordingPermissions() {
+  return capture.checkPermissions();
+}

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -4,8 +4,6 @@ import { createServer } from 'node:net';
 import { join, resolve } from 'node:path';
 import treeKill from 'tree-kill';
 
-import { resolveNativeBinaryPath } from '@stitch/audio-capture';
-
 const HEALTH_POLL_INTERVAL_MS = 100;
 const HEALTH_TIMEOUT_MS = 30_000;
 const HOSTNAME = '127.0.0.1';
@@ -131,7 +129,6 @@ export async function spawnServer(port: number): Promise<string> {
   if (app.isPackaged) {
     const suffix = process.platform === 'win32' ? '.exe' : '';
     const sandboxBin = join(process.resourcesPath, `stitch-sandbox${suffix}`);
-    sidecarEnv.STITCH_AUDIO_CAPTURE_BIN = resolveNativeBinaryPath();
     sidecarEnv.SANDBOX_EXEC_PATH = sandboxBin;
   } else {
     const root = getMonorepoRoot();

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -3,7 +3,14 @@ import { contextBridge, ipcRenderer } from 'electron';
 import type {
   MeetingCallDetectedPayload,
   MeetingCallEndedPayload,
+  RecordingDeviceChangedPayload,
+  RecordingWarningPayload,
 } from '@stitch/shared/chat/realtime';
+import type {
+  StartRecordingInput,
+  StartRecordingResponse,
+  StopRecordingResponse,
+} from '@stitch/shared/recordings/types';
 
 function onIpc<TPayload>(channel: string, callback: (payload: TPayload) => void): () => void {
   const subscription = (_event: Electron.IpcRendererEvent, payload: TPayload) => callback(payload);
@@ -77,5 +84,24 @@ contextBridge.exposeInMainWorld('api', {
       onIpc('meeting:call-detected', callback),
     onCallEnded: (callback: (payload: MeetingCallEndedPayload) => void) =>
       onIpc('meeting:call-ended', callback),
+  },
+  recording: {
+    start: (input: StartRecordingInput) =>
+      ipcRenderer.invoke('recording:start', input) as Promise<StartRecordingResponse>,
+    stop: () => ipcRenderer.invoke('recording:stop') as Promise<StopRecordingResponse>,
+    listDevices: () =>
+      ipcRenderer.invoke('recording:listDevices') as Promise<{
+        microphoneDevices: string[];
+        speakerDevices: string[];
+      }>,
+    checkPermissions: () =>
+      ipcRenderer.invoke('recording:checkPermissions') as Promise<{
+        microphone: 'granted' | 'denied' | 'unknown';
+        screenCapture: 'granted' | 'denied' | 'unknown';
+      }>,
+    onWarning: (callback: (payload: RecordingWarningPayload) => void) =>
+      onIpc('recording:warning', callback),
+    onDeviceChanged: (callback: (payload: RecordingDeviceChangedPayload) => void) =>
+      onIpc('recording:device-changed', callback),
   },
 });

--- a/apps/web/src/components/recordings/meeting-recording-banner.tsx
+++ b/apps/web/src/components/recordings/meeting-recording-banner.tsx
@@ -9,7 +9,6 @@ import type { MeetingCallDetectedPayload } from '@stitch/shared/chat/realtime';
 import { PLATFORM_CONFIG } from './shared/formatting';
 
 import { Button } from '@/components/ui/button';
-import { useSSE } from '@/hooks/sse/sse-context';
 import { recordingsQueryOptions, useStartRecording } from '@/lib/queries/recordings';
 
 const WARNING_LABELS: Record<string, string> = {
@@ -19,16 +18,21 @@ const WARNING_LABELS: Record<string, string> = {
 };
 
 export function RecordingEventListener() {
-  useSSE({
-    'recording-warning': (payload) => {
+  React.useEffect(() => {
+    const unsubscribeWarning = window.api?.recording?.onWarning((payload) => {
       const label = WARNING_LABELS[payload.code] ?? payload.message;
       toast.warning(label);
-    },
-    'recording-device-changed': (payload) => {
+    });
+    const unsubscribeDeviceChanged = window.api?.recording?.onDeviceChanged((payload) => {
       const deviceLabel = payload.deviceName ?? 'unknown device';
       toast.info(`Audio ${payload.kind} device changed to: ${deviceLabel}`);
-    },
-  });
+    });
+
+    return () => {
+      unsubscribeWarning?.();
+      unsubscribeDeviceChanged?.();
+    };
+  }, []);
 
   return null;
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,7 +1,14 @@
 import type {
   MeetingCallDetectedPayload,
   MeetingCallEndedPayload,
+  RecordingDeviceChangedPayload,
+  RecordingWarningPayload,
 } from '@stitch/shared/chat/realtime';
+import type {
+  StartRecordingInput,
+  StartRecordingResponse,
+  StopRecordingResponse,
+} from '@stitch/shared/recordings/types';
 
 export type ContextMenuParams = {
   x: number;
@@ -78,6 +85,20 @@ declare global {
       meeting?: {
         onCallDetected: (callback: (payload: MeetingCallDetectedPayload) => void) => () => void;
         onCallEnded: (callback: (payload: MeetingCallEndedPayload) => void) => () => void;
+      };
+      recording?: {
+        start: (input: StartRecordingInput) => Promise<StartRecordingResponse>;
+        stop: () => Promise<StopRecordingResponse>;
+        listDevices: () => Promise<{
+          microphoneDevices: string[];
+          speakerDevices: string[];
+        }>;
+        checkPermissions: () => Promise<{
+          microphone: 'granted' | 'denied' | 'unknown';
+          screenCapture: 'granted' | 'denied' | 'unknown';
+        }>;
+        onWarning: (callback: (payload: RecordingWarningPayload) => void) => () => void;
+        onDeviceChanged: (callback: (payload: RecordingDeviceChangedPayload) => void) => () => void;
       };
     };
   }

--- a/apps/web/src/lib/queries/recordings.ts
+++ b/apps/web/src/lib/queries/recordings.ts
@@ -50,6 +50,10 @@ type AudioPermissionsStatus = {
 export const audioDevicesQueryOptions = queryOptions({
   queryKey: recordingsKeys.devices(),
   queryFn: async (): Promise<AudioDeviceList> => {
+    if (window.api?.recording?.listDevices) {
+      return window.api.recording.listDevices();
+    }
+
     const res = await serverFetch('/recordings/devices');
     if (!res.ok) throw new Error('Failed to fetch audio devices');
     return res.json() as Promise<AudioDeviceList>;
@@ -61,6 +65,10 @@ export const audioDevicesQueryOptions = queryOptions({
 export const audioPermissionsQueryOptions = queryOptions({
   queryKey: ['recordings', 'permissions'] as const,
   queryFn: async (): Promise<AudioPermissionsStatus> => {
+    if (window.api?.recording?.checkPermissions) {
+      return window.api.recording.checkPermissions();
+    }
+
     const res = await serverFetch('/recordings/permissions');
     if (!res.ok) throw new Error('Failed to check audio permissions');
     return res.json() as Promise<AudioPermissionsStatus>;
@@ -91,7 +99,14 @@ async function preflightPermissionCheck(): Promise<void> {
       return;
     }
 
-    // Fallback for non-Electron (dev server): use the native binary check
+    if (window.api?.recording?.checkPermissions) {
+      const permissions = await window.api.recording.checkPermissions();
+      if (permissions.microphone === 'granted' && permissions.screenCapture === 'granted') {
+        return;
+      }
+    }
+
+    // Fallback for non-Electron (dev server): use the server permission route
     const res = await serverFetch('/recordings/permissions');
     if (!res.ok) return;
 
@@ -134,6 +149,10 @@ export function useStartRecording() {
     mutationFn: async (input: StartRecordingInput): Promise<StartRecordingResponse> => {
       await preflightPermissionCheck();
 
+      if (window.api?.recording?.start) {
+        return window.api.recording.start(input);
+      }
+
       const res = await serverFetch('/recordings/start', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -158,7 +177,15 @@ export function useStopRecording() {
 
   return useMutation({
     mutationFn: async (): Promise<StopRecordingResponse> => {
-      const res = await serverFetch('/recordings/stop', { method: 'POST' });
+      if (window.api?.recording?.stop) {
+        return window.api.recording.stop();
+      }
+
+      const res = await serverFetch('/recordings/stop', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ durationMs: null, fileSizeBytes: null }),
+      });
       if (!res.ok) {
         const err = (await res.json().catch(() => ({}))) as { error?: string };
         throw new Error(err.error ?? 'Failed to stop recording');

--- a/bun.lock
+++ b/bun.lock
@@ -157,7 +157,6 @@
         "@openrouter/ai-sdk-provider": "catalog:ai",
         "@stitch-connectors/google": "workspace:*",
         "@stitch-connectors/sdk": "workspace:*",
-        "@stitch/audio-capture": "workspace:*",
         "@stitch/registry-embeddings": "workspace:*",
         "@stitch/sandbox": "workspace:*",
         "@stitch/scheduler": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -150,6 +150,7 @@
         "@ai-sdk/openai-compatible": "catalog:ai",
         "@aws-sdk/credential-providers": "^3.1008.0",
         "@hono/node-server": "^1.19.11",
+        "@hono/node-ws": "^1.3.1",
         "@hono/zod-validator": "^0.7.6",
         "@lancedb/lancedb": "^0.27.2",
         "@libpdf/core": "^0.3.6",
@@ -465,6 +466,8 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+
+    "@hono/node-ws": ["@hono/node-ws@1.3.1", "", { "dependencies": { "ws": "^8.17.0" }, "peerDependencies": { "@hono/node-server": "^1.19.11", "hono": "^4.6.0" } }, "sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA=="],
 
     "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
 
@@ -2453,6 +2456,8 @@
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 

--- a/packages/audio-capture/src/index.ts
+++ b/packages/audio-capture/src/index.ts
@@ -105,5 +105,3 @@ export function createMeetingDetector(
     },
   };
 }
-
-export type { AudioChunkConfig, AudioDeviceList, AudioPermissionsStatus } from './types.js';

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,6 +22,7 @@
     "@ai-sdk/openai-compatible": "catalog:ai",
     "@aws-sdk/credential-providers": "^3.1008.0",
     "@hono/node-server": "^1.19.11",
+    "@hono/node-ws": "^1.3.1",
     "@hono/zod-validator": "^0.7.6",
     "@lancedb/lancedb": "^0.27.2",
     "@libpdf/core": "^0.3.6",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,7 +29,6 @@
     "@openrouter/ai-sdk-provider": "catalog:ai",
     "@stitch-connectors/google": "workspace:*",
     "@stitch-connectors/sdk": "workspace:*",
-    "@stitch/audio-capture": "workspace:*",
     "@stitch/registry-embeddings": "workspace:*",
     "@stitch/sandbox": "workspace:*",
     "@stitch/scheduler": "workspace:*",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,5 @@
 import { serve } from '@hono/node-server';
+import { createNodeWebSocket } from '@hono/node-ws';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 
@@ -21,6 +22,7 @@ import { ollamaModelsRouter } from '@/routes/ollama-models.js';
 import { permissionsRouter } from '@/routes/permissions.js';
 import { questionsRouter } from '@/routes/questions.js';
 import { queueRouter } from '@/routes/queue.js';
+import { createRecordingsIngestRouter } from '@/routes/recordings-ingest.js';
 import { recordingsRouter } from '@/routes/recordings.js';
 import { settingsRouter } from '@/routes/settings.js';
 import { shortcutsRouter } from '@/routes/shortcuts.js';
@@ -50,6 +52,7 @@ const { port, hostname } = parseArgs();
 const log = Log.create({ service: 'server' });
 
 const app = new Hono();
+const nodeWebSocket = createNodeWebSocket({ app });
 
 app.use(cors());
 app.get('/health', (c) => c.json({ status: 'ok', paths: PATHS }));
@@ -69,6 +72,7 @@ app.route('/llm/provider', providerRouter);
 app.route('/llm/ollama/models', ollamaModelsRouter);
 app.route('/settings', settingsRouter);
 app.route('/skills', skillsRouter);
+app.route('/recordings', createRecordingsIngestRouter(nodeWebSocket.upgradeWebSocket));
 app.route('/recordings', recordingsRouter);
 app.route('/shortcuts', shortcutsRouter);
 app.route('/usage', usageRouter);
@@ -78,6 +82,7 @@ app.route('/agenda', agendaRouter);
 registerShutdownHandlers();
 await init();
 
-serve({ fetch: app.fetch, port, hostname }, (info) => {
+const server = serve({ fetch: app.fetch, port, hostname }, (info) => {
   log.info({ address: info.address, port: info.port }, 'server ready');
 });
+nodeWebSocket.injectWebSocket(server);

--- a/packages/server/src/lib/events.ts
+++ b/packages/server/src/lib/events.ts
@@ -1,22 +1,31 @@
-import type { SseEventName, SseEventPayloadMap } from '@stitch/shared/chat/realtime';
+import type { RecordingAudioChunkPayload, SseEventPayloadMap } from '@stitch/shared/chat/realtime';
 
-type Listener<K extends SseEventName> = (data: SseEventPayloadMap[K]) => void;
+type InternalEventPayloadMap = SseEventPayloadMap & {
+  'recording-audio-chunk': RecordingAudioChunkPayload;
+};
 
-const listeners = new Map<SseEventName, Set<Listener<SseEventName>>>();
+type InternalEventName = keyof InternalEventPayloadMap;
 
-export function on<K extends SseEventName>(event: K, listener: Listener<K>): () => void {
+type Listener<K extends InternalEventName> = (data: InternalEventPayloadMap[K]) => void;
+
+const listeners = new Map<InternalEventName, Set<Listener<InternalEventName>>>();
+
+export function on<K extends InternalEventName>(event: K, listener: Listener<K>): () => void {
   let set = listeners.get(event);
   if (!set) {
     set = new Set();
     listeners.set(event, set);
   }
-  set.add(listener as Listener<SseEventName>);
+  set.add(listener as Listener<InternalEventName>);
   return () => {
-    set.delete(listener as Listener<SseEventName>);
+    set.delete(listener as Listener<InternalEventName>);
   };
 }
 
-export function emit<K extends SseEventName>(event: K, data: SseEventPayloadMap[K]): void {
+export function emit<K extends InternalEventName>(
+  event: K,
+  data: InternalEventPayloadMap[K],
+): void {
   const set = listeners.get(event);
   if (!set) return;
   for (const listener of set) {

--- a/packages/server/src/recordings/service.ts
+++ b/packages/server/src/recordings/service.ts
@@ -2,24 +2,18 @@ import { and, desc, eq, sql } from 'drizzle-orm';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { createAudioCaptureHandle } from '@stitch/audio-capture';
-import type {
-  AudioChunkConfig,
-  AudioDeviceList,
-  AudioPermissionsStatus,
-} from '@stitch/audio-capture';
 import { createRecordingAnalysisId, createRecordingId } from '@stitch/shared/id';
 import type {
   ListRecordingsResponse,
   Recording,
   StartRecordingInput,
   StartRecordingResponse,
+  StopRecordingInput,
   StopRecordingResponse,
 } from '@stitch/shared/recordings/types';
 
 import { getDb } from '@/db/client.js';
 import { providerConfig, recordingAnalyses, recordings, userSettings } from '@/db/schema.js';
-import * as Events from '@/lib/events.js';
 import * as Log from '@/lib/log.js';
 import { computeTotalPages } from '@/lib/paginated-query.js';
 import { PATHS } from '@/lib/paths.js';
@@ -39,7 +33,6 @@ type ActiveRecording = {
   transcriptionSession: LiveTranscriptionSession | null;
 };
 
-const capture = createAudioCaptureHandle();
 let activeRecording: ActiveRecording | null = null;
 const log = Log.create({ service: 'recordings' });
 
@@ -87,7 +80,7 @@ type ResolvedTranscriptionConfig = {
   sampleRateHz: number;
   encoding: string;
   pricing: TranscriptionPricing;
-  audioChunkConfig: AudioChunkConfig;
+  audioChunkConfig: StartRecordingResponse['audioChunkConfig'];
 };
 
 async function resolveTranscriptionConfig(): Promise<ResolvedTranscriptionConfig | null> {
@@ -149,7 +142,7 @@ async function resolveTranscriptionConfig(): Promise<ResolvedTranscriptionConfig
     encoding,
     pricing: model.pricing,
     audioChunkConfig: {
-      encoding: encoding as AudioChunkConfig['encoding'],
+      encoding: encoding,
       sampleRateHz: model.audio.sampleRate,
     },
   };
@@ -231,7 +224,7 @@ export async function listRecordings(input: {
 export async function startRecording(
   input: StartRecordingInput,
 ): Promise<ServiceResult<StartRecordingResponse>> {
-  if (activeRecording !== null || capture.getActive() !== null) {
+  if (activeRecording !== null) {
     return err('Recording already in progress', 400);
   }
 
@@ -241,30 +234,27 @@ export async function startRecording(
   const title = input.title?.trim() || defaultTitle();
   const outputDir = path.join(PATHS.dirPaths.recordings, id);
   const filePath = path.join(outputDir, 'raw_audio.ogg');
+  let settings: RecordingCaptureSettings;
+  let transcriptionConfig: ResolvedTranscriptionConfig;
 
   try {
-    const [settings, transcriptionConfig, userName] = await Promise.all([
+    const [resolvedSettings, resolvedTranscriptionConfig, userName] = await Promise.all([
       readCaptureSettings(),
       resolveTranscriptionConfig(),
       readUserName(),
     ]);
 
-    if (!transcriptionConfig) {
+    if (!resolvedTranscriptionConfig) {
       return err(
         'No transcription model configured. Please configure a transcription model in settings.',
         400,
       );
     }
 
+    settings = resolvedSettings;
+    transcriptionConfig = resolvedTranscriptionConfig;
+
     await fs.mkdir(outputDir, { recursive: true });
-    await capture.start({
-      outputPath: filePath,
-      channels: 1,
-      micDeviceId: settings.inputDeviceId,
-      speakerDeviceId: settings.outputDeviceId,
-      speakerGain: settings.speakerGain,
-      audioChunkConfig: transcriptionConfig.audioChunkConfig,
-    });
 
     await db.insert(recordings).values({
       id,
@@ -275,25 +265,6 @@ export async function startRecording(
       mimeType: 'audio/ogg',
       filePath,
       startedAt: now,
-    });
-
-    capture.onEvent((event) => {
-      if (event.type === 'warning') {
-        Events.emit('recording-warning', { code: event.code, message: event.message });
-      } else if (event.type === 'deviceChanged') {
-        Events.emit('recording-device-changed', {
-          kind: event.kind,
-          deviceName: event.deviceName,
-        });
-      } else if (event.type === 'audioChunk') {
-        Events.emit('recording-audio-chunk', {
-          recordingId: id,
-          source: event.source,
-          samplesB64: event.samplesB64,
-          sampleRateHz: event.sampleRateHz,
-          numSamples: event.numSamples,
-        });
-      }
     });
 
     let transcriptionSession: LiveTranscriptionSession | null = null;
@@ -368,7 +339,15 @@ export async function startRecording(
     return err('Recording not found', 404);
   }
 
-  return ok({ recording: toRecording(row) });
+  return ok({
+    recording: toRecording(row),
+    recordingId: id,
+    outputPath: filePath,
+    micDeviceId: settings.inputDeviceId,
+    speakerDeviceId: settings.outputDeviceId,
+    speakerGain: settings.speakerGain,
+    audioChunkConfig: transcriptionConfig.audioChunkConfig,
+  });
 }
 
 export async function getRecordingAudioFile(
@@ -389,7 +368,9 @@ export async function getRecordingAudioFile(
   return ok({ filePath: row.filePath, mimeType: row.mimeType });
 }
 
-export async function stopRecording(): Promise<ServiceResult<StopRecordingResponse>> {
+export async function stopRecording(
+  input: StopRecordingInput,
+): Promise<ServiceResult<StopRecordingResponse>> {
   const current = activeRecording;
   if (!current) {
     return err('No active recording', 400);
@@ -403,10 +384,8 @@ export async function stopRecording(): Promise<ServiceResult<StopRecordingRespon
     const sessionResult = (await current.transcriptionSession?.stop()) ?? null;
     const transcript = sessionResult?.transcript ?? [];
 
-    const stop = await capture.stop();
-    const endedAt = stop?.endedAt ?? Date.now();
-    const durationMs = stop?.durationMs ?? null;
-    const stat = await fs.stat(current.filePath).catch(() => null);
+    const endedAt = Date.now();
+    const durationMs = input.durationMs;
 
     await db
       .update(recordings)
@@ -414,7 +393,7 @@ export async function stopRecording(): Promise<ServiceResult<StopRecordingRespon
         status: 'completed',
         endedAt,
         durationMs,
-        fileSizeBytes: stat?.size ?? null,
+        fileSizeBytes: input.fileSizeBytes,
         updatedAt: Date.now(),
       })
       .where(and(eq(recordings.id, current.id), eq(recordings.status, 'recording')));
@@ -434,8 +413,7 @@ export async function stopRecording(): Promise<ServiceResult<StopRecordingRespon
       {
         recordingId: current.id,
         filePath: current.filePath,
-        stopped: stop,
-        fileSizeBytes: stat?.size ?? null,
+        fileSizeBytes: input.fileSizeBytes,
         transcriptEntries: transcript.length,
         costUsd: sessionResult?.costUsd ?? 0,
       },
@@ -507,24 +485,17 @@ export async function deleteRecording(recordingId: Recording['id']): Promise<Ser
   return ok(null);
 }
 
-export async function listAudioDevices(): Promise<ServiceResult<AudioDeviceList>> {
-  try {
-    const devices = await capture.listDevices();
-    return ok(devices);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to list audio devices';
-    log.warn({ error: message }, 'failed to list audio devices');
-    return err(message, 500);
-  }
+export async function listAudioDevices(): Promise<
+  ServiceResult<{ microphoneDevices: string[]; speakerDevices: string[] }>
+> {
+  return err('Audio devices are only available from the desktop app', 500);
 }
 
-export async function checkAudioPermissions(): Promise<ServiceResult<AudioPermissionsStatus>> {
-  try {
-    const permissions = await capture.checkPermissions();
-    return ok(permissions);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to check audio permissions';
-    log.warn({ error: message }, 'failed to check audio permissions');
-    return err(message, 500);
-  }
+export async function checkAudioPermissions(): Promise<
+  ServiceResult<{
+    microphone: 'granted' | 'denied' | 'unknown';
+    screenCapture: 'granted' | 'denied' | 'unknown';
+  }>
+> {
+  return err('Audio permissions are only available from the desktop app', 500);
 }

--- a/packages/server/src/routes/recordings-ingest.test.ts
+++ b/packages/server/src/routes/recordings-ingest.test.ts
@@ -1,0 +1,84 @@
+import { serve } from '@hono/node-server';
+import { createNodeWebSocket } from '@hono/node-ws';
+import { afterEach, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+
+import type { RecordingAudioChunkPayload } from '@stitch/shared/chat/realtime';
+
+import * as Events from '@/lib/events.js';
+import { createRecordingsIngestRouter } from '@/routes/recordings-ingest.js';
+
+type TestServer = ReturnType<typeof serve>;
+
+const servers: TestServer[] = [];
+
+afterEach(() => {
+  for (const server of servers.splice(0)) {
+    server.close();
+  }
+});
+
+async function createTestServer(): Promise<{ url: string; server: TestServer }> {
+  const app = new Hono();
+  const nodeWebSocket = createNodeWebSocket({ app });
+  app.route('/recordings', createRecordingsIngestRouter(nodeWebSocket.upgradeWebSocket));
+
+  let server!: TestServer;
+  const port = await new Promise<number>((resolve) => {
+    server = serve({ fetch: app.fetch, port: 0, hostname: '127.0.0.1' }, (info) => {
+      resolve(info.port);
+    });
+    nodeWebSocket.injectWebSocket(server);
+  });
+  servers.push(server);
+
+  return { url: `ws://127.0.0.1:${port}/recordings/ingest`, server };
+}
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ws.addEventListener('open', () => resolve(), { once: true });
+    ws.addEventListener('error', () => reject(new Error('WebSocket failed to open')), { once: true });
+  });
+}
+
+test('emits recording audio chunks from WebSocket ingest messages', async () => {
+  const { url } = await createTestServer();
+  const payloadPromise = new Promise<RecordingAudioChunkPayload>((resolve) => {
+    const unsubscribe = Events.on('recording-audio-chunk', (payload) => {
+      unsubscribe();
+      resolve(payload);
+    });
+  });
+
+  const ws = new WebSocket(url);
+  await waitForOpen(ws);
+
+  ws.send(
+    JSON.stringify({
+      type: 'start',
+      recordingId: 'rec_test',
+      audioChunkConfig: { encoding: 'f32le', sampleRateHz: 16_000 },
+    }),
+  );
+  ws.send(
+    JSON.stringify({
+      type: 'chunk',
+      recordingId: 'rec_test',
+      source: 'mic',
+      samplesB64: 'AAAA',
+      sampleRateHz: 16_000,
+      numSamples: 512,
+    }),
+  );
+
+   expect(payloadPromise).resolves.toEqual({
+    recordingId: 'rec_test',
+    source: 'mic',
+    samplesB64: 'AAAA',
+    sampleRateHz: 16_000,
+    numSamples: 512,
+  });
+
+  ws.close();
+});

--- a/packages/server/src/routes/recordings-ingest.ts
+++ b/packages/server/src/routes/recordings-ingest.ts
@@ -1,0 +1,75 @@
+import type { createNodeWebSocket } from '@hono/node-ws';
+import { Hono } from 'hono';
+import { z } from 'zod';
+
+import type { RecordingIngestMessage } from '@stitch/shared/chat/realtime';
+
+import * as Events from '@/lib/events.js';
+
+type UpgradeWebSocket = ReturnType<typeof createNodeWebSocket>['upgradeWebSocket'];
+
+const ingestMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('start'),
+    recordingId: z.string().min(1),
+    audioChunkConfig: z.object({
+      encoding: z.enum(['f32le', 'pcm_s16le']),
+      sampleRateHz: z.number().int().positive(),
+    }),
+  }),
+  z.object({
+    type: z.literal('chunk'),
+    recordingId: z.string().min(1),
+    source: z.enum(['mic', 'speaker']),
+    samplesB64: z.string(),
+    sampleRateHz: z.number().int().positive(),
+    numSamples: z.number().int().nonnegative(),
+  }),
+  z.object({
+    type: z.literal('stop'),
+    recordingId: z.string().min(1),
+  }),
+]);
+
+function parseIngestMessage(data: unknown): RecordingIngestMessage | null {
+  if (typeof data !== 'string') {
+    return null;
+  }
+
+  try {
+    return ingestMessageSchema.parse(JSON.parse(data)) as RecordingIngestMessage;
+  } catch {
+    return null;
+  }
+}
+
+export function createRecordingsIngestRouter(upgradeWebSocket: UpgradeWebSocket): Hono {
+  const router = new Hono();
+
+  router.get(
+    '/ingest',
+    upgradeWebSocket(() => ({
+      onMessage(event, ws) {
+        const message = parseIngestMessage(event.data);
+        if (!message) {
+          ws.close(1003, 'Invalid recording ingest message');
+          return;
+        }
+
+        if (message.type !== 'chunk') {
+          return;
+        }
+
+        Events.emit('recording-audio-chunk', {
+          recordingId: message.recordingId,
+          source: message.source,
+          samplesB64: message.samplesB64,
+          sampleRateHz: message.sampleRateHz,
+          numSamples: message.numSamples,
+        });
+      },
+    })),
+  );
+
+  return router;
+}

--- a/packages/server/src/routes/recordings.ts
+++ b/packages/server/src/routes/recordings.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs/promises';
 import { Readable } from 'node:stream';
 import { z } from 'zod';
 
-import type { StartRecordingInput } from '@stitch/shared/recordings/types';
+import type { StartRecordingInput, StopRecordingInput } from '@stitch/shared/recordings/types';
 
 import { unwrapResult } from '@/lib/route-helpers.js';
 import { paginationQuerySchema } from '@/lib/route-schemas.js';
@@ -28,6 +28,11 @@ import {
 const startRecordingSchema = z.object({
   title: z.string().trim().min(1).max(200).optional(),
   platform: z.enum(['manual', 'zoom', 'teams', 'slack', 'discord', 'google-meet']).optional(),
+});
+
+const stopRecordingSchema = z.object({
+  durationMs: z.number().int().nonnegative().nullable(),
+  fileSizeBytes: z.number().int().nonnegative().nullable(),
 });
 
 const recordingIdParamSchema = z.object({
@@ -56,8 +61,9 @@ recordingsRouter.post('/start', zValidator('json', startRecordingSchema), async 
   return unwrapResult(c, result, 201);
 });
 
-recordingsRouter.post('/stop', async (c) => {
-  const result = await stopRecording();
+recordingsRouter.post('/stop', zValidator('json', stopRecordingSchema), async (c) => {
+  const body = c.req.valid('json') as StopRecordingInput;
+  const result = await stopRecording(body);
   return unwrapResult(c, result);
 });
 

--- a/packages/server/src/shutdown.ts
+++ b/packages/server/src/shutdown.ts
@@ -9,7 +9,7 @@ const log = Log.create({ service: 'shutdown' });
 async function shutdown(signal: string) {
   log.info({ signal }, 'shutting down');
   await stopScheduler();
-  await stopRecording().catch((error) => {
+  await stopRecording({ durationMs: null, fileSizeBytes: null }).catch((error) => {
     log.warn({ error }, 'failed to stop recording during shutdown');
   });
   await shutdownConnectorRuntime();

--- a/packages/shared/src/chat/realtime.ts
+++ b/packages/shared/src/chat/realtime.ts
@@ -231,9 +231,6 @@ export const SSE_EVENT_NAMES = [
   'permission-response-resolved',
   'session-todos-updated',
   'recording-analysis-updated',
-  'recording-warning',
-  'recording-device-changed',
-  'recording-audio-chunk',
   'recording-transcript-entry',
 ] as const;
 
@@ -261,9 +258,6 @@ export type SseEventPayloadMap = {
   'permission-response-resolved': PermissionResponseResolvedPayload;
   'session-todos-updated': SessionTodosUpdatedPayload;
   'recording-analysis-updated': RecordingAnalysisUpdatedPayload;
-  'recording-warning': RecordingWarningPayload;
-  'recording-device-changed': RecordingDeviceChangedPayload;
-  'recording-audio-chunk': RecordingAudioChunkPayload;
   'recording-transcript-entry': RecordingTranscriptEntryPayload;
 };
 

--- a/packages/shared/src/chat/realtime.ts
+++ b/packages/shared/src/chat/realtime.ts
@@ -177,6 +177,31 @@ export type RecordingAudioChunkPayload = {
   numSamples: number;
 };
 
+export type RecordingIngestAudioChunkConfig = {
+  encoding: 'f32le' | 'pcm_s16le';
+  sampleRateHz: number;
+};
+
+export type RecordingIngestStartMessage = {
+  type: 'start';
+  recordingId: string;
+  audioChunkConfig: RecordingIngestAudioChunkConfig;
+};
+
+export type RecordingIngestChunkMessage = {
+  type: 'chunk';
+} & RecordingAudioChunkPayload;
+
+export type RecordingIngestStopMessage = {
+  type: 'stop';
+  recordingId: string;
+};
+
+export type RecordingIngestMessage =
+  | RecordingIngestStartMessage
+  | RecordingIngestChunkMessage
+  | RecordingIngestStopMessage;
+
 export type RecordingTranscriptEntryPayload = {
   recordingId: string;
   source: 'mic' | 'speaker';

--- a/packages/shared/src/recordings/types.ts
+++ b/packages/shared/src/recordings/types.ts
@@ -36,6 +36,20 @@ export type StartRecordingInput = {
 
 export type StartRecordingResponse = {
   recording: Recording;
+  recordingId: PrefixedString<'rec'>;
+  outputPath: string;
+  micDeviceId: string | null;
+  speakerDeviceId: string | null;
+  speakerGain: number;
+  audioChunkConfig: {
+    encoding: 'f32le' | 'pcm_s16le';
+    sampleRateHz: number;
+  };
+};
+
+export type StopRecordingInput = {
+  durationMs: number | null;
+  fileSizeBytes: number | null;
 };
 
 export type StopRecordingResponse = {


### PR DESCRIPTION
## Change Summary

Adds the server WebSocket audio-ingest endpoint and moves native audio capture ownership into Electron main. This keeps the server responsible for recording state, persistence, transcription, and ingest while Electron owns the platform-specific capture process.

### New Features
- Server recording ingest WebSocket at `/recordings/ingest` for desktop audio chunks.
- Electron main recording IPC for start, stop, device listing, permissions, warnings, and device-change notifications.

### Improvements & Refactors
- Refactored server recording startup/stop flow so it no longer spawns or imports the native audio capture package.
- Switched renderer recording controls to use desktop IPC with HTTP fallbacks for non-Electron contexts.
- Split internal recording audio chunk events from public SSE event types.

Closes #236
Closes #237