### PR TITLE
Toolset deactivation: renewal and rehydration guard

### DIFF
--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -28,6 +28,7 @@ import { ToolAssembler } from '@/llm/stream/tool-assembler.js';
 import { processMemories } from '@/memory/processor.js';
 import { MAX_STEPS, MAX_STEPS_WARNING } from '@/tools/runtime/registry.js';
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
+import { getToolsetSettings } from '@/tools/toolsets/settings.js';
 import { recordUsageEvent } from '@/usage/ledger.js';
 import { calculateMessageCostUsd } from '@/utils/cost.js';
 import * as Usage from '@/utils/usage.js';
@@ -510,6 +511,7 @@ class StreamRunner {
       for (const call of stepResult.toolCalls) {
         this.state.toolCallHistory.push(call);
       }
+      await this.renewToolsetActivity(stepResult.toolCalls);
 
       const doomLoopState = await this.deps.checkAndHandleDoomLoop({
         sessionId: this.ctx.sessionId,
@@ -983,6 +985,16 @@ class StreamRunner {
       },
       'stream.finished',
     );
+  }
+
+  private async renewToolsetActivity(toolCalls: ToolCallRecord[]): Promise<void> {
+    const settings = await getToolsetSettings();
+    const currentTurn = getSessionToolsetState(this.ctx.sessionId).turnCounter;
+    const expiresAtTurn = currentTurn + settings.ttlTurns - 1;
+
+    for (const call of toolCalls) {
+      this.ctx.toolsetManager.renewTtlForTool(call.toolName, expiresAtTurn);
+    }
   }
 
   private hasUserFacingTextPart(): boolean {

--- a/packages/server/src/llm/stream/session-toolsets.ts
+++ b/packages/server/src/llm/stream/session-toolsets.ts
@@ -17,6 +17,7 @@ export type SessionExpiredToolset = {
   id: string;
   expiredAtTurn: number;
   toolNames: string[];
+  manuallyDeactivated?: boolean;
 };
 
 export type SessionToolsetState = {
@@ -47,7 +48,7 @@ function normalizeState(state: SessionToolsetState | null | undefined): SessionT
         ? state.active.map((entry) => ({
             id: entry.id,
             scope: entry.scope,
-            expiresAtTurn: Number.isFinite(entry.expiresAtTurn) ? entry.expiresAtTurn : undefined,
+            ...(Number.isFinite(entry.expiresAtTurn) && { expiresAtTurn: entry.expiresAtTurn }),
           }))
         : [],
       expired: Array.isArray(state.expired)
@@ -55,6 +56,7 @@ function normalizeState(state: SessionToolsetState | null | undefined): SessionT
             id: entry.id,
             expiredAtTurn: Number.isFinite(entry.expiredAtTurn) ? entry.expiredAtTurn : 0,
             toolNames: Array.isArray(entry.toolNames) ? entry.toolNames : [],
+            ...(entry.manuallyDeactivated === true && { manuallyDeactivated: true }),
           }))
         : [],
     };

