### PR TITLE
Improve toolset type boundaries

### DIFF
--- a/connectors/google/src/calendar/tools.ts
+++ b/connectors/google/src/calendar/tools.ts
@@ -203,17 +203,3 @@ export function createCalendarTools(
 
   return tools;
 }
-
-export const CALENDAR_TOOL_SUMMARIES = [
-  {
-    name: 'calendar_list',
-    description: 'List upcoming Google Calendar events with optional date/text filtering',
-  },
-  { name: 'calendar_get', description: 'Get full details for a specific calendar event' },
-  { name: 'calendar_create', description: 'Create a new calendar event (requires write access)' },
-  {
-    name: 'calendar_update',
-    description: 'Update an existing calendar event (requires write access)',
-  },
-  { name: 'calendar_delete', description: 'Delete a calendar event (requires write access)' },
-];

--- a/connectors/google/src/calendar/tools.ts
+++ b/connectors/google/src/calendar/tools.ts
@@ -60,9 +60,7 @@ const sendUpdatesEnum = z
   .enum(['all', 'externalOnly', 'none'])
   .optional()
   .default('all')
-  .describe(
-    'Who to notify about the change: "all" (default), "externalOnly", or "none"',
-  );
+  .describe('Who to notify about the change: "all" (default), "externalOnly", or "none"');
 
 const calendarUpdateSchema = z.object({
   account: z
@@ -75,8 +73,14 @@ const calendarUpdateSchema = z.object({
   location: z.string().optional().describe('New event location'),
   startDateTime: z.string().optional().describe('New start time (ISO 8601)'),
   endDateTime: z.string().optional().describe('New end time (ISO 8601)'),
-  timeZone: z.string().optional().describe('Time zone for start/end times (e.g. "America/Chicago")'),
-  attendees: z.array(z.string()).optional().describe('Replacement list of attendee email addresses'),
+  timeZone: z
+    .string()
+    .optional()
+    .describe('Time zone for start/end times (e.g. "America/Chicago")'),
+  attendees: z
+    .array(z.string())
+    .optional()
+    .describe('Replacement list of attendee email addresses'),
   addMeet: z
     .boolean()
     .optional()
@@ -100,7 +104,7 @@ export function createCalendarTools(
     account?: string,
   ) => Promise<{ client: GoogleClient; usedAccount: string | null }>,
   hasWrite: boolean,
-) {
+): Record<string, Tool> {
   const tools: Record<string, Tool> = {
     calendar_list: tool({
       description:
@@ -191,12 +195,7 @@ export function createCalendarTools(
       inputSchema: calendarDeleteSchema,
       execute: async (input: z.infer<typeof calendarDeleteSchema>) => {
         const { client, usedAccount } = await resolveClient(input.account);
-        await CalendarApi.deleteEvent(
-          client,
-          input.eventId,
-          input.calendarId,
-          input.sendUpdates,
-        );
+        await CalendarApi.deleteEvent(client, input.eventId, input.calendarId, input.sendUpdates);
         return { deleted: true, eventId: input.eventId, usedAccount };
       },
     });

--- a/connectors/google/src/docs/tools.ts
+++ b/connectors/google/src/docs/tools.ts
@@ -183,14 +183,3 @@ export function createDocsTools(
 
   return tools;
 }
-
-export const DOCS_TOOL_SUMMARIES = [
-  { name: 'docs_search', description: 'Search Google Docs files by Drive query filters' },
-  { name: 'docs_read', description: 'Read a Google Docs document as plain text' },
-  { name: 'docs_create', description: 'Create a Google Docs document (requires write access)' },
-  { name: 'docs_update', description: 'Update a Google Docs document (requires write access)' },
-  {
-    name: 'docs_edit',
-    description: 'Edit a Google Docs document by replacing exact text (requires write access)',
-  },
-];

--- a/connectors/google/src/drive/tools.ts
+++ b/connectors/google/src/drive/tools.ts
@@ -24,7 +24,9 @@ const driveFileSchema = z.object({
   mimeType: z
     .string()
     .optional()
-    .describe('Optional MIME type of the file. Providing this skips an extra metadata lookup if known from a previous search.'),
+    .describe(
+      'Optional MIME type of the file. Providing this skips an extra metadata lookup if known from a previous search.',
+    ),
 });
 
 const driveWriteSchema = z.object({
@@ -111,16 +113,3 @@ export function createDriveTools(
 
   return tools;
 }
-
-export const DRIVE_TOOL_SUMMARIES = [
-  { name: 'drive_search', description: 'Search Google Drive files using Drive query syntax' },
-  {
-    name: 'drive_read',
-    description: 'Read file content from Google Drive (Docs as text, Sheets as CSV)',
-  },
-  { name: 'drive_info', description: 'Get metadata for a Google Drive file (including owners)' },
-  {
-    name: 'drive_write',
-    description: 'Create a new text or Markdown file in Google Drive (requires write access)',
-  },
-];

--- a/connectors/google/src/gmail/tools.ts
+++ b/connectors/google/src/gmail/tools.ts
@@ -238,7 +238,7 @@ export function createGmailTools(
   ) => Promise<{ client: GoogleClient; usedAccount: string | null }>,
   permissions: { canSend: boolean; canModify: boolean; canManageFilters: boolean },
   config?: { tempPath?: string },
-) {
+): Record<string, Tool> {
   const { canSend, canModify, canManageFilters } = permissions;
   const tools: Record<string, Tool> = {
     gmail_search: tool({

--- a/connectors/google/src/gmail/tools.ts
+++ b/connectors/google/src/gmail/tools.ts
@@ -385,32 +385,3 @@ export function createGmailTools(
 
   return tools;
 }
-
-export const GMAIL_TOOL_SUMMARIES = [
-  { name: 'gmail_search', description: 'Search Gmail messages using Gmail search syntax' },
-  { name: 'gmail_read', description: 'Read the full content of a Gmail message by ID' },
-  {
-    name: 'gmail_download_attachments',
-    description: 'Download attachments from a Gmail message by ID to temporary local files',
-  },
-  { name: 'gmail_send', description: 'Send an email or reply to a thread (requires write access)' },
-  {
-    name: 'gmail_list_labels',
-    description: 'List Gmail labels with metadata and visibility settings',
-  },
-  { name: 'gmail_get_label', description: 'Get details for a single Gmail label by ID' },
-  {
-    name: 'gmail_modify_labels',
-    description: 'Create, update, or delete Gmail labels; requires operation=create|update|delete',
-  },
-  {
-    name: 'gmail_modify_messages',
-    description:
-      'Add or remove labels on messages or threads; requires addLabelIds/removeLabelIds and cannot add SPAM and TRASH together',
-  },
-  {
-    name: 'gmail_filters',
-    description:
-      'List, get, create, or delete Gmail filters; requires operation=list|get|create|delete (requires settings access)',
-  },
-];

--- a/connectors/google/src/toolsets.ts
+++ b/connectors/google/src/toolsets.ts
@@ -8,10 +8,10 @@
 
 import type { ConnectorIconSource } from '@stitch/shared/connectors/types';
 
-import { CALENDAR_TOOL_SUMMARIES, createCalendarTools } from './calendar/tools.js';
-import { DOCS_TOOL_SUMMARIES, createDocsTools } from './docs/tools.js';
-import { DRIVE_TOOL_SUMMARIES, createDriveTools } from './drive/tools.js';
-import { GMAIL_TOOL_SUMMARIES, createGmailTools } from './gmail/tools.js';
+import { createCalendarTools } from './calendar/tools.js';
+import { createDocsTools } from './docs/tools.js';
+import { createDriveTools } from './drive/tools.js';
+import { createGmailTools } from './gmail/tools.js';
 import {
   hasGmailModifyAccess,
   hasGmailSendAccess,
@@ -61,6 +61,26 @@ export type GoogleToolsetDefinition = {
 };
 
 type Resolver = (account?: string) => Promise<{ client: GoogleClient; usedAccount: string | null }>;
+
+const SUMMARY_RESOLVER: Resolver = async () => {
+  throw new Error('Summary resolver should not be executed.');
+};
+
+function summarizeTools(tools: Record<string, Tool>): { name: string; description: string }[] {
+  return Object.entries(tools).map(([name, tool]) => ({
+    name,
+    description: summarizeToolDescription(tool.description),
+  }));
+}
+
+function summarizeToolDescription(description: string | undefined): string {
+  return (
+    description
+      ?.split('\n')
+      .find((line) => line.trim())
+      ?.trim() ?? ''
+  );
+}
 
 type BuildGoogleToolsetsInput = {
   scopes: string[];
@@ -114,12 +134,7 @@ function createGmailToolset(
   const canSend = hasGmailSendAccess(scopes) && canWriteCapability;
   const canModify = hasGmailModifyAccess(scopes) && canWriteCapability;
   const canManageFilters = hasGmailSettingsAccess(scopes) && canWriteCapability;
-  const summaries = GMAIL_TOOL_SUMMARIES.filter((t) => {
-    if (t.name === 'gmail_send') return canSend;
-    if (t.name === 'gmail_modify_labels' || t.name === 'gmail_modify_messages') return canModify;
-    if (t.name === 'gmail_filters') return canManageFilters;
-    return true;
-  });
+  const permissions = { canSend, canModify, canManageFilters };
 
   return {
     id: 'google-gmail',
@@ -146,18 +161,14 @@ function createGmailToolset(
         : 'You do not have settings access. Managing Gmail filters is not available.',
       'Do not add SPAM and TRASH in the same gmail_modify_messages call. Apply those actions in separate steps if needed.',
     ].join('\n'),
-    tools: () => summaries,
-    activate: (resolveClient) =>
-      createGmailTools(resolveClient, { canSend, canModify, canManageFilters }, config),
+    tools: () => summarizeTools(createGmailTools(SUMMARY_RESOLVER, permissions, config)),
+    activate: (resolveClient) => createGmailTools(resolveClient, permissions, config),
   };
 }
 
 function createDriveToolset(scopes: string[], capabilities: string[]): GoogleToolsetDefinition {
   const canWrite =
     hasWriteAccess(scopes, 'drive') && hasCapability(capabilities, GOOGLE_CAPABILITY_DRIVE_WRITE);
-  const summaries = canWrite
-    ? DRIVE_TOOL_SUMMARIES
-    : DRIVE_TOOL_SUMMARIES.filter((t) => t.name !== 'drive_write');
 
   return {
     id: 'google-drive',
@@ -176,7 +187,7 @@ function createDriveToolset(scopes: string[], capabilities: string[]): GoogleToo
         ? 'You have write access. Use drive_write to create new text or Markdown files.'
         : 'You have read-only access. Creating files is not available.',
     ].join('\n'),
-    tools: () => summaries,
+    tools: () => summarizeTools(createDriveTools(SUMMARY_RESOLVER, canWrite)),
     activate: (resolveClient) => createDriveTools(resolveClient, canWrite),
   };
 }
@@ -185,14 +196,6 @@ function createCalendarToolset(scopes: string[], capabilities: string[]): Google
   const canWrite =
     hasWriteAccess(scopes, 'calendar') &&
     hasCapability(capabilities, GOOGLE_CAPABILITY_CALENDAR_WRITE);
-  const summaries = canWrite
-    ? CALENDAR_TOOL_SUMMARIES
-    : CALENDAR_TOOL_SUMMARIES.filter(
-        (t) =>
-          t.name !== 'calendar_create' &&
-          t.name !== 'calendar_update' &&
-          t.name !== 'calendar_delete',
-      );
 
   return {
     id: 'google-calendar',
@@ -211,7 +214,7 @@ function createCalendarToolset(scopes: string[], capabilities: string[]): Google
         ? 'You have write access. Use calendar_create to schedule new events, calendar_update to modify existing events, and calendar_delete to remove them. Pass addMeet: true to automatically attach a Google Meet link.'
         : 'You have read-only access. Creating, updating, and deleting events is not available.',
     ].join('\n'),
-    tools: () => summaries,
+    tools: () => summarizeTools(createCalendarTools(SUMMARY_RESOLVER, canWrite)),
     activate: (resolveClient) => createCalendarTools(resolveClient, canWrite),
   };
 }
@@ -219,11 +222,6 @@ function createCalendarToolset(scopes: string[], capabilities: string[]): Google
 function createDocsToolset(scopes: string[], capabilities: string[]): GoogleToolsetDefinition {
   const canWrite =
     hasWriteAccess(scopes, 'docs') && hasCapability(capabilities, GOOGLE_CAPABILITY_DOCS_WRITE);
-  const summaries = canWrite
-    ? DOCS_TOOL_SUMMARIES
-    : DOCS_TOOL_SUMMARIES.filter(
-        (t) => t.name !== 'docs_create' && t.name !== 'docs_update' && t.name !== 'docs_edit',
-      );
 
   return {
     id: 'google-docs',
@@ -240,7 +238,7 @@ function createDocsToolset(scopes: string[], capabilities: string[]): GoogleTool
         ? 'You have write access. Use docs_create to create docs, docs_update to append or replace content, and docs_edit for targeted text replacement.'
         : 'You have read-only access. Creating and updating docs is not available.',
     ].join('\n'),
-    tools: () => summaries,
+    tools: () => summarizeTools(createDocsTools(SUMMARY_RESOLVER, canWrite)),
     activate: (resolveClient) => createDocsTools(resolveClient, canWrite),
   };
 }

--- a/connectors/google/src/toolsets.ts
+++ b/connectors/google/src/toolsets.ts
@@ -21,6 +21,7 @@ import {
 } from './scopes.js';
 
 import type { GoogleClient } from './client.js';
+import type { Tool } from 'ai';
 
 export const GOOGLE_CAPABILITY_GMAIL_READ = 'google.gmail.read';
 export const GOOGLE_CAPABILITY_GMAIL_WRITE = 'google.gmail.write';
@@ -56,7 +57,7 @@ export type GoogleToolsetDefinition = {
   icon?: ConnectorIconSource;
   instructions?: string;
   tools: () => { name: string; description: string }[];
-  activate: (resolveClient: Resolver) => Record<string, unknown>;
+  activate: (resolveClient: Resolver) => Record<string, Tool>;
 };
 
 type Resolver = (account?: string) => Promise<{ client: GoogleClient; usedAccount: string | null }>;

--- a/packages/server/src/code-mode/filter.test.ts
+++ b/packages/server/src/code-mode/filter.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test } from 'bun:test';
 
 import { applyToolFilter } from '@/code-mode/filter.js';
 import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
-import type { Toolset } from '@/tools/toolsets/types.js';
+import type { Toolset, ToolsetKind } from '@/tools/toolsets/types.js';
 import type { Tool } from 'ai';
 
 function clearToolsets(): void {
@@ -11,9 +11,10 @@ function clearToolsets(): void {
   }
 }
 
-function registerTestToolset(id: string, toolNames: string[]): void {
+function registerTestToolset(id: string, toolNames: string[], kind: ToolsetKind = 'native'): void {
   const toolset: Toolset = {
     id,
+    kind,
     name: id,
     description: `${id} test toolset`,
     tools: () => toolNames.map((name) => ({ name, description: `${name} test tool` })),
@@ -38,9 +39,11 @@ describe('applyToolFilter', () => {
 
   test('excludes tools from excluded toolset IDs', () => {
     registerTestToolset('browser', ['browser']);
-    registerTestToolset('mcp:mcp_abcdefghijklmnopqrstuvwxyz', [
-      'mcp_abcdefghijklmnopqrstuvwxyz_search',
-    ]);
+    registerTestToolset(
+      'mcp:mcp_abcdefghijklmnopqrstuvwxyz',
+      ['mcp_abcdefghijklmnopqrstuvwxyz_search'],
+      'mcp',
+    );
 
     const input = buildTools(['browser', 'mcp_abcdefghijklmnopqrstuvwxyz_search', 'read']);
     const result = applyToolFilter(input, {

--- a/packages/server/src/connectors/google-toolsets.ts
+++ b/packages/server/src/connectors/google-toolsets.ts
@@ -36,6 +36,7 @@ const refreshInFlight = new Map<string, Promise<string>>();
 function toServerToolset(def: GoogleToolsetDefinition): Toolset {
   return {
     id: def.id,
+    kind: 'connector',
     name: def.name,
     description: def.description,
     icon: def.icon,

--- a/packages/server/src/connectors/google-toolsets.ts
+++ b/packages/server/src/connectors/google-toolsets.ts
@@ -25,7 +25,6 @@ import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
 import { registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
 import type { Toolset } from '@/tools/toolsets/types.js';
-import type { Tool } from 'ai';
 
 const log = Log.create({ service: 'google-toolsets' });
 const REFRESH_BUFFER_MS = 60_000;
@@ -226,7 +225,7 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
         };
         clientCache.set(cacheKey, result);
         return result;
-      }) as Record<string, Tool>;
+      });
     },
   };
 }

--- a/packages/server/src/llm/compaction.test.ts
+++ b/packages/server/src/llm/compaction.test.ts
@@ -514,6 +514,7 @@ describe('buildActiveToolsetInstructionsBlock', () => {
   test('returns empty string when active toolsets have no instructions', () => {
     registerToolset({
       id: 'no-instructions',
+      kind: 'native',
       name: 'No Instructions',
       description: 'Toolset without instructions',
       tools: () => [],
@@ -528,6 +529,7 @@ describe('buildActiveToolsetInstructionsBlock', () => {
   test('includes instructions for active toolsets that have them', () => {
     registerToolset({
       id: 'browser',
+      kind: 'native',
       name: 'Browser',
       description: 'Browser toolset',
       instructions: 'Use browser_navigate to open pages.',
@@ -545,6 +547,7 @@ describe('buildActiveToolsetInstructionsBlock', () => {
   test('omits toolsets that have no instructions even when mixed with ones that do', () => {
     registerToolset({
       id: 'with-instructions',
+      kind: 'native',
       name: 'With Instructions',
       description: 'Has instructions',
       instructions: 'Do something specific.',
@@ -553,6 +556,7 @@ describe('buildActiveToolsetInstructionsBlock', () => {
     });
     registerToolset({
       id: 'without-instructions',
+      kind: 'native',
       name: 'Without Instructions',
       description: 'No instructions',
       tools: () => [],
@@ -568,6 +572,7 @@ describe('buildActiveToolsetInstructionsBlock', () => {
   test('includes multiple toolset instruction blocks', () => {
     registerToolset({
       id: 'ts-alpha',
+      kind: 'native',
       name: 'Alpha',
       description: 'Alpha',
       instructions: 'Alpha instructions.',
@@ -576,6 +581,7 @@ describe('buildActiveToolsetInstructionsBlock', () => {
     });
     registerToolset({
       id: 'ts-beta',
+      kind: 'native',
       name: 'Beta',
       description: 'Beta',
       instructions: 'Beta instructions.',

--- a/packages/server/src/llm/stream/tool-assembler.test.ts
+++ b/packages/server/src/llm/stream/tool-assembler.test.ts
@@ -35,6 +35,7 @@ describe('buildExpiredToolsetsPrompt', () => {
   test('builds a model-visible notice for expired run-only toolsets', () => {
     registerToolset({
       id: 'browser',
+      kind: 'native',
       name: 'Browser',
       description: 'Browser toolset',
       tools: () => [{ name: 'browser_open', description: 'open' }],
@@ -65,6 +66,7 @@ describe('ToolAssembler expired toolset handling', () => {
 
     registerToolset({
       id: 'browser',
+      kind: 'native',
       name: 'Browser',
       description: 'Browser toolset',
       tools: () => [{ name: 'browser_open', description: 'open' }],
@@ -98,6 +100,7 @@ describe('ToolAssembler expired toolset handling', () => {
 
     registerToolset({
       id: 'browser',
+      kind: 'native',
       name: 'Browser',
       description: 'Browser toolset',
       tools: () => [{ name: 'browser_open', description: 'open' }],

--- a/packages/server/src/llm/stream/tool-assembler.ts
+++ b/packages/server/src/llm/stream/tool-assembler.ts
@@ -12,9 +12,9 @@ import { buildSkillsSystemPrompt } from '@/skills/service.js';
 import { createInspectImageTool } from '@/tools/core/inspect-image.js';
 import { createTaskTool } from '@/tools/core/task.js';
 import { createToolsetTools } from '@/tools/core/toolset-management.js';
-import { resultNormalizationMiddleware } from '@/tools/runtime/middleware.js';
+import { createNormalizedToolRuntime } from '@/tools/runtime/normalized-runtime.js';
 import { createTools } from '@/tools/runtime/registry.js';
-import { createToolRuntime, defineRuntimeTool } from '@/tools/runtime/runtime.js';
+import { defineRuntimeTool } from '@/tools/runtime/runtime.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
@@ -40,13 +40,11 @@ type AssembledTools = {
 };
 
 async function buildAvailableToolsetsPrompt(manager: ToolsetManager): Promise<string> {
-  const catalog = await manager.getCatalogWithState();
+  const catalog = await manager.getCatalogWithState({ includeTools: true });
   if (catalog.length === 0) return '';
 
   const lines = catalog.map((item) => {
-    const toolset = getToolset(item.id);
-    const tools = toolset
-      ?.tools()
+    const tools = (item.tools ?? [])
       .slice(0, 3)
       .map((tool) => `${tool.name}: ${tool.description}`)
       .join('; ');
@@ -182,7 +180,7 @@ export class ToolAssembler {
   }
 
   private buildToolsetMetaTools(manager: ToolsetManager): Record<string, Tool> {
-    const runtime = createToolRuntime(this.toolContext).use(resultNormalizationMiddleware());
+    const runtime = createNormalizedToolRuntime(this.toolContext);
     return runtime.toAiToolRecord(
       Object.entries(createToolsetTools(manager, this.toolContext.sessionId)).map(([name, tool]) =>
         defineRuntimeTool(name, tool, { source: 'meta' }),
@@ -194,7 +192,7 @@ export class ToolAssembler {
     const canUseTaskTool = this.opts.allowTaskTool ?? true;
     if (!canUseTaskTool) return null;
 
-    const runtime = createToolRuntime(this.toolContext).use(resultNormalizationMiddleware());
+    const runtime = createNormalizedToolRuntime(this.toolContext);
     return runtime.wrapTool(
       'task',
       createTaskTool(this.toolContext, {
@@ -210,7 +208,7 @@ export class ToolAssembler {
   }
 
   private buildInspectImageTool(): Tool {
-    const runtime = createToolRuntime(this.toolContext).use(resultNormalizationMiddleware());
+    const runtime = createNormalizedToolRuntime(this.toolContext);
     return runtime.wrapTool(
       'inspect_image',
       createInspectImageTool(this.toolContext, {

--- a/packages/server/src/mcp/tool-executor.test.ts
+++ b/packages/server/src/mcp/tool-executor.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 
 import type { McpServerWithTools } from '@/mcp/service.js';
-import { refreshMcpToolsets } from '@/mcp/tool-executor.js';
+import { getMcpServerPresentation, refreshMcpToolsets } from '@/mcp/tool-executor.js';
 import {
   getToolset,
   listToolsetIds,
@@ -155,5 +155,63 @@ describe('refreshMcpToolsets', () => {
     );
 
     expect(getToolset('mcp:mcp_test_server')?.name).toBe('Exa');
+  });
+
+  test('attaches presentation to the toolset and reads it back through the registry', async () => {
+    await refreshMcpToolsets(
+      { refreshTools: true },
+      {
+        getMcpServersWithCachedTools: async () => [TEST_SERVER],
+        fetchMcpTools: async () => ({
+          data: [{ name: 'lookup', description: 'Lookup data', inputSchema: {} }],
+        }),
+        fetchServerInfo: async () => null,
+        fetchServerPrompts: async () => [],
+        findRegistryServer: async () => null,
+        buildServerPresentation: async () => ({
+          serverId: TEST_SERVER.id,
+          name: TEST_SERVER.name,
+          iconPath: '/mcp/icons/test',
+          tools: { lookup: { title: 'Lookup', iconPath: '/mcp/icons/lookup' } },
+        }),
+      },
+    );
+
+    expect(getToolset('mcp:mcp_test_server')?.presentation).toMatchObject({
+      serverId: TEST_SERVER.id,
+      iconPath: '/mcp/icons/test',
+    });
+    expect(getMcpServerPresentation(TEST_SERVER.id)).toMatchObject({
+      serverId: TEST_SERVER.id,
+      iconPath: '/mcp/icons/test',
+    });
+  });
+
+  test('removing a stale server also drops its presentation', async () => {
+    const deps = {
+      fetchMcpTools: async () => ({
+        data: [{ name: 'lookup', description: 'Lookup data', inputSchema: {} }],
+      }),
+      fetchServerInfo: async () => null,
+      fetchServerPrompts: async () => [],
+      findRegistryServer: async () => null,
+      buildServerPresentation: async () => ({
+        serverId: TEST_SERVER.id,
+        name: TEST_SERVER.name,
+        tools: {},
+      }),
+    } as const;
+
+    await refreshMcpToolsets(
+      { refreshTools: true },
+      { ...deps, getMcpServersWithCachedTools: async () => [TEST_SERVER] },
+    );
+    expect(getMcpServerPresentation(TEST_SERVER.id)).toBeDefined();
+
+    await refreshMcpToolsets(
+      { refreshTools: true },
+      { ...deps, getMcpServersWithCachedTools: async () => [] },
+    );
+    expect(getMcpServerPresentation(TEST_SERVER.id)).toBeUndefined();
   });
 });

--- a/packages/server/src/mcp/tool-executor.test.ts
+++ b/packages/server/src/mcp/tool-executor.test.ts
@@ -53,6 +53,7 @@ describe('refreshMcpToolsets', () => {
   test('removes stale mcp toolsets that no longer exist', async () => {
     registerToolset({
       id: 'mcp:stale-server',
+      kind: 'mcp',
       name: 'Stale',
       description: 'stale',
       tools: () => [],

--- a/packages/server/src/mcp/tool-executor.ts
+++ b/packages/server/src/mcp/tool-executor.ts
@@ -13,7 +13,12 @@ import type { McpServerWithTools } from '@/mcp/service.js';
 import { permissionMiddleware } from '@/tools/runtime/middleware.js';
 import { createToolRuntime } from '@/tools/runtime/runtime.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
-import { listToolsets, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
+import {
+  getToolset,
+  listToolsets,
+  registerToolset,
+  unregisterToolset,
+} from '@/tools/toolsets/registry.js';
 import type { Toolset, ToolsetPrompt } from '@/tools/toolsets/types.js';
 import type { Tool } from 'ai';
 
@@ -21,7 +26,6 @@ export { evictMcpClient } from '@/mcp/client.js';
 
 const log = Log.create({ service: 'mcp-tool-executor' });
 
-const serverPresentationById = new Map<string, McpServerPresentation>();
 let refreshInFlight: Promise<void> | null = null;
 
 type McpToolExecutorDeps = {
@@ -148,8 +152,8 @@ async function fetchServerPrompts(server: McpServerWithTools): Promise<ToolsetPr
   }
 }
 
-function buildMcpToolsetId(server: McpServerWithTools): string {
-  return `mcp:${server.id}`;
+function buildMcpToolsetId(serverId: string): string {
+  return `mcp:${serverId}`;
 }
 
 function buildToolsetDescription(
@@ -205,8 +209,9 @@ function createMcpToolset(
   liveInfo: McpServerLiveInfo | null,
   registryServer: McpRegistryServer | null,
   prompts: ToolsetPrompt[],
+  presentation: McpServerPresentation,
 ): Toolset {
-  const toolsetId = buildMcpToolsetId(server);
+  const toolsetId = buildMcpToolsetId(server.id);
   const cachedTools = server.tools ?? [];
   const displayName = registryServer?.name ?? server.name ?? liveInfo?.title ?? liveInfo?.name;
   const description = buildToolsetDescription(server, liveInfo, registryServer);
@@ -218,6 +223,7 @@ function createMcpToolset(
     description,
     instructions: buildMcpInstructions({ server, liveInfo, prompts }),
     prompts: prompts.length > 0 ? prompts : undefined,
+    presentation,
     tools: () =>
       cachedTools.map((tool) => ({
         name: formatMcpToolName(server.id, tool.name),
@@ -244,19 +250,13 @@ async function refreshMcpToolsetsInternal(
     : configuredServers;
 
   const desiredMcpToolsetIds = new Set(
-    configuredServers.map((server) => buildMcpToolsetId(server)),
+    configuredServers.map((server) => buildMcpToolsetId(server.id)),
   );
   const staleIds = listToolsets()
     .filter((toolset) => toolset.kind === 'mcp' && !desiredMcpToolsetIds.has(toolset.id))
     .map((toolset) => toolset.id);
   for (const staleId of staleIds) {
     unregisterToolset(staleId);
-  }
-
-  for (const [serverId] of serverPresentationById.entries()) {
-    if (!desiredMcpToolsetIds.has(`mcp:${serverId}`)) {
-      serverPresentationById.delete(serverId);
-    }
   }
 
   if (serversToRefresh.length === 0) {
@@ -294,13 +294,22 @@ async function refreshMcpToolsetsInternal(
     ),
   );
 
-  const registeredIds: string[] = [];
-  for (const [index, server] of serverSnapshots.entries()) {
-    const liveInfo = infoResults[index]?.status === 'fulfilled' ? infoResults[index].value : null;
-    const prompts = promptResults[index]?.status === 'fulfilled' ? promptResults[index].value : [];
-    const registryServer =
-      registryResults[index]?.status === 'fulfilled' ? registryResults[index].value : null;
+  const resolved = serverSnapshots.map((server, index) => ({
+    server,
+    liveInfo: infoResults[index]?.status === 'fulfilled' ? infoResults[index].value : null,
+    prompts: promptResults[index]?.status === 'fulfilled' ? promptResults[index].value : [],
+    registryServer:
+      registryResults[index]?.status === 'fulfilled' ? registryResults[index].value : null,
+  }));
 
+  const presentations = await Promise.all(
+    resolved.map((entry) =>
+      deps.buildServerPresentation(entry.server, entry.liveInfo, entry.registryServer),
+    ),
+  );
+
+  const registeredIds: string[] = [];
+  for (const [index, { server, liveInfo, prompts, registryServer }] of resolved.entries()) {
     if (liveInfo) {
       log.info(
         {
@@ -317,12 +326,15 @@ async function refreshMcpToolsetsInternal(
       );
     }
 
-    const toolset = createMcpToolset(server, liveInfo, registryServer, prompts);
+    const toolset = createMcpToolset(
+      server,
+      liveInfo,
+      registryServer,
+      prompts,
+      presentations[index],
+    );
     registerToolset(toolset);
     registeredIds.push(toolset.id);
-
-    const presentation = await deps.buildServerPresentation(server, liveInfo, registryServer);
-    serverPresentationById.set(server.id, presentation);
   }
 
   log.info(
@@ -365,5 +377,5 @@ export async function refreshMcpToolsets(
 }
 
 export function getMcpServerPresentation(serverId: string): McpServerPresentation | undefined {
-  return serverPresentationById.get(serverId);
+  return getToolset(buildMcpToolsetId(serverId))?.presentation;
 }

--- a/packages/server/src/mcp/tool-executor.ts
+++ b/packages/server/src/mcp/tool-executor.ts
@@ -13,7 +13,7 @@ import type { McpServerWithTools } from '@/mcp/service.js';
 import { permissionMiddleware } from '@/tools/runtime/middleware.js';
 import { createToolRuntime } from '@/tools/runtime/runtime.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
-import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
+import { listToolsets, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
 import type { Toolset, ToolsetPrompt } from '@/tools/toolsets/types.js';
 import type { Tool } from 'ai';
 
@@ -213,6 +213,7 @@ function createMcpToolset(
 
   return {
     id: toolsetId,
+    kind: 'mcp',
     name: displayName,
     description,
     instructions: buildMcpInstructions({ server, liveInfo, prompts }),
@@ -245,9 +246,9 @@ async function refreshMcpToolsetsInternal(
   const desiredMcpToolsetIds = new Set(
     configuredServers.map((server) => buildMcpToolsetId(server)),
   );
-  const staleIds = listToolsetIds().filter(
-    (id) => id.startsWith('mcp:') && !desiredMcpToolsetIds.has(id),
-  );
+  const staleIds = listToolsets()
+    .filter((toolset) => toolset.kind === 'mcp' && !desiredMcpToolsetIds.has(toolset.id))
+    .map((toolset) => toolset.id);
   for (const staleId of staleIds) {
     unregisterToolset(staleId);
   }

--- a/packages/server/src/routes/config.test.ts
+++ b/packages/server/src/routes/config.test.ts
@@ -3,18 +3,10 @@ import { describe, expect, it } from 'bun:test';
 import { getToolsetSource } from '@/routes/config.js';
 
 describe('config route toolset source classification', () => {
-  it('classifies built-in toolsets as native', () => {
-    expect(getToolsetSource('browser')).toBe('native');
-    expect(getToolsetSource('agenda')).toBe('native');
-    expect(getToolsetSource('session-history')).toBe('native');
-    expect(getToolsetSource('recordings')).toBe('native');
-  });
-
-  it('classifies MCP toolsets by prefix', () => {
-    expect(getToolsetSource('mcp:deepwiki')).toBe('mcp');
-  });
-
-  it('falls back to provider when toolset id is unknown', () => {
-    expect(getToolsetSource('unknown-toolset')).toBe('provider');
+  it('returns the explicit toolset kind', () => {
+    expect(getToolsetSource({ kind: 'native' })).toBe('native');
+    expect(getToolsetSource({ kind: 'connector' })).toBe('connector');
+    expect(getToolsetSource({ kind: 'mcp' })).toBe('mcp');
+    expect(getToolsetSource({ kind: 'provider' })).toBe('provider');
   });
 });

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -6,7 +6,6 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { formatMcpToolName } from '@stitch/shared/mcp/types';
 import { TOOL_ENABLED_SCOPES } from '@stitch/shared/tools/types';
 
-import { listConnectorDefinitions } from '@/connectors/registry.js';
 import { getBrowserKnownTools } from '@/lib/browser/tool-config.js';
 import { getMcpServersWithCachedTools } from '@/mcp/service.js';
 import { getMcpServerPresentation } from '@/mcp/tool-executor.js';
@@ -14,6 +13,7 @@ import { deletePerm, getPerms, upsertPerm } from '@/permission/service.js';
 import { getToolEnabledStates, setToolEnabledState } from '@/tools/enabled-service.js';
 import { STITCH_KNOWN_TOOLS } from '@/tools/runtime/registry.js';
 import { listToolsets } from '@/tools/toolsets/registry.js';
+import type { ToolsetKind } from '@/tools/toolsets/types.js';
 
 const upsertPermissionSchema = z.object({
   toolName: z.string().min(1),
@@ -29,20 +29,8 @@ const upsertToolEnabledSchema = z.object({
 
 export const configRouter = new Hono();
 
-type ToolsetSource = 'native' | 'provider' | 'connector' | 'mcp';
-
-const NATIVE_TOOLSET_IDS = new Set(['browser', 'agenda', 'session-history', 'recordings']);
-
-export function getToolsetSource(toolsetId: string): ToolsetSource {
-  if (toolsetId.startsWith('mcp:')) return 'mcp';
-  if (NATIVE_TOOLSET_IDS.has(toolsetId)) return 'native';
-
-  const connectorDefs = listConnectorDefinitions();
-  if (connectorDefs.some((definition) => toolsetId.startsWith(`${definition.id}-`))) {
-    return 'connector';
-  }
-
-  return 'provider';
+export function getToolsetSource(toolset: { kind: ToolsetKind }): ToolsetKind {
+  return toolset.kind;
 }
 
 function humanizeToolName(name: string): string {
@@ -99,7 +87,7 @@ configRouter.get('/toolsets', async (c) => {
       name: toolset.name,
       description: toolset.description,
       icon: toolset.icon ?? null,
-      source: getToolsetSource(toolset.id),
+      source: getToolsetSource(toolset),
       toolCount: toolset.tools().length,
       hasInstructions: !!toolset.instructions,
       promptCount: toolset.prompts?.length ?? 0,

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -14,6 +14,7 @@ import { getToolEnabledStates, setToolEnabledState } from '@/tools/enabled-servi
 import { STITCH_KNOWN_TOOLS } from '@/tools/runtime/registry.js';
 import { listToolsets } from '@/tools/toolsets/registry.js';
 import type { ToolsetKind } from '@/tools/toolsets/types.js';
+import { toToolsetView } from '@/tools/toolsets/view.js';
 
 const upsertPermissionSchema = z.object({
   toolName: z.string().min(1),
@@ -31,14 +32,6 @@ export const configRouter = new Hono();
 
 export function getToolsetSource(toolset: { kind: ToolsetKind }): ToolsetKind {
   return toolset.kind;
-}
-
-function humanizeToolName(name: string): string {
-  return name
-    .split(/[_-]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(' ');
 }
 
 configRouter.get('/tools', async (c) => {
@@ -82,20 +75,27 @@ configRouter.get('/mcp-tools', async (c) => {
 
 configRouter.get('/toolsets', async (c) => {
   const toolsets = listToolsets()
-    .map((toolset) => ({
-      id: toolset.id,
-      name: toolset.name,
-      description: toolset.description,
-      icon: toolset.icon ?? null,
-      source: getToolsetSource(toolset),
-      toolCount: toolset.tools().length,
-      hasInstructions: !!toolset.instructions,
-      promptCount: toolset.prompts?.length ?? 0,
-      tools: toolset.tools().map((tool) => ({
-        toolName: tool.name,
-        displayName: humanizeToolName(tool.name),
-      })),
-    }))
+    .map((toolset) => {
+      const view = toToolsetView(toolset, {
+        active: false,
+        persisted: false,
+        includeTools: true,
+      });
+      return {
+        id: view.id,
+        name: view.name,
+        description: view.description,
+        icon: view.icon,
+        source: getToolsetSource(toolset),
+        toolCount: view.tools?.length ?? 0,
+        hasInstructions: view.hasInstructions,
+        promptCount: view.promptCount,
+        tools: (view.tools ?? []).map((tool) => ({
+          toolName: tool.name,
+          displayName: tool.displayName,
+        })),
+      };
+    })
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return c.json({ toolsets });

--- a/packages/server/src/tools/core/toolset-management.test.ts
+++ b/packages/server/src/tools/core/toolset-management.test.ts
@@ -35,6 +35,7 @@ function makeTool(description: string): Tool {
 function registerTestToolset(overrides: Partial<Toolset> = {}): Toolset {
   const toolset: Toolset = {
     id: 'test-toolset',
+    kind: 'native',
     name: 'Test Toolset',
     description: 'Test-only toolset',
     instructions: 'Use this toolset carefully.',
@@ -185,6 +186,7 @@ describe('toolset management tools', () => {
   test('activate_toolset humanizes MCP tool names in message', async () => {
     registerTestToolset({
       id: 'mcp:mcp_12345678901234567890123456',
+      kind: 'mcp',
       name: 'Exa',
       tools: () => [
         {
@@ -230,6 +232,7 @@ describe('toolset management tools', () => {
   test('activate_toolset includes warning and collisions when tool names overlap', async () => {
     registerToolset({
       id: 'first-toolset',
+      kind: 'native',
       name: 'First',
       description: 'First toolset',
       tools: () => [{ name: 'search', description: 'search' }],
@@ -238,6 +241,7 @@ describe('toolset management tools', () => {
 
     registerToolset({
       id: 'second-toolset',
+      kind: 'native',
       name: 'Second',
       description: 'Second toolset',
       tools: () => [
@@ -265,6 +269,7 @@ describe('toolset management tools', () => {
   test('activate_toolset omits warning and collisions when no overlap exists', async () => {
     registerToolset({
       id: 'no-overlap-a',
+      kind: 'native',
       name: 'A',
       description: 'A',
       tools: () => [{ name: 'tool_a', description: 'a' }],
@@ -273,6 +278,7 @@ describe('toolset management tools', () => {
 
     registerToolset({
       id: 'no-overlap-b',
+      kind: 'native',
       name: 'B',
       description: 'B',
       tools: () => [{ name: 'tool_b', description: 'b' }],
@@ -296,6 +302,7 @@ describe('toolset management tools', () => {
       clearToolsets();
       registerToolset({
         id: 'browser-toolset',
+        kind: 'native',
         name: 'Browser',
         description: 'Control a headless browser',
         tools: () => [],
@@ -303,6 +310,7 @@ describe('toolset management tools', () => {
       } satisfies Toolset);
       registerToolset({
         id: 'database-toolset',
+        kind: 'native',
         name: 'Database',
         description: 'Query and manage SQL databases',
         tools: () => [],
@@ -310,6 +318,7 @@ describe('toolset management tools', () => {
       } satisfies Toolset);
       registerToolset({
         id: 'email-sender',
+        kind: 'native',
         name: 'Email',
         description: 'Send and receive messages',
         tools: () => [],

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -2,7 +2,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 
 import type { PrefixedString } from '@stitch/shared/id';
-import { parseMcpToolName } from '@stitch/shared/mcp/types';
+import { humanizeToolName } from '@stitch/shared/tools/display';
 
 import {
   getToolsetExpiresAtTurn,
@@ -14,6 +14,7 @@ import { isToolEnabled } from '@/tools/enabled-service.js';
 import type { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
 import { getToolsetSettings } from '@/tools/toolsets/settings.js';
+import { toToolsetView } from '@/tools/toolsets/view.js';
 
 /**
  * Create the three toolset management meta-tools bound to a specific ToolsetManager instance.
@@ -28,13 +29,6 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
       expired: current.expired.filter((entry) => !manager.isActive(entry.id)),
     });
   };
-
-  const humanizeToolName = (name: string) =>
-    (parseMcpToolName(name)?.toolName ?? name)
-      .split(/[_-]+/)
-      .filter(Boolean)
-      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-      .join(' ');
 
   const resolveActivationState = async (input: {
     persist?: boolean;
@@ -120,27 +114,14 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
         );
       }
 
-      const tools = toolset.tools();
       return {
         toolsetId: toolset.id,
-        name: toolset.name,
-        description: toolset.description,
-        icon: toolset.icon ?? null,
-        active: manager.isActive(toolsetId),
-        persisted: manager.isPersisted(toolsetId),
-        hasInstructions: !!toolset.instructions,
-        promptCount: toolset.prompts?.length ?? 0,
-        prompts:
-          toolset.prompts?.map((p) => ({
-            name: p.name,
-            description: p.description,
-            arguments: p.arguments,
-          })) ?? [],
-        tools: tools.map((t) => ({
-          name: t.name,
-          displayName: humanizeToolName(t.name),
-          description: t.description,
-        })),
+        ...toToolsetView(toolset, {
+          active: manager.isActive(toolsetId),
+          persisted: manager.isPersisted(toolsetId),
+          includePrompts: true,
+          includeTools: true,
+        }),
       };
     },
   });

--- a/packages/server/src/tools/runtime/normalized-runtime.ts
+++ b/packages/server/src/tools/runtime/normalized-runtime.ts
@@ -1,0 +1,7 @@
+import { resultNormalizationMiddleware } from '@/tools/runtime/middleware.js';
+import { createToolRuntime } from '@/tools/runtime/runtime.js';
+import type { ToolRuntimeContext } from '@/tools/runtime/runtime.js';
+
+export function createNormalizedToolRuntime(context: ToolRuntimeContext) {
+  return createToolRuntime(context).use(resultNormalizationMiddleware());
+}

--- a/packages/server/src/tools/runtime/registry.ts
+++ b/packages/server/src/tools/runtime/registry.ts
@@ -54,8 +54,8 @@ import {
   DISPLAY_NAME as WRITE_DISPLAY_NAME,
 } from '@/tools/core/write.js';
 import { getDisabledToolIdentifiers } from '@/tools/enabled-service.js';
-import { resultNormalizationMiddleware } from '@/tools/runtime/middleware.js';
-import { createToolRuntime, defineRuntimeTool } from '@/tools/runtime/runtime.js';
+import { createNormalizedToolRuntime } from '@/tools/runtime/normalized-runtime.js';
+import { defineRuntimeTool } from '@/tools/runtime/runtime.js';
 
 export const MAX_STEPS = 25;
 
@@ -156,7 +156,7 @@ export async function createTools(context: {
     ([name, mod]) => ('alwaysActive' in mod && mod.alwaysActive) || !disabledTools.has(name),
   );
 
-  const runtime = createToolRuntime(context).use(resultNormalizationMiddleware());
+  const runtime = createNormalizedToolRuntime(context);
   return runtime.toAiToolRecord(
     enabledToolEntries.map(([name, mod]) =>
       defineRuntimeTool(name, mod.createRegisteredTool(context), {

--- a/packages/server/src/tools/toolsets/agenda.ts
+++ b/packages/server/src/tools/toolsets/agenda.ts
@@ -319,6 +319,7 @@ Use when the user wants to see what lists exist or get an overview of their agen
 export function createAgendaToolset(): Toolset {
   return {
     id: AGENDA_TOOLSET_ID,
+    kind: 'native',
     name: 'Agenda',
     description:
       "Manage the user's agenda — a persistent system for tracking todos organized into lists. Activate to add items, update status, manage lists, and check what's pending or due.",

--- a/packages/server/src/tools/toolsets/agenda.ts
+++ b/packages/server/src/tools/toolsets/agenda.ts
@@ -91,7 +91,7 @@ const TOOL_SUMMARIES = [
   { name: 'agenda_list_lists', description: 'Show all agenda lists with counts' },
 ];
 
-function createAgendaTools(context: ToolContext, userTimezone: string) {
+function createAgendaTools(context: ToolContext, userTimezone: string): Record<string, Tool> {
   const agenda_add_item = tool({
     description: `Create a new agenda item. Requires a title. Optionally set priority (low/medium/high/urgent), dueAt (ISO date), listName (auto-creates list if missing), and description.
 
@@ -341,7 +341,7 @@ export function createAgendaToolset(): Toolset {
     tools: () => TOOL_SUMMARIES,
     activate: async (context: ToolContext) => {
       const userTimezone = await resolveUserTimezone();
-      return createAgendaTools(context, userTimezone) as unknown as Record<string, Tool>;
+      return createAgendaTools(context, userTimezone);
     },
   };
 }

--- a/packages/server/src/tools/toolsets/agenda.ts
+++ b/packages/server/src/tools/toolsets/agenda.ts
@@ -16,7 +16,7 @@ import {
 import { isServiceError } from '@/lib/service-result.js';
 import { listSettings } from '@/settings/service.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
-import type { Toolset } from '@/tools/toolsets/types.js';
+import { TOOLSET_SUMMARY_CONTEXT, summarizeTools, type Toolset } from '@/tools/toolsets/types.js';
 import type { Tool } from 'ai';
 
 const AGENDA_TOOLSET_ID = 'agenda';
@@ -81,15 +81,6 @@ async function resolveUserTimezone(): Promise<string> {
   if (isServiceError(settingsResult)) return 'UTC';
   return settingsResult.data['profile.timezone'] || 'UTC';
 }
-
-const TOOL_SUMMARIES = [
-  { name: 'agenda_add_item', description: 'Create a new agenda item in a list' },
-  { name: 'agenda_update_item', description: 'Update an existing agenda item' },
-  { name: 'agenda_list_items', description: 'List agenda items with optional filters' },
-  { name: 'agenda_get_item', description: 'Get full details of a single agenda item' },
-  { name: 'agenda_create_list', description: 'Create a new agenda list' },
-  { name: 'agenda_list_lists', description: 'Show all agenda lists with counts' },
-];
 
 function createAgendaTools(context: ToolContext, userTimezone: string): Record<string, Tool> {
   const agenda_add_item = tool({
@@ -338,7 +329,7 @@ export function createAgendaToolset(): Toolset {
       "If the user mentions something that sounds like a task but doesn't explicitly ask to track it, do NOT add it automatically — only act on clear intent.",
       'When updating status, briefly confirm what changed.',
     ].join('\n'),
-    tools: () => TOOL_SUMMARIES,
+    tools: () => summarizeTools(createAgendaTools(TOOLSET_SUMMARY_CONTEXT, 'UTC')),
     activate: async (context: ToolContext) => {
       const userTimezone = await resolveUserTimezone();
       return createAgendaTools(context, userTimezone);

--- a/packages/server/src/tools/toolsets/browser.ts
+++ b/packages/server/src/tools/toolsets/browser.ts
@@ -1,6 +1,6 @@
 import { BROWSER_TOOL_INSTRUCTIONS } from '@/lib/browser/tool-config.js';
 import { createRegisteredTools } from '@/tools/core/browser.js';
-import type { Toolset } from '@/tools/toolsets/types.js';
+import { TOOLSET_SUMMARY_CONTEXT, summarizeTools, type Toolset } from '@/tools/toolsets/types.js';
 
 export function createBrowserToolset(): Toolset {
   return {
@@ -9,41 +9,7 @@ export function createBrowserToolset(): Toolset {
     description:
       'Control a Chrome browser: navigate pages, click elements, type text, take screenshots, and interact with web applications.',
     instructions: BROWSER_TOOL_INSTRUCTIONS,
-    tools: () => [
-      {
-        name: 'browser_snapshot',
-        description: 'Capture a fresh snapshot with refs, URL, tabs, and page state.',
-      },
-      {
-        name: 'browser_navigate',
-        description: 'Navigate URLs, run web search, and manage tab focus/history.',
-      },
-      {
-        name: 'browser_interact',
-        description: 'Click, type, press, hover, select, scroll, resize, or evaluate scripts.',
-      },
-      {
-        name: 'browser_wait',
-        description: 'Wait by time or selector for deterministic page readiness.',
-      },
-      {
-        name: 'browser_screenshot',
-        description: 'Capture viewport, full-page, or element screenshots.',
-      },
-      {
-        name: 'browser_dialog',
-        description: 'Inspect and handle alert/confirm/prompt dialogs.',
-      },
-      {
-        name: 'browser_content',
-        description: 'Extract content, search visible text, and find DOM elements by selector.',
-      },
-      {
-        name: 'browser_batch',
-        description:
-          'Run up to 5 browser actions in sequence with page-change and error stopping rules.',
-      },
-    ],
+    tools: () => summarizeTools(createRegisteredTools(TOOLSET_SUMMARY_CONTEXT)),
     activate: async (context) => createRegisteredTools(context),
   };
 }

--- a/packages/server/src/tools/toolsets/browser.ts
+++ b/packages/server/src/tools/toolsets/browser.ts
@@ -5,6 +5,7 @@ import { TOOLSET_SUMMARY_CONTEXT, summarizeTools, type Toolset } from '@/tools/t
 export function createBrowserToolset(): Toolset {
   return {
     id: 'browser',
+    kind: 'native',
     name: 'Browser',
     description:
       'Control a Chrome browser: navigate pages, click elements, type text, take screenshots, and interact with web applications.',

--- a/packages/server/src/tools/toolsets/manager.test.ts
+++ b/packages/server/src/tools/toolsets/manager.test.ts
@@ -31,6 +31,7 @@ describe('ToolsetManager.activate collision detection', () => {
   test('returns empty collisions when no overlap exists', async () => {
     registerToolset({
       id: 'ts-a',
+      kind: 'native',
       name: 'A',
       description: 'A',
       tools: () => [{ name: 'tool_a', description: 'a' }],
@@ -39,6 +40,7 @@ describe('ToolsetManager.activate collision detection', () => {
 
     registerToolset({
       id: 'ts-b',
+      kind: 'native',
       name: 'B',
       description: 'B',
       tools: () => [{ name: 'tool_b', description: 'b' }],
@@ -56,6 +58,7 @@ describe('ToolsetManager.activate collision detection', () => {
   test('reports collisions when two toolsets share a tool name', async () => {
     registerToolset({
       id: 'ts-x',
+      kind: 'native',
       name: 'X',
       description: 'X',
       tools: () => [{ name: 'search', description: 'search' }],
@@ -64,6 +67,7 @@ describe('ToolsetManager.activate collision detection', () => {
 
     registerToolset({
       id: 'ts-y',
+      kind: 'native',
       name: 'Y',
       description: 'Y',
       tools: () => [
@@ -87,6 +91,7 @@ describe('ToolsetManager.activate collision detection', () => {
   test('returns no collisions when activating the first toolset', async () => {
     registerToolset({
       id: 'ts-only',
+      kind: 'native',
       name: 'Only',
       description: 'Only',
       tools: () => [{ name: 'tool_a', description: 'a' }],
@@ -103,6 +108,7 @@ describe('ToolsetManager.activate collision detection', () => {
   test('already-active toolset returns empty collisions', async () => {
     registerToolset({
       id: 'ts-once',
+      kind: 'native',
       name: 'Once',
       description: 'Once',
       tools: () => [{ name: 'tool_a', description: 'a' }],
@@ -126,6 +132,7 @@ describe('ToolsetManager.getActiveTools ordering', () => {
   test('returns tools sorted alphabetically by key', async () => {
     registerToolset({
       id: 'ts-alpha',
+      kind: 'native',
       name: 'Alpha',
       description: 'Alpha toolset',
       tools: () => [
@@ -140,6 +147,7 @@ describe('ToolsetManager.getActiveTools ordering', () => {
 
     registerToolset({
       id: 'ts-beta',
+      kind: 'native',
       name: 'Beta',
       description: 'Beta toolset',
       tools: () => [{ name: 'mango_tool', description: 'm' }],
@@ -159,6 +167,7 @@ describe('ToolsetManager.getActiveTools ordering', () => {
   test('activation order does not affect key order', async () => {
     registerToolset({
       id: 'ts-first',
+      kind: 'native',
       name: 'First',
       description: 'First',
       tools: () => [{ name: 'b_tool', description: 'b' }],
@@ -167,6 +176,7 @@ describe('ToolsetManager.getActiveTools ordering', () => {
 
     registerToolset({
       id: 'ts-second',
+      kind: 'native',
       name: 'Second',
       description: 'Second',
       tools: () => [{ name: 'a_tool', description: 'a' }],
@@ -194,6 +204,7 @@ describe('ToolsetManager activation state', () => {
   test('tracks persisted active toolsets separately from run-only toolsets', async () => {
     registerToolset({
       id: 'persisted',
+      kind: 'native',
       name: 'Persisted',
       description: 'Persisted',
       tools: () => [{ name: 'persisted_tool', description: 'persisted' }],
@@ -201,6 +212,7 @@ describe('ToolsetManager activation state', () => {
     } satisfies Toolset);
     registerToolset({
       id: 'run-only',
+      kind: 'native',
       name: 'Run Only',
       description: 'Run only',
       tools: () => [{ name: 'run_tool', description: 'run' }],
@@ -221,6 +233,7 @@ describe('ToolsetManager activation state', () => {
   test('renews TTL state when a tool from a TTL toolset is used', async () => {
     registerToolset({
       id: 'ttl-toolset',
+      kind: 'native',
       name: 'TTL',
       description: 'TTL',
       tools: () => [{ name: 'ttl_tool', description: 'ttl' }],

--- a/packages/server/src/tools/toolsets/manager.test.ts
+++ b/packages/server/src/tools/toolsets/manager.test.ts
@@ -88,6 +88,34 @@ describe('ToolsetManager.activate collision detection', () => {
     expect(result.status === 'activated' && result.collisions).toEqual(['search']);
   });
 
+  test('does not report stale collisions after deactivation', async () => {
+    registerToolset({
+      id: 'ts-x',
+      kind: 'native',
+      name: 'X',
+      description: 'X',
+      tools: () => [{ name: 'search', description: 'search' }],
+      activate: async () => ({ search: makeTool('search from X') }),
+    } satisfies Toolset);
+
+    registerToolset({
+      id: 'ts-y',
+      kind: 'native',
+      name: 'Y',
+      description: 'Y',
+      tools: () => [{ name: 'search', description: 'search' }],
+      activate: async () => ({ search: makeTool('search from Y') }),
+    } satisfies Toolset);
+
+    const manager = createManager();
+    await manager.activate('ts-x');
+    manager.deactivate('ts-x');
+    const result = await manager.activate('ts-y');
+
+    expect(result.status).toBe('activated');
+    expect(result.status === 'activated' && result.collisions).toEqual([]);
+  });
+
   test('returns no collisions when activating the first toolset', async () => {
     registerToolset({
       id: 'ts-only',
@@ -227,7 +255,85 @@ describe('ToolsetManager activation state', () => {
     expect(manager.getPersistableActivationState()).toEqual([
       { id: 'persisted', scope: 'until_deactivated' },
     ]);
+    expect(manager.getPersistedIds()).toEqual(new Set(['persisted']));
     expect(manager.getExpiredRunToolsets()).toEqual([{ id: 'run-only', toolNames: ['run_tool'] }]);
+  });
+
+  test('preserves restored persisted state before activation', async () => {
+    registerToolset({
+      id: 'restored',
+      kind: 'native',
+      name: 'Restored',
+      description: 'Restored',
+      tools: () => [{ name: 'restored_tool', description: 'restored' }],
+      activate: async () => ({ restored_tool: makeTool('restored') }),
+    } satisfies Toolset);
+
+    const manager = new ToolsetManager(
+      {
+        sessionId: 'ses_test' as never,
+        messageId: 'msg_test' as never,
+        streamRunId: 'run_test',
+      },
+      [{ id: 'restored', scope: 'until_deactivated' }],
+    );
+
+    expect(manager.isActive('restored')).toBe(false);
+    expect(manager.isPersisted('restored')).toBe(true);
+    expect(manager.getActiveIds()).toEqual(new Set());
+    expect(manager.getPersistedIds()).toEqual(new Set(['restored']));
+
+    const catalog = await manager.getCatalogWithState();
+    expect(catalog.find((entry) => entry.id === 'restored')).toMatchObject({
+      active: false,
+      persisted: true,
+    });
+  });
+
+  test('can unpin restored persisted state before activation', async () => {
+    const manager = new ToolsetManager(
+      {
+        sessionId: 'ses_test' as never,
+        messageId: 'msg_test' as never,
+        streamRunId: 'run_test',
+      },
+      [{ id: 'restored', scope: 'until_deactivated' }],
+    );
+
+    expect(manager.unpin('restored')).toBe(true);
+    expect(manager.isPersisted('restored')).toBe(false);
+    expect(manager.getPersistedIds()).toEqual(new Set());
+    expect(manager.getPersistableActivationState()).toEqual([]);
+  });
+
+  test('deactivation removes activated restored state', async () => {
+    registerToolset({
+      id: 'restored',
+      kind: 'native',
+      name: 'Restored',
+      description: 'Restored',
+      tools: () => [{ name: 'restored_tool', description: 'restored' }],
+      activate: async () => ({ restored_tool: makeTool('restored') }),
+    } satisfies Toolset);
+
+    const manager = new ToolsetManager(
+      {
+        sessionId: 'ses_test' as never,
+        messageId: 'msg_test' as never,
+        streamRunId: 'run_test',
+      },
+      [{ id: 'restored', scope: 'until_deactivated' }],
+    );
+
+    await manager.activate('restored');
+    expect(manager.deactivate('restored')).toBe(true);
+
+    expect(manager.isActive('restored')).toBe(false);
+    expect(manager.isPersisted('restored')).toBe(false);
+    expect(manager.getActiveIds()).toEqual(new Set());
+    expect(manager.getPersistedIds()).toEqual(new Set());
+    expect(manager.getPersistableActivationState()).toEqual([]);
+    expect(manager.getActiveTools()).toEqual({});
   });
 
   test('renews TTL state when a tool from a TTL toolset is used', async () => {
@@ -253,6 +359,26 @@ describe('ToolsetManager activation state', () => {
     expect(manager.renewTtlForTool('ttl_tool', 5)).toBe('ttl-toolset');
     expect(manager.getPersistableActivationState()).toEqual([
       { id: 'ttl-toolset', scope: 'ttl_turns', expiresAtTurn: 5 },
+    ]);
+  });
+
+  test('does not renew TTL for unknown tools or non-TTL toolsets', async () => {
+    registerToolset({
+      id: 'persisted',
+      kind: 'native',
+      name: 'Persisted',
+      description: 'Persisted',
+      tools: () => [{ name: 'persisted_tool', description: 'persisted' }],
+      activate: async () => ({ persisted_tool: makeTool('persisted') }),
+    } satisfies Toolset);
+
+    const manager = createManager();
+    await manager.activate('persisted', { scope: 'until_deactivated' });
+
+    expect(manager.renewTtlForTool('missing_tool', 5)).toBeNull();
+    expect(manager.renewTtlForTool('persisted_tool', 5)).toBeNull();
+    expect(manager.getPersistableActivationState()).toEqual([
+      { id: 'persisted', scope: 'until_deactivated' },
     ]);
   });
 });

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -84,12 +84,11 @@ export class ToolsetManager {
     const toolsetTools = await toolset.activate(this.context);
     const allTools = runtime.toAiToolRecord(
       Object.entries(toolsetTools).map(([name, tool]) =>
-        defineRuntimeTool(name, tool, { source: toolsetId.startsWith('mcp:') ? 'mcp' : 'toolset' }),
+        defineRuntimeTool(name, tool, { source: toolset.kind === 'mcp' ? 'mcp' : 'toolset' }),
       ),
     );
-    const disabledMcpTools = toolsetId.startsWith('mcp:')
-      ? await getDisabledToolIdentifiers('mcp_tool')
-      : new Set<string>();
+    const disabledMcpTools =
+      toolset.kind === 'mcp' ? await getDisabledToolIdentifiers('mcp_tool') : new Set<string>();
     const tools =
       disabledMcpTools.size === 0
         ? allTools

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -1,12 +1,11 @@
-import type { ConnectorIconSource } from '@stitch/shared/connectors/types';
-
 import * as Log from '@/lib/log.js';
 import type { SessionActiveToolset, SessionToolsetScope } from '@/llm/stream/session-toolsets.js';
 import { getDisabledToolIdentifiers, isToolEnabled } from '@/tools/enabled-service.js';
-import { resultNormalizationMiddleware } from '@/tools/runtime/middleware.js';
-import { createToolRuntime, defineRuntimeTool } from '@/tools/runtime/runtime.js';
+import { createNormalizedToolRuntime } from '@/tools/runtime/normalized-runtime.js';
+import { defineRuntimeTool } from '@/tools/runtime/runtime.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 import { getToolset, listToolsets } from '@/tools/toolsets/registry.js';
+import { toToolsetView, type ToolsetView } from '@/tools/toolsets/view.js';
 import type { Tool } from 'ai';
 
 const log = Log.create({ service: 'toolset-manager' });
@@ -80,7 +79,7 @@ export class ToolsetManager {
       return { status: 'disabled' };
     }
 
-    const runtime = createToolRuntime(this.context).use(resultNormalizationMiddleware());
+    const runtime = createNormalizedToolRuntime(this.context);
     const toolsetTools = await toolset.activate(this.context);
     const allTools = runtime.toAiToolRecord(
       Object.entries(toolsetTools).map(([name, tool]) =>
@@ -232,30 +231,16 @@ export class ToolsetManager {
    * Disabled toolsets are excluded so the LLM never sees or attempts to use them.
    * Used by the list_toolsets meta-tool.
    */
-  async getCatalogWithState(): Promise<
-    Array<{
-      id: string;
-      name: string;
-      description: string;
-      icon?: ConnectorIconSource;
-      active: boolean;
-      persisted: boolean;
-      hasInstructions: boolean;
-      promptCount: number;
-    }>
-  > {
+  async getCatalogWithState(options?: { includeTools?: boolean }): Promise<ToolsetView[]> {
     const disabledIds = await getDisabledToolIdentifiers('toolset');
     return listToolsets()
       .filter((ts) => !disabledIds.has(ts.id))
-      .map((ts) => ({
-        id: ts.id,
-        name: ts.name,
-        description: ts.description,
-        icon: ts.icon,
-        active: this.activeIds.has(ts.id),
-        persisted: this.persistedIds.has(ts.id),
-        hasInstructions: !!ts.instructions,
-        promptCount: ts.prompts?.length ?? 0,
-      }));
+      .map((ts) =>
+        toToolsetView(ts, {
+          active: this.activeIds.has(ts.id),
+          persisted: this.persistedIds.has(ts.id),
+          includeTools: options?.includeTools,
+        }),
+      );
   }
 }

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -10,22 +10,18 @@ import type { Tool } from 'ai';
 
 const log = Log.create({ service: 'toolset-manager' });
 
+type ToolsetActivationEntry = {
+  state: SessionActiveToolset;
+  tools?: Record<string, Tool>;
+};
+
 /**
  * Per-session manager that tracks which toolsets are currently active.
  * Tools from active toolsets are merged with core tools each step.
  * This is mutable — toolsets can be activated/deactivated between LLM steps.
  */
 export class ToolsetManager {
-  /** Set of currently active toolset IDs */
-  private readonly activeIds = new Set<string>();
-
-  /** Subset of active toolsets that should persist across future turns. */
-  private readonly persistedIds = new Set<string>();
-
-  private readonly activationState = new Map<string, SessionActiveToolset>();
-
-  /** Cached tool instances for each active toolset (lazy-populated on activate) */
-  private readonly activeToolCache = new Map<string, Record<string, Tool>>();
+  private readonly activations = new Map<string, ToolsetActivationEntry>();
 
   private readonly context: ToolContext;
 
@@ -34,10 +30,7 @@ export class ToolsetManager {
     for (const entry of activationState) {
       const state =
         typeof entry === 'string' ? { id: entry, scope: 'until_deactivated' as const } : entry;
-      this.activationState.set(state.id, state);
-      if (state.scope === 'until_deactivated') {
-        this.persistedIds.add(state.id);
-      }
+      this.activations.set(state.id, { state });
     }
   }
 
@@ -53,10 +46,11 @@ export class ToolsetManager {
     | { status: 'not_found' }
     | { status: 'disabled' }
   > {
-    if (this.activeIds.has(toolsetId)) {
+    const existing = this.activations.get(toolsetId);
+    if (existing?.tools) {
       return {
         status: 'activated',
-        toolNames: Object.keys(this.activeToolCache.get(toolsetId) ?? {}),
+        toolNames: Object.keys(existing.tools),
         collisions: [],
       };
     }
@@ -104,12 +98,13 @@ export class ToolsetManager {
       );
     }
 
-    this.activeIds.add(toolsetId);
-    this.setActivationState(
-      toolsetId,
-      state ?? this.activationState.get(toolsetId) ?? { scope: 'current_run' },
-    );
-    this.activeToolCache.set(toolsetId, tools);
+    this.activations.set(toolsetId, {
+      state: this.buildActivationState(
+        toolsetId,
+        state ?? existing?.state ?? { scope: 'current_run' },
+      ),
+      tools,
+    });
 
     log.info(
       {
@@ -126,14 +121,11 @@ export class ToolsetManager {
 
   /** Deactivate a toolset, removing its tools from the active set. */
   deactivate(toolsetId: string): boolean {
-    if (!this.activeIds.has(toolsetId)) {
+    if (!this.activations.get(toolsetId)?.tools) {
       return false;
     }
 
-    this.activeIds.delete(toolsetId);
-    this.persistedIds.delete(toolsetId);
-    this.activationState.delete(toolsetId);
-    this.activeToolCache.delete(toolsetId);
+    this.activations.delete(toolsetId);
 
     log.info({ event: 'toolset.deactivated', toolsetId }, 'toolset deactivated');
     return true;
@@ -141,39 +133,46 @@ export class ToolsetManager {
 
   /** Check if a toolset is currently active. */
   isActive(toolsetId: string): boolean {
-    return this.activeIds.has(toolsetId);
+    return !!this.activations.get(toolsetId)?.tools;
   }
 
   /** Return the set of currently active toolset IDs. */
   getActiveIds(): Set<string> {
-    return new Set(this.activeIds);
+    return new Set(this.getActiveEntries().map(([id]) => id));
   }
 
-  /** Return the set of active toolset IDs that should persist across future turns. */
+  /** Return the set of toolset IDs that should persist across future turns. */
   getPersistedIds(): Set<string> {
-    return new Set(this.persistedIds);
+    return new Set(
+      [...this.activations.values()]
+        .filter((entry) => entry.state.scope === 'until_deactivated')
+        .map((entry) => entry.state.id),
+    );
   }
 
   getPersistableActivationState(): SessionActiveToolset[] {
-    return [...this.activationState.values()]
-      .filter((entry) => this.activeIds.has(entry.id) && entry.scope !== 'current_run')
-      .map((entry) => ({ ...entry }));
+    return this.getActiveEntries()
+      .map(([, entry]) => entry.state)
+      .filter((state) => state.scope !== 'current_run')
+      .map((state) => ({ ...state }));
   }
 
   getExpiredRunToolsets(): Array<{ id: string; toolNames: string[] }> {
-    return [...this.activeIds]
-      .filter((id) => this.activationState.get(id)?.scope === 'current_run')
-      .map((id) => ({ id, toolNames: Object.keys(this.activeToolCache.get(id) ?? {}) }));
+    return this.getActiveEntries()
+      .filter(([, entry]) => entry.state.scope === 'current_run')
+      .map(([id, entry]) => ({ id, toolNames: Object.keys(entry.tools) }));
   }
 
   renewTtlForTool(toolName: string, expiresAtTurn: number): string | null {
-    for (const [toolsetId, tools] of this.activeToolCache.entries()) {
-      if (!(toolName in tools)) continue;
+    for (const [toolsetId, entry] of this.getActiveEntries()) {
+      if (!(toolName in entry.tools)) continue;
 
-      const state = this.activationState.get(toolsetId);
-      if (state?.scope !== 'ttl_turns') return null;
+      if (entry.state.scope !== 'ttl_turns') return null;
 
-      this.activationState.set(toolsetId, { ...state, expiresAtTurn });
+      this.activations.set(toolsetId, {
+        ...entry,
+        state: { ...entry.state, expiresAtTurn },
+      });
       return toolsetId;
     }
 
@@ -181,37 +180,36 @@ export class ToolsetManager {
   }
 
   pin(toolsetId: string): boolean {
-    if (!this.activeIds.has(toolsetId)) {
+    if (!this.isActive(toolsetId)) {
       return false;
     }
 
-    this.persistedIds.add(toolsetId);
     this.setActivationState(toolsetId, { scope: 'until_deactivated' });
     return true;
   }
 
   unpin(toolsetId: string): boolean {
-    const deleted = this.persistedIds.delete(toolsetId);
-    if (deleted) {
-      this.setActivationState(toolsetId, { scope: 'current_run' });
+    if (!this.isPersisted(toolsetId)) {
+      return false;
     }
-    return deleted;
+
+    this.setActivationState(toolsetId, { scope: 'current_run' });
+    return true;
   }
 
   isPersisted(toolsetId: string): boolean {
-    return this.persistedIds.has(toolsetId);
+    return this.activations.get(toolsetId)?.state.scope === 'until_deactivated';
   }
 
   setActivationState(
     toolsetId: string,
     state: { scope: SessionToolsetScope; expiresAtTurn?: number },
   ): void {
-    this.activationState.set(toolsetId, { id: toolsetId, ...state });
-    if (state.scope === 'until_deactivated') {
-      this.persistedIds.add(toolsetId);
-    } else {
-      this.persistedIds.delete(toolsetId);
-    }
+    const existing = this.activations.get(toolsetId);
+    this.activations.set(toolsetId, {
+      state: this.buildActivationState(toolsetId, state),
+      tools: existing?.tools,
+    });
   }
 
   /**
@@ -220,8 +218,8 @@ export class ToolsetManager {
    */
   getActiveTools(): Record<string, Tool> {
     const merged: Record<string, Tool> = {};
-    for (const tools of this.activeToolCache.values()) {
-      Object.assign(merged, tools);
+    for (const [, entry] of this.getActiveEntries()) {
+      Object.assign(merged, entry.tools);
     }
     return Object.fromEntries(Object.entries(merged).sort(([a], [b]) => a.localeCompare(b)));
   }
@@ -237,10 +235,26 @@ export class ToolsetManager {
       .filter((ts) => !disabledIds.has(ts.id))
       .map((ts) =>
         toToolsetView(ts, {
-          active: this.activeIds.has(ts.id),
-          persisted: this.persistedIds.has(ts.id),
+          active: this.isActive(ts.id),
+          persisted: this.isPersisted(ts.id),
           includeTools: options?.includeTools,
         }),
       );
+  }
+
+  private buildActivationState(
+    toolsetId: string,
+    state: { scope: SessionToolsetScope; expiresAtTurn?: number },
+  ): SessionActiveToolset {
+    return { id: toolsetId, ...state };
+  }
+
+  private getActiveEntries(): Array<
+    [string, ToolsetActivationEntry & { tools: Record<string, Tool> }]
+  > {
+    return [...this.activations.entries()].filter(
+      (entry): entry is [string, ToolsetActivationEntry & { tools: Record<string, Tool> }] =>
+        !!entry[1].tools,
+    );
   }
 }

--- a/packages/server/src/tools/toolsets/recordings.ts
+++ b/packages/server/src/tools/toolsets/recordings.ts
@@ -28,7 +28,7 @@ const TOOL_SUMMARIES = [
   },
 ];
 
-function createRecordingsTools(_context: ToolContext) {
+function createRecordingsTools(_context: ToolContext): Record<string, Tool> {
   const recordings_search = tool({
     description: `Search recording history using title, analysis summary, and transcript-derived content.
 
@@ -210,7 +210,7 @@ export function createRecordingsToolset(): Toolset {
     ].join('\n'),
     tools: () => TOOL_SUMMARIES,
     activate: async (context: ToolContext) => {
-      return createRecordingsTools(context) as unknown as Record<string, Tool>;
+      return createRecordingsTools(context);
     },
   };
 }

--- a/packages/server/src/tools/toolsets/recordings.ts
+++ b/packages/server/src/tools/toolsets/recordings.ts
@@ -185,6 +185,7 @@ Use this when analysis is missing or stale.`,
 export function createRecordingsToolset(): Toolset {
   return {
     id: RECORDINGS_TOOLSET_ID,
+    kind: 'native',
     name: 'Recordings',
     description:
       'Search recordings and work with transcription/analysis results, including summaries, topics, and action items.',

--- a/packages/server/src/tools/toolsets/recordings.ts
+++ b/packages/server/src/tools/toolsets/recordings.ts
@@ -6,27 +6,12 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { getRecordingAnalysis, startRecordingAnalysis } from '@/recordings/analysis-service.js';
 import { getRecordingAnalysesByIds, searchRecordings } from '@/recordings/search-service.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
-import type { Toolset } from '@/tools/toolsets/types.js';
+import { TOOLSET_SUMMARY_CONTEXT, summarizeTools, type Toolset } from '@/tools/toolsets/types.js';
 import type { Tool } from 'ai';
 
 const RECORDINGS_TOOLSET_ID = 'recordings';
 const RECORDING_STATUSES = ['recording', 'completed', 'failed'] as const;
 const RECORDING_PLATFORMS = ['manual', 'zoom', 'teams', 'slack', 'discord', 'google-meet'] as const;
-
-const TOOL_SUMMARIES = [
-  {
-    name: 'recordings_search',
-    description: 'Search recordings and transcription analysis with ranked snippets',
-  },
-  {
-    name: 'recordings_get_analysis',
-    description: 'Fetch structured analysis for one recording',
-  },
-  {
-    name: 'recordings_start_analysis',
-    description: 'Start or re-run transcription and analysis for a completed recording',
-  },
-];
 
 function createRecordingsTools(_context: ToolContext): Record<string, Tool> {
   const recordings_search = tool({
@@ -208,7 +193,7 @@ export function createRecordingsToolset(): Toolset {
       'Use recordings_get_analysis for details only after narrowing to one or a few recordings.',
       'Use recordings_start_analysis when a completed recording has no analysis or needs a forced refresh.',
     ].join('\n'),
-    tools: () => TOOL_SUMMARIES,
+    tools: () => summarizeTools(createRecordingsTools(TOOLSET_SUMMARY_CONTEXT)),
     activate: async (context: ToolContext) => {
       return createRecordingsTools(context);
     },

--- a/packages/server/src/tools/toolsets/session-history.ts
+++ b/packages/server/src/tools/toolsets/session-history.ts
@@ -115,6 +115,7 @@ Use this after session_history_search to inspect a specific session without dump
 export function createSessionHistoryToolset(): Toolset {
   return {
     id: SESSION_HISTORY_TOOLSET_ID,
+    kind: 'native',
     name: 'Session History',
     description:
       'Search and inspect prior chat sessions with bounded, relevance-ranked results for cross-session recall.',

--- a/packages/server/src/tools/toolsets/session-history.ts
+++ b/packages/server/src/tools/toolsets/session-history.ts
@@ -21,7 +21,7 @@ const TOOL_SUMMARIES = [
   },
 ];
 
-function createSessionHistoryTools(context: ToolContext) {
+function createSessionHistoryTools(context: ToolContext): Record<string, Tool> {
   const session_history_search = tool({
     description: `Search chat history across past sessions.
 
@@ -136,7 +136,7 @@ export function createSessionHistoryToolset(): Toolset {
     ].join('\n'),
     tools: () => TOOL_SUMMARIES,
     activate: async (context: ToolContext) => {
-      return createSessionHistoryTools(context) as unknown as Record<string, Tool>;
+      return createSessionHistoryTools(context);
     },
   };
 }

--- a/packages/server/src/tools/toolsets/session-history.ts
+++ b/packages/server/src/tools/toolsets/session-history.ts
@@ -5,21 +5,10 @@ import type { PrefixedString } from '@stitch/shared/id';
 
 import { getSessionHistoryMessages, searchSessionHistory } from '@/chat/history-search-service.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
-import type { Toolset } from '@/tools/toolsets/types.js';
+import { TOOLSET_SUMMARY_CONTEXT, summarizeTools, type Toolset } from '@/tools/toolsets/types.js';
 import type { Tool } from 'ai';
 
 const SESSION_HISTORY_TOOLSET_ID = 'session-history';
-
-const TOOL_SUMMARIES = [
-  {
-    name: 'session_history_search',
-    description: 'Search prior sessions by query with relevance-ranked snippets',
-  },
-  {
-    name: 'session_history_get',
-    description: 'Read a bounded slice of messages for one session',
-  },
-];
 
 function createSessionHistoryTools(context: ToolContext): Record<string, Tool> {
   const session_history_search = tool({
@@ -134,7 +123,7 @@ export function createSessionHistoryToolset(): Toolset {
       'Prefer small limits (3-5 sessions, 20-30 messages) to avoid unnecessary context growth.',
       'Do not request includeToolResults unless tool output details are essential to answer the user.',
     ].join('\n'),
-    tools: () => TOOL_SUMMARIES,
+    tools: () => summarizeTools(createSessionHistoryTools(TOOLSET_SUMMARY_CONTEXT)),
     activate: async (context: ToolContext) => {
       return createSessionHistoryTools(context);
     },

--- a/packages/server/src/tools/toolsets/types.ts
+++ b/packages/server/src/tools/toolsets/types.ts
@@ -1,5 +1,6 @@
 import type { ConnectorIconSource } from '@stitch/shared/connectors/types';
 
+import type { McpServerPresentation } from '@/mcp/presentation.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 import type { Tool } from 'ai';
 
@@ -42,6 +43,11 @@ export type Toolset = {
   instructions?: string;
   /** MCP prompt templates available from this toolset (user-controlled). */
   prompts?: ToolsetPrompt[];
+  /**
+   * UI presentation metadata (server/tool titles and icon paths) for MCP
+   * toolsets. Owned by the toolset so registry and presentation never desync.
+   */
+  presentation?: McpServerPresentation;
   /** Return brief summaries of all tools in this toolset (for list_toolsets) */
   tools: () => ToolSummary[];
   /** Instantiate and return the actual AI SDK Tool objects */

--- a/packages/server/src/tools/toolsets/types.ts
+++ b/packages/server/src/tools/toolsets/types.ts
@@ -43,3 +43,25 @@ export type Toolset = {
   /** Instantiate and return the actual AI SDK Tool objects */
   activate: (context: ToolContext) => Promise<Record<string, Tool>>;
 };
+
+export const TOOLSET_SUMMARY_CONTEXT: ToolContext = {
+  sessionId: 'ses_summary',
+  messageId: 'msg_summary',
+  streamRunId: 'summary',
+};
+
+export function summarizeTools(tools: Record<string, Tool>): ToolSummary[] {
+  return Object.entries(tools).map(([name, tool]) => ({
+    name,
+    description: summarizeToolDescription(tool.description),
+  }));
+}
+
+function summarizeToolDescription(description: string | undefined): string {
+  return (
+    description
+      ?.split('\n')
+      .find((line) => line.trim())
+      ?.trim() ?? ''
+  );
+}

--- a/packages/server/src/tools/toolsets/types.ts
+++ b/packages/server/src/tools/toolsets/types.ts
@@ -16,6 +16,8 @@ export type ToolsetPrompt = {
   arguments?: { name: string; description?: string; required?: boolean }[];
 };
 
+export type ToolsetKind = 'native' | 'provider' | 'connector' | 'mcp';
+
 /**
  * A Toolset is a named group of related tools managed as a single unit.
  * Toolsets can be activated/deactivated dynamically during a session to
@@ -24,6 +26,8 @@ export type ToolsetPrompt = {
 export type Toolset = {
   /** Unique identifier, e.g. "browser", "mcp:<serverName>" */
   id: string;
+  /** Origin category used by runtime, settings, and UI layers. */
+  kind: ToolsetKind;
   /** Human-readable display name */
   name: string;
   /** Brief description for LLM discovery (included in system prompt catalog) */

--- a/packages/server/src/tools/toolsets/view.ts
+++ b/packages/server/src/tools/toolsets/view.ts
@@ -1,0 +1,63 @@
+import { humanizeToolName } from '@stitch/shared/tools/display';
+
+import type { Toolset, ToolsetPrompt } from '@/tools/toolsets/types.js';
+
+type ToolsetViewOptions = {
+  active: boolean;
+  persisted: boolean;
+  includePrompts?: boolean;
+  includeTools?: boolean;
+};
+
+type ToolsetPromptView = {
+  name: string;
+  description?: string;
+  arguments?: ToolsetPrompt['arguments'];
+};
+
+type ToolsetToolView = {
+  name: string;
+  displayName: string;
+  description: string;
+};
+
+export type ToolsetView = {
+  id: string;
+  name: string;
+  description: string;
+  icon: Toolset['icon'] | null;
+  active: boolean;
+  persisted: boolean;
+  hasInstructions: boolean;
+  promptCount: number;
+  prompts?: ToolsetPromptView[];
+  tools?: ToolsetToolView[];
+};
+
+export function toToolsetView(toolset: Toolset, options: ToolsetViewOptions): ToolsetView {
+  return {
+    id: toolset.id,
+    name: toolset.name,
+    description: toolset.description,
+    icon: toolset.icon ?? null,
+    active: options.active,
+    persisted: options.persisted,
+    hasInstructions: !!toolset.instructions,
+    promptCount: toolset.prompts?.length ?? 0,
+    ...(options.includePrompts && {
+      prompts:
+        toolset.prompts?.map((prompt) => ({
+          name: prompt.name,
+          description: prompt.description,
+          arguments: prompt.arguments,
+        })) ?? [],
+    }),
+    ...(options.includeTools && {
+      tools: toolset.tools().map((tool) => ({
+        name: tool.name,
+        displayName: humanizeToolName(tool.name),
+        description: tool.description,
+      })),
+    }),
+  };
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -27,6 +27,7 @@
     "./todos/types": "./src/todos/types.ts",
     "./tools/bash-families": "./src/tools/bash-families.ts",
     "./tools/bash-presets": "./src/tools/bash-presets.ts",
+    "./tools/display": "./src/tools/display.ts",
     "./tools/types": "./src/tools/types.ts",
     "./usage/types": "./src/usage/types.ts",
     "./connectors/types": "./src/connectors/types.ts",

--- a/packages/shared/src/tools/display.ts
+++ b/packages/shared/src/tools/display.ts
@@ -1,0 +1,9 @@
+import { parseMcpToolName } from '../mcp/types.js';
+
+export function humanizeToolName(name: string): string {
+  return (parseMcpToolName(name)?.toolName ?? name)
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}


### PR DESCRIPTION
## Change Summary

Consolidates toolset metadata around explicit toolset kinds and shared view/presentation helpers so native, connector, provider, and MCP toolsets are classified and displayed through the same boundary.

### New Features
- **Explicit Toolset Kinds**: Adds a `kind` field to toolsets and uses it for source classification instead of inferring source from IDs or connector prefixes.
- **Shared Toolset Views**: Introduces a reusable toolset view mapper with consistent prompt/tool summaries and display names across config routes and LLM toolset management.

### Improvements & Refactors
- Derives tool summaries from actual tool definitions for native and Google connector toolsets, reducing duplicated summary metadata.
- Moves MCP presentation metadata onto the MCP toolset itself so registry state and UI presentation stay synchronized.
- Simplifies `ToolsetManager` activation state into one activation map while preserving persisted, TTL, and current-run semantics.
- Centralizes normalized runtime creation for core and toolset tools.

### Bug Fixes
- Prevents stale tool collision state after deactivating a toolset.
- Removes stale MCP presentation data when an MCP server is no longer configured.

### Documentation
- None.