### PR TITLE
Fix agent tool selection and Windows bash behavior

### DIFF
--- a/packages/server/src/lib/shell.test.ts
+++ b/packages/server/src/lib/shell.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 
-import { inferWindowsShellFromProfile, pickWindowsShell } from '@/lib/shell.js';
+import {
+  buildCmdArgv,
+  buildPowerShellArgv,
+  buildWindowsShellArgv,
+  inferWindowsShellFromProfile,
+  pickWindowsShell,
+} from '@/lib/shell.js';
 
 describe('shell preferences', () => {
   test('infers pwsh from PowerShell profile metadata', () => {
@@ -60,5 +66,39 @@ describe('shell preferences', () => {
         comspec: 'C:\\Windows\\System32\\cmd.exe',
       }),
     ).toBe('C:\\Windows\\System32\\cmd.exe');
+  });
+
+  test('builds encoded PowerShell argv', () => {
+    const command = 'Get-ChildItem -LiteralPath "C:\\Program Files"';
+    const argv = buildPowerShellArgv(command);
+
+    expect(argv.slice(0, -1)).toEqual([
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-EncodedCommand',
+    ]);
+    expect(Buffer.from(argv.at(-1) ?? '', 'base64').toString('utf16le')).toBe(command);
+  });
+
+  test('builds cmd argv', () => {
+    const command = 'dir "C:\\Program Files"';
+
+    expect(buildCmdArgv(command)).toEqual(['/d', '/s', '/c', command]);
+  });
+
+  test('round-trips PowerShell commands with shell-sensitive characters', () => {
+    const command = '"quoted value"; $env:Path; Write-Output "a & b"\nWrite-Output done';
+    const argv = buildWindowsShellArgv('pwsh.exe', command);
+
+    expect(Buffer.from(argv.at(-1) ?? '', 'base64').toString('utf16le')).toBe(command);
+  });
+
+  test('uses cmd argv for non-PowerShell Windows shells', () => {
+    const command = 'echo hello';
+
+    expect(buildWindowsShellArgv('cmd.exe', command)).toEqual(['/d', '/s', '/c', command]);
   });
 });

