### PR TITLE
chore: remove unnecessary bun usages in CI workflows

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -28,11 +28,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup Bun
-        uses: ./.github/actions/setup-bun
-
       - name: Build website registry artifacts
-        run: bun run scripts/build-website-registries.mjs
+        run: node scripts/build-website-registries.mjs
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/setup-bun
 
       - name: Build website registry artifacts
-        run: node scripts/build-website-registries.mjs
+        run: bun run scripts/build-website-registries.mjs
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
       - name: Build website registry artifacts
         run: node scripts/build-website-registries.mjs
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,9 +86,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        uses: ./.github/actions/setup-bun
-
       - name: Setup git committer
         uses: ./.github/actions/setup-git-committer
         with:


### PR DESCRIPTION
## Change Summary

Remove redundant `Setup Bun` step from the `version` job in `release.yml`, and swap `bun run` for `node` in the `deploy-cloudflare` build step.

### Improvements
- **`version` job in `release.yml`**: Removed unnecessary `Setup Bun` step — the job only runs a `node` heredoc using `node:fs`, which is pre-installed on GitHub-hosted runners
- **`deploy` job in `deploy-cloudflare.yml`**: `scripts/build-website-registries.mjs` uses only `node:fs` and `node:path`, so invoke it directly with `node` instead of `bun run`
