### PR TITLE
Improve unsigned macOS update flow

### DIFF
--- a/apps/desktop/src/main/ipc/updater.ts
+++ b/apps/desktop/src/main/ipc/updater.ts
@@ -12,6 +12,7 @@ export function registerUpdaterHandlers(
   ipcMain.handle('updater:check', () => updater.checkForUpdates());
   ipcMain.handle('updater:getState', (): UpdaterStatePayload => updater.getState());
   ipcMain.handle('updater:install', () => updater.installUpdate());
+  ipcMain.handle('updater:openManualUpdateAndQuit', () => updater.openManualUpdateAndQuit());
 
   updater.onEvent((state) => {
     const win = getWindow();

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,5 +1,10 @@
-import { app } from 'electron';
+import { app, shell } from 'electron';
 import { autoUpdater, type ProgressInfo, type UpdateInfo } from 'electron-updater';
+import { createWriteStream } from 'node:fs';
+import { mkdir, rename, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 
 import type { UpdaterStatePayload } from './ipc-types.js';
 
@@ -13,8 +18,39 @@ const NETWORK_ERROR_CODES = [
   'ECONNREFUSED',
 ];
 
+const RELEASES_URL = 'https://github.com/UseStitch/stitch/releases/latest';
+const RELEASE_DOWNLOAD_BASE_URL = 'https://github.com/UseStitch/stitch/releases/latest/download';
+
 function isNetworkError(error: Error): boolean {
   return NETWORK_ERROR_CODES.some((code) => error.message.includes(code));
+}
+
+async function downloadLatestMacDmg(): Promise<string> {
+  const downloadsDir = app.getPath('downloads');
+  await mkdir(downloadsDir, { recursive: true });
+
+  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
+  const fileName = `Stitch-macos-${arch}.dmg`;
+  const filePath = path.join(downloadsDir, fileName);
+  const partialPath = `${filePath}.download`;
+  const downloadUrl = `${RELEASE_DOWNLOAD_BASE_URL}/${fileName}`;
+
+  const response = await fetch(downloadUrl, {
+    headers: { 'User-Agent': 'Stitch Desktop' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download ${fileName}: ${response.status} ${response.statusText}`);
+  }
+  if (!response.body) {
+    throw new Error(`Failed to download ${fileName}: response body was empty`);
+  }
+
+  await rm(partialPath, { force: true });
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(partialPath));
+  await rename(partialPath, filePath);
+
+  return filePath;
 }
 
 type UpdaterOptions = {
@@ -102,5 +138,20 @@ export function createUpdater(options: UpdaterOptions) {
     return true;
   }
 
-  return { init, checkForUpdates, getState, onEvent, installUpdate };
+  async function openManualUpdateAndQuit(): Promise<boolean> {
+    const filePath = process.platform === 'darwin' ? await downloadLatestMacDmg() : null;
+
+    if (filePath) {
+      const error = await shell.openPath(filePath);
+      if (error) throw new Error(error);
+    } else {
+      await shell.openExternal(RELEASES_URL);
+    }
+
+    await options.prepareForInstall();
+    app.quit();
+    return true;
+  }
+
+  return { init, checkForUpdates, getState, onEvent, installUpdate, openManualUpdateAndQuit };
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -68,6 +68,8 @@ contextBridge.exposeInMainWorld('api', {
     check: () => ipcRenderer.invoke('updater:check') as Promise<UpdaterStatePayload>,
     getState: () => ipcRenderer.invoke('updater:getState') as Promise<UpdaterStatePayload>,
     install: () => ipcRenderer.invoke('updater:install') as Promise<boolean>,
+    openManualUpdateAndQuit: () =>
+      ipcRenderer.invoke('updater:openManualUpdateAndQuit') as Promise<boolean>,
   },
   spellcheck: {
     replaceMisspelling: (word: string) => ipcRenderer.invoke('spellcheck:replaceMisspelling', word),

--- a/apps/web/src/components/settings/general.tsx
+++ b/apps/web/src/components/settings/general.tsx
@@ -102,6 +102,9 @@ const UPDATER_STATUS_LABELS: Record<string, string> = {
   installing: 'Installing update and restarting...',
 };
 
+const MAC_MANUAL_UPDATE_DESCRIPTION =
+  'Download the latest macOS installer, open it, then quit Stitch so you can replace the app safely.';
+
 function updaterStatusLabel(status: string, progress?: number): string {
   if (status === 'downloading') {
     return `Downloading update${progress ? ` (${Math.round(progress)}%)` : '...'}`;
@@ -109,33 +112,59 @@ function updaterStatusLabel(status: string, progress?: number): string {
   return UPDATER_STATUS_LABELS[status] ?? 'Check for updates manually.';
 }
 
-const RELEASES_URL = 'https://github.com/UseStitch/stitch/releases/latest';
-
 function AppUpdatesContent() {
   const isMac = window.electron?.platform === 'darwin';
 
   if (isMac) {
-    return (
-      <SettingRows>
-        <SettingRow
-          label="Desktop app updates"
-          description="Auto-updates are not available on macOS. Download the latest version from the releases page."
-        >
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="shrink-0"
-            onClick={() => void window.api?.shell?.openExternal(RELEASES_URL)}
-          >
-            Download update
-          </Button>
-        </SettingRow>
-      </SettingRows>
-    );
+    return <MacManualUpdatesContent />;
   }
 
   return <AutoUpdatesContent />;
+}
+
+function MacManualUpdatesContent() {
+  const [quitPending, setQuitPending] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  async function handleManualUpdate() {
+    const openManualUpdateAndQuit = window.api?.updater?.openManualUpdateAndQuit;
+    if (!openManualUpdateAndQuit) return;
+
+    setQuitPending(true);
+    setError(null);
+    try {
+      await openManualUpdateAndQuit();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setQuitPending(false);
+    }
+  }
+
+  return (
+    <SettingRows>
+      <SettingRow label="Desktop app updates" description={MAC_MANUAL_UPDATE_DESCRIPTION}>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={handleManualUpdate}
+          disabled={quitPending}
+        >
+          {quitPending ? (
+            <>
+              <LoaderIcon className="size-3.5 animate-spin" />
+              Downloading...
+            </>
+          ) : (
+            'Download and quit'
+          )}
+        </Button>
+      </SettingRow>
+      {error ? <p className="pb-2 text-xs text-destructive">{error}</p> : null}
+    </SettingRows>
+  );
 }
 
 function AutoUpdatesContent() {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -88,6 +88,7 @@ declare global {
         check: () => Promise<DesktopUpdaterState>;
         getState: () => Promise<DesktopUpdaterState>;
         install: () => Promise<boolean>;
+        openManualUpdateAndQuit: () => Promise<boolean>;
       };
       spellcheck?: {
         replaceMisspelling: (word: string) => Promise<void>;


### PR DESCRIPTION
## 🚀 Change Summary

Improves the unsigned macOS update experience by downloading the latest matching DMG from GitHub, opening it for the user, and quitting Stitch cleanly so the app can be replaced safely.

### 🛠 Improvements & Refactors
- Adds a macOS manual update action that downloads the latest architecture-specific DMG from GitHub releases.
- Opens the downloaded installer before shutting down the tray, meeting detection, recording capture, and local server.
- Updates the Settings UI to show a clear "Download and quit" flow with inline error feedback.