### PR TITLE
Eliminate navigation delay when starting a new chat session

### DIFF
--- a/apps/web/src/components/home/new-session-page.tsx
+++ b/apps/web/src/components/home/new-session-page.tsx
@@ -60,7 +60,7 @@ export function NewSessionPage() {
       assistantMessageId,
     });
 
-    void navigate({ to: '/session/$id', params: { id: session.id }, viewTransition: true });
+    void navigate({ to: '/session/$id', params: { id: session.id } });
   }
 
   return (
@@ -70,7 +70,7 @@ export function NewSessionPage() {
           <h1 className="text-3xl font-bold tracking-tight">What can I help you with?</h1>
           <p className="text-base text-muted-foreground">Select a model and start a conversation</p>
         </div>
-        <div style={{ viewTransitionName: 'chat-input' }}>
+        <div>
           <ChatInput
             value={value}
             onChange={setValue}

--- a/apps/web/src/routes/session.$id.tsx
+++ b/apps/web/src/routes/session.$id.tsx
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 import { createFileRoute, redirect } from '@tanstack/react-router';
 
 import { SessionPage } from '@/components/session/session-page';
@@ -5,6 +7,7 @@ import { useActions } from '@/lib/actions';
 import { sessionQueryOptions, sessionMessagesInfiniteQueryOptions } from '@/lib/queries/chat';
 import { visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
 import { queuedMessagesQueryOptions } from '@/lib/queries/queue';
+import { sessionTodosQueryOptions } from '@/lib/queries/todos';
 import { useSessionHotkeys } from '@/lib/use-session-hotkeys';
 
 export const Route = createFileRoute('/session/$id')({
@@ -15,10 +18,12 @@ export const Route = createFileRoute('/session/$id')({
       throw redirect({ to: '/automations/sessions/$id', params: { id: params.id } });
     }
 
-    await Promise.all([
+    // Prefetch remaining data without blocking navigation
+    void Promise.all([
       context.queryClient.ensureInfiniteQueryData(sessionMessagesInfiniteQueryOptions(params.id)),
       context.queryClient.ensureQueryData(visibleProviderModelsQueryOptions),
       context.queryClient.ensureQueryData(queuedMessagesQueryOptions(params.id)),
+      context.queryClient.ensureQueryData(sessionTodosQueryOptions(params.id)),
     ]);
   },
   component: SessionRouteComponent,
@@ -30,5 +35,9 @@ function SessionRouteComponent() {
   const actions = useActions();
   useSessionHotkeys(actions);
 
-  return <SessionPage sessionId={id} />;
+  return (
+    <React.Suspense>
+      <SessionPage sessionId={id} />
+    </React.Suspense>
+  );
 }


### PR DESCRIPTION
## Change Summary

Eliminates the visible 1-2 second lag when starting a new chat from the home page. The user was stuck staring at a frozen home screen while multiple sequential network requests completed before navigation could finish.

### Improvements and Refactors
- **Non-blocking route loader**: Changed the session route loader from awaiting all queries (which blocked the route transition) to fire-and-forget prefetches. Only the session query is awaited (for the automation redirect check), and it is always a cache hit since the home page seeds it.
- **Suspense boundary**: Wrapped SessionPage in a React.Suspense boundary so deferred data can resolve after navigation completes.
- **Removed view transition hold**: Removed viewTransition: true from the home-to-session navigation, which was causing the browser to hold the old frame until the entire new page was ready to paint.
- **Added todos to prefetch batch**: sessionTodosQueryOptions was missing from the loader entirely, causing a post-render suspense waterfall (third sequential network roundtrip after the route had already loaded).

### Root Cause
The delay was a waterfall of blocking operations:
1. createSession roundtrip (~50ms, unavoidable - need the ID for URL)
2. Route loader awaiting 4 queries before allowing navigation (~200-400ms)
3. viewTransition: true holding the old frame during all of the above
