### PR TITLE
improvement: auto-generate release notes from conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,3 +381,20 @@ jobs:
           else
             gh release create "${TAG}" "${assets[@]}" --target "${COMMIT}" --title "${TAG}" --notes-file release-notes.md
           fi
+
+  purge-caches:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete stale caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # For each cache prefix, keep only the most recently accessed entry and delete the rest
+          gh api "repos/${GH_REPO}/actions/caches?per_page=100" \
+            --jq '.actions_caches | sort_by(.last_accessed_at) | reverse | group_by(.key | split("-") | .[0:3] | join("-")) | map(.[1:]) | flatten | .[].id' \
+          | while read -r id; do
+            echo "Deleting stale cache $id"
+            gh api --method DELETE "repos/${GH_REPO}/actions/caches/$id"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,6 +275,12 @@ jobs:
       - build-linux-server
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.version.outputs.commit }}
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -292,6 +298,63 @@ jobs:
         env:
           TAG: ${{ needs.version.outputs.tag }}
         run: mv release-assets/server-linux-x64/stitch-server release-assets/server-linux-x64/stitch-server-linux-x64-${TAG}
+
+      - name: Generate release notes
+        env:
+          TAG: ${{ needs.version.outputs.tag }}
+        run: |
+          prev=$(git tag --sort=-version:refname | grep -v "^${TAG}$" | head -n1)
+          from=${prev:-$(git rev-list --max-parents=0 HEAD)}
+
+          declare -a feats fixes improvements docs chores other
+
+          while IFS= read -r subject; do
+            # Skip version bump commits
+            if [[ "$subject" =~ ^chore(\([^)]*\))?!?:\ bump\ version ]]; then continue; fi
+
+            if [[ "$subject" =~ ^feat(\([^)]*\))?!?:\ (.*) ]]; then
+              feats+=("- ${BASH_REMATCH[2]}")
+            elif [[ "$subject" =~ ^fix(\([^)]*\))?!?:\ (.*) ]]; then
+              fixes+=("- ${BASH_REMATCH[2]}")
+            elif [[ "$subject" =~ ^(improvement|refactor|perf)(\([^)]*\))?!?:\ (.*) ]]; then
+              improvements+=("- ${BASH_REMATCH[3]}")
+            elif [[ "$subject" =~ ^docs(\([^)]*\))?!?:\ (.*) ]]; then
+              docs+=("- ${BASH_REMATCH[2]}")
+            elif [[ "$subject" =~ ^chore(\([^)]*\))?!?:\ (.*) ]]; then
+              chores+=("- ${BASH_REMATCH[2]}")
+            else
+              other+=("- ${subject}")
+            fi
+          done < <(git log "${from}..${TAG}" --pretty=format:"%s")
+
+          {
+            if [ ${#feats[@]} -gt 0 ]; then
+              echo "### New Features"
+              printf '%s\n' "${feats[@]}"
+            fi
+            if [ ${#fixes[@]} -gt 0 ]; then
+              echo "### Bug Fixes"
+              printf '%s\n' "${fixes[@]}"
+            fi
+            if [ ${#improvements[@]} -gt 0 ]; then
+              echo "### Improvements"
+              printf '%s\n' "${improvements[@]}"
+            fi
+            if [ ${#docs[@]} -gt 0 ]; then
+              echo "### Documentation"
+              printf '%s\n' "${docs[@]}"
+            fi
+            if [ ${#chores[@]} -gt 0 ]; then
+              echo "### Chores"
+              printf '%s\n' "${chores[@]}"
+            fi
+            if [ ${#other[@]} -gt 0 ]; then
+              echo "### Other Changes"
+              printf '%s\n' "${other[@]}"
+            fi
+          } > release-notes.md
+
+          cat release-notes.md
 
       - name: Create GitHub release and upload assets
         env:
@@ -316,5 +379,5 @@ jobs:
           if gh release view "${TAG}" >/dev/null 2>&1; then
             gh release upload "${TAG}" "${assets[@]}" --clobber
           else
-            gh release create "${TAG}" "${assets[@]}" --target "${COMMIT}" --title "${TAG}" --notes "Release ${TAG}"
+            gh release create "${TAG}" "${assets[@]}" --target "${COMMIT}" --title "${TAG}" --notes-file release-notes.md
           fi


### PR DESCRIPTION
## 🚀 Change Summary

Replaces the static \Release \\ release body with automatically generated release notes, and adds a post-release cache cleanup to prevent the Actions cache quota from filling up.

### ✨ New Features
- **Auto-generated release notes**: The release workflow now generates markdown release notes from conventional commit prefixes (\eat:\, \ix:\, \improvement:\, \efactor:\, \docs:\, \chore:\) between the previous tag and the new tag, grouped into sections with PR numbers preserved

### 🛠 Improvements & Refactors
- Release notes are generated entirely in shell — no extra tooling required
- \chore: bump version\ commits are excluded; all other \chore:\ commits appear in their own section

### 🐛 Bug Fixes
- **Actions cache quota**: Repo was at 9.8 GB / 10 GB, causing the Windows build to fail. Added a \purge-caches\ job that runs after each release and deletes all but the most recent entry per cache prefix, keeping quota healthy automatically