### PR TITLE
Refactor desktop main process + server status improvements

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,100 +1,34 @@
-import {
-  app,
-  BrowserWindow,
-  dialog,
-  ipcMain,
-  nativeImage,
-  shell,
-  systemPreferences,
-} from 'electron';
-import { randomUUID } from 'node:crypto';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { app, dialog, type BrowserWindow } from 'electron';
 
-import type {
-  StartRecordingInput,
-  StartRecordingResponse,
-  StopRecordingResponse,
-} from '@stitch/shared/recordings/types';
-
+import { registerDevtoolsHandlers } from './ipc/devtools.js';
+import { registerFilesHandlers } from './ipc/files.js';
+import { registerPermissionsHandlers } from './ipc/permissions.js';
+import { registerRecordingHandlers } from './ipc/recording.js';
+import { registerServerHandlers } from './ipc/server.js';
+import { registerShellHandlers } from './ipc/shell.js';
+import { registerSpellcheckHandlers } from './ipc/spellcheck.js';
+import { registerUpdaterHandlers } from './ipc/updater.js';
+import { registerWindowHandlers } from './ipc/window.js';
 import {
   configureMeetingDetectionEnv,
   startMeetingDetection,
   stopMeetingDetection,
-} from './meeting-detection';
-import {
-  checkRecordingPermissions,
-  configureRecordingCaptureEnv,
-  listRecordingDevices,
-  startRecordingCapture,
-  stopRecordingCapture,
-} from './recording-capture';
-import { resolveResourcePath } from './resources';
-import {
-  normalizeRemoteUrl,
-  readServerConnectionConfig,
-  writeServerConnectionConfig,
-  type ServerConnectionConfig,
-} from './server-config';
-import { checkHealth, findAvailablePort, killServer, spawnServer } from './sidecar';
-import { destroyTray, initTray } from './tray';
-import { createUpdater } from './updater';
+} from './meeting-detection.js';
+import { configureRecordingCaptureEnv, stopRecordingCapture } from './recording-capture.js';
+import { readServerConnectionConfig, type ServerConnectionConfig } from './server-config.js';
+import { findAvailablePort, killServer, spawnServer } from './sidecar.js';
+import { resetTccPermissionsIfVersionChanged } from './tcc-permissions.js';
+import { destroyTray, initTray } from './tray.js';
+import { createUpdater } from './updater.js';
+import { createWindow } from './window.js';
 
-const WEB_DEV_URL = 'http://localhost:5173';
-const WINDOW_ICON_NAME = 'icon.png';
-const DEV_SERVER_POLL_MS = 200;
-const DEV_SERVER_TIMEOUT_MS = 30_000;
 const DEV_APP_NAME = 'stitch-dev';
 const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1_000;
 
-/**
- * With adhoc code signing, macOS ties TCC permissions to the exact code signature hash.
- * After an app update the hash changes but old TCC entries remain, causing permissions
- * to appear granted in System Settings while being silently rejected at runtime.
- * This detects version changes and resets TCC so macOS will re-prompt.
- */
-async function resetTccPermissionsIfVersionChanged(): Promise<boolean> {
-  if (process.platform !== 'darwin' || !app.isPackaged) return false;
-
-  const versionFile = join(app.getPath('userData'), '.last-tcc-version');
-  const currentVersion = app.getVersion();
-
-  try {
-    const lastVersion = (await readFile(versionFile, 'utf-8')).trim();
-    if (lastVersion === currentVersion) return false;
-  } catch {
-    // File doesn't exist — first run or upgrade from before this logic
-  }
-
-  const { execSync } = await import('node:child_process');
-  const bundleId = 'com.stitch.desktop';
-
-  for (const service of ['Microphone', 'ScreenCapture']) {
-    try {
-      execSync(`tccutil reset ${service} ${bundleId}`, { timeout: 5_000 });
-    } catch {
-      // tccutil may fail if no entry exists
-    }
-  }
-
-  await mkdir(join(app.getPath('userData')), { recursive: true });
-  await writeFile(versionFile, currentVersion, 'utf-8');
-
-  return true;
-}
-
 function configureAppIdentityForEnvironment(): void {
-  if (app.isPackaged) {
-    return;
-  }
-
+  if (app.isPackaged) return;
   app.setName('Stitch Dev');
-  app.setPath('userData', join(app.getPath('appData'), DEV_APP_NAME));
-}
-
-function getPackagedWebDistPath(): string {
-  return join(process.resourcesPath, 'web/dist/index.html');
+  app.setPath('userData', app.getPath('appData') + '/' + DEV_APP_NAME);
 }
 
 // Enforce single instance before any other initialization.
@@ -106,10 +40,14 @@ if (!gotTheLock) {
 }
 
 let mainWindow: BrowserWindow | null = null;
-let serverUrl: string | null = null;
-let serverConnectionConfig: ServerConnectionConfig = { mode: 'local', remoteUrl: null };
 let isQuitting = false;
 let isShuttingDown = false;
