### PR TITLE
Toolset deactivation: model-visible expiry notices

### DIFF
--- a/packages/server/drizzle/0026_lethal_phantom_reporter.sql
+++ b/packages/server/drizzle/0026_lethal_phantom_reporter.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `sessions` ADD `toolset_state` blob;

--- a/packages/server/drizzle/0026_lethal_phantom_reporter.sql
+++ b/packages/server/drizzle/0026_lethal_phantom_reporter.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `sessions` ADD `toolset_state` blob;

--- a/packages/server/drizzle/0026_mixed_guardsmen.sql
+++ b/packages/server/drizzle/0026_mixed_guardsmen.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `sessions` ADD `toolset_state` blob;--> statement-breakpoint
+ALTER TABLE `sessions` DROP COLUMN `active_toolset_ids`;

--- a/packages/server/drizzle/meta/0026_snapshot.json
+++ b/packages/server/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,2653 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ff09e1bf-f7df-434d-861a-0c501af0165f",
+  "prevId": "cf7c0ce3-b9c1-409a-a321-bf8dc6b71c29",
+  "tables": {
+    "agenda_item_events": {
+      "name": "agenda_item_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_item_events_item_id_idx": {
+          "name": "agenda_item_events_item_id_idx",
+          "columns": [
+            "item_id"
+          ],
+          "isUnique": false
+        },
+        "agenda_item_events_created_at_idx": {
+          "name": "agenda_item_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_item_events_item_id_agenda_items_id_fk": {
+          "name": "agenda_item_events_item_id_agenda_items_id_fk",
+          "tableFrom": "agenda_item_events",
+          "tableTo": "agenda_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_item_events_type_check": {
+          "name": "agenda_item_events_type_check",
+          "value": "\"agenda_item_events\".\"type\" in ('created', 'status_change', 'updated', 'comment')"
+        }
+      }
+    },
+    "agenda_items": {
+      "name": "agenda_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'todo'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_items_list_id_idx": {
+          "name": "agenda_items_list_id_idx",
+          "columns": [
+            "list_id"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_status_idx": {
+          "name": "agenda_items_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_due_at_idx": {
+          "name": "agenda_items_due_at_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_created_at_idx": {
+          "name": "agenda_items_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_items_list_id_agenda_lists_id_fk": {
+          "name": "agenda_items_list_id_agenda_lists_id_fk",
+          "tableFrom": "agenda_items",
+          "tableTo": "agenda_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_items_type_check": {
+          "name": "agenda_items_type_check",
+          "value": "\"agenda_items\".\"type\" in ('todo', 'reminder', 'checkup')"
+        },
+        "agenda_items_status_check": {
+          "name": "agenda_items_status_check",
+          "value": "\"agenda_items\".\"status\" in ('open', 'in_progress', 'done', 'cancelled')"
+        },
+        "agenda_items_priority_check": {
+          "name": "agenda_items_priority_check",
+          "value": "\"agenda_items\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      }
+    },
+    "agenda_lists": {
+      "name": "agenda_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_lists_name_uidx": {
+          "name": "agenda_lists_name_uidx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "agenda_lists_created_at_idx": {
+          "name": "agenda_lists_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "auth_issue": {
+          "name": "auth_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lance_migrations": {
+      "name": "lance_migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "prev_id": {
+          "name": "prev_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'applied'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "is_attributable": {
+          "name": "is_attributable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_index": {
+          "name": "attempt_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_run_id_idx": {
+          "name": "llm_usage_events_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ollama_models": {
+      "name": "ollama_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_limit": {
+          "name": "input_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_limit": {
+          "name": "output_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_cost_per_million": {
+          "name": "input_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_cost_per_million": {
+          "name": "output_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_cost_per_million": {
+          "name": "cache_read_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_per_million": {
+          "name": "cache_write_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_tool_calls": {
+          "name": "supports_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_vision": {
+          "name": "supports_vision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_reasoning": {
+          "name": "supports_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permission_responses": {
+      "name": "permission_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_reminder": {
+          "name": "system_reminder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_responses_session_id_sessions_id_fk": {
+          "name": "permission_responses_session_id_sessions_id_fk",
+          "tableFrom": "permission_responses",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_messages": {
+      "name": "queued_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "queued_messages_session_id_sessions_id_fk": {
+          "name": "queued_messages_session_id_sessions_id_fk",
+          "tableFrom": "queued_messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_analyses": {
+      "name": "recording_analyses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_sections": {
+          "name": "topic_sections",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_provider_id": {
+          "name": "transcription_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_model_id": {
+          "name": "transcription_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_provider_id": {
+          "name": "analysis_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_model_id": {
+          "name": "analysis_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recording_analyses_recording_id_uidx": {
+          "name": "recording_analyses_recording_id_uidx",
+          "columns": [
+            "recording_id"
+          ],
+          "isUnique": true
+        },
+        "recording_analyses_status_idx": {
+          "name": "recording_analyses_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recording_analyses_recording_id_recordings_id_fk": {
+          "name": "recording_analyses_recording_id_recordings_id_fk",
+          "tableFrom": "recording_analyses",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recording_analyses_status_check": {
+          "name": "recording_analyses_status_check",
+          "value": "\"recording_analyses\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "recordings": {
+      "name": "recordings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'recording'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'audio/ogg'"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recordings_created_at_idx": {
+          "name": "recordings_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "recordings_status_idx": {
+          "name": "recordings_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recordings_status_check": {
+          "name": "recordings_status_check",
+          "value": "\"recordings\".\"status\" in ('recording', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": [
+            "job_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "queue_enabled": {
+          "name": "queue_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "queued_count": {
+          "name": "queued_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": [
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "session_todos": {
+      "name": "session_todos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_todos_session_id_idx": {
+          "name": "session_todos_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "session_todos_order_idx": {
+          "name": "session_todos_order_idx",
+          "columns": [
+            "session_id",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_todos_session_id_sessions_id_fk": {
+          "name": "session_todos_session_id_sessions_id_fk",
+          "tableFrom": "session_todos",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "active_toolset_ids": {
+          "name": "active_toolset_ids",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "toolset_state": {
+          "name": "toolset_state",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_automation_id_automations_id_fk": {
+          "name": "sessions_automation_id_automations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_metadata": {
+      "name": "skill_metadata",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_external": {
+          "name": "is_external",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "skill_metadata_source_uidx": {
+          "name": "skill_metadata_source_uidx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_enabled": {
+      "name": "tool_enabled",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_enabled_scope_identifier_uidx": {
+          "name": "tool_enabled_scope_identifier_uidx",
+          "columns": [
+            "scope",
+            "identifier"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": [
+            "tool_name",
+            "pattern"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/0026_snapshot.json
+++ b/packages/server/drizzle/meta/0026_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "ff09e1bf-f7df-434d-861a-0c501af0165f",
+  "id": "54b322e9-e0c9-46b1-afc8-8afa7aa783b8",
   "prevId": "cf7c0ce3-b9c1-409a-a321-bf8dc6b71c29",
   "tables": {
     "agenda_item_events": {
@@ -68,16 +68,12 @@
       "indexes": {
         "agenda_item_events_item_id_idx": {
           "name": "agenda_item_events_item_id_idx",
-          "columns": [
-            "item_id"
-          ],
+          "columns": ["item_id"],
           "isUnique": false
         },
         "agenda_item_events_created_at_idx": {
           "name": "agenda_item_events_created_at_idx",
-          "columns": [
-            "created_at"
-          ],
+          "columns": ["created_at"],
           "isUnique": false
         }
       },
@@ -86,12 +82,8 @@
           "name": "agenda_item_events_item_id_agenda_items_id_fk",
           "tableFrom": "agenda_item_events",
           "tableTo": "agenda_items",
-          "columnsFrom": [
-            "item_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -215,30 +207,22 @@
       "indexes": {
         "agenda_items_list_id_idx": {
           "name": "agenda_items_list_id_idx",
-          "columns": [
-            "list_id"
-          ],
+          "columns": ["list_id"],
           "isUnique": false
         },
         "agenda_items_status_idx": {
           "name": "agenda_items_status_idx",
-          "columns": [
-            "status"
-          ],
+          "columns": ["status"],
           "isUnique": false
         },
         "agenda_items_due_at_idx": {
           "name": "agenda_items_due_at_idx",
-          "columns": [
-            "due_at"
-          ],
+          "columns": ["due_at"],
           "isUnique": false
         },
         "agenda_items_created_at_idx": {
           "name": "agenda_items_created_at_idx",
-          "columns": [
-            "created_at"
-          ],
+          "columns": ["created_at"],
           "isUnique": false
         }
       },
@@ -247,12 +231,8 @@
           "name": "agenda_items_list_id_agenda_lists_id_fk",
           "tableFrom": "agenda_items",
           "tableTo": "agenda_lists",
-          "columnsFrom": [
-            "list_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["list_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -340,16 +320,12 @@
       "indexes": {
         "agenda_lists_name_uidx": {
           "name": "agenda_lists_name_uidx",
-          "columns": [
-            "name"
-          ],
+          "columns": ["name"],
           "isUnique": true
         },
         "agenda_lists_created_at_idx": {
           "name": "agenda_lists_created_at_idx",
-          "columns": [
-            "created_at"
-          ],
+          "columns": ["created_at"],
           "isUnique": false
         }
       },
@@ -568,9 +544,7 @@
       "indexes": {
         "connector_instances_connector_id_idx": {
           "name": "connector_instances_connector_id_idx",
-          "columns": [
-            "connector_id"
-          ],
+          "columns": ["connector_id"],
           "isUnique": false
         }
       },
@@ -906,31 +880,22 @@
       "indexes": {
         "llm_usage_events_run_id_idx": {
           "name": "llm_usage_events_run_id_idx",
-          "columns": [
-            "run_id"
-          ],
+          "columns": ["run_id"],
           "isUnique": false
         },
         "llm_usage_events_source_idx": {
           "name": "llm_usage_events_source_idx",
-          "columns": [
-            "source"
-          ],
+          "columns": ["source"],
           "isUnique": false
         },
         "llm_usage_events_created_at_idx": {
           "name": "llm_usage_events_created_at_idx",
-          "columns": [
-            "created_at"
-          ],
+          "columns": ["created_at"],
           "isUnique": false
         },
         "llm_usage_events_provider_model_idx": {
           "name": "llm_usage_events_provider_model_idx",
-          "columns": [
-            "provider_id",
-            "model_id"
-          ],
+          "columns": ["provider_id", "model_id"],
           "isUnique": false
         }
       },
@@ -1116,12 +1081,8 @@
           "name": "messages_session_id_sessions_id_fk",
           "tableFrom": "messages",
           "tableTo": "sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1165,10 +1126,7 @@
       "indexes": {
         "model_visibility_provider_model_idx": {
           "name": "model_visibility_provider_model_idx",
-          "columns": [
-            "provider_id",
-            "model_id"
-          ],
+          "columns": ["provider_id", "model_id"],
           "isUnique": true
         }
       },
@@ -1403,12 +1361,8 @@
           "name": "permission_responses_session_id_sessions_id_fk",
           "tableFrom": "permission_responses",
           "tableTo": "sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1529,12 +1483,8 @@
           "name": "questions_session_id_sessions_id_fk",
           "tableFrom": "questions",
           "tableTo": "sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1603,12 +1553,8 @@
           "name": "queued_messages_session_id_sessions_id_fk",
           "tableFrom": "queued_messages",
           "tableTo": "sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1761,16 +1707,12 @@
       "indexes": {
         "recording_analyses_recording_id_uidx": {
           "name": "recording_analyses_recording_id_uidx",
-          "columns": [
-            "recording_id"
-          ],
+          "columns": ["recording_id"],
           "isUnique": true
         },
         "recording_analyses_status_idx": {
           "name": "recording_analyses_status_idx",
-          "columns": [
-            "status"
-          ],
+          "columns": ["status"],
           "isUnique": false
         }
       },
@@ -1779,12 +1721,8 @@
           "name": "recording_analyses_recording_id_recordings_id_fk",
           "tableFrom": "recording_analyses",
           "tableTo": "recordings",
-          "columnsFrom": [
-            "recording_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["recording_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1907,16 +1845,12 @@
       "indexes": {
         "recordings_created_at_idx": {
           "name": "recordings_created_at_idx",
-          "columns": [
-            "created_at"
-          ],
+          "columns": ["created_at"],
           "isUnique": false
         },
         "recordings_status_idx": {
           "name": "recordings_status_idx",
-          "columns": [
-            "status"
-          ],
+          "columns": ["status"],
           "isUnique": false
         }
       },
@@ -2001,16 +1935,12 @@
       "indexes": {
         "scheduled_job_runs_job_id_idx": {
           "name": "scheduled_job_runs_job_id_idx",
-          "columns": [
-            "job_id"
-          ],
+          "columns": ["job_id"],
           "isUnique": false
         },
         "scheduled_job_runs_key_idx": {
           "name": "scheduled_job_runs_key_idx",
-          "columns": [
-            "key"
-          ],
+          "columns": ["key"],
           "isUnique": false
         }
       },
@@ -2019,12 +1949,8 @@
           "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
           "tableFrom": "scheduled_job_runs",
           "tableTo": "scheduled_jobs",
-          "columnsFrom": [
-            "job_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2187,16 +2113,12 @@
       "indexes": {
         "scheduled_jobs_key_uidx": {
           "name": "scheduled_jobs_key_uidx",
-          "columns": [
-            "key"
-          ],
+          "columns": ["key"],
           "isUnique": true
         },
         "scheduled_jobs_next_run_at_idx": {
           "name": "scheduled_jobs_next_run_at_idx",
-          "columns": [
-            "next_run_at"
-          ],
+          "columns": ["next_run_at"],
           "isUnique": false
         }
       },
@@ -2273,17 +2195,12 @@
       "indexes": {
         "session_todos_session_id_idx": {
           "name": "session_todos_session_id_idx",
-          "columns": [
-            "session_id"
-          ],
+          "columns": ["session_id"],
           "isUnique": false
         },
         "session_todos_order_idx": {
           "name": "session_todos_order_idx",
-          "columns": [
-            "session_id",
-            "sort_order"
-          ],
+          "columns": ["session_id", "sort_order"],
           "isUnique": false
         }
       },
@@ -2292,12 +2209,8 @@
           "name": "session_todos_session_id_sessions_id_fk",
           "tableFrom": "session_todos",
           "tableTo": "sessions",
-          "columnsFrom": [
-            "session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -2353,14 +2266,6 @@
           "autoincrement": false,
           "default": false
         },
-        "active_toolset_ids": {
-          "name": "active_toolset_ids",
-          "type": "blob",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false,
-          "default": "'[]'"
-        },
         "toolset_state": {
           "name": "toolset_state",
           "type": "blob",
@@ -2389,12 +2294,8 @@
           "name": "sessions_automation_id_automations_id_fk",
           "tableFrom": "sessions",
           "tableTo": "automations",
-          "columnsFrom": [
-            "automation_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["automation_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -2402,12 +2303,8 @@
           "name": "sessions_parent_session_id_sessions_id_fk",
           "tableFrom": "sessions",
           "tableTo": "sessions",
-          "columnsFrom": [
-            "parent_session_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_session_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -2466,9 +2363,7 @@
       "indexes": {
         "skill_metadata_source_uidx": {
           "name": "skill_metadata_source_uidx",
-          "columns": [
-            "source"
-          ],
+          "columns": ["source"],
           "isUnique": true
         }
       },
@@ -2520,10 +2415,7 @@
       "indexes": {
         "tool_enabled_scope_identifier_uidx": {
           "name": "tool_enabled_scope_identifier_uidx",
-          "columns": [
-            "scope",
-            "identifier"
-          ],
+          "columns": ["scope", "identifier"],
           "isUnique": true
         }
       },
@@ -2581,10 +2473,7 @@
       "indexes": {
         "tool_permissions_tool_pattern_idx": {
           "name": "tool_permissions_tool_pattern_idx",
-          "columns": [
-            "tool_name",
-            "pattern"
-          ],
+          "columns": ["tool_name", "pattern"],
           "isUnique": true
         }
       },

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -187,8 +187,8 @@
     {
       "idx": 26,
       "version": "6",
-      "when": 1780762852525,
-      "tag": "0026_lethal_phantom_reporter",
+      "when": 1780765566023,
+      "tag": "0026_mixed_guardsmen",
       "breakpoints": true
     }
   ]

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1780349118310,
       "tag": "0025_lean_gorilla_man",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1780762852525,
+      "tag": "0026_lethal_phantom_reporter",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -45,6 +45,7 @@ import type { ShortcutActionId, ShortcutCategory } from '@stitch/shared/shortcut
 import type { SkillId } from '@stitch/shared/skills/types';
 
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
+import type { SessionToolsetState } from '@/llm/stream/session-toolsets.js';
 import type { LanguageModelUsage } from 'ai';
 
 export const userSettings = sqliteTable('user_settings', {
@@ -117,6 +118,7 @@ export const sessions = sqliteTable('sessions', {
     .$type<string[]>()
     .notNull()
     .default([]),
+  toolsetState: blob('toolset_state', { mode: 'json' }).$type<SessionToolsetState | null>(),
   createdAt: integer('created_at', { mode: 'number' })
     .notNull()
     .$defaultFn(() => Date.now()),

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -114,10 +114,6 @@ export const sessions = sqliteTable('sessions', {
     .$type<PrefixedString<'ses'> | null>()
     .references((): ReturnType<typeof text> => sessions.id),
   isUnread: integer('is_unread', { mode: 'boolean' }).notNull().default(false),
-  activeToolsetIds: blob('active_toolset_ids', { mode: 'json' })
-    .$type<string[]>()
-    .notNull()
-    .default([]),
   toolsetState: blob('toolset_state', { mode: 'json' }).$type<SessionToolsetState | null>(),
   createdAt: integer('created_at', { mode: 'number' })
     .notNull()

--- a/packages/server/src/llm/compaction.test.ts
+++ b/packages/server/src/llm/compaction.test.ts
@@ -2,10 +2,15 @@ import { describe, test, expect, beforeEach } from 'bun:test';
 
 import type { StoredPart } from '@stitch/shared/chat/messages';
 
+import { getDb } from '@/db/client.js';
+import { sessions } from '@/db/schema.js';
+import { setupTestDb } from '@/db/test-helpers.js';
 import { isOverflow, buildActiveToolsetInstructionsBlock } from '@/llm/compaction.js';
 import { buildHistoryMessages } from '@/llm/history-messages.js';
 import { setSessionToolsetState } from '@/llm/stream/session-toolsets.js';
 import { registerToolset, unregisterToolset, listToolsetIds } from '@/tools/toolsets/registry.js';
+
+setupTestDb();
 
 describe('isOverflow', () => {
   const defaultLimits = { context: 200_000, output: 8_192 };
@@ -497,6 +502,7 @@ describe('buildActiveToolsetInstructionsBlock', () => {
     for (const id of listToolsetIds()) {
       unregisterToolset(id);
     }
+    getDb().insert(sessions).values({ id: sessionId, title: 'Compaction test' }).run();
     setActiveToolsets([]);
   });
 

--- a/packages/server/src/llm/compaction.test.ts
+++ b/packages/server/src/llm/compaction.test.ts
@@ -4,7 +4,7 @@ import type { StoredPart } from '@stitch/shared/chat/messages';
 
 import { isOverflow, buildActiveToolsetInstructionsBlock } from '@/llm/compaction.js';
 import { buildHistoryMessages } from '@/llm/history-messages.js';
-import { setSessionActiveToolsetIds } from '@/llm/stream/session-toolsets.js';
+import { setSessionToolsetState } from '@/llm/stream/session-toolsets.js';
 import { registerToolset, unregisterToolset, listToolsetIds } from '@/tools/toolsets/registry.js';
 
 describe('isOverflow', () => {
@@ -485,11 +485,19 @@ describe('buildHistoryMessages', () => {
 describe('buildActiveToolsetInstructionsBlock', () => {
   const sessionId = 'ses_test_compaction' as never;
 
+  const setActiveToolsets = (ids: string[]) => {
+    setSessionToolsetState(sessionId, {
+      turnCounter: 0,
+      active: ids.map((id) => ({ id, scope: 'until_deactivated' })),
+      expired: [],
+    });
+  };
+
   beforeEach(() => {
     for (const id of listToolsetIds()) {
       unregisterToolset(id);
     }
-    setSessionActiveToolsetIds(sessionId, []);
+    setActiveToolsets([]);
   });
 
   test('returns empty string when no toolsets are active', () => {
@@ -505,7 +513,7 @@ describe('buildActiveToolsetInstructionsBlock', () => {
       tools: () => [],
       activate: async () => ({}),
     });
-    setSessionActiveToolsetIds(sessionId, ['no-instructions']);
+    setActiveToolsets(['no-instructions']);
 
     const result = buildActiveToolsetInstructionsBlock(sessionId);
     expect(result).toBe('');
@@ -520,7 +528,7 @@ describe('buildActiveToolsetInstructionsBlock', () => {
       tools: () => [],
       activate: async () => ({}),
     });
-    setSessionActiveToolsetIds(sessionId, ['browser']);
+    setActiveToolsets(['browser']);
 
     const result = buildActiveToolsetInstructionsBlock(sessionId);
     expect(result).toContain('## Active Toolset Instructions');
@@ -544,7 +552,7 @@ describe('buildActiveToolsetInstructionsBlock', () => {
       tools: () => [],
       activate: async () => ({}),
     });
-    setSessionActiveToolsetIds(sessionId, ['with-instructions', 'without-instructions']);
+    setActiveToolsets(['with-instructions', 'without-instructions']);
 
     const result = buildActiveToolsetInstructionsBlock(sessionId);
     expect(result).toContain('### With Instructions Toolset Instructions');
@@ -568,7 +576,7 @@ describe('buildActiveToolsetInstructionsBlock', () => {
       tools: () => [],
       activate: async () => ({}),
     });
-    setSessionActiveToolsetIds(sessionId, ['ts-alpha', 'ts-beta']);
+    setActiveToolsets(['ts-alpha', 'ts-beta']);
 
     const result = buildActiveToolsetInstructionsBlock(sessionId);
     expect(result).toContain('### Alpha Toolset Instructions');

--- a/packages/server/src/llm/compaction.ts
+++ b/packages/server/src/llm/compaction.ts
@@ -19,7 +19,7 @@ import { createProvider } from '@/llm/provider/provider.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
 import { mapAIError, toStreamErrorDetails } from '@/llm/stream/ai-error-mapper.js';
-import { getSessionActiveToolsetIds } from '@/llm/stream/session-toolsets.js';
+import { getSessionToolsetState } from '@/llm/stream/session-toolsets.js';
 import { retrieveMemoryContext } from '@/memory/retriever.js';
 import { getSessionTodosPromptBlock } from '@/todos/service.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
@@ -580,7 +580,7 @@ export async function buildCompactedHistory(
 }
 
 export function buildActiveToolsetInstructionsBlock(sessionId: PrefixedString<'ses'>): string {
-  const activeIds = getSessionActiveToolsetIds(sessionId);
+  const activeIds = getSessionToolsetState(sessionId).active.map((entry) => entry.id);
   const instructionBlocks = activeIds
     .map((id) => getToolset(id))
     .filter((ts): ts is NonNullable<ReturnType<typeof getToolset>> => !!ts?.instructions)

--- a/packages/server/src/llm/stream/runner.test.ts
+++ b/packages/server/src/llm/stream/runner.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test } from 'bun:test';
 
 import type { SseEventName, SseEventPayloadMap } from '@stitch/shared/chat/realtime';
 
+import { setupTestDb } from '@/db/test-helpers.js';
 import * as Events from '@/lib/events.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { runStream } from '@/llm/stream/runner.js';
@@ -30,6 +31,8 @@ const CREDENTIALS: ProviderCredentials = {
   providerId: 'openai',
   auth: { method: 'api-key', apiKey: 'test-key' },
 };
+
+setupTestDb();
 
 function createTextModel(text: string): MockLanguageModelV3 {
   return new MockLanguageModelV3({

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -22,7 +22,7 @@ import {
   isPermissionRejectedError,
   isStreamAbortedError,
 } from '@/llm/stream/errors.js';
-import { setSessionActiveToolsetIds } from '@/llm/stream/session-toolsets.js';
+import { getSessionToolsetState, setSessionToolsetState } from '@/llm/stream/session-toolsets.js';
 import { executeStepWithRetry, type StepOptions } from '@/llm/stream/step-executor.js';
 import { ToolAssembler } from '@/llm/stream/tool-assembler.js';
 import { processMemories } from '@/memory/processor.js';
@@ -941,7 +941,16 @@ class StreamRunner {
     });
 
     await this.deps.markSessionUnread(this.ctx.sessionId);
-    setSessionActiveToolsetIds(this.ctx.sessionId, this.ctx.toolsetManager.getPersistedIds());
+    const currentToolsetState = getSessionToolsetState(this.ctx.sessionId);
+    const nextTurnCounter = currentToolsetState.turnCounter + 1;
+    setSessionToolsetState(this.ctx.sessionId, {
+      turnCounter: nextTurnCounter,
+      active: this.ctx.toolsetManager.getActivationState(),
+      expired: this.ctx.toolsetManager.getExpiredRunToolsets().map((entry) => ({
+        ...entry,
+        expiredAtTurn: nextTurnCounter,
+      })),
+    });
 
     const toolCallCount = this.state.accumulatedParts.filter((p) => p.type === 'tool-call').length;
     const toolErrorCount = this.state.accumulatedParts.filter(

--- a/packages/server/src/llm/stream/session-toolsets.test.ts
+++ b/packages/server/src/llm/stream/session-toolsets.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  getSessionToolsetState,
+  setSessionToolsetState,
+} from '@/llm/stream/session-toolsets.js';
+
+describe('session toolset state fallback', () => {
+  test('stores and clones structured active and expired state', () => {
+    const sessionId = 'ses_toolset_state' as never;
+    setSessionToolsetState(sessionId, {
+      turnCounter: 2,
+      active: [{ id: 'browser', scope: 'until_deactivated' }],
+      expired: [{ id: 'agenda', expiredAtTurn: 2, toolNames: ['agenda_list'] }],
+    });
+
+    const state = getSessionToolsetState(sessionId);
+    state.active.push({ id: 'mutated', scope: 'until_deactivated' });
+    state.expired[0]?.toolNames.push('mutated_tool');
+
+    expect(getSessionToolsetState(sessionId)).toEqual({
+      turnCounter: 2,
+      active: [{ id: 'browser', scope: 'until_deactivated' }],
+      expired: [{ id: 'agenda', expiredAtTurn: 2, toolNames: ['agenda_list'] }],
+    });
+  });
+});

--- a/packages/server/src/llm/stream/session-toolsets.test.ts
+++ b/packages/server/src/llm/stream/session-toolsets.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, test } from 'bun:test';
 
-import {
-  getSessionToolsetState,
-  setSessionToolsetState,
-} from '@/llm/stream/session-toolsets.js';
+import { getDb } from '@/db/client.js';
+import { sessions } from '@/db/schema.js';
+import { setupTestDb } from '@/db/test-helpers.js';
+import { getSessionToolsetState, setSessionToolsetState } from '@/llm/stream/session-toolsets.js';
 
-describe('session toolset state fallback', () => {
+setupTestDb();
+
+describe('session toolset state persistence', () => {
   test('stores and clones structured active and expired state', () => {
     const sessionId = 'ses_toolset_state' as never;
+    getDb().insert(sessions).values({ id: sessionId, title: 'Toolset state test' }).run();
+
     setSessionToolsetState(sessionId, {
       turnCounter: 2,
       active: [{ id: 'browser', scope: 'until_deactivated' }],

--- a/packages/server/src/llm/stream/session-toolsets.ts
+++ b/packages/server/src/llm/stream/session-toolsets.ts
@@ -5,35 +5,102 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { getDb, isDbInitialized } from '@/db/client.js';
 import { sessions } from '@/db/schema.js';
 
-// Fallback used only when DB is not initialized (e.g. unit tests).
-const inMemoryFallback = new Map<string, string[]>();
+export type SessionToolsetScope = 'current_run' | 'ttl_turns' | 'until_deactivated';
 
-export function getSessionActiveToolsetIds(sessionId: PrefixedString<'ses'>): string[] {
-  if (!isDbInitialized()) return inMemoryFallback.get(sessionId) ?? [];
+export type SessionActiveToolset = {
+  id: string;
+  scope: SessionToolsetScope;
+};
+
+export type SessionExpiredToolset = {
+  id: string;
+  expiredAtTurn: number;
+  toolNames: string[];
+};
+
+export type SessionToolsetState = {
+  turnCounter: number;
+  active: SessionActiveToolset[];
+  expired: SessionExpiredToolset[];
+};
+
+const EMPTY_SESSION_TOOLSET_STATE: SessionToolsetState = {
+  turnCounter: 0,
+  active: [],
+  expired: [],
+};
+
+// Fallback used only when DB is not initialized (e.g. unit tests).
+const inMemoryFallback = new Map<string, SessionToolsetState>();
+
+function cloneState(state: SessionToolsetState): SessionToolsetState {
+  return {
+    turnCounter: state.turnCounter,
+    active: state.active.map((entry) => ({ ...entry })),
+    expired: state.expired.map((entry) => ({ ...entry, toolNames: [...entry.toolNames] })),
+  };
+}
+
+function normalizeState(
+  state: SessionToolsetState | null | undefined,
+  legacyActiveIds: string[] = [],
+): SessionToolsetState {
+  if (state) {
+    return {
+      turnCounter: Number.isFinite(state.turnCounter) ? state.turnCounter : 0,
+      active: Array.isArray(state.active)
+        ? state.active.map((entry) => ({ id: entry.id, scope: entry.scope }))
+        : [],
+      expired: Array.isArray(state.expired)
+        ? state.expired.map((entry) => ({
+            id: entry.id,
+            expiredAtTurn: Number.isFinite(entry.expiredAtTurn) ? entry.expiredAtTurn : 0,
+            toolNames: Array.isArray(entry.toolNames) ? entry.toolNames : [],
+          }))
+        : [],
+    };
+  }
+
+  return {
+    ...EMPTY_SESSION_TOOLSET_STATE,
+    active: legacyActiveIds.map((id) => ({ id, scope: 'until_deactivated' })),
+  };
+}
+
+export function getSessionToolsetState(sessionId: PrefixedString<'ses'>): SessionToolsetState {
+  if (!isDbInitialized()) {
+    return cloneState(inMemoryFallback.get(sessionId) ?? EMPTY_SESSION_TOOLSET_STATE);
+  }
   const row = getDb()
-    .select({ activeToolsetIds: sessions.activeToolsetIds })
+    .select({ activeToolsetIds: sessions.activeToolsetIds, toolsetState: sessions.toolsetState })
     .from(sessions)
     .where(eq(sessions.id, sessionId))
     .get();
-  return row?.activeToolsetIds ?? [];
+
+  return normalizeState(row?.toolsetState, row?.activeToolsetIds ?? []);
 }
 
-export function setSessionActiveToolsetIds(
+export function setSessionToolsetState(
   sessionId: PrefixedString<'ses'>,
-  toolsetIds: Iterable<string>,
+  state: SessionToolsetState,
 ): void {
-  const ids = [...toolsetIds];
+  const nextState = normalizeState(state);
+  const activeIds = nextState.active.map((entry) => entry.id);
   if (!isDbInitialized()) {
-    if (ids.length === 0) {
+    if (
+      nextState.active.length === 0 &&
+      nextState.expired.length === 0 &&
+      nextState.turnCounter === 0
+    ) {
       inMemoryFallback.delete(sessionId);
     } else {
-      inMemoryFallback.set(sessionId, ids);
+      inMemoryFallback.set(sessionId, cloneState(nextState));
     }
     return;
   }
   getDb()
     .update(sessions)
-    .set({ activeToolsetIds: ids, updatedAt: Date.now() })
+    .set({ activeToolsetIds: activeIds, toolsetState: nextState, updatedAt: Date.now() })
     .where(eq(sessions.id, sessionId))
     .run();
 }

--- a/packages/server/src/llm/stream/session-toolsets.ts
+++ b/packages/server/src/llm/stream/session-toolsets.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm';
 
 import type { PrefixedString } from '@stitch/shared/id';
 
-import { getDb, isDbInitialized } from '@/db/client.js';
+import { getDb } from '@/db/client.js';
 import { sessions } from '@/db/schema.js';
 
 export type SessionToolsetScope = 'current_run' | 'ttl_turns' | 'until_deactivated';
@@ -30,9 +30,6 @@ const EMPTY_SESSION_TOOLSET_STATE: SessionToolsetState = {
   expired: [],
 };
 
-// Fallback used only when DB is not initialized (e.g. unit tests).
-const inMemoryFallback = new Map<string, SessionToolsetState>();
-
 function cloneState(state: SessionToolsetState): SessionToolsetState {
   return {
     turnCounter: state.turnCounter,
@@ -41,10 +38,7 @@ function cloneState(state: SessionToolsetState): SessionToolsetState {
   };
 }
 
-function normalizeState(
-  state: SessionToolsetState | null | undefined,
-  legacyActiveIds: string[] = [],
-): SessionToolsetState {
+function normalizeState(state: SessionToolsetState | null | undefined): SessionToolsetState {
   if (state) {
     return {
       turnCounter: Number.isFinite(state.turnCounter) ? state.turnCounter : 0,
@@ -61,23 +55,17 @@ function normalizeState(
     };
   }
 
-  return {
-    ...EMPTY_SESSION_TOOLSET_STATE,
-    active: legacyActiveIds.map((id) => ({ id, scope: 'until_deactivated' })),
-  };
+  return EMPTY_SESSION_TOOLSET_STATE;
 }
 
 export function getSessionToolsetState(sessionId: PrefixedString<'ses'>): SessionToolsetState {
-  if (!isDbInitialized()) {
-    return cloneState(inMemoryFallback.get(sessionId) ?? EMPTY_SESSION_TOOLSET_STATE);
-  }
   const row = getDb()
-    .select({ activeToolsetIds: sessions.activeToolsetIds, toolsetState: sessions.toolsetState })
+    .select({ toolsetState: sessions.toolsetState })
     .from(sessions)
     .where(eq(sessions.id, sessionId))
     .get();
 
-  return normalizeState(row?.toolsetState, row?.activeToolsetIds ?? []);
+  return normalizeState(row?.toolsetState);
 }
 
 export function setSessionToolsetState(
@@ -85,22 +73,9 @@ export function setSessionToolsetState(
   state: SessionToolsetState,
 ): void {
   const nextState = normalizeState(state);
-  const activeIds = nextState.active.map((entry) => entry.id);
-  if (!isDbInitialized()) {
-    if (
-      nextState.active.length === 0 &&
-      nextState.expired.length === 0 &&
-      nextState.turnCounter === 0
-    ) {
-      inMemoryFallback.delete(sessionId);
-    } else {
-      inMemoryFallback.set(sessionId, cloneState(nextState));
-    }
-    return;
-  }
   getDb()
     .update(sessions)
-    .set({ activeToolsetIds: activeIds, toolsetState: nextState, updatedAt: Date.now() })
+    .set({ toolsetState: cloneState(nextState), updatedAt: Date.now() })
     .where(eq(sessions.id, sessionId))
     .run();
 }

--- a/packages/server/src/llm/stream/tool-assembler.test.ts
+++ b/packages/server/src/llm/stream/tool-assembler.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 
+import { getDb } from '@/db/client.js';
+import { sessions } from '@/db/schema.js';
+import { setupTestDb } from '@/db/test-helpers.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { getSessionToolsetState, setSessionToolsetState } from '@/llm/stream/session-toolsets.js';
 import { buildExpiredToolsetsPrompt, ToolAssembler } from '@/llm/stream/tool-assembler.js';
@@ -11,6 +14,8 @@ const CREDENTIALS: ProviderCredentials = {
   providerId: 'openai',
   auth: { method: 'api-key', apiKey: 'test-key' },
 };
+
+setupTestDb();
 
 function clearToolsets(): void {
   for (const id of listToolsetIds()) {
@@ -42,7 +47,9 @@ describe('buildExpiredToolsetsPrompt', () => {
 
     expect(prompt).toContain('## Toolset Expiry Notice');
     expect(prompt).toContain('Browser (browser) expired');
-    expect(prompt).toContain('Do not call their tools unless you first call `activate_toolset` again');
+    expect(prompt).toContain(
+      'Do not call their tools unless you first call `activate_toolset` again',
+    );
     expect(prompt).toContain('browser_open');
   });
 });
@@ -54,6 +61,8 @@ describe('ToolAssembler expired toolset handling', () => {
 
   test('adds expiry notice next turn and does not load expired tools', async () => {
     const sessionId = 'ses_expired_toolsets' as never;
+    getDb().insert(sessions).values({ id: sessionId, title: 'Expired toolsets test' }).run();
+
     registerToolset({
       id: 'browser',
       name: 'Browser',

--- a/packages/server/src/llm/stream/tool-assembler.test.ts
+++ b/packages/server/src/llm/stream/tool-assembler.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import type { ProviderCredentials } from '@/llm/provider/provider.js';
+import { getSessionToolsetState, setSessionToolsetState } from '@/llm/stream/session-toolsets.js';
+import { buildExpiredToolsetsPrompt, ToolAssembler } from '@/llm/stream/tool-assembler.js';
+import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
+import type { Toolset } from '@/tools/toolsets/types.js';
+import type { Tool } from 'ai';
+
+const CREDENTIALS: ProviderCredentials = {
+  providerId: 'openai',
+  auth: { method: 'api-key', apiKey: 'test-key' },
+};
+
+function clearToolsets(): void {
+  for (const id of listToolsetIds()) {
+    unregisterToolset(id);
+  }
+}
+
+function makeTool(description: string): Tool {
+  return { description, parameters: { type: 'object', properties: {} } } as unknown as Tool;
+}
+
+describe('buildExpiredToolsetsPrompt', () => {
+  beforeEach(() => {
+    clearToolsets();
+  });
+
+  test('builds a model-visible notice for expired run-only toolsets', () => {
+    registerToolset({
+      id: 'browser',
+      name: 'Browser',
+      description: 'Browser toolset',
+      tools: () => [{ name: 'browser_open', description: 'open' }],
+      activate: async () => ({ browser_open: makeTool('open') }),
+    } satisfies Toolset);
+
+    const prompt = buildExpiredToolsetsPrompt([
+      { id: 'browser', expiredAtTurn: 1, toolNames: ['browser_open'] },
+    ]);
+
+    expect(prompt).toContain('## Toolset Expiry Notice');
+    expect(prompt).toContain('Browser (browser) expired');
+    expect(prompt).toContain('Do not call their tools unless you first call `activate_toolset` again');
+    expect(prompt).toContain('browser_open');
+  });
+});
+
+describe('ToolAssembler expired toolset handling', () => {
+  beforeEach(() => {
+    clearToolsets();
+  });
+
+  test('adds expiry notice next turn and does not load expired tools', async () => {
+    const sessionId = 'ses_expired_toolsets' as never;
+    registerToolset({
+      id: 'browser',
+      name: 'Browser',
+      description: 'Browser toolset',
+      tools: () => [{ name: 'browser_open', description: 'open' }],
+      activate: async () => ({ browser_open: makeTool('open') }),
+    } satisfies Toolset);
+    setSessionToolsetState(sessionId, {
+      turnCounter: 1,
+      active: [],
+      expired: [{ id: 'browser', expiredAtTurn: 1, toolNames: ['browser_open'] }],
+    });
+
+    const assembled = await ToolAssembler.create({
+      sessionId,
+      messageId: 'msg_expired_toolsets' as never,
+      streamRunId: 'run_expired_toolsets',
+      credentials: CREDENTIALS,
+      modelId: 'openai/gpt-5.3-codex',
+      abortSignal: new AbortController().signal,
+    }).assemble();
+
+    expect(assembled.promptAdditions.join('\n')).toContain('Toolset Expiry Notice');
+    expect(assembled.toolsetManager.getActiveTools()).not.toHaveProperty('browser_open');
+    expect(getSessionToolsetState(sessionId).expired).toEqual([]);
+  });
+});

--- a/packages/server/src/llm/stream/tool-assembler.ts
+++ b/packages/server/src/llm/stream/tool-assembler.ts
@@ -3,7 +3,11 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { createCodeModeTool } from '@/code-mode/tool.js';
 import * as Log from '@/lib/log.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
-import { getSessionActiveToolsetIds } from '@/llm/stream/session-toolsets.js';
+import {
+  getSessionToolsetState,
+  setSessionToolsetState,
+  type SessionExpiredToolset,
+} from '@/llm/stream/session-toolsets.js';
 import { buildSkillsSystemPrompt } from '@/skills/service.js';
 import { createInspectImageTool } from '@/tools/core/inspect-image.js';
 import { createTaskTool } from '@/tools/core/task.js';
@@ -60,6 +64,28 @@ async function buildAvailableToolsetsPrompt(manager: ToolsetManager): Promise<st
   ].join('\n');
 }
 
+export function buildExpiredToolsetsPrompt(expired: SessionExpiredToolset[]): string {
+  if (expired.length === 0) return '';
+
+  const lines = expired.map((entry) => {
+    const toolset = getToolset(entry.id);
+    const name = toolset?.name ?? entry.id;
+    const tools =
+      entry.toolNames.length > 0
+        ? ` Tools no longer available: ${entry.toolNames.join(', ')}.`
+        : '';
+    return `- ${name} (${entry.id}) expired at the last turn boundary.${tools}`;
+  });
+
+  return [
+    '## Toolset Expiry Notice',
+    '',
+    'These toolsets were active in the previous run but are not loaded for this turn. Do not call their tools unless you first call `activate_toolset` again.',
+    '',
+    ...lines,
+  ].join('\n');
+}
+
 export class ToolAssembler {
   private readonly toolContext: ToolContext;
 
@@ -76,8 +102,17 @@ export class ToolAssembler {
   }
 
   async assemble(): Promise<AssembledTools> {
+    const sessionState = getSessionToolsetState(this.opts.sessionId);
     const persistedToolsetIds =
-      this.opts.activeToolsetIds ?? getSessionActiveToolsetIds(this.opts.sessionId);
+      this.opts.activeToolsetIds ?? sessionState.active.map((entry) => entry.id);
+    const expiredPrompt = this.opts.activeToolsetIds
+      ? ''
+      : buildExpiredToolsetsPrompt(sessionState.expired);
+
+    if (!this.opts.activeToolsetIds && sessionState.expired.length > 0) {
+      setSessionToolsetState(this.opts.sessionId, { ...sessionState, expired: [] });
+    }
+
     const toolsetManager = new ToolsetManager(this.toolContext, persistedToolsetIds);
     await this.restoreToolsets(toolsetManager, persistedToolsetIds);
 
@@ -109,9 +144,12 @@ export class ToolAssembler {
         execute_typescript: codeModeResult.tool,
       },
       toolsetManager,
-      promptAdditions: [codeModeResult.getSystemPrompt(), toolsetsPrompt, skillsPrompt].filter(
-        Boolean,
-      ),
+      promptAdditions: [
+        codeModeResult.getSystemPrompt(),
+        expiredPrompt,
+        toolsetsPrompt,
+        skillsPrompt,
+      ].filter(Boolean),
     };
   }
 

--- a/packages/server/src/permission/service.test.ts
+++ b/packages/server/src/permission/service.test.ts
@@ -37,8 +37,8 @@ const messageId = 'msg_permission' as PrefixedString<'msg'>;
 async function seedSessions(): Promise<void> {
   const db = getDb();
   await db.insert(sessions).values([
-    { id: sessionId, title: 'Test session', activeToolsetIds: [] },
-    { id: otherSessionId, title: 'Other session', activeToolsetIds: [] },
+    { id: sessionId, title: 'Test session' },
+    { id: otherSessionId, title: 'Other session' },
   ]);
 }
 

--- a/packages/server/src/question/service.test.ts
+++ b/packages/server/src/question/service.test.ts
@@ -29,8 +29,8 @@ const messageId = 'msg_question' as PrefixedString<'msg'>;
 async function seedSessions(): Promise<void> {
   const db = getDb();
   await db.insert(sessions).values([
-    { id: sessionId, title: 'Test session', activeToolsetIds: [] },
-    { id: otherSessionId, title: 'Other session', activeToolsetIds: [] },
+    { id: sessionId, title: 'Test session' },
+    { id: otherSessionId, title: 'Other session' },
   ]);
 }
 

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import type { PrefixedString } from '@stitch/shared/id';
 import { parseMcpToolName } from '@stitch/shared/mcp/types';
 
-import { setSessionActiveToolsetIds } from '@/llm/stream/session-toolsets.js';
+import { getSessionToolsetState, setSessionToolsetState } from '@/llm/stream/session-toolsets.js';
 import { isToolEnabled } from '@/tools/enabled-service.js';
 import type { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
@@ -14,6 +14,15 @@ import { getToolset } from '@/tools/toolsets/registry.js';
  * These are always-active tools that let the LLM discover, activate, and deactivate toolsets.
  */
 export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedString<'ses'>) {
+  const persistManagerState = () => {
+    const current = getSessionToolsetState(sessionId);
+    setSessionToolsetState(sessionId, {
+      ...current,
+      active: manager.getActivationState(),
+      expired: current.expired.filter((entry) => manager.isActive(entry.id)),
+    });
+  };
+
   const humanizeToolName = (name: string) =>
     (parseMcpToolName(name)?.toolName ?? name)
       .split(/[_-]+/)
@@ -110,7 +119,7 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
         const toolsetName = getToolset(toolsetId)?.name ?? toolsetId;
         if (persist === true) {
           manager.pin(toolsetId);
-          setSessionActiveToolsetIds(sessionId, manager.getPersistedIds());
+          persistManagerState();
         }
 
         return {
@@ -140,7 +149,7 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
 
       if (persist === true) {
         manager.pin(toolsetId);
-        setSessionActiveToolsetIds(sessionId, manager.getPersistedIds());
+        persistManagerState();
       }
 
       const { toolNames, collisions } = result;
@@ -197,7 +206,7 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
         };
       }
 
-      setSessionActiveToolsetIds(sessionId, manager.getPersistedIds());
+      persistManagerState();
 
       return {
         toolsetId,

--- a/packages/server/src/tools/toolsets/manager.test.ts
+++ b/packages/server/src/tools/toolsets/manager.test.ts
@@ -185,3 +185,34 @@ describe('ToolsetManager.getActiveTools ordering', () => {
     expect(Object.keys(manager1.getActiveTools())).toEqual(['a_tool', 'b_tool']);
   });
 });
+
+describe('ToolsetManager activation state', () => {
+  beforeEach(() => {
+    clearToolsets();
+  });
+
+  test('tracks persisted active toolsets separately from run-only toolsets', async () => {
+    registerToolset({
+      id: 'persisted',
+      name: 'Persisted',
+      description: 'Persisted',
+      tools: () => [{ name: 'persisted_tool', description: 'persisted' }],
+      activate: async () => ({ persisted_tool: makeTool('persisted') }),
+    } satisfies Toolset);
+    registerToolset({
+      id: 'run-only',
+      name: 'Run Only',
+      description: 'Run only',
+      tools: () => [{ name: 'run_tool', description: 'run' }],
+      activate: async () => ({ run_tool: makeTool('run') }),
+    } satisfies Toolset);
+
+    const manager = createManager();
+    await manager.activate('persisted');
+    await manager.activate('run-only');
+    manager.pin('persisted');
+
+    expect(manager.getActivationState()).toEqual([{ id: 'persisted', scope: 'until_deactivated' }]);
+    expect(manager.getExpiredRunToolsets()).toEqual([{ id: 'run-only', toolNames: ['run_tool'] }]);
+  });
+});

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -142,6 +142,18 @@ export class ToolsetManager {
     return new Set(this.persistedIds);
   }
 
+  getActivationState(): Array<{ id: string; scope: 'until_deactivated' }> {
+    return [...this.persistedIds]
+      .filter((id) => this.activeIds.has(id))
+      .map((id) => ({ id, scope: 'until_deactivated' }));
+  }
+
+  getExpiredRunToolsets(): Array<{ id: string; toolNames: string[] }> {
+    return [...this.activeIds]
+      .filter((id) => !this.persistedIds.has(id))
+      .map((id) => ({ id, toolNames: Object.keys(this.activeToolCache.get(id) ?? {}) }));
+  }
+
   pin(toolsetId: string): boolean {
     if (!this.activeIds.has(toolsetId)) {
       return false;


### PR DESCRIPTION
## Change Summary

Adds structured per-session toolset state and model-visible expiry notices for run-only toolsets, so tools that disappear at turn boundaries are explicitly called out on the next turn.

### New Features
- Structured session toolset state tracks turn count, persisted active toolsets, and expired run-only toolsets.
- Expired run-only toolsets inject a compact system prompt notice on the next turn and are then cleared.

### Improvements & Refactors
- Runtime toolset persistence now reads/writes structured state while migrating legacy active toolset IDs at read time.
- Active toolset instruction compaction uses structured state.

### Bug Fixes
- Explicit deactivation now updates structured persistence state so deactivated toolsets are not restored.