### PR TITLE
fix: deduplicate tool permission requests

### DIFF
--- a/packages/server/src/permission/service.test.ts
+++ b/packages/server/src/permission/service.test.ts
@@ -9,6 +9,14 @@ import { permissionResponses, sessions, toolPermissions } from '@/db/schema.js';
 import { setupTestDb } from '@/db/test-helpers.js';
 import * as Events from '@/lib/events.js';
 import { interactionBroker } from '@/lib/interactions/broker.js';
+import {
+  abortPermissionResponses,
+  allowPermissionResponse,
+  alternativePermissionResponse,
+  rejectPermissionResponse,
+  requestPermissionResponse,
+  upsertPerm,
+} from '@/permission/service.js';
 
 setupTestDb();
 
@@ -40,6 +48,14 @@ async function waitForEvents(count: number): Promise<void> {
   }
 }
 
+async function waitForRequestedEvents(count: number): Promise<void> {
+  while (
+    emittedEvents.filter(([name]) => name === 'permission-response-requested').length < count
+  ) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
 describe('permission service interactions', () => {
   beforeEach(async () => {
     emittedEvents = [];
@@ -54,9 +70,6 @@ describe('permission service interactions', () => {
   });
 
   test('requestPermissionResponse broadcasts and resolves through allowPermissionResponse', async () => {
-    const { requestPermissionResponse, allowPermissionResponse } =
-      await import('@/permission/service.js');
-
     const promise = requestPermissionResponse({
       sessionId,
       messageId,
@@ -100,10 +113,167 @@ describe('permission service interactions', () => {
     expect(row?.status).toBe('allowed');
   });
 
-  test('alternativePermissionResponse resolves with alternative entry', async () => {
-    const { requestPermissionResponse, alternativePermissionResponse } =
-      await import('@/permission/service.js');
+  test('deduplicates concurrent permission requests with the same key', async () => {
+    const dedupeKey = 'permission:dedupe:same';
 
+    const first = requestPermissionResponse({
+      sessionId,
+      messageId,
+      streamRunId: 'run_permission',
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      toolInput: { command: 'pwd' },
+      systemReminder: 'Tool execution requires user approval',
+      dedupeKey,
+    });
+    const second = requestPermissionResponse({
+      sessionId,
+      messageId,
+      streamRunId: 'run_permission',
+      toolCallId: 'call_2',
+      toolName: 'bash',
+      toolInput: { command: 'pwd' },
+      systemReminder: 'Tool execution requires user approval',
+      dedupeKey,
+    });
+
+    await waitForRequestedEvents(1);
+
+    const requestedEvents = emittedEvents.filter(
+      ([name]) => name === 'permission-response-requested',
+    ) as Array<[string, SseEventPayloadMap['permission-response-requested']]>;
+    expect(requestedEvents).toHaveLength(1);
+
+    const db = getDb();
+    const rows = await db
+      .select()
+      .from(permissionResponses)
+      .where(
+        and(
+          eq(permissionResponses.sessionId, sessionId),
+          eq(permissionResponses.status, 'pending'),
+        ),
+      );
+    expect(rows).toHaveLength(1);
+
+    await allowPermissionResponse(requestedEvents[0][1].permissionResponse.id);
+
+    expect(first).resolves.toEqual({ decision: 'allow' });
+    expect(second).resolves.toEqual({ decision: 'allow' });
+  });
+
+  test('does not deduplicate permission requests with different keys', async () => {
+    const first = requestPermissionResponse({
+      sessionId,
+      messageId,
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      toolInput: { command: 'pwd' },
+      systemReminder: 'Tool execution requires user approval',
+      dedupeKey: 'permission:dedupe:first',
+    });
+    const second = requestPermissionResponse({
+      sessionId,
+      messageId,
+      toolCallId: 'call_2',
+      toolName: 'bash',
+      toolInput: { command: 'ls' },
+      systemReminder: 'Tool execution requires user approval',
+      dedupeKey: 'permission:dedupe:second',
+    });
+
+    await waitForRequestedEvents(2);
+
+    const requestedEvents = emittedEvents.filter(
+      ([name]) => name === 'permission-response-requested',
+    ) as Array<[string, SseEventPayloadMap['permission-response-requested']]>;
+    expect(requestedEvents).toHaveLength(2);
+
+    await rejectPermissionResponse(requestedEvents[0][1].permissionResponse.id);
+    await rejectPermissionResponse(requestedEvents[1][1].permissionResponse.id);
+
+    expect(first).resolves.toEqual({ decision: 'reject' });
+    expect(second).resolves.toEqual({ decision: 'reject' });
+  });
+
+  test('clears dedupe key after permission resolution', async () => {
+    const dedupeKey = 'permission:dedupe:reusable';
+
+    const first = requestPermissionResponse({
+      sessionId,
+      messageId,
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      toolInput: { command: 'pwd' },
+      systemReminder: 'Tool execution requires user approval',
+      dedupeKey,
+    });
+
+    await waitForRequestedEvents(1);
+    const firstRequested = emittedEvents.find(
+      ([name]) => name === 'permission-response-requested',
+    )![1] as SseEventPayloadMap['permission-response-requested'];
+
+    await allowPermissionResponse(firstRequested.permissionResponse.id);
+    expect(first).resolves.toEqual({ decision: 'allow' });
+
+    const second = requestPermissionResponse({
+      sessionId,
+      messageId,
+      toolCallId: 'call_2',
+      toolName: 'bash',
+      toolInput: { command: 'pwd' },
+      systemReminder: 'Tool execution requires user approval',
+      dedupeKey,
+    });
+
+    await waitForRequestedEvents(2);
+
+    const requestedEvents = emittedEvents.filter(
+      ([name]) => name === 'permission-response-requested',
+    ) as Array<[string, SseEventPayloadMap['permission-response-requested']]>;
+    expect(requestedEvents).toHaveLength(2);
+
+    await rejectPermissionResponse(requestedEvents[1][1].permissionResponse.id);
+    expect(second).resolves.toEqual({ decision: 'reject' });
+  });
+
+  test('deduplicated permission requests reject together on abort', async () => {
+    const dedupeKey = 'permission:dedupe:abort';
+
+    const first = requestPermissionResponse({
+      sessionId,
+      messageId,
+      streamRunId: 'run_permission',
+      toolCallId: 'call_1',
+      toolName: 'bash',
+      toolInput: { command: 'pwd' },
+      systemReminder: 'Tool execution requires user approval',
+      dedupeKey,
+    });
+    const second = requestPermissionResponse({
+      sessionId,
+      messageId,
+      streamRunId: 'run_permission',
+      toolCallId: 'call_2',
+      toolName: 'bash',
+      toolInput: { command: 'pwd' },
+      systemReminder: 'Tool execution requires user approval',
+      dedupeKey,
+    });
+
+    await waitForRequestedEvents(1);
+    await abortPermissionResponses(sessionId);
+
+    const requestedEvents = emittedEvents.filter(
+      ([name]) => name === 'permission-response-requested',
+    );
+    expect(requestedEvents).toHaveLength(1);
+    expect(first).rejects.toThrow('Permission response aborted by session abort');
+    expect(second).rejects.toThrow('Permission response aborted by session abort');
+  });
+
+  test('alternativePermissionResponse resolves with alternative entry', async () => {
     const promise = requestPermissionResponse({
       sessionId,
       messageId,
@@ -138,9 +308,6 @@ describe('permission service interactions', () => {
   });
 
   test('abortPermissionResponses rejects pending permissions for the session', async () => {
-    const { requestPermissionResponse, abortPermissionResponses, rejectPermissionResponse } =
-      await import('@/permission/service.js');
-
     const first = requestPermissionResponse({
       sessionId,
       messageId,
@@ -195,7 +362,6 @@ describe('permission service interactions', () => {
 
 describe('upsertPerm', () => {
   test('deletes existing global rule before inserting when pattern is null', async () => {
-    const { upsertPerm } = await import('@/permission/service.js');
     const db = getDb();
 
     await upsertPerm({ toolName: 'bash', permission: 'allow', pattern: null });
@@ -209,7 +375,6 @@ describe('upsertPerm', () => {
   });
 
   test('does not delete when pattern is a non-null string', async () => {
-    const { upsertPerm } = await import('@/permission/service.js');
     const db = getDb();
 
     await upsertPerm({ toolName: 'bash', permission: 'allow', pattern: '/home/*' });
@@ -223,7 +388,6 @@ describe('upsertPerm', () => {
   });
 
   test('calling upsertPerm twice with null pattern replaces the global rule', async () => {
-    const { upsertPerm } = await import('@/permission/service.js');
     const db = getDb();
 
     await upsertPerm({ toolName: 'bash', permission: 'ask', pattern: null });

--- a/packages/server/src/permission/service.ts
+++ b/packages/server/src/permission/service.ts
@@ -22,6 +22,7 @@ import { PermissionResponseAbortedError } from '@/llm/stream/errors.js';
 import { resolvePermissionFromRules } from '@/permission/policy.js';
 
 const log = Log.create({ service: 'permission-service' });
+const pendingPermissionRequests = new Map<string, Promise<PermissionDecisionResult>>();
 
 type PermissionResponseRow = typeof permissionResponses.$inferSelect;
 
@@ -96,7 +97,7 @@ export async function getPermissionDecision(opts: {
   return resolvePermissionFromRules(rows, opts.patternTargets ?? []);
 }
 
-export async function requestPermissionResponse(opts: {
+type RequestPermissionResponseOptions = {
   sessionId: PrefixedString<'ses'>;
   messageId: PrefixedString<'msg'>;
   streamRunId?: string;
@@ -105,8 +106,13 @@ export async function requestPermissionResponse(opts: {
   toolInput: unknown;
   systemReminder: string;
   suggestion?: PermissionSuggestion | null;
+  dedupeKey?: string;
   abortSignal?: AbortSignal;
-}): Promise<PermissionDecisionResult> {
+};
+
+async function createPermissionResponse(
+  opts: RequestPermissionResponseOptions,
+): Promise<PermissionDecisionResult> {
   const db = getDb();
   const id = createPermissionResponseId();
   const now = Date.now();
@@ -154,6 +160,23 @@ export async function requestPermissionResponse(opts: {
     abortSignal: opts.abortSignal,
     abortError: () => new PermissionResponseAbortedError(),
   });
+}
+
+export async function requestPermissionResponse(
+  opts: RequestPermissionResponseOptions,
+): Promise<PermissionDecisionResult> {
+  if (!opts.dedupeKey) {
+    return createPermissionResponse(opts);
+  }
+
+  const existing = pendingPermissionRequests.get(opts.dedupeKey);
+  if (existing) return existing;
+
+  const promise = createPermissionResponse(opts).finally(() => {
+    pendingPermissionRequests.delete(opts.dedupeKey!);
+  });
+  pendingPermissionRequests.set(opts.dedupeKey, promise);
+  return promise;
 }
 
 async function resolvePermissionResponse(opts: {

--- a/packages/server/src/tools/runtime/middleware.ts
+++ b/packages/server/src/tools/runtime/middleware.ts
@@ -3,10 +3,20 @@ import { isToolDataResult, isToolErrorResult } from '@stitch/shared/tools/types'
 import * as Log from '@/lib/log.js';
 import { PermissionRejectedError, StreamProtocolViolationError } from '@/llm/stream/errors.js';
 import { getPermissionDecision, requestPermissionResponse } from '@/permission/service.js';
+import type { ToolExecutionInput, ToolMiddleware } from '@/tools/runtime/runtime.js';
 import { truncateOutput } from '@/tools/runtime/truncation.js';
-import type { ToolMiddleware } from '@/tools/runtime/runtime.js';
 
 const log = Log.create({ service: 'tools' });
+
+function createPermissionDedupeKey(input: ToolExecutionInput, patternTargets: string[]): string {
+  return JSON.stringify([
+    input.context.sessionId,
+    input.context.messageId,
+    input.context.streamRunId,
+    input.toolName,
+    [...patternTargets].sort(),
+  ]);
+}
 
 type TruncationMeta = {
   __stitchToolResultMeta: {
@@ -46,7 +56,10 @@ export function resultNormalizationMiddleware(): ToolMiddleware {
   };
 }
 
-export function truncationMiddleware(options?: { maxLines?: number; maxBytes?: number }): ToolMiddleware {
+export function truncationMiddleware(options?: {
+  maxLines?: number;
+  maxBytes?: number;
+}): ToolMiddleware {
   return (next) => async (input) => {
     const execOptions = input.executeOptions as Record<string, unknown> | undefined;
     if (execOptions?.['skipTruncation'] === true) {
@@ -114,7 +127,9 @@ export function permissionMiddleware(): ToolMiddleware {
       throw new PermissionRejectedError(input.toolName);
     }
 
-    const meta = input.executeOptions as { toolCallId: string; abortSignal?: AbortSignal } | undefined;
+    const meta = input.executeOptions as
+      | { toolCallId: string; abortSignal?: AbortSignal }
+      | undefined;
     const toolCallId = meta?.toolCallId;
     if (!toolCallId) {
       log.error(
@@ -141,6 +156,7 @@ export function permissionMiddleware(): ToolMiddleware {
       toolInput: input.args,
       systemReminder: 'Tool execution requires user approval',
       suggestion: behavior.getSuggestion(input.args),
+      dedupeKey: createPermissionDedupeKey(input, patternTargets),
       abortSignal: meta?.abortSignal,
     });
 


### PR DESCRIPTION
## 🚀 Change Summary

Deduplicates concurrent tool permission requests for the same permission surface so parallel identical tool calls share a single pending user approval instead of creating duplicate prompts.

### 🐛 Bug Fixes
- Coalesce pending permission requests by session, message, stream run, tool, and permission pattern targets.
- Reuse the shared decision for duplicate requests and clear the dedupe key after resolution or abort.

### 🛠 Improvements & Refactors
- Adds regression coverage for duplicate requests, distinct requests, key cleanup, and abort behavior.