--- a/packages/server/src/llm/stream/tool-assembler-rehydration.test.ts
+++ b/packages/server/src/llm/stream/tool-assembler-rehydration.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+
+import { getDb } from '@/db/client.js';
+import { sessions, userSettings } from '@/db/schema.js';
+import { setupTestDb } from '@/db/test-helpers.js';
+import type { ProviderCredentials } from '@/llm/provider/provider.js';
+import { setSessionToolsetState } from '@/llm/stream/session-toolsets.js';
+import { ToolAssembler } from '@/llm/stream/tool-assembler.js';
+import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
+import type { Toolset } from '@/tools/toolsets/types.js';
+import type { Tool } from 'ai';
+
+const CREDENTIALS: ProviderCredentials = {
+  providerId: 'openai',
+  auth: { method: 'api-key', apiKey: 'test-key' },
+};
+
+function clearToolsets(): void {
+  for (const id of listToolsetIds()) {
+    unregisterToolset(id);
+  }
+}
+
+function makeTool(description: string): Tool {
+  return { description, parameters: { type: 'object', properties: {} } } as unknown as Tool;
+}
+
+describe('ToolAssembler rehydration settings', () => {
+  setupTestDb();
+
+  beforeEach(() => {
+    clearToolsets();
+  });
+
+  test('guard returns structured recovery when auto rehydrate is disabled', async () => {
+    const sessionId = 'ses_rehydrate_disabled' as never;
+    getDb().insert(sessions).values({ id: sessionId }).run();
+    getDb()
+      .update(userSettings)
+      .set({ value: 'false' })
+      .where(eq(userSettings.key, 'toolsets.autoRehydrate'))
+      .run();
+    registerToolset({
+      id: 'browser',
+      name: 'Browser',
+      description: 'Browser toolset',
+      tools: () => [{ name: 'browser_open', description: 'open' }],
+      activate: async () => ({ browser_open: makeTool('open') }),
+    } satisfies Toolset);
+    setSessionToolsetState(sessionId, {
+      turnCounter: 3,
+      active: [],
+      expired: [{ id: 'browser', expiredAtTurn: 3, toolNames: ['browser_open'] }],
+    });
+
+    const assembled = await ToolAssembler.create({
+      sessionId,
+      messageId: 'msg_rehydrate_disabled' as never,
+      streamRunId: 'run_rehydrate_disabled',
+      credentials: CREDENTIALS,
+      modelId: 'openai/gpt-5.3-codex',
+      abortSignal: new AbortController().signal,
+    }).assemble();
+    const result = (await assembled.staticTools.browser_open?.execute?.({}, {} as never)) as {
+      status: string;
+      autoRehydrate: boolean;
+    };
+
+    expect(result).toMatchObject({ status: 'not_active', autoRehydrate: false });
+    expect(assembled.toolsetManager.getActiveTools()).not.toHaveProperty('browser_open');
+  });
+});

--- a/packages/server/src/llm/stream/tool-assembler.test.ts
+++ b/packages/server/src/llm/stream/tool-assembler.test.ts
@@ -136,4 +136,69 @@ describe('ToolAssembler expired toolset handling', () => {
     expect(expired.promptAdditions.join('\n')).toContain('Toolset Expiry Notice');
     expect(expired.toolsetManager.getActiveTools()).not.toHaveProperty('browser_open');
   });
+
+  test('guard tool auto-reactivates an expired toolset', async () => {
+    const sessionId = 'ses_rehydrate_toolsets' as never;
+    registerToolset({
+      id: 'browser',
+      name: 'Browser',
+      description: 'Browser toolset',
+      tools: () => [{ name: 'browser_open', description: 'open' }],
+      activate: async () => ({ browser_open: makeTool('open') }),
+    } satisfies Toolset);
+    setSessionToolsetState(sessionId, {
+      turnCounter: 3,
+      active: [],
+      expired: [{ id: 'browser', expiredAtTurn: 3, toolNames: ['browser_open'] }],
+    });
+
+    const assembled = await ToolAssembler.create({
+      sessionId,
+      messageId: 'msg_rehydrate_toolsets' as never,
+      streamRunId: 'run_rehydrate_toolsets',
+      credentials: CREDENTIALS,
+      modelId: 'openai/gpt-5.3-codex',
+      abortSignal: new AbortController().signal,
+    }).assemble();
+
+    const result = (await assembled.staticTools.browser_open?.execute?.({}, {} as never)) as {
+      status: string;
+    };
+
+    expect(result.status).toBe('reactivated');
+    expect(assembled.toolsetManager.getActiveTools()).toHaveProperty('browser_open');
+  });
+
+  test('manual deactivation blocks guard auto-reactivation', async () => {
+    const sessionId = 'ses_manual_rehydrate' as never;
+    registerToolset({
+      id: 'browser',
+      name: 'Browser',
+      description: 'Browser toolset',
+      tools: () => [{ name: 'browser_open', description: 'open' }],
+      activate: async () => ({ browser_open: makeTool('open') }),
+    } satisfies Toolset);
+    setSessionToolsetState(sessionId, {
+      turnCounter: 3,
+      active: [],
+      expired: [{ id: 'browser', expiredAtTurn: 3, toolNames: ['browser_open'] }],
+    });
+
+    const assembled = await ToolAssembler.create({
+      sessionId,
+      messageId: 'msg_manual_rehydrate' as never,
+      streamRunId: 'run_manual_rehydrate',
+      credentials: CREDENTIALS,
+      modelId: 'openai/gpt-5.3-codex',
+      abortSignal: new AbortController().signal,
+    }).assemble();
+    assembled.toolsetManager.deactivate('browser');
+
+    const result = (await assembled.staticTools.browser_open?.execute?.({}, {} as never)) as {
+      status: string;
+    };
+
+    expect(result.status).toBe('not_active');
+    expect(assembled.toolsetManager.getActiveTools()).not.toHaveProperty('browser_open');
+  });
 });