+
+// Shared mutable server state — passed by reference to IPC handlers that own it.
+const serverState = {
+  serverUrl: '',
+  serverConnectionConfig: { mode: 'local', remoteUrl: null } as ServerConnectionConfig,
+};
 
 async function startLocalServer(): Promise<string> {
   const port = await findAvailablePort();
@@ -117,13 +55,19 @@ async function startLocalServer(): Promise<string> {
 }
 
 async function resolveServerUrl(): Promise<string> {
-  serverConnectionConfig = await readServerConnectionConfig();
+  serverState.serverConnectionConfig = await readServerConnectionConfig();
 
-  if (serverConnectionConfig.mode === 'remote' && serverConnectionConfig.remoteUrl) {
-    return serverConnectionConfig.remoteUrl;
+  if (
+    serverState.serverConnectionConfig.mode === 'remote' &&
+    serverState.serverConnectionConfig.remoteUrl
+  ) {
+    return serverState.serverConnectionConfig.remoteUrl;
   }
 
-  serverConnectionConfig = { mode: 'local', remoteUrl: serverConnectionConfig.remoteUrl };
+  serverState.serverConnectionConfig = {
+    mode: 'local',
+    remoteUrl: serverState.serverConnectionConfig.remoteUrl,
+  };
   return startLocalServer();
 }
 
@@ -137,318 +81,56 @@ async function shutdownRuntime(): Promise<void> {
 }
 
 const updater = createUpdater({
-  getWindow: () => mainWindow,
   prepareForInstall: async () => {
     isQuitting = true;
     await shutdownRuntime();
   },
 });
 
-async function waitForDevServer(url: string): Promise<void> {
-  const deadline = Date.now() + DEV_SERVER_TIMEOUT_MS;
+function registerAllIpcHandlers(): void {
+  const getWindow = () => mainWindow;
+  const getServerUrl = () => serverState.serverUrl;
 
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
-      if (res.ok) return;
-    } catch {
-      // server not ready yet
-    }
-    await new Promise((resolve) => setTimeout(resolve, DEV_SERVER_POLL_MS));
-  }
-
-  throw new Error(`Dev server at ${url} failed to start within ${DEV_SERVER_TIMEOUT_MS}ms`);
+  registerWindowHandlers(getWindow);
+  registerDevtoolsHandlers(getWindow);
+  registerSpellcheckHandlers(getWindow);
+  registerShellHandlers();
+  registerFilesHandlers();
+  registerPermissionsHandlers();
+  registerRecordingHandlers(getServerUrl, getWindow);
+  registerServerHandlers(serverState, startLocalServer, getWindow);
+  registerUpdaterHandlers(updater, getWindow);
 }
 
-async function createWindow() {
-  const isMac = process.platform === 'darwin';
-  const iconCandidates = process.platform === 'win32' ? ['icon.png', 'icon.ico'] : ['icon.png'];
-  const windowIcon = iconCandidates
-    .map((name) => nativeImage.createFromPath(resolveResourcePath(name)))
-    .find((image) => !image.isEmpty());
-
-  mainWindow = new BrowserWindow({
-    width: 1280,
-    height: 800,
-    ...(windowIcon ? { icon: windowIcon } : { icon: resolveResourcePath(WINDOW_ICON_NAME) }),
-    frame: false,
-    ...(isMac ? { titleBarStyle: 'hiddenInset' } : {}),
-    minWidth: 800,
-    minHeight: 600,
-    webPreferences: {
-      preload: join(__dirname, '../preload/index.js'),
-      contextIsolation: true,
-      nodeIntegration: false,
-    },
+function onContextMenu(params: Electron.ContextMenuParams): void {
+  mainWindow?.webContents.send('context-menu', {
+    x: params.x,
+    y: params.y,
+    misspelledWord: params.misspelledWord,
+    dictionarySuggestions: params.dictionarySuggestions,
+    selectionText: params.selectionText,
+    isEditable: params.isEditable,
+    editFlags: params.editFlags,
   });
-
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    void shell.openExternal(url);
-    return { action: 'deny' };
-  });
-
-  if (windowIcon) {
-    mainWindow.setIcon(windowIcon);
-  }
-
-  mainWindow.webContents.on(
-    'did-fail-load',
-    (_event, errorCode, errorDescription, validatedURL) => {
-      dialog.showErrorBox(
-        'Failed to load Stitch UI',
-        `errorCode=${errorCode}\nerror=${errorDescription}\nurl=${validatedURL}`,
-      );
-    },
-  );
-
-  // Hide to tray on close instead of quitting, unless the app is actually quitting.
-  mainWindow.on('close', (event) => {
-    if (!isQuitting) {
-      event.preventDefault();
-      mainWindow?.hide();
-    }
-  });
-
-  mainWindow.webContents.on('context-menu', (_e, params) => {
-    mainWindow?.webContents.send('context-menu', {
-      x: params.x,
-      y: params.y,
-      misspelledWord: params.misspelledWord,
-      dictionarySuggestions: params.dictionarySuggestions,
-      selectionText: params.selectionText,
-      isEditable: params.isEditable,
-      editFlags: params.editFlags,
-    });
-  });
-
-  mainWindow.on('enter-full-screen', () => {
-    mainWindow?.webContents.send('window:fullscreen-changed', true);
-  });
-
-  mainWindow.on('leave-full-screen', () => {
-    mainWindow?.webContents.send('window:fullscreen-changed', false);
-  });
-
-  if (!app.isPackaged && process.env['ELECTRON_RENDERER_URL']) {
-    await waitForDevServer(process.env['ELECTRON_RENDERER_URL']);
-    void mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL']);
-  } else if (!app.isPackaged) {
-    await waitForDevServer(WEB_DEV_URL);
-    void mainWindow.loadURL(WEB_DEV_URL);
-  } else {
-    void mainWindow.loadFile(getPackagedWebDistPath());
-  }
-
-  if (!app.isPackaged) {
-    mainWindow.webContents.openDevTools();
-  }
 }
 
-async function serverJson<T>(path: string, init?: RequestInit): Promise<T> {
-  if (!serverUrl) {
-    throw new Error('Server is not ready');
-  }
-
-  const res = await fetch(`${serverUrl}${path}`, init);
-  if (!res.ok) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new Error(body.error ?? `Server request failed: ${path}`);
-  }
-
-  return res.json() as Promise<T>;
+async function spawnMainWindow(): Promise<BrowserWindow> {
+  return createWindow(onContextMenu, () => {
+    if (!isQuitting) mainWindow?.hide();
+  });
 }
-
-ipcMain.handle('window:minimize', () => {
-  mainWindow?.minimize();
-});
-
-ipcMain.handle('window:maximize', () => {
-  if (mainWindow?.isMaximized()) {
-    mainWindow.unmaximize();
-  } else {
-    mainWindow?.maximize();
-  }
-});
-
-ipcMain.handle('window:close', () => {
-  // Hide to tray instead of closing so notifications and tray keep working
-  mainWindow?.hide();
-});
-
-ipcMain.handle('window:isMaximized', () => {
-  return mainWindow?.isMaximized() ?? false;
-});
-
-ipcMain.handle('window:isFullScreen', () => {
-  return mainWindow?.isFullScreen() ?? false;
-});
-
-ipcMain.handle('get-server-config', () => ({
-  url: serverUrl,
-  mode: serverConnectionConfig.mode,
-  remoteUrl: serverConnectionConfig.remoteUrl,
-}));
-
-ipcMain.handle('server:test-remote', async (_event, rawUrl: string) => {
-  try {
-    const url = normalizeRemoteUrl(rawUrl);
-    const ok = await checkHealth(url);
-    return ok ? { ok: true, url } : { ok: false, error: 'Server health check failed' };
-  } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : 'Invalid server URL' };
-  }
-});
-
-ipcMain.handle('server:set-config', async (_event, config: ServerConnectionConfig) => {
-  let nextConfig: ServerConnectionConfig;
-
-  if (config.mode === 'remote') {
-    const remoteUrl = normalizeRemoteUrl(config.remoteUrl ?? '');
-    if (!(await checkHealth(remoteUrl))) {
-      throw new Error('Remote server health check failed');
-    }
-    nextConfig = { mode: 'remote', remoteUrl };
-  } else {
-    nextConfig = { mode: 'local', remoteUrl: config.remoteUrl?.trim() || null };
-  }
-
-  await stopRecordingCapture().catch(() => null);
-  await killServer();
-
-  const nextUrl = nextConfig.mode === 'remote' ? nextConfig.remoteUrl! : await startLocalServer();
-
-  serverConnectionConfig = nextConfig;
-  serverUrl = nextUrl;
-  await writeServerConnectionConfig(nextConfig);
-
-  mainWindow?.webContents.send('server:config-changed', {
-    url: serverUrl,
-    mode: serverConnectionConfig.mode,
-    remoteUrl: serverConnectionConfig.remoteUrl,
-  });
-
-  return {
-    url: serverUrl,
-    mode: serverConnectionConfig.mode,
-    remoteUrl: serverConnectionConfig.remoteUrl,
-  };
-});
-
-ipcMain.handle('devtools:toggle', () => {
-  mainWindow?.webContents.toggleDevTools();
-});
-
-ipcMain.handle('devtools:inspect', (_event, x: number, y: number) => {
-  mainWindow?.webContents.inspectElement(x, y);
-});
-
-ipcMain.handle('spellcheck:replaceMisspelling', (_event, word: string) => {
-  mainWindow?.webContents.replaceMisspelling(word);
-});
-
-ipcMain.handle('spellcheck:addToDictionary', (_event, word: string) => {
-  mainWindow?.webContents.session.addWordToSpellCheckerDictionary(word);
-});
-
-ipcMain.handle('shell:openExternal', (_event, url: string) => {
-  void shell.openExternal(url);
-});
-
-ipcMain.handle('files:writeTmp', async (_event, data: ArrayBuffer, ext: string) => {
-  const dir = join(tmpdir(), 'stitch-paste');
-  await mkdir(dir, { recursive: true });
-  const filename = `${randomUUID()}.${ext}`;
-  const filePath = join(dir, filename);
-  await writeFile(filePath, Buffer.from(data));
-  return filePath;
-});
-
-ipcMain.handle('dialog:openPath', async () => {
-  const result = await dialog.showOpenDialog({
-    properties: ['openFile', 'openDirectory', 'multiSelections'],
-  });
-  return result.canceled ? [] : result.filePaths;
-});
-
-ipcMain.handle('permissions:requestMicrophone', async () => {
-  if (process.platform !== 'darwin') return true;
-  return systemPreferences.askForMediaAccess('microphone');
-});
-
-ipcMain.handle('permissions:getScreenCaptureStatus', () => {
-  if (process.platform !== 'darwin') return 'granted';
-  return systemPreferences.getMediaAccessStatus('screen');
-});
-
-ipcMain.handle('permissions:openScreenCaptureSettings', () => {
-  if (process.platform === 'darwin') {
-    void shell.openExternal(
-      'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
-    );
-  }
-});
-
-ipcMain.handle('recording:start', async (_event, input: StartRecordingInput) => {
-  const startResponse = await serverJson<StartRecordingResponse>('/recordings/start', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(input),
-  });
-
-  try {
-    await startRecordingCapture({ ...startResponse, serverUrl: serverUrl! }, () => mainWindow);
-  } catch (error) {
-    await serverJson('/recordings/stop', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ durationMs: null, fileSizeBytes: null }),
-    }).catch(() => null);
-    throw error;
-  }
-
-  return startResponse;
-});
-
-ipcMain.handle('recording:stop', async () => {
-  const stopInput = await stopRecordingCapture();
-  return serverJson<StopRecordingResponse>('/recordings/stop', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(stopInput),
-  });
-});
-
-ipcMain.handle('recording:listDevices', () => {
-  return listRecordingDevices();
-});
-
-ipcMain.handle('recording:checkPermissions', () => {
-  return checkRecordingPermissions();
-});
-
-ipcMain.handle('updater:check', () => {
-  return updater.checkForUpdates();
-});
-
-ipcMain.handle('updater:getState', () => {
-  return updater.getState();
-});
-
-ipcMain.handle('updater:install', () => {
-  return updater.installUpdate();
-});
 
 void app.whenReady().then(async () => {
   try {
     configureMeetingDetectionEnv();
     configureRecordingCaptureEnv();
 
-    // Register launch at startup for packaged builds only.
+    registerAllIpcHandlers();
+
     if (app.isPackaged) {
       app.setLoginItemSettings({ openAtLogin: true });
     }
 
-    // When a second instance attempts to launch, focus the existing window.
     app.on('second-instance', () => {
       if (mainWindow) {
         if (mainWindow.isMinimized()) mainWindow.restore();
@@ -457,14 +139,14 @@ void app.whenReady().then(async () => {
       }
     });
 
-    serverUrl = await resolveServerUrl();
+    serverState.serverUrl = await resolveServerUrl();
 
     const permissionsWereReset = await resetTccPermissionsIfVersionChanged();
 
-    await createWindow();
+    mainWindow = await spawnMainWindow();
     startMeetingDetection(() => mainWindow);
 
-    if (permissionsWereReset && mainWindow) {
+    if (permissionsWereReset) {
       void dialog.showMessageBox(mainWindow, {
         type: 'info',
         title: 'Permissions Required',
@@ -477,24 +159,20 @@ void app.whenReady().then(async () => {
 
     if (process.platform !== 'darwin') {
       updater.init();
-      setTimeout(() => {
-        void updater.checkForUpdates();
-      }, 15_000);
-      setInterval(() => {
-        void updater.checkForUpdates();
-      }, UPDATE_CHECK_INTERVAL_MS);
+      setTimeout(() => void updater.checkForUpdates(), 15_000);
+      setInterval(() => void updater.checkForUpdates(), UPDATE_CHECK_INTERVAL_MS);
     }
 
-    // Initialize system tray
-    const getWindow = () => mainWindow;
-    initTray(getWindow);
+    initTray(() => mainWindow);
 
     app.on('activate', () => {
       if (mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.show();
         mainWindow.focus();
       } else {
-        void createWindow();
+        void spawnMainWindow().then((win) => {
+          mainWindow = win;
+        });
       }
     });
   } catch (error) {

--- a/apps/desktop/src/main/ipc-types.ts
+++ b/apps/desktop/src/main/ipc-types.ts
@@ -1,0 +1,34 @@
+import type {
+  StartRecordingInput,
+  StartRecordingResponse,
+  StopRecordingResponse,
+} from '@stitch/shared/recordings/types';
+
+export type ServerConfigPayload = {
+  url: string;
+  mode: 'local' | 'remote';
+  remoteUrl: string | null;
+};
+
+export type ServerTestRemoteResult =
+  | { ok: true; url: string }
+  | { ok: false; error: string };
+
+export type UpdaterStatePayload = {
+  status: 'idle' | 'checking' | 'available' | 'downloading' | 'downloaded' | 'no-update' | 'error';
+  version?: string;
+  progress?: number;
+  error?: string;
+};
+
+export type RecordingDevicesPayload = {
+  microphoneDevices: string[];
+  speakerDevices: string[];
+};
+
+export type RecordingPermissionsPayload = {
+  microphone: 'granted' | 'denied' | 'unknown';
+  screenCapture: 'granted' | 'denied' | 'unknown';
+};
+
+export type { StartRecordingInput, StartRecordingResponse, StopRecordingResponse };

--- a/apps/desktop/src/main/ipc/devtools.ts
+++ b/apps/desktop/src/main/ipc/devtools.ts
@@ -1,0 +1,11 @@
+import { ipcMain, type BrowserWindow } from 'electron';
+
+export function registerDevtoolsHandlers(getWindow: () => BrowserWindow | null): void {
+  ipcMain.handle('devtools:toggle', () => {
+    getWindow()?.webContents.toggleDevTools();
+  });
+
+  ipcMain.handle('devtools:inspect', (_event, x: number, y: number) => {
+    getWindow()?.webContents.inspectElement(x, y);
+  });
+}

--- a/apps/desktop/src/main/ipc/files.ts
+++ b/apps/desktop/src/main/ipc/files.ts
@@ -1,0 +1,23 @@
+import { ipcMain, dialog } from 'electron';
+import { randomUUID } from 'node:crypto';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export function registerFilesHandlers(): void {
+  ipcMain.handle('files:writeTmp', async (_event, data: ArrayBuffer, ext: string) => {
+    const dir = join(tmpdir(), 'stitch-paste');
+    await mkdir(dir, { recursive: true });
+    const filename = `${randomUUID()}.${ext}`;
+    const filePath = join(dir, filename);
+    await writeFile(filePath, Buffer.from(data));
+    return filePath;
+  });
+
+  ipcMain.handle('dialog:openPath', async () => {
+    const result = await dialog.showOpenDialog({
+      properties: ['openFile', 'openDirectory', 'multiSelections'],
+    });
+    return result.canceled ? [] : result.filePaths;
+  });
+}

--- a/apps/desktop/src/main/ipc/permissions.ts
+++ b/apps/desktop/src/main/ipc/permissions.ts
@@ -1,0 +1,21 @@
+import { ipcMain, shell, systemPreferences } from 'electron';
+
+export function registerPermissionsHandlers(): void {
+  ipcMain.handle('permissions:requestMicrophone', async () => {
+    if (process.platform !== 'darwin') return true;
+    return systemPreferences.askForMediaAccess('microphone');
+  });
+
+  ipcMain.handle('permissions:getScreenCaptureStatus', () => {
+    if (process.platform !== 'darwin') return 'granted';
+    return systemPreferences.getMediaAccessStatus('screen');
+  });
+
+  ipcMain.handle('permissions:openScreenCaptureSettings', () => {
+    if (process.platform === 'darwin') {
+      void shell.openExternal(
+        'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
+      );
+    }
+  });
+}

--- a/apps/desktop/src/main/ipc/recording.ts
+++ b/apps/desktop/src/main/ipc/recording.ts
@@ -1,0 +1,50 @@
+import { ipcMain, type BrowserWindow } from 'electron';
+
+import type { StartRecordingInput, StartRecordingResponse, StopRecordingResponse } from '../ipc-types.js';
+import {
+  checkRecordingPermissions,
+  listRecordingDevices,
+  startRecordingCapture,
+  stopRecordingCapture,
+} from '../recording-capture.js';
+import { serverJson } from '../server-client.js';
+
+export function registerRecordingHandlers(
+  getServerUrl: () => string,
+  getWindow: () => BrowserWindow | null,
+): void {
+  ipcMain.handle('recording:start', async (_event, input: StartRecordingInput) => {
+    const serverUrl = getServerUrl();
+    const startResponse = await serverJson<StartRecordingResponse>(serverUrl, '/recordings/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+
+    try {
+      await startRecordingCapture({ ...startResponse, serverUrl }, () => getWindow());
+    } catch (error) {
+      await serverJson(serverUrl, '/recordings/stop', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ durationMs: null, fileSizeBytes: null }),
+      }).catch(() => null);
+      throw error;
+    }
+
+    return startResponse;
+  });
+
+  ipcMain.handle('recording:stop', async () => {
+    const serverUrl = getServerUrl();
+    const stopInput = await stopRecordingCapture();
+    return serverJson<StopRecordingResponse>(serverUrl, '/recordings/stop', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(stopInput),
+    });
+  });
+
+  ipcMain.handle('recording:listDevices', () => listRecordingDevices());
+  ipcMain.handle('recording:checkPermissions', () => checkRecordingPermissions());
+}

--- a/apps/desktop/src/main/ipc/server.ts
+++ b/apps/desktop/src/main/ipc/server.ts
@@ -1,0 +1,82 @@
+import { ipcMain, type BrowserWindow } from 'electron';
+
+import type { ServerConfigPayload, ServerTestRemoteResult } from '../ipc-types.js';
+import { normalizeRemoteUrl, writeServerConnectionConfig, type ServerConnectionConfig } from '../server-config.js';
+import { checkHealth } from '../sidecar.js';
+import { stopRecordingCapture } from '../recording-capture.js';
+import { killServer } from '../sidecar.js';
+
+type ServerState = {
+  serverUrl: string;
+  serverConnectionConfig: ServerConnectionConfig;
+};
+
+type StartLocalServer = () => Promise<string>;
+
+export function registerServerHandlers(
+  state: ServerState,
+  startLocalServer: StartLocalServer,
+  getWindow: () => BrowserWindow | null,
+): void {
+  ipcMain.handle('get-server-config', (): ServerConfigPayload => ({
+    url: state.serverUrl,
+    mode: state.serverConnectionConfig.mode,
+    remoteUrl: state.serverConnectionConfig.remoteUrl,
+  }));
+
+  ipcMain.handle(
+    'server:test-remote',
+    async (_event, rawUrl: string): Promise<ServerTestRemoteResult> => {
+      try {
+        const url = normalizeRemoteUrl(rawUrl);
+        const ok = await checkHealth(url);
+        return ok ? { ok: true, url } : { ok: false, error: 'Server health check failed' };
+      } catch (error) {
+        return {
+          ok: false,
+          error: error instanceof Error ? error.message : 'Invalid server URL',
+        };
+      }
+    },
+  );
+
+  ipcMain.handle(
+    'server:set-config',
+    async (_event, config: ServerConnectionConfig): Promise<ServerConfigPayload> => {
+      let nextConfig: ServerConnectionConfig;
+
+      if (config.mode === 'remote') {
+        const remoteUrl = normalizeRemoteUrl(config.remoteUrl ?? '');
+        if (!(await checkHealth(remoteUrl))) {
+          throw new Error('Remote server health check failed');
+        }
+        nextConfig = { mode: 'remote', remoteUrl };
+      } else {
+        nextConfig = { mode: 'local', remoteUrl: config.remoteUrl?.trim() || null };
+      }
+
+      await stopRecordingCapture().catch(() => null);
+      await killServer();
+
+      const nextUrl =
+        nextConfig.mode === 'remote' ? nextConfig.remoteUrl! : await startLocalServer();
+
+      state.serverUrl = nextUrl;
+      state.serverConnectionConfig = nextConfig;
+      await writeServerConnectionConfig(nextConfig);
+
+      const payload: ServerConfigPayload = {
+        url: state.serverUrl,
+        mode: state.serverConnectionConfig.mode,
+        remoteUrl: state.serverConnectionConfig.remoteUrl,
+      };
+
+      const win = getWindow();
+      if (win && !win.isDestroyed()) {
+        win.webContents.send('server:config-changed', payload);
+      }
+
+      return payload;
+    },
+  );
+}

--- a/apps/desktop/src/main/ipc/shell.ts
+++ b/apps/desktop/src/main/ipc/shell.ts
@@ -1,0 +1,7 @@
+import { ipcMain, shell } from 'electron';
+
+export function registerShellHandlers(): void {
+  ipcMain.handle('shell:openExternal', (_event, url: string) => {
+    void shell.openExternal(url);
+  });
+}

--- a/apps/desktop/src/main/ipc/spellcheck.ts
+++ b/apps/desktop/src/main/ipc/spellcheck.ts
@@ -1,0 +1,11 @@
+import { ipcMain, type BrowserWindow } from 'electron';
+
+export function registerSpellcheckHandlers(getWindow: () => BrowserWindow | null): void {
+  ipcMain.handle('spellcheck:replaceMisspelling', (_event, word: string) => {
+    getWindow()?.webContents.replaceMisspelling(word);
+  });
+
+  ipcMain.handle('spellcheck:addToDictionary', (_event, word: string) => {
+    getWindow()?.webContents.session.addWordToSpellCheckerDictionary(word);
+  });
+}

--- a/apps/desktop/src/main/ipc/updater.ts
+++ b/apps/desktop/src/main/ipc/updater.ts
@@ -1,0 +1,22 @@
+import { ipcMain, type BrowserWindow } from 'electron';
+
+import type { UpdaterStatePayload } from '../ipc-types.js';
+import type { createUpdater } from '../updater.js';
+
+type Updater = ReturnType<typeof createUpdater>;
+
+export function registerUpdaterHandlers(
+  updater: Updater,
+  getWindow: () => BrowserWindow | null,
+): void {
+  ipcMain.handle('updater:check', () => updater.checkForUpdates());
+  ipcMain.handle('updater:getState', (): UpdaterStatePayload => updater.getState());
+  ipcMain.handle('updater:install', () => updater.installUpdate());
+
+  updater.onEvent((state) => {
+    const win = getWindow();
+    if (win && !win.isDestroyed()) {
+      win.webContents.send('updater:event', state);
+    }
+  });
+}

--- a/apps/desktop/src/main/ipc/window.ts
+++ b/apps/desktop/src/main/ipc/window.ts
@@ -1,0 +1,28 @@
+import { ipcMain, type BrowserWindow } from 'electron';
+
+export function registerWindowHandlers(getWindow: () => BrowserWindow | null): void {
+  ipcMain.handle('window:minimize', () => {
+    getWindow()?.minimize();
+  });
+
+  ipcMain.handle('window:maximize', () => {
+    const win = getWindow();
+    if (win?.isMaximized()) {
+      win.unmaximize();
+    } else {
+      win?.maximize();
+    }
+  });
+
+  ipcMain.handle('window:close', () => {
+    getWindow()?.hide();
+  });
+
+  ipcMain.handle('window:isMaximized', () => {
+    return getWindow()?.isMaximized() ?? false;
+  });
+
+  ipcMain.handle('window:isFullScreen', () => {
+    return getWindow()?.isFullScreen() ?? false;
+  });
+}

--- a/apps/desktop/src/main/server-client.ts
+++ b/apps/desktop/src/main/server-client.ts
@@ -1,0 +1,8 @@
+export async function serverJson<T>(serverUrl: string, path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${serverUrl}${path}`, init);
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(body.error ?? `Server request failed: ${path}`);
+  }
+  return res.json() as Promise<T>;
+}

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -6,6 +6,7 @@ import treeKill from 'tree-kill';
 
 const HEALTH_POLL_INTERVAL_MS = 100;
 const HEALTH_TIMEOUT_MS = 30_000;
+const KILL_TIMEOUT_MS = 5_000;
 const HOSTNAME = '127.0.0.1';
 
 let serverProcess: ChildProcess | null = null;
@@ -71,48 +72,52 @@ async function waitForHealthy(url: string): Promise<void> {
   throw new Error(`Server failed to become healthy within ${HEALTH_TIMEOUT_MS}ms`);
 }
 
-function killStaleServers(): Promise<void> {
+function findStalePids(): number[] {
   try {
-    const cmd =
-      process.platform === 'win32'
-        ? 'tasklist /FI "IMAGENAME eq stitch-server.exe" /FO CSV /NH'
-        : 'pgrep -f stitch-server';
-
-    const output = execSync(cmd, { encoding: 'utf8', timeout: 3_000 }).trim();
-    if (!output) return Promise.resolve();
-
-    const pids =
-      process.platform === 'win32'
-        ? output
-            .split('\n')
-            .map((line) => parseInt(line.split(',')[1]?.replace(/"/g, '') ?? '', 10))
-            .filter(Number.isFinite)
-        : output
-            .split('\n')
-            .map((s) => parseInt(s, 10))
-            .filter(Number.isFinite);
-
-    for (const pid of pids) {
-      try {
-        process.kill(pid, 'SIGTERM');
-      } catch {
-        // already dead or not owned
-      }
+    if (process.platform === 'win32') {
+      const output = execSync('tasklist /FI "IMAGENAME eq stitch-server.exe" /FO CSV /NH', {
+        encoding: 'utf8',
+        timeout: 3_000,
+      }).trim();
+      if (!output) return [];
+      return output
+        .split('\n')
+        .map((line) => parseInt(line.split(',')[1]?.replace(/"/g, '') ?? '', 10))
+        .filter(Number.isFinite);
     }
 
-    if (pids.length > 0) {
-      console.log(`[sidecar] killed ${pids.length} stale stitch-server process(es)`);
-    }
+    const output = execSync('pgrep -f stitch-server', {
+      encoding: 'utf8',
+      timeout: 3_000,
+    }).trim();
+    if (!output) return [];
+    return output
+      .split('\n')
+      .map((s) => parseInt(s, 10))
+      .filter(Number.isFinite);
   } catch {
-    // pgrep returns exit code 1 when no matches — ignore
+    // pgrep returns exit code 1 when no matches; tasklist may fail — ignore
+    return [];
   }
+}
 
-  return Promise.resolve();
+function killStaleServers(): void {
+  const pids = findStalePids();
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // already dead or not owned
+    }
+  }
+  if (pids.length > 0) {
+    console.log(`[sidecar] killed ${pids.length} stale stitch-server process(es)`);
+  }
 }
 
 export async function spawnServer(port: number): Promise<string> {
   if (app.isPackaged) {
-    await killStaleServers();
+    killStaleServers();
   }
 
   const { cmd, args, cwd } = getSidecarCommand(port);
@@ -128,12 +133,10 @@ export async function spawnServer(port: number): Promise<string> {
 
   if (app.isPackaged) {
     const suffix = process.platform === 'win32' ? '.exe' : '';
-    const sandboxBin = join(process.resourcesPath, `stitch-sandbox${suffix}`);
-    sidecarEnv.SANDBOX_EXEC_PATH = sandboxBin;
+    sidecarEnv.SANDBOX_EXEC_PATH = join(process.resourcesPath, `stitch-sandbox${suffix}`);
   } else {
     const root = getMonorepoRoot();
-    const sandboxEntry = join(root, 'packages/server/src/code-mode/sandbox-process.ts');
-    sidecarEnv.SANDBOX_EXEC_PATH = sandboxEntry;
+    sidecarEnv.SANDBOX_EXEC_PATH = join(root, 'packages/server/src/code-mode/sandbox-process.ts');
   }
 
   serverProcess = spawn(cmd, args, {
@@ -164,8 +167,6 @@ export async function spawnServer(port: number): Promise<string> {
 
   return url;
 }
-
-const KILL_TIMEOUT_MS = 5_000;
 
 export async function killServer(): Promise<void> {
   const proc = serverProcess;

--- a/apps/desktop/src/main/tcc-permissions.ts
+++ b/apps/desktop/src/main/tcc-permissions.ts
@@ -1,0 +1,37 @@
+import { app } from 'electron';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+// With adhoc code signing, macOS ties TCC permissions to the exact code signature hash.
+// After an app update the hash changes but old TCC entries remain, causing permissions
+// to appear granted in System Settings while being silently rejected at runtime.
+// This detects version changes and resets TCC so macOS will re-prompt.
+export async function resetTccPermissionsIfVersionChanged(): Promise<boolean> {
+  if (process.platform !== 'darwin' || !app.isPackaged) return false;
+
+  const versionFile = join(app.getPath('userData'), '.last-tcc-version');
+  const currentVersion = app.getVersion();
+
+  try {
+    const lastVersion = (await readFile(versionFile, 'utf-8')).trim();
+    if (lastVersion === currentVersion) return false;
+  } catch {
+    // File doesn't exist — first run or upgrade from before this logic
+  }
+
+  const { execSync } = await import('node:child_process');
+  const bundleId = 'com.stitch.desktop';
+
+  for (const service of ['Microphone', 'ScreenCapture']) {
+    try {
+      execSync(`tccutil reset ${service} ${bundleId}`, { timeout: 5_000 });
+    } catch {
+      // tccutil may fail if no entry exists
+    }
+  }
+
+  await mkdir(join(app.getPath('userData')), { recursive: true });
+  await writeFile(versionFile, currentVersion, 'utf-8');
+
+  return true;
+}

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron';
 import { autoUpdater, type ProgressInfo, type UpdateInfo } from 'electron-updater';
 
-import type { BrowserWindow } from 'electron';
+import type { UpdaterStatePayload } from './ipc-types.js';
 
 const NETWORK_ERROR_CODES = [
   'ERR_INTERNET_DISCONNECTED',
@@ -17,50 +17,29 @@ function isNetworkError(error: Error): boolean {
   return NETWORK_ERROR_CODES.some((code) => error.message.includes(code));
 }
 
-type UpdaterStatus =
-  | 'idle'
-  | 'checking'
-  | 'available'
-  | 'downloading'
-  | 'downloaded'
-  | 'no-update'
-  | 'error';
-
-type UpdaterState = {
-  status: UpdaterStatus;
-  version?: string;
-  progress?: number;
-  error?: string;
-};
-
 type UpdaterOptions = {
-  getWindow: () => BrowserWindow | null;
   prepareForInstall: () => void | Promise<void>;
 };
 
-const UPDATER_EVENT_CHANNEL = 'updater:event';
-
 export function createUpdater(options: UpdaterOptions) {
   let initialized = false;
-  let state: UpdaterState = { status: 'idle' };
+  let state: UpdaterStatePayload = { status: 'idle' };
+  let eventListener: ((state: UpdaterStatePayload) => void) | null = null;
 
-  function emit(next: UpdaterState): void {
+  function emit(next: UpdaterStatePayload): void {
     state = next;
-    const win = options.getWindow();
-    if (!win || win.isDestroyed()) return;
-    win.webContents.send(UPDATER_EVENT_CHANNEL, state);
+    eventListener?.(state);
   }
 
-  function toVersionState(status: UpdaterStatus, info: UpdateInfo): UpdaterState {
+  function toVersionState(
+    status: UpdaterStatePayload['status'],
+    info: UpdateInfo,
+  ): UpdaterStatePayload {
     return { status, version: info.version };
   }
 
-  function toDownloadingState(progress: ProgressInfo): UpdaterState {
-    return {
-      status: 'downloading',
-      version: state.version,
-      progress: progress.percent,
-    };
+  function toDownloadingState(progress: ProgressInfo): UpdaterStatePayload {
+    return { status: 'downloading', version: state.version, progress: progress.percent };
   }
 
   function init(): void {
@@ -75,36 +54,17 @@ export function createUpdater(options: UpdaterOptions) {
     autoUpdater.autoDownload = true;
     autoUpdater.autoInstallOnAppQuit = false;
 
-    autoUpdater.on('checking-for-update', () => {
-      emit({ status: 'checking' });
-    });
-
-    autoUpdater.on('update-available', (info) => {
-      emit(toVersionState('available', info));
-    });
-
-    autoUpdater.on('download-progress', (progress) => {
-      emit(toDownloadingState(progress));
-    });
-
-    autoUpdater.on('update-downloaded', (info) => {
-      emit(toVersionState('downloaded', info));
-    });
-
-    autoUpdater.on('update-not-available', (info) => {
-      emit(toVersionState('no-update', info));
-    });
-
+    autoUpdater.on('checking-for-update', () => emit({ status: 'checking' }));
+    autoUpdater.on('update-available', (info) => emit(toVersionState('available', info)));
+    autoUpdater.on('download-progress', (progress) => emit(toDownloadingState(progress)));
+    autoUpdater.on('update-downloaded', (info) => emit(toVersionState('downloaded', info)));
+    autoUpdater.on('update-not-available', (info) => emit(toVersionState('no-update', info)));
     autoUpdater.on('error', (error) => {
-      if (isNetworkError(error)) {
-        emit({ status: 'idle' });
-        return;
-      }
-      emit({ status: 'error', error: error.message });
+      emit(isNetworkError(error) ? { status: 'idle' } : { status: 'error', error: error.message });
     });
   }
 
-  async function checkForUpdates(): Promise<UpdaterState> {
+  async function checkForUpdates(): Promise<UpdaterStatePayload> {
     if (!app.isPackaged) {
       emit({ status: 'idle' });
       return state;
@@ -124,8 +84,12 @@ export function createUpdater(options: UpdaterOptions) {
     }
   }
 
-  function getState(): UpdaterState {
+  function getState(): UpdaterStatePayload {
     return state;
+  }
+
+  function onEvent(listener: (state: UpdaterStatePayload) => void): void {
+    eventListener = listener;
   }
 
   async function installUpdate(): Promise<boolean> {
@@ -138,10 +102,5 @@ export function createUpdater(options: UpdaterOptions) {
     return true;
   }
 
-  return {
-    init,
-    checkForUpdates,
-    getState,
-    installUpdate,
-  };
+  return { init, checkForUpdates, getState, onEvent, installUpdate };
 }

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -1,0 +1,103 @@
+import { app, dialog, nativeImage, shell, BrowserWindow } from 'electron';
+import { join } from 'node:path';
+
+import { resolveResourcePath } from './resources.js';
+
+const WEB_DEV_URL = 'http://localhost:5173';
+const WINDOW_ICON_NAME = 'icon.png';
+const DEV_SERVER_POLL_MS = 200;
+const DEV_SERVER_TIMEOUT_MS = 30_000;
+
+function getPackagedWebDistPath(): string {
+  return join(process.resourcesPath, 'web/dist/index.html');
+}
+
+async function waitForDevServer(url: string): Promise<void> {
+  const deadline = Date.now() + DEV_SERVER_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(3000) });
+      if (res.ok) return;
+    } catch {
+      // server not ready yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, DEV_SERVER_POLL_MS));
+  }
+
+  throw new Error(`Dev server at ${url} failed to start within ${DEV_SERVER_TIMEOUT_MS}ms`);
+}
+
+function resolveWindowIcon(): Electron.NativeImage | undefined {
+  const candidates = process.platform === 'win32' ? ['icon.png', 'icon.ico'] : ['icon.png'];
+  return candidates
+    .map((name) => nativeImage.createFromPath(resolveResourcePath(name)))
+    .find((image) => !image.isEmpty());
+}
+
+export async function createWindow(
+  onContextMenu: (params: Electron.ContextMenuParams) => void,
+  onClose: () => void,
+): Promise<BrowserWindow> {
+  const isMac = process.platform === 'darwin';
+  const windowIcon = resolveWindowIcon();
+
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    ...(windowIcon ? { icon: windowIcon } : { icon: resolveResourcePath(WINDOW_ICON_NAME) }),
+    frame: false,
+    ...(isMac ? { titleBarStyle: 'hiddenInset' } : {}),
+    minWidth: 800,
+    minHeight: 600,
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  if (windowIcon) {
+    win.setIcon(windowIcon);
+  }
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    void shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  win.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
+    dialog.showErrorBox(
+      'Failed to load Stitch UI',
+      `errorCode=${errorCode}\nerror=${errorDescription}\nurl=${validatedURL}`,
+    );
+  });
+
+  win.on('close', (event) => {
+    event.preventDefault();
+    onClose();
+  });
+
+  win.webContents.on('context-menu', (_e, params) => {
+    onContextMenu(params);
+  });
+
+  win.on('enter-full-screen', () => {
+    win.webContents.send('window:fullscreen-changed', true);
+  });
+
+  win.on('leave-full-screen', () => {
+    win.webContents.send('window:fullscreen-changed', false);
+  });
+
+  const devUrl = process.env['ELECTRON_RENDERER_URL'] ?? WEB_DEV_URL;
+  if (!app.isPackaged) {
+    await waitForDevServer(devUrl);
+    void win.loadURL(devUrl);
+    win.webContents.openDevTools();
+  } else {
+    void win.loadFile(getPackagedWebDistPath());
+  }
+
+  return win;
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -6,11 +6,17 @@ import type {
   RecordingDeviceChangedPayload,
   RecordingWarningPayload,
 } from '@stitch/shared/chat/realtime';
+
 import type {
+  RecordingDevicesPayload,
+  RecordingPermissionsPayload,
+  ServerConfigPayload,
+  ServerTestRemoteResult,
   StartRecordingInput,
   StartRecordingResponse,
   StopRecordingResponse,
-} from '@stitch/shared/recordings/types';
+  UpdaterStatePayload,
+} from '../main/ipc-types.js';
 
 function onIpc<TPayload>(channel: string, callback: (payload: TPayload) => void): () => void {
   const subscription = (_event: Electron.IpcRendererEvent, payload: TPayload) => callback(payload);
@@ -30,32 +36,14 @@ contextBridge.exposeInMainWorld('electron', {
 });
 
 contextBridge.exposeInMainWorld('api', {
-  getServerConfig: () =>
-    ipcRenderer.invoke('get-server-config') as Promise<{
-      url: string;
-      mode: 'local' | 'remote';
-      remoteUrl: string | null;
-    }>,
+  getServerConfig: () => ipcRenderer.invoke('get-server-config') as Promise<ServerConfigPayload>,
   server: {
     testRemote: (url: string) =>
-      ipcRenderer.invoke('server:test-remote', url) as Promise<{
-        ok: boolean;
-        url?: string;
-        error?: string;
-      }>,
+      ipcRenderer.invoke('server:test-remote', url) as Promise<ServerTestRemoteResult>,
     setConfig: (config: { mode: 'local' | 'remote'; remoteUrl: string | null }) =>
-      ipcRenderer.invoke('server:set-config', config) as Promise<{
-        url: string;
-        mode: 'local' | 'remote';
-        remoteUrl: string | null;
-      }>,
-    onConfigChanged: (
-      callback: (config: {
-        url: string;
-        mode: 'local' | 'remote';
-        remoteUrl: string | null;
-      }) => void,
-    ) => onIpc('server:config-changed', callback),
+      ipcRenderer.invoke('server:set-config', config) as Promise<ServerConfigPayload>,
+    onConfigChanged: (callback: (config: ServerConfigPayload) => void) =>
+      onIpc('server:config-changed', callback),
   },
   window: {
     minimize: () => ipcRenderer.invoke('window:minimize'),
@@ -77,20 +65,8 @@ contextBridge.exposeInMainWorld('api', {
     openPath: () => ipcRenderer.invoke('dialog:openPath') as Promise<string[]>,
   },
   updater: {
-    check: () =>
-      ipcRenderer.invoke('updater:check') as Promise<{
-        status: string;
-        version?: string;
-        progress?: number;
-        error?: string;
-      }>,
-    getState: () =>
-      ipcRenderer.invoke('updater:getState') as Promise<{
-        status: string;
-        version?: string;
-        progress?: number;
-        error?: string;
-      }>,
+    check: () => ipcRenderer.invoke('updater:check') as Promise<UpdaterStatePayload>,
+    getState: () => ipcRenderer.invoke('updater:getState') as Promise<UpdaterStatePayload>,
     install: () => ipcRenderer.invoke('updater:install') as Promise<boolean>,
   },
   spellcheck: {
@@ -116,15 +92,9 @@ contextBridge.exposeInMainWorld('api', {
       ipcRenderer.invoke('recording:start', input) as Promise<StartRecordingResponse>,
     stop: () => ipcRenderer.invoke('recording:stop') as Promise<StopRecordingResponse>,
     listDevices: () =>
-      ipcRenderer.invoke('recording:listDevices') as Promise<{
-        microphoneDevices: string[];
-        speakerDevices: string[];
-      }>,
+      ipcRenderer.invoke('recording:listDevices') as Promise<RecordingDevicesPayload>,
     checkPermissions: () =>
-      ipcRenderer.invoke('recording:checkPermissions') as Promise<{
-        microphone: 'granted' | 'denied' | 'unknown';
-        screenCapture: 'granted' | 'denied' | 'unknown';
-      }>,
+      ipcRenderer.invoke('recording:checkPermissions') as Promise<RecordingPermissionsPayload>,
     onWarning: (callback: (payload: RecordingWarningPayload) => void) =>
       onIpc('recording:warning', callback),
     onDeviceChanged: (callback: (payload: RecordingDeviceChangedPayload) => void) =>

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -274,6 +274,7 @@ function ToolCallRowActions({ actions }: { actions: ToolCallAction[] }) {
             size="xs"
             className="h-5 px-1.5 text-[11px] leading-3 text-muted-foreground"
             title="Open child session"
+            nativeButton={false}
             render={<Link to="/session/$id" params={{ id: action.sessionId }} />}
           >
             <ExternalLinkIcon className="size-3" />

--- a/apps/web/src/components/layout/server-status.tsx
+++ b/apps/web/src/components/layout/server-status.tsx
@@ -1,16 +1,29 @@
 import { HardDrive, Check } from 'lucide-react';
+import * as React from 'react';
 import { useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useSSE } from '@/hooks/sse/sse-context';
-import { serverFetch } from '@/lib/api';
+import { serverFetch, type ServerConnectionConfig } from '@/lib/api';
 
 type Tab = 'servers' | 'info';
 
+function useServerConfig() {
+  const [config, setConfig] = React.useState<ServerConnectionConfig | null>(null);
+
+  React.useEffect(() => {
+    void window.api?.getServerConfig().then(setConfig);
+    return window.api?.server?.onConfigChanged(setConfig);
+  }, []);
+
+  return config;
+}
+
 export function ServerStatus() {
   const [activeTab, setActiveTab] = useState<Tab>('servers');
+  const serverConfig = useServerConfig();
 
   const { data: isHealthy } = useQuery({
     queryKey: ['health'],
@@ -25,6 +38,9 @@ export function ServerStatus() {
   const { isConnected: isSseConnected, lastHeartbeat } = useSSE();
 
   const overallHealthy = isHealthy && isSseConnected;
+
+  const serverLabel = serverConfig?.mode === 'remote' ? 'Remote Server' : 'Local Server';
+  const serverSubtitle = serverConfig?.mode === 'remote' ? serverConfig.url : undefined;
 
   return (
     <Popover>
@@ -60,7 +76,7 @@ export function ServerStatus() {
         <div className="flex flex-col gap-4 bg-popover p-4">
           {activeTab === 'servers' ? (
             <>
-              <StatusItem active={!!isHealthy} label="Local Server" />
+              <StatusItem active={!!isHealthy} label={serverLabel} subtitle={serverSubtitle} />
               <StatusItem
                 active={isSseConnected}
                 label="Event Bus"


### PR DESCRIPTION
## Change Summary

Decomposed the 520-line apps/desktop/src/main/index.ts god file into focused modules, fixed a Base UI accessibility warning, and improved the server status indicator.

### Improvements and Refactors
- Desktop main process decomposition: Extracted 30 IPC handlers into domain modules under src/main/ipc/ (window, recording, server, permissions, files, shell, devtools, spellcheck, updater). index.ts reduced from 520 to 198 lines
- Shared IPC type contracts: Added src/main/ipc-types.ts as single source of truth for types crossing the main/preload boundary
- Module extractions: createWindow() to window.ts, TCC permissions reset to tcc-permissions.ts, serverJson() to server-client.ts
- Updater decoupled from window: Replaced getWindow dependency with an onEvent() subscriber
- Sidecar cleanup: Extracted findStalePids() to remove inline platform-switch duplication

### New Features
- Server status indicator now shows Local Server or Remote Server based on active connection mode, with remote URL shown as subtitle

### Bug Fixes
- Added nativeButton=false to Button rendered as TanStack Link in tool-call-group.tsx