--- a/packages/server/src/lib/shell.ts
+++ b/packages/server/src/lib/shell.ts
@@ -23,8 +23,40 @@ type TerminalProfileWithGuid = TerminalProfile & {
 
 type ShellResolution = {
   shell: string;
+  exe: string;
   source: string;
+  buildArgv: (command: string) => string[];
 };
+
+export function buildPowerShellArgv(command: string): string[] {
+  const encodedCommand = Buffer.from(command, 'utf16le').toString('base64');
+  return [
+    '-NoLogo',
+    '-NoProfile',
+    '-NonInteractive',
+    '-ExecutionPolicy',
+    'Bypass',
+    '-EncodedCommand',
+    encodedCommand,
+  ];
+}
+
+export function buildCmdArgv(command: string): string[] {
+  return ['/d', '/s', '/c', command];
+}
+
+function buildPosixArgv(command: string): string[] {
+  return ['-c', command];
+}
+
+export function buildWindowsShellArgv(shell: string, command: string): string[] {
+  const lowerShell = shell.toLowerCase();
+  if (lowerShell.includes('pwsh') || lowerShell.includes('powershell')) {
+    return buildPowerShellArgv(command);
+  }
+
+  return buildCmdArgv(command);
+}
 
 export function inferWindowsShellFromProfile(profile: TerminalProfile): WindowsShellPreference {
   const text = [profile.name, profile.source, profile.commandline]
@@ -68,25 +100,37 @@ export function resolvePreferredShell(): ShellResolution {
   if (process.platform === 'win32') {
     const profile = readWindowsTerminalDefaultProfile();
     const preferred = profile ? inferWindowsShellFromProfile(profile) : null;
+    const shell = pickWindowsShell({
+      preferred,
+      hasPwsh: commandExists('pwsh.exe'),
+      hasPowershell: commandExists('powershell.exe'),
+      comspec: process.env.COMSPEC,
+    });
 
     return {
-      shell: pickWindowsShell({
-        preferred,
-        hasPwsh: commandExists('pwsh.exe'),
-        hasPowershell: commandExists('powershell.exe'),
-        comspec: process.env.COMSPEC,
-      }),
+      shell,
+      exe: shell,
       source: preferred ? 'windows-terminal-default-profile' : 'windows-fallback',
+      buildArgv: (command) => buildWindowsShellArgv(shell, command),
     };
   }
 
   if (process.env.SHELL && process.env.SHELL.trim().length > 0) {
-    return { shell: process.env.SHELL, source: 'process.env.SHELL' };
+    return {
+      shell: process.env.SHELL,
+      exe: process.env.SHELL,
+      source: 'process.env.SHELL',
+      buildArgv: buildPosixArgv,
+    };
   }
 
+  const shell = process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh';
+
   return {
-    shell: process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh',
+    shell,
+    exe: shell,
     source: 'platform-default',
+    buildArgv: buildPosixArgv,
   };
 }
 

--- a/packages/server/src/llm/prompt/base-system-prompt.txt
+++ b/packages/server/src/llm/prompt/base-system-prompt.txt
@@ -82,7 +82,8 @@ Do not use `bash` for file reads, writes, searches, or edits when dedicated tool
 - Use `list_toolsets({ query: "<domain>" })` when the user names a specific domain (Gmail, browser, calendar, etc.).
 - Use `list_toolsets` with no arguments only when the needed domain is unclear.
 - Use `activate_toolset` to load a toolset. Set `persist=true` when it will be needed across future turns.
-- Use `deactivate_toolset` to free context when a toolset is no longer needed.
+- Do not deactivate a toolset you are likely to use again this session. Leave it active.
+- Use `deactivate_toolset` only to free context when switching to an unrelated domain or when the toolset is clearly no longer needed.
 - Only activate toolsets you need for the current task. Do not activate all at once.
 - If a toolset is already active, call its tools directly — do not re-list or re-activate.
 - If the capability does not appear in the catalog, it is not available. Do not retry with synonyms or variants.

--- a/packages/server/src/llm/prompt/base-system-prompt.txt
+++ b/packages/server/src/llm/prompt/base-system-prompt.txt
@@ -4,6 +4,7 @@ You are assisting users on their local machine. You can run shell commands, read
 
 - Always use tools to get data. Never fabricate file contents, command output, URLs, paths, or specific values.
 - If a tool returns an error or empty result, report that honestly. Do not fill the gap with guesses.
+- NEVER substitute plausible-looking fabricated output for results you couldn't actually produce. If a tool returns empty or no usable data, retry with a different tool/query or report the gap honestly. Never invent numbers, prices, dates, or file contents to fill a chart or answer.
 - When you lack information and no tool can provide it, say so plainly.
 - When your answer is based on file contents or tool output, reference the source (file path or tool used).
 - Do not expose secrets (tokens, keys, passwords, credentials).
@@ -17,12 +18,15 @@ You are assisting users on their local machine. You can run shell commands, read
 - Prefer minimal, reversible changes.
 - If a task is large, break it into small steps and report progress briefly.
 - For ambiguous multi-step requests where the direction materially changes the outcome, clarify scope before starting. For clear requests, proceed directly.
+- When you say you will do something, do it in the same turn. Never end a turn with only a plan when the task can be acted on safely.
 
 ## Verification
 
 After completing non-trivial work, verify the result before reporting success:
 - Run tests, linters, or build commands when relevant.
-- Re-read modified files to confirm changes applied correctly.
+- Trust tool results. Do not re-read a file you just wrote unless the edit reported failure.
+- Do not re-run a command that already succeeded.
+- Verify once at meaningful checkpoints, not after every step.
 - Check command exit codes and output for unexpected errors.
 - If you cannot verify (no test suite, no way to run it), state what the user should check.
 
@@ -43,15 +47,22 @@ Use `todo` when:
 - You are implementing, debugging, refactoring, researching, or verifying non-trivial work.
 - You discover follow-up work that must be tracked.
 
-Do not use `todo` for single-step answers, quick factual responses, or conversational turns.
+Do not use `todo` for single-step answers, quick factual responses, or conversational turns. For 2-3 step tasks, a todo list is optional.
 
 Rules:
 - Write the initial todo list before starting substantial work.
 - Keep exactly one item `in_progress` while actively working.
 - Mark an item `completed` only after the work is done, including verification.
 - If work becomes blocked, keep the blocked item `in_progress` and add a todo that states the blocker.
-- Update the todo list as soon as progress changes. Do not batch updates at the end.
+- Update the todo list at meaningful milestones, not after every tool call. Do not batch updates at the end.
 - The todo tool replaces the full list each time, so always send the complete current list.
+
+## Tool Selection
+
+Choose domain-specific tools before generic tools:
+- When a task matches a specialized data domain such as financial data, email, calendar, GitHub, or databases, prefer the matching domain-specific toolset over generic web search.
+- Web search is a last resort for facts no specialized tool can provide.
+- Stock prices, earnings, and financials require a financial data toolset, not web search.
 
 ## Tool Use
 

--- a/packages/server/src/llm/prompt/base-system-prompt.txt
+++ b/packages/server/src/llm/prompt/base-system-prompt.txt
@@ -77,6 +77,7 @@ Prefer the most specific tool for the job:
 - `webfetch` — fetch a known URL.
 
 Do not use `bash` for file reads, writes, searches, or edits when dedicated tools exist.
+On Windows, the `bash` tool runs commands in PowerShell (pwsh/powershell). Use PowerShell syntax, not bash/sh syntax. Pipes, aliases, and quoting follow PowerShell conventions.
 
 **Toolsets** are groups of additional tools you can discover and load on demand:
 - Use `list_toolsets({ query: "<domain>" })` when the user names a specific domain (Gmail, browser, calendar, etc.).

--- a/packages/server/src/llm/prompt/builder.ts
+++ b/packages/server/src/llm/prompt/builder.ts
@@ -75,6 +75,15 @@ ${buildLiquidUiCatalogPrompt()}
 </liquid_ui>`;
 }
 
+function buildEnforcementGuidance(): string {
+  return `## Enforcement Guidance
+
+- Mandatory tool use: never answer from memory when a tool can produce the fact, including calculations, current data, file contents, system state, or financial/market data.
+- Tool persistence: keep using tools until the task is complete and verified. If a tool returns empty or partial data, try a different query or strategy before giving up.
+- Anti-fabrication: if you cannot produce a result with tools, state the blocker honestly instead of filling gaps with plausible output.
+- Act, don't ask: act immediately when the request has an obvious safe default. Ask at most one focused question only when truly blocked.`;
+}
+
 export function buildSystemPrompt(input: {
   useBasePrompt: boolean;
   systemPrompt: string | null;
@@ -98,6 +107,8 @@ export function buildSystemPrompt(input: {
   }
 
   let result = `${identity(userName)}\n\n${buildPromptEnvironment({ userTimezone })}\n\n${promptBody}`;
+
+  result = `${result}\n\n${buildEnforcementGuidance()}`;
 
   if (input.codeModePrompt?.trim()) {
     result = `${result}\n\n${input.codeModePrompt.trim()}`;

--- a/packages/server/src/llm/stream/tool-assembler.ts
+++ b/packages/server/src/llm/stream/tool-assembler.ts
@@ -54,7 +54,7 @@ async function buildAvailableToolsetsPrompt(manager: ToolsetManager): Promise<st
   return [
     '## Available Toolsets',
     '',
-    'Use `activate_toolset` when a listed toolset clearly matches the task. Prefer matching domain-specific data toolsets over generic web search: financial data for stock prices, earnings, and financials; email for email; calendar for calendar; GitHub/repository-knowledge for GitHub repository questions; databases for database questions. Use web search only when no specialized toolset can provide the needed facts. Do not activate unrelated toolsets.',
+    'Use `activate_toolset` when a listed toolset clearly matches the task. Prefer matching domain-specific data toolsets over generic web search: financial data for stock prices, earnings, and financials; email for email; calendar for calendar; GitHub/repository-knowledge for GitHub repository questions; databases for database questions. Use web search only when no specialized toolset can provide the needed facts. Do not activate unrelated toolsets. If a toolset is already active, call its tools directly; do not re-activate it. Do not deactivate a toolset you are likely to use again this session; only deactivate to free context when switching to an unrelated domain.',
     '',
     ...lines,
   ].join('\n');

--- a/packages/server/src/llm/stream/tool-assembler.ts
+++ b/packages/server/src/llm/stream/tool-assembler.ts
@@ -54,7 +54,7 @@ async function buildAvailableToolsetsPrompt(manager: ToolsetManager): Promise<st
   return [
     '## Available Toolsets',
     '',
-    'Use `activate_toolset` when a listed toolset clearly matches the task. For web/current-info tasks, prefer relevant web-search MCP toolsets when available. For GitHub repository questions, prefer relevant repository-knowledge MCP toolsets when available. Do not activate unrelated toolsets.',
+    'Use `activate_toolset` when a listed toolset clearly matches the task. Prefer matching domain-specific data toolsets over generic web search: financial data for stock prices, earnings, and financials; email for email; calendar for calendar; GitHub/repository-knowledge for GitHub repository questions; databases for database questions. Use web search only when no specialized toolset can provide the needed facts. Do not activate unrelated toolsets.',
     '',
     ...lines,
   ].join('\n');

--- a/packages/server/src/tools/core/bash.ts
+++ b/packages/server/src/tools/core/bash.ts
@@ -1,5 +1,5 @@
 import { tool } from 'ai';
-import { spawn, type ChildProcess } from 'node:child_process';
+import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { z } from 'zod';
 
@@ -47,6 +47,35 @@ function normalizeTimeout(timeout: number | undefined): number {
     throw new Error('timeout must be a positive number');
   }
   return Math.min(Math.trunc(timeout), MAX_TIMEOUT_MS);
+}
+
+function spawnShellCommand(input: {
+  shell: string;
+  exe: string;
+  argv: string[];
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}): ChildProcess {
+  const options: SpawnOptions = {
+    cwd: input.cwd,
+    env: input.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: process.platform !== 'win32',
+    windowsHide: process.platform === 'win32',
+  };
+
+  if (process.platform === 'win32') {
+    return spawn(input.exe, input.argv, {
+      ...options,
+      detached: false,
+    });
+  }
+
+  return spawn(input.command, [], {
+    ...options,
+    shell: input.shell,
+  });
 }
 
 async function killProcessTree(proc: ChildProcess, exited: () => boolean): Promise<void> {
@@ -100,14 +129,14 @@ Parameter sourcing:
     execute: async (input, { abortSignal }) => {
       const workdir = await validateExistingDirectoryPath(input.workdir);
       const timeout = normalizeTimeout(input.timeout);
-      const shell = resolvePreferredShell().shell;
-      const proc = spawn(input.command, {
-        shell,
+      const shellResolution = resolvePreferredShell();
+      const proc = spawnShellCommand({
+        shell: shellResolution.shell,
+        exe: shellResolution.exe,
+        argv: shellResolution.buildArgv(input.command),
+        command: input.command,
         cwd: workdir,
         env: process.env,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        detached: process.platform !== 'win32',
-        windowsHide: process.platform === 'win32',
       });
 
       let output = '';
@@ -149,6 +178,9 @@ Parameter sourcing:
 
         proc.once('exit', () => {
           exited = true;
+        });
+
+        proc.once('close', () => {
           cleanup();
           resolve();
         });


### PR DESCRIPTION
## 🚀 Change Summary

Improves agent reliability by tightening prompt guidance around tool-backed facts, domain-specific tool selection, anti-fabrication, verification discipline, and toolset persistence. Also fixes Windows bash execution by invoking the selected shell executable directly with encoded PowerShell commands to avoid console-window flashes and preserve shell-sensitive commands.

### ✨ New Features
- **Agent reliability guidance**: Adds mandatory tool-use, anti-fabrication, act-don't-ask, and domain-specific tool selection guidance across the base and assembled system prompts.
- **Windows bash shell execution**: Resolves preferred shells into executable/argv builders and uses direct Windows shell invocation with encoded PowerShell commands.

### 🛠 Improvements & Refactors
- Reduces toolset activation/deactivation churn by instructing agents to reuse active toolsets and only deactivate when switching domains.
- Adds regression coverage for PowerShell/cmd argv construction and shell-sensitive command round-tripping.

Closes #258