--- a/packages/server/src/llm/stream/tool-assembler.test.ts
+++ b/packages/server/src/llm/stream/tool-assembler.test.ts
@@ -139,6 +139,8 @@ describe('ToolAssembler expired toolset handling', () => {
 
   test('guard tool auto-reactivates an expired toolset', async () => {
     const sessionId = 'ses_rehydrate_toolsets' as never;
+    getDb().insert(sessions).values({ id: sessionId, title: 'Rehydrate toolsets test' }).run();
+
     registerToolset({
       id: 'browser',
       name: 'Browser',
@@ -171,6 +173,8 @@ describe('ToolAssembler expired toolset handling', () => {
 
   test('manual deactivation blocks guard auto-reactivation', async () => {
     const sessionId = 'ses_manual_rehydrate' as never;
+    getDb().insert(sessions).values({ id: sessionId, title: 'Manual rehydrate test' }).run();
+
     registerToolset({
       id: 'browser',
       name: 'Browser',

--- a/packages/server/src/llm/stream/tool-assembler.ts
+++ b/packages/server/src/llm/stream/tool-assembler.ts
@@ -1,3 +1,6 @@
+import { tool, type Tool } from 'ai';
+import { z } from 'zod';
+
 import type { PrefixedString } from '@stitch/shared/id';
 
 import { createCodeModeTool } from '@/code-mode/tool.js';
@@ -19,7 +22,7 @@ import { createToolRuntime, defineRuntimeTool } from '@/tools/runtime/runtime.js
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
-import type { Tool } from 'ai';
+import { getToolsetSettings } from '@/tools/toolsets/settings.js';
 
 const log = Log.create({ service: 'tool-assembler' });
 
@@ -107,12 +110,15 @@ export class ToolAssembler {
     const activeEntries = this.opts.activeToolsetIds
       ? this.opts.activeToolsetIds.map((id) => ({ id, scope: 'until_deactivated' as const }))
       : this.getRestorableToolsets(sessionState.active, sessionState.turnCounter);
-    const expiredPrompt = this.opts.activeToolsetIds
-      ? ''
-      : buildExpiredToolsetsPrompt([
+    const expiredEntries = this.opts.activeToolsetIds
+      ? []
+      : [
           ...sessionState.expired,
           ...this.getExpiredTtlToolsets(sessionState.active, sessionState.turnCounter),
-        ]);
+        ];
+    const expiredPrompt = this.opts.activeToolsetIds
+      ? ''
+      : buildExpiredToolsetsPrompt(expiredEntries);
 
     if (!this.opts.activeToolsetIds) {
       setSessionToolsetState(this.opts.sessionId, {
@@ -132,10 +138,23 @@ export class ToolAssembler {
     const metaTools = this.buildToolsetMetaTools(toolsetManager);
     const taskTool = this.buildTaskTool(toolsetManager);
     const inspectImageTool = this.buildInspectImageTool();
+    const reservedToolNames = new Set([
+      ...Object.keys(coreTools),
+      ...Object.keys(metaTools),
+      ...(taskTool ? ['task'] : []),
+      'inspect_image',
+      'execute_typescript',
+    ]);
+    const guardTools = this.buildRehydrationGuardTools(
+      expiredEntries,
+      toolsetManager,
+      reservedToolNames,
+      sessionState.turnCounter,
+    );
     const codeModeResult = createCodeModeTool({
       getTools: () =>
         this.mergeTools({
-          staticTools: { ...coreTools, ...metaTools },
+          staticTools: { ...coreTools, ...metaTools, ...guardTools },
           taskTool,
           inspectImageTool,
           dynamicTools: toolsetManager.getActiveTools(),
@@ -148,7 +167,7 @@ export class ToolAssembler {
     return {
       staticTools: {
         ...this.mergeTools({
-          staticTools: { ...coreTools, ...metaTools },
+          staticTools: { ...coreTools, ...metaTools, ...guardTools },
           taskTool,
           inspectImageTool,
           dynamicTools: {},
@@ -213,6 +232,98 @@ export class ToolAssembler {
         defineRuntimeTool(name, tool, { source: 'meta' }),
       ),
     );
+  }
+
+  private buildRehydrationGuardTools(
+    expired: SessionExpiredToolset[],
+    manager: ToolsetManager,
+    reservedToolNames: Set<string>,
+    currentTurn: number,
+  ): Record<string, Tool> {
+    const guards: Record<string, Tool> = {};
+
+    for (const entry of expired) {
+      const toolset = getToolset(entry.id);
+      if (!toolset) continue;
+
+      for (const toolInfo of toolset.tools()) {
+        if (!entry.toolNames.includes(toolInfo.name) || reservedToolNames.has(toolInfo.name)) {
+          continue;
+        }
+
+        guards[toolInfo.name] = tool({
+          description: `Recovery guard for expired tool ${toolInfo.name}. Reactivates ${toolset.name} when safe; does not execute the original stale tool call.`,
+          inputSchema: z.record(z.string(), z.unknown()),
+          execute: async () =>
+            this.rehydrateExpiredToolset(entry, manager, reservedToolNames, currentTurn),
+        });
+      }
+    }
+
+    return guards;
+  }
+
+  private async rehydrateExpiredToolset(
+    expired: SessionExpiredToolset,
+    manager: ToolsetManager,
+    reservedToolNames: Set<string>,
+    currentTurn: number,
+  ): Promise<Record<string, unknown>> {
+    const toolset = getToolset(expired.id);
+    if (!toolset || expired.manuallyDeactivated || manager.wasManuallyDeactivated(expired.id)) {
+      return {
+        status: 'not_active',
+        toolsetId: expired.id,
+        message: `Toolset "${expired.id}" is not active. Call activate_toolset before using its tools.`,
+      };
+    }
+
+    const settings = await getToolsetSettings();
+    if (!settings.autoRehydrate) {
+      return {
+        status: 'not_active',
+        toolsetId: expired.id,
+        autoRehydrate: false,
+        message: `Toolset "${toolset.name}" is not active. Call activate_toolset("${expired.id}") before using its tools.`,
+      };
+    }
+
+    const activeToolNames = new Set(Object.keys(manager.getActiveTools()));
+    const collision = toolset
+      .tools()
+      .map((toolInfo) => toolInfo.name)
+      .find((toolName) => activeToolNames.has(toolName) || reservedToolNames.has(toolName));
+    if (collision) {
+      return {
+        status: 'not_active',
+        toolsetId: expired.id,
+        collision,
+        message: `Toolset "${toolset.name}" is not active and cannot be auto-reactivated because tool "${collision}" would collide. Call activate_toolset explicitly if you still need it.`,
+      };
+    }
+
+    const result = await manager.activate(expired.id, {
+      scope: 'ttl_turns',
+      expiresAtTurn: currentTurn + settings.ttlTurns - 1,
+    });
+
+    if (result.status !== 'activated') {
+      return {
+        status: 'not_active',
+        toolsetId: expired.id,
+        reason: result.status,
+        message: `Toolset "${toolset.name}" is not active and could not be auto-reactivated. Call activate_toolset before using its tools.`,
+      };
+    }
+
+    return {
+      status: 'reactivated',
+      toolsetId: expired.id,
+      toolsetName: toolset.name,
+      tools: result.toolNames,
+      message:
+        'The toolset has been reactivated. Retry the original tool call now that the tool is available.',
+    };
   }
 
   private buildTaskTool(toolsetManager: ToolsetManager): Tool | null {

--- a/packages/server/src/tools/toolsets/manager.test.ts
+++ b/packages/server/src/tools/toolsets/manager.test.ts
@@ -215,4 +215,29 @@ describe('ToolsetManager activation state', () => {
     expect(manager.getActivationState()).toEqual([{ id: 'persisted', scope: 'until_deactivated' }]);
     expect(manager.getExpiredRunToolsets()).toEqual([{ id: 'run-only', toolNames: ['run_tool'] }]);
   });
+
+  test('renews TTL state when a tool from a TTL toolset is used', async () => {
+    registerToolset({
+      id: 'ttl-toolset',
+      name: 'TTL',
+      description: 'TTL',
+      tools: () => [{ name: 'ttl_tool', description: 'ttl' }],
+      activate: async () => ({ ttl_tool: makeTool('ttl') }),
+    } satisfies Toolset);
+
+    const manager = new ToolsetManager(
+      {
+        sessionId: 'ses_test' as never,
+        messageId: 'msg_test' as never,
+        streamRunId: 'run_test',
+      },
+      [{ id: 'ttl-toolset', scope: 'ttl_turns', expiresAtTurn: 1 }],
+    );
+    await manager.activate('ttl-toolset');
+
+    expect(manager.renewTtlForTool('ttl_tool', 5)).toBe('ttl-toolset');
+    expect(manager.getActivationState()).toEqual([
+      { id: 'ttl-toolset', scope: 'ttl_turns', expiresAtTurn: 5 },
+    ]);
+  });
 });

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -25,6 +25,8 @@ export class ToolsetManager {
 
   private readonly activationState = new Map<string, SessionActiveToolset>();
 
+  private readonly manuallyDeactivatedIds = new Set<string>();
+
   /** Cached tool instances for each active toolset (lazy-populated on activate) */
   private readonly activeToolCache = new Map<string, Record<string, Tool>>();
 
@@ -107,6 +109,7 @@ export class ToolsetManager {
     }
 
     this.activeIds.add(toolsetId);
+    this.manuallyDeactivatedIds.delete(toolsetId);
     this.setActivationState(
       toolsetId,
       state ?? this.activationState.get(toolsetId) ?? { scope: 'current_run' },
@@ -128,6 +131,7 @@ export class ToolsetManager {
 
   /** Deactivate a toolset, removing its tools from the active set. */
   deactivate(toolsetId: string): boolean {
+    this.manuallyDeactivatedIds.add(toolsetId);
     if (!this.activeIds.has(toolsetId)) {
       return false;
     }
@@ -168,6 +172,20 @@ export class ToolsetManager {
       .map((id) => ({ id, toolNames: Object.keys(this.activeToolCache.get(id) ?? {}) }));
   }
 
+  renewTtlForTool(toolName: string, expiresAtTurn: number): string | null {
+    for (const [toolsetId, tools] of this.activeToolCache.entries()) {
+      if (!(toolName in tools)) continue;
+
+      const state = this.activationState.get(toolsetId);
+      if (state?.scope !== 'ttl_turns') return null;
+
+      this.activationState.set(toolsetId, { ...state, expiresAtTurn });
+      return toolsetId;
+    }
+
+    return null;
+  }
+
   pin(toolsetId: string): boolean {
     if (!this.activeIds.has(toolsetId)) {
       return false;
@@ -188,6 +206,10 @@ export class ToolsetManager {
 
   isPersisted(toolsetId: string): boolean {
     return this.persistedIds.has(toolsetId);
+  }
+
+  wasManuallyDeactivated(toolsetId: string): boolean {
+    return this.manuallyDeactivatedIds.has(toolsetId);
   }
 
   setActivationState(

--- a/packages/server/src/tools/toolsets/settings.test.ts
+++ b/packages/server/src/tools/toolsets/settings.test.ts
@@ -13,9 +13,10 @@ describe('parseToolsetSettings', () => {
         new Map([
           ['toolsets.defaultScope', 'current_run'],
           ['toolsets.ttlTurns', '5'],
+          ['toolsets.autoRehydrate', 'false'],
         ]),
       ),
-    ).toEqual({ defaultScope: 'current_run', ttlTurns: 5 });
+    ).toEqual({ defaultScope: 'current_run', ttlTurns: 5, autoRehydrate: false });
   });
 
   test('ignores invalid values', () => {
@@ -24,6 +25,7 @@ describe('parseToolsetSettings', () => {
         new Map([
           ['toolsets.defaultScope', 'invalid'],
           ['toolsets.ttlTurns', '0'],
+          ['toolsets.autoRehydrate', 'invalid'],
         ]),
       ),
     ).toEqual(DEFAULT_TOOLSET_SETTINGS);

--- a/packages/server/src/tools/toolsets/settings.ts
+++ b/packages/server/src/tools/toolsets/settings.ts
@@ -7,11 +7,13 @@ import type { SessionToolsetScope } from '@/llm/stream/session-toolsets.js';
 type ToolsetSettings = {
   defaultScope: SessionToolsetScope;
   ttlTurns: number;
+  autoRehydrate: boolean;
 };
 
 export const DEFAULT_TOOLSET_SETTINGS: ToolsetSettings = {
   defaultScope: 'ttl_turns',
   ttlTurns: 3,
+  autoRehydrate: true,
 };
 
 function parseDefaultScope(value: string | undefined): SessionToolsetScope | undefined {
@@ -27,10 +29,20 @@ function parseTtlTurns(value: string | undefined): number | undefined {
   return Number.isFinite(parsed) && parsed >= 1 ? parsed : undefined;
 }
 
+function parseBoolean(value: string | undefined): boolean | undefined {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return undefined;
+}
+
 export function parseToolsetSettings(values: Map<string, string>): ToolsetSettings {
   return {
-    defaultScope: parseDefaultScope(values.get('toolsets.defaultScope')) ?? DEFAULT_TOOLSET_SETTINGS.defaultScope,
+    defaultScope:
+      parseDefaultScope(values.get('toolsets.defaultScope')) ??
+      DEFAULT_TOOLSET_SETTINGS.defaultScope,
     ttlTurns: parseTtlTurns(values.get('toolsets.ttlTurns')) ?? DEFAULT_TOOLSET_SETTINGS.ttlTurns,
+    autoRehydrate:
+      parseBoolean(values.get('toolsets.autoRehydrate')) ?? DEFAULT_TOOLSET_SETTINGS.autoRehydrate,
   };
 }
 

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -12,6 +12,7 @@ export const SETTINGS_KEYS = [
   'compaction.reserved',
   'toolsets.defaultScope',
   'toolsets.ttlTurns',
+  'toolsets.autoRehydrate',
   'appearance.mode',
   'appearance.theme',
   'onboarding.status',
@@ -63,6 +64,7 @@ export const SETTINGS_SCHEMAS: Record<SettingsKey, z.ZodType> = {
   'compaction.reserved': z.coerce.number().int().min(0),
   'toolsets.defaultScope': z.enum(['current_run', 'ttl_turns', 'until_deactivated']),
   'toolsets.ttlTurns': z.coerce.number().int().min(1),
+  'toolsets.autoRehydrate': z.coerce.boolean(),
   'appearance.mode': z.enum(['light', 'dark', 'system']),
   'appearance.theme': z.enum(['default', 'dracula', 'solarized', 'tokyonight']),
   'onboarding.status': z.enum(['pending', 'completed']),
@@ -168,6 +170,11 @@ export const SETTINGS_DEFAULTS: SettingDefault[] = [
     key: 'toolsets.ttlTurns',
     value: '3',
     description: 'Turns of inactivity before a TTL-scoped toolset expires.',
+  },
+  {
+    key: 'toolsets.autoRehydrate',
+    value: 'true',
+    description: 'Auto-reactivate an expired toolset when the model calls one of its tools.',
   },
   {
     key: 'appearance.mode',


### PR DESCRIPTION
## Change Summary

Adds activity-based TTL renewal and a recovery guard for stale tool calls from recently expired toolsets.

### New Features
- TTL-scoped toolsets renew their expiry when one of their tools is actually called.
- Recently expired tool names get temporary recovery guards that can auto-reactivate the toolset when safe.
- Adds toolsets.autoRehydrate with a default enabled setting and structured recovery when disabled.

### Improvements & Refactors
- Manual deactivation is tracked in-run so explicit deactivate_toolset blocks same-turn auto-reactivation.
- Guard tools return structured recovery results instead of executing stale tool arguments.