### PR TITLE
refactor(skills): move to pure file directory approach

### DIFF
--- a/apps/web/src/components/settings/skills.tsx
+++ b/apps/web/src/components/settings/skills.tsx
@@ -135,7 +135,7 @@ function SkillEditor({ skill, onBack }: { skill: Skill | null; onBack: () => voi
     };
 
     if (skill) {
-      await updateSkill.mutateAsync({ id: skill.id, input });
+      await updateSkill.mutateAsync({ name: skill.name, input });
     } else {
       await createSkill.mutateAsync(input);
     }
@@ -217,7 +217,7 @@ export function SkillsSettings() {
   function handleDelete(skill: Skill) {
     const confirmed = window.confirm(`Delete skill "${skill.name}"?`);
     if (!confirmed) return;
-    deleteSkill.mutate(skill.id);
+    deleteSkill.mutate(skill.name);
   }
 
   if (view.type === 'editor') {
@@ -257,7 +257,7 @@ export function SkillsSettings() {
         ) : (
           skills.map((skill) => (
             <div
-              key={skill.id}
+              key={skill.name}
               className="flex items-center justify-between gap-4 border-b border-border/50 px-4 py-3 last:border-b-0"
             >
               <div className="min-w-0 flex-1">

--- a/apps/web/src/lib/queries/skills.ts
+++ b/apps/web/src/lib/queries/skills.ts
@@ -77,8 +77,8 @@ export function useCreateSkill() {
 export function useUpdateSkill() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ id, input }: { id: string; input: SkillUpdateInput }) => {
-      const res = await serverFetch(`/skills/${id}`, {
+    mutationFn: async ({ name, input }: { name: string; input: SkillUpdateInput }) => {
+      const res = await serverFetch(`/skills/${encodeURIComponent(name)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
@@ -97,8 +97,8 @@ export function useUpdateSkill() {
 export function useDeleteSkill() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: string) => {
-      const res = await serverFetch(`/skills/${id}`, { method: 'DELETE' });
+    mutationFn: async (name: string) => {
+      const res = await serverFetch(`/skills/${encodeURIComponent(name)}`, { method: 'DELETE' });
       if (!res.ok) throw await parseError(res, 'Failed to delete skill');
     },
     onSuccess: () => {

--- a/packages/server/drizzle/0030_tough_peter_parker.sql
+++ b/packages/server/drizzle/0030_tough_peter_parker.sql
@@ -1,0 +1,1 @@
+DROP TABLE `skill_metadata`;

--- a/packages/server/drizzle/meta/0030_snapshot.json
+++ b/packages/server/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,2304 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d194ec97-b9c0-4ecb-95ee-ec411b941079",
+  "prevId": "a80cf1c1-e08c-4a8b-86b6-686c1b6a18ed",
+  "tables": {
+    "agenda_items": {
+      "name": "agenda_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'todo'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_items_list_id_idx": {
+          "name": "agenda_items_list_id_idx",
+          "columns": ["list_id"],
+          "isUnique": false
+        },
+        "agenda_items_status_idx": {
+          "name": "agenda_items_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "agenda_items_due_at_idx": {
+          "name": "agenda_items_due_at_idx",
+          "columns": ["due_at"],
+          "isUnique": false
+        },
+        "agenda_items_created_at_idx": {
+          "name": "agenda_items_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_items_list_id_agenda_lists_id_fk": {
+          "name": "agenda_items_list_id_agenda_lists_id_fk",
+          "tableFrom": "agenda_items",
+          "tableTo": "agenda_lists",
+          "columnsFrom": ["list_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_items_type_check": {
+          "name": "agenda_items_type_check",
+          "value": "\"agenda_items\".\"type\" in ('todo', 'reminder', 'checkup')"
+        },
+        "agenda_items_status_check": {
+          "name": "agenda_items_status_check",
+          "value": "\"agenda_items\".\"status\" in ('open', 'in_progress', 'done', 'cancelled')"
+        },
+        "agenda_items_priority_check": {
+          "name": "agenda_items_priority_check",
+          "value": "\"agenda_items\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      }
+    },
+    "agenda_lists": {
+      "name": "agenda_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_lists_name_uidx": {
+          "name": "agenda_lists_name_uidx",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "agenda_lists_created_at_idx": {
+          "name": "agenda_lists_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "auth_issue": {
+          "name": "auth_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": ["connector_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lance_migrations": {
+      "name": "lance_migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "prev_id": {
+          "name": "prev_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'applied'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "is_attributable": {
+          "name": "is_attributable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_index": {
+          "name": "attempt_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_run_id_idx": {
+          "name": "llm_usage_events_run_id_idx",
+          "columns": ["run_id"],
+          "isUnique": false
+        },
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": ["source"],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": ["provider_id", "model_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ollama_models": {
+      "name": "ollama_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_limit": {
+          "name": "input_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_limit": {
+          "name": "output_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_cost_per_million": {
+          "name": "input_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_cost_per_million": {
+          "name": "output_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_cost_per_million": {
+          "name": "cache_read_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_per_million": {
+          "name": "cache_write_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_tool_calls": {
+          "name": "supports_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_vision": {
+          "name": "supports_vision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_reasoning": {
+          "name": "supports_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "permission_responses": {
+      "name": "permission_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "system_reminder": {
+          "name": "system_reminder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "entry": {
+          "name": "entry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "permission_responses_session_id_sessions_id_fk": {
+          "name": "permission_responses_session_id_sessions_id_fk",
+          "tableFrom": "permission_responses",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_analyses": {
+      "name": "recording_analyses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "transcript": {
+          "name": "transcript",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "topic_sections": {
+          "name": "topic_sections",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_provider_id": {
+          "name": "transcription_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_model_id": {
+          "name": "transcription_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_provider_id": {
+          "name": "analysis_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_model_id": {
+          "name": "analysis_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recording_analyses_recording_id_uidx": {
+          "name": "recording_analyses_recording_id_uidx",
+          "columns": ["recording_id"],
+          "isUnique": true
+        },
+        "recording_analyses_status_idx": {
+          "name": "recording_analyses_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recording_analyses_recording_id_recordings_id_fk": {
+          "name": "recording_analyses_recording_id_recordings_id_fk",
+          "tableFrom": "recording_analyses",
+          "tableTo": "recordings",
+          "columnsFrom": ["recording_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recording_analyses_status_check": {
+          "name": "recording_analyses_status_check",
+          "value": "\"recording_analyses\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "recordings": {
+      "name": "recordings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'recording'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'audio/ogg'"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recordings_created_at_idx": {
+          "name": "recordings_created_at_idx",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "recordings_status_idx": {
+          "name": "recordings_status_idx",
+          "columns": ["status"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recordings_status_check": {
+          "name": "recordings_status_check",
+          "value": "\"recordings\".\"status\" in ('recording', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": ["job_id"],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": ["key"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": ["job_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": ["key"],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": ["next_run_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "session_todos": {
+      "name": "session_todos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_todos_session_id_idx": {
+          "name": "session_todos_session_id_idx",
+          "columns": ["session_id"],
+          "isUnique": false
+        },
+        "session_todos_order_idx": {
+          "name": "session_todos_order_idx",
+          "columns": ["session_id", "sort_order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_todos_session_id_sessions_id_fk": {
+          "name": "session_todos_session_id_sessions_id_fk",
+          "tableFrom": "session_todos",
+          "tableTo": "sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "toolset_state": {
+          "name": "toolset_state",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_automation_id_automations_id_fk": {
+          "name": "sessions_automation_id_automations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "automations",
+          "columnsFrom": ["automation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": ["parent_session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_enabled": {
+      "name": "tool_enabled",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_enabled_scope_identifier_uidx": {
+          "name": "tool_enabled_scope_identifier_uidx",
+          "columns": ["scope", "identifier"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": ["tool_name", "pattern"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1780862829070,
       "tag": "0029_drop_queued_messages",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "6",
+      "when": 1780863726814,
+      "tag": "0030_tough_peter_parker",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/db/schema.ts
+++ b/packages/server/src/db/schema.ts
@@ -37,7 +37,6 @@ import type {
 } from '@stitch/shared/recordings/types';
 import type { SettingsKey } from '@stitch/shared/settings/types';
 import type { ShortcutActionId, ShortcutCategory } from '@stitch/shared/shortcuts/types';
-import type { SkillId } from '@stitch/shared/skills/types';
 
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import type { SessionToolsetState } from '@/llm/stream/session-toolsets.js';
@@ -322,23 +321,6 @@ export const toolEnabled = sqliteTable(
       .$defaultFn(() => Date.now()),
   },
   (table) => [uniqueIndex('tool_enabled_scope_identifier_uidx').on(table.scope, table.identifier)],
-);
-
-export const skillMetadata = sqliteTable(
-  'skill_metadata',
-  {
-    id: text('id').$type<SkillId>().primaryKey(),
-    name: text('name').notNull(),
-    isExternal: integer('is_external', { mode: 'boolean' }).notNull().default(false),
-    source: text('source'),
-    createdAt: integer('created_at', { mode: 'number' })
-      .notNull()
-      .$defaultFn(() => Date.now()),
-    updatedAt: integer('updated_at', { mode: 'number' })
-      .notNull()
-      .$defaultFn(() => Date.now()),
-  },
-  (table) => [uniqueIndex('skill_metadata_source_uidx').on(table.source)],
 );
 
 export const mcpServers = sqliteTable('mcp_servers', {

--- a/packages/server/src/routes/skills.ts
+++ b/packages/server/src/routes/skills.ts
@@ -7,7 +7,6 @@ import {
   importSkillSchema,
   updateSkillSchema,
 } from '@stitch/shared/skills/types';
-import type { SkillId } from '@stitch/shared/skills/types';
 
 import { unwrapResult } from '@/lib/route-helpers.js';
 import {
@@ -19,7 +18,7 @@ import {
   updateSkill,
 } from '@/skills/service.js';
 
-const skillIdSchema = z.object({ id: z.string().min(1) });
+const skillNameSchema = z.object({ name: z.string().min(1) });
 const searchSkillsSchema = z.object({ q: z.string().default('') });
 
 export const skillsRouter = new Hono();
@@ -46,18 +45,18 @@ skillsRouter.post('/import', zValidator('json', importSkillSchema), async (c) =>
 });
 
 skillsRouter.put(
-  '/:id',
-  zValidator('param', skillIdSchema),
+  '/:name',
+  zValidator('param', skillNameSchema),
   zValidator('json', updateSkillSchema),
   async (c) => {
-    const { id } = c.req.valid('param');
-    const result = await updateSkill(id as SkillId, c.req.valid('json'));
+    const { name } = c.req.valid('param');
+    const result = await updateSkill(name, c.req.valid('json'));
     return unwrapResult(c, result);
   },
 );
 
-skillsRouter.delete('/:id', zValidator('param', skillIdSchema), async (c) => {
-  const { id } = c.req.valid('param');
-  const result = await deleteSkill(id as SkillId);
+skillsRouter.delete('/:name', zValidator('param', skillNameSchema), async (c) => {
+  const { name } = c.req.valid('param');
+  const result = await deleteSkill(name);
   return unwrapResult(c, result, 204);
 });

--- a/packages/server/src/skills/service-built-ins.test.ts
+++ b/packages/server/src/skills/service-built-ins.test.ts
@@ -4,16 +4,11 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { getDb } from '@/db/client.js';
-import { skillMetadata } from '@/db/schema.js';
-import { setupTestDb } from '@/db/test-helpers.js';
 import { PATHS } from '@/lib/paths.js';
 import { buildSkillsSystemPrompt, syncBuiltInSkills } from '@/skills/service.js';
 
 let tempDir: string;
 let originalSkillsDir: string;
-
-setupTestDb();
 
 beforeEach(async () => {
   tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stitch-skills-test-'));
@@ -27,7 +22,7 @@ afterEach(async () => {
 });
 
 describe('syncBuiltInSkills', () => {
-  test('inserts missing built-in skills', async () => {
+  test('writes missing built-in skills to disk', async () => {
     await syncBuiltInSkills([
       {
         name: 'test-skill',
@@ -37,71 +32,34 @@ describe('syncBuiltInSkills', () => {
       },
     ]);
 
-    const rows = await getDb().select().from(skillMetadata);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({
-      name: 'test-skill',
-      isExternal: false,
-      source: 'builtin:test-skill',
-    });
-
     const mdPath = path.join(tempDir, 'test-skill', 'SKILL.md');
     const content = await fs.readFile(mdPath, 'utf8');
     expect(content).toContain('name: test-skill');
     expect(content).toContain('Test instructions.');
   });
 
-  test('updates existing skills when content changes', async () => {
-    await syncBuiltInSkills([
-      {
-        name: 'test-skill',
-        description: 'Old description.',
-        content: 'Old instructions.',
-        files: [],
-      },
-    ]);
-
-    await syncBuiltInSkills([
-      {
-        name: 'test-skill',
-        description: 'New description.',
-        content: 'New instructions.',
-        files: [],
-      },
-    ]);
-
-    const rows = await getDb().select().from(skillMetadata);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({
-      name: 'test-skill',
-      source: 'builtin:test-skill',
-      isExternal: false,
-    });
-
-    const mdPath = path.join(tempDir, 'test-skill', 'SKILL.md');
-    const content = await fs.readFile(mdPath, 'utf8');
-    expect(content).toContain('New description.');
-    expect(content).toContain('New instructions.');
-  });
-
-  test('does not update unchanged built-in skills', async () => {
+  test('skips existing skill directories', async () => {
     const skill = {
       name: 'test-skill',
       description: 'Use this test skill.',
-      content: 'Test instructions.',
+      content: 'Original instructions.',
       files: [],
     };
 
     await syncBuiltInSkills([skill]);
-    const [before] = await getDb().select().from(skillMetadata);
 
-    await syncBuiltInSkills([skill]);
-    const [after] = await getDb().select().from(skillMetadata);
+    // Manually modify the file to simulate a user edit
+    const mdPath = path.join(tempDir, 'test-skill', 'SKILL.md');
+    await fs.writeFile(mdPath, 'user modified content', 'utf8');
 
-    expect(after.updatedAt).toBe(before.updatedAt);
+    await syncBuiltInSkills([{ ...skill, content: 'New instructions.' }]);
+
+    // File should remain as the user left it
+    const content = await fs.readFile(mdPath, 'utf8');
+    expect(content).toBe('user modified content');
   });
 
-  test('syncs companion files to the skill directory', async () => {
+  test('syncs companion files for new skills', async () => {
     await syncBuiltInSkills([
       {
         name: 'test-skill',
@@ -124,96 +82,22 @@ describe('syncBuiltInSkills', () => {
     expect(await fs.readFile(scriptPath, 'utf8')).toBe('print("hello")');
   });
 
-  test('updates changed companion files', async () => {
-    await syncBuiltInSkills([
-      {
-        name: 'test-skill',
-        description: 'A skill.',
-        content: 'Instructions.',
-        files: [{ relativePath: 'references/guide.md', content: 'Version 1' }],
-      },
-    ]);
-
-    await syncBuiltInSkills([
-      {
-        name: 'test-skill',
-        description: 'A skill.',
-        content: 'Instructions.',
-        files: [{ relativePath: 'references/guide.md', content: 'Version 2' }],
-      },
-    ]);
-
-    const guidePath = path.join(tempDir, 'test-skill', 'references', 'guide.md');
-    expect(await fs.readFile(guidePath, 'utf8')).toBe('Version 2');
-  });
-
-  test('removes stale companion files from built-in skills', async () => {
-    await syncBuiltInSkills([
-      {
-        name: 'test-skill',
-        description: 'A skill.',
-        content: 'Instructions.',
-        files: [
-          { relativePath: 'references/old.md', content: 'old content' },
-          { relativePath: 'references/keep.md', content: 'keep this' },
-        ],
-      },
-    ]);
-
-    await syncBuiltInSkills([
-      {
-        name: 'test-skill',
-        description: 'A skill.',
-        content: 'Instructions.',
-        files: [{ relativePath: 'references/keep.md', content: 'keep this' }],
-      },
-    ]);
-
-    const oldPath = path.join(tempDir, 'test-skill', 'references', 'old.md');
-    const keepPath = path.join(tempDir, 'test-skill', 'references', 'keep.md');
-
-    expect(existsSync(oldPath)).toBe(false);
-    expect(existsSync(keepPath)).toBe(true);
-  });
-
-  test('removes empty directories after stale file removal', async () => {
-    await syncBuiltInSkills([
-      {
-        name: 'test-skill',
-        description: 'A skill.',
-        content: 'Instructions.',
-        files: [{ relativePath: 'agents/old-agent.md', content: 'agent content' }],
-      },
-    ]);
-
-    await syncBuiltInSkills([
-      {
-        name: 'test-skill',
-        description: 'A skill.',
-        content: 'Instructions.',
-        files: [],
-      },
-    ]);
-
-    const agentsDir = path.join(tempDir, 'test-skill', 'agents');
-    expect(existsSync(agentsDir)).toBe(false);
-  });
-
-  test('does not update when companion files are unchanged', async () => {
+  test('does not write companion files for existing skill directories', async () => {
     const skill = {
       name: 'test-skill',
       description: 'A skill.',
       content: 'Instructions.',
-      files: [{ relativePath: 'references/guide.md', content: 'stable content' }],
+      files: [{ relativePath: 'references/guide.md', content: 'original' }],
     };
 
     await syncBuiltInSkills([skill]);
-    const [before] = await getDb().select().from(skillMetadata);
 
-    await syncBuiltInSkills([skill]);
-    const [after] = await getDb().select().from(skillMetadata);
+    await syncBuiltInSkills([
+      { ...skill, files: [{ relativePath: 'references/guide.md', content: 'updated' }] },
+    ]);
 
-    expect(after.updatedAt).toBe(before.updatedAt);
+    const guidePath = path.join(tempDir, 'test-skill', 'references', 'guide.md');
+    expect(await fs.readFile(guidePath, 'utf8')).toBe('original');
   });
 });
 
@@ -235,5 +119,18 @@ describe('buildSkillsSystemPrompt', () => {
   test('returns empty string when no skills exist', async () => {
     const prompt = await buildSkillsSystemPrompt();
     expect(prompt).toBe('');
+  });
+
+  test('does not write skills that already exist', async () => {
+    await syncBuiltInSkills([
+      {
+        name: 'test-skill',
+        description: 'Use this test skill.',
+        content: 'Test instructions.',
+        files: [],
+      },
+    ]);
+
+    expect(existsSync(path.join(tempDir, 'test-skill'))).toBe(true);
   });
 });

--- a/packages/server/src/skills/service.ts
+++ b/packages/server/src/skills/service.ts
@@ -1,9 +1,7 @@
-import { eq, inArray } from 'drizzle-orm';
 import { existsSync } from 'node:fs';
 import { mkdir, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { createSkillId } from '@stitch/shared/id';
 import {
   createSkillSchema,
   importSkillSchema,
@@ -12,14 +10,11 @@ import {
 import type {
   Skill,
   SkillCreateInput,
-  SkillId,
   SkillImportInput,
   SkillSearchResult,
   SkillUpdateInput,
 } from '@stitch/shared/skills/types';
 
-import { getDb, isDbInitialized } from '@/db/client.js';
-import { skillMetadata } from '@/db/schema.js';
 import * as Log from '@/lib/log.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
@@ -65,29 +60,6 @@ type SkillsDownloadResponse = {
 const SKILLS_API_BASE = 'https://skills.sh';
 const FETCH_TIMEOUT_MS = 10_000;
 
-type MetadataRow = {
-  id: SkillId;
-  isExternal: boolean;
-  source: string | null;
-  createdAt: number;
-  updatedAt: number;
-};
-
-function getMetadata(name: string): MetadataRow | null {
-  if (!isDbInitialized()) return null;
-
-  const row = getDb().select().from(skillMetadata).where(eq(skillMetadata.name, name)).get();
-  if (!row) return null;
-
-  return {
-    id: row.id,
-    isExternal: row.isExternal,
-    source: row.source,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-  };
-}
-
 async function readSkillFromDisk(name: string): Promise<Skill | null> {
   const markdown = await readSkillMdFile(name);
   if (!markdown) return null;
@@ -97,24 +69,14 @@ async function readSkillFromDisk(name: string): Promise<Skill | null> {
 
   const skillDir = getSkillDir(name);
   const files = await listSkillFiles(skillDir);
-  const metadata = getMetadata(name);
 
   return {
-    id: metadata?.id ?? createSkillId(),
     name: parsed.name,
     description: parsed.description,
     content: parsed.content,
     location: getSkillMdPath(name),
-    isExternal: metadata?.isExternal ?? false,
-    source: metadata?.source ?? null,
-    createdAt: metadata?.createdAt ?? Date.now(),
-    updatedAt: metadata?.updatedAt ?? Date.now(),
     files,
   };
-}
-
-function toSourceKey(source: string, slug: string): string {
-  return `${source.trim().toLowerCase()}/${slug.trim().toLowerCase()}`;
 }
 
 export async function listSkills(): Promise<ServiceResult<Skill[]>> {
@@ -157,29 +119,11 @@ export async function createSkill(input: SkillCreateInput): Promise<ServiceResul
 
   await writeSkillMdFile(value.name, buildSkillMd(value));
 
-  const now = Date.now();
-  const id = createSkillId();
-  if (isDbInitialized()) {
-    await getDb().insert(skillMetadata).values({
-      id,
-      name: value.name,
-      isExternal: false,
-      source: null,
-      createdAt: now,
-      updatedAt: now,
-    });
-  }
-
   return ok({
-    id,
     name: value.name,
     description: value.description.trim(),
     content: value.content.trim(),
     location: getSkillMdPath(value.name),
-    isExternal: false,
-    source: null,
-    createdAt: now,
-    updatedAt: now,
     files: [],
   });
 }
@@ -188,120 +132,61 @@ export async function syncBuiltInSkills(builtInSkills: BuiltInSkill[]): Promise<
   await ensureSkillsDir();
 
   for (const skill of builtInSkills) {
-    const source = `builtin:${skill.name}`;
     const skillDir = getSkillDir(skill.name);
-    const existingContent = await readSkillMdFile(skill.name);
-    const newContent = buildSkillMd(skill);
 
-    const skillMdChanged = existingContent !== newContent;
-    const filesChanged = await syncCompanionFiles(skillDir, skill.files);
+    if (existsSync(skillDir)) continue;
 
-    if (!skillMdChanged && !filesChanged) continue;
-
-    if (skillMdChanged) {
-      await writeSkillMdFile(skill.name, newContent);
-    }
-
-    if (isDbInitialized()) {
-      const existing = getDb()
-        .select()
-        .from(skillMetadata)
-        .where(eq(skillMetadata.name, skill.name))
-        .get();
-
-      if (!existing) {
-        await getDb().insert(skillMetadata).values({
-          id: createSkillId(),
-          name: skill.name,
-          isExternal: false,
-          source,
-          createdAt: Date.now(),
-          updatedAt: Date.now(),
-        });
-      } else {
-        await getDb()
-          .update(skillMetadata)
-          .set({ source, updatedAt: Date.now() })
-          .where(eq(skillMetadata.name, skill.name));
-      }
-    }
+    await writeSkillMdFile(skill.name, buildSkillMd(skill));
+    await syncCompanionFiles(skillDir, skill.files);
   }
 }
 
 export async function updateSkill(
-  id: SkillId,
+  name: string,
   input: SkillUpdateInput,
 ): Promise<ServiceResult<Skill>> {
   const parsed = updateSkillSchema.safeParse(input);
   if (!parsed.success) return err(parsed.error.issues[0]?.message ?? 'Invalid skill', 400);
 
-  if (!isDbInitialized()) return err('Database not initialized', 500);
-
-  const existing = getDb().select().from(skillMetadata).where(eq(skillMetadata.id, id)).get();
-  if (!existing) return err(new SkillNotFoundError(id).message, 404);
-
-  const currentName = existing.name;
   const value = parsed.data;
-
   await ensureSkillsDir();
 
-  if (value.name !== currentName) {
+  const currentDir = getSkillDir(name);
+  if (!existsSync(currentDir)) {
+    return err(new SkillNotFoundError(name).message, 404);
+  }
+
+  if (value.name !== name) {
     const newDir = getSkillDir(value.name);
     if (existsSync(newDir)) {
       return err(new SkillNameCollisionError(value.name).message, 409);
     }
-
-    const existingDir = getSkillDir(currentName);
-    if (existsSync(existingDir)) {
-      await rename(existingDir, newDir);
-    } else {
-      await mkdir(newDir, { recursive: true });
-    }
-
-    await getDb()
-      .update(skillMetadata)
-      .set({ name: value.name, updatedAt: Date.now() })
-      .where(eq(skillMetadata.id, id));
-  } else {
-    await getDb()
-      .update(skillMetadata)
-      .set({ updatedAt: Date.now() })
-      .where(eq(skillMetadata.id, id));
+    await rename(currentDir, newDir);
   }
 
   await writeSkillMdFile(value.name, buildSkillMd(value));
 
   const targetDir = getSkillDir(value.name);
   const files = await listSkillFiles(targetDir);
-  const metadata = getMetadata(value.name);
 
   return ok({
-    id,
     name: value.name,
     description: value.description.trim(),
     content: value.content.trim(),
     location: getSkillMdPath(value.name),
-    isExternal: metadata?.isExternal ?? false,
-    source: metadata?.source ?? null,
-    createdAt: metadata?.createdAt ?? Date.now(),
-    updatedAt: metadata?.updatedAt ?? Date.now(),
     files,
   });
 }
 
-export async function deleteSkill(id: SkillId): Promise<ServiceResult<null>> {
-  if (!isDbInitialized()) return err('Database not initialized', 500);
+export async function deleteSkill(name: string): Promise<ServiceResult<null>> {
+  await ensureSkillsDir();
 
-  const existing = getDb().select().from(skillMetadata).where(eq(skillMetadata.id, id)).get();
-  if (!existing) return err(new SkillNotFoundError(id).message, 404);
-
-  const skillDir = getSkillDir(existing.name);
-  if (existsSync(skillDir)) {
-    await rm(skillDir, { recursive: true, force: true });
+  const skillDir = getSkillDir(name);
+  if (!existsSync(skillDir)) {
+    return err(new SkillNotFoundError(name).message, 404);
   }
 
-  await getDb().delete(skillMetadata).where(eq(skillMetadata.id, id));
-
+  await rm(skillDir, { recursive: true, force: true });
   return ok(null);
 }
 
@@ -343,21 +228,7 @@ export async function searchSkillsDirectory(
       })
       .sort((a, b) => b.installs - a.installs);
 
-    if (!isDbInitialized() || results.length === 0) return ok(results);
-
-    const sourceKeys = results.map((skill) => toSourceKey(skill.source, skill.slug));
-    const existing = await getDb()
-      .select({ source: skillMetadata.source })
-      .from(skillMetadata)
-      .where(inArray(skillMetadata.source, sourceKeys));
-    const importedSources = new Set(existing.flatMap((row) => (row.source ? [row.source] : [])));
-
-    return ok(
-      results.map((skill) => ({
-        ...skill,
-        isImported: importedSources.has(toSourceKey(skill.source, skill.slug)),
-      })),
-    );
+    return ok(results);
   } catch (error) {
     log.error({ error, query: trimmedQuery }, 'skills.sh search threw');
     return err('Failed to search skills directory', 500);
@@ -372,20 +243,6 @@ export async function importSkillFromDirectory(
 
   const { source, slug } = parsed.data;
   if (!source.includes('/')) return err('Skill source must be an owner/repo value', 400);
-
-  const sourceKey = toSourceKey(source, slug);
-
-  if (isDbInitialized()) {
-    const existingSource = getDb()
-      .select()
-      .from(skillMetadata)
-      .where(eq(skillMetadata.source, sourceKey))
-      .get();
-    if (existingSource) {
-      const skill = await readSkillFromDisk(existingSource.name);
-      if (skill) return ok(skill);
-    }
-  }
 
   try {
     const encodedSlug = slug.split('/').map(encodeURIComponent).join('/');
@@ -466,31 +323,13 @@ export async function importSkillFromDirectory(
       await writeFile(filePath, file.contents, 'utf8');
     }
 
-    const now = Date.now();
-    const id = createSkillId();
-    if (isDbInitialized()) {
-      await getDb().insert(skillMetadata).values({
-        id,
-        name: value.name,
-        isExternal: true,
-        source: sourceKey,
-        createdAt: now,
-        updatedAt: now,
-      });
-    }
-
     const skillFiles = await listSkillFiles(skillDir);
 
     return ok({
-      id,
       name: value.name,
       description: value.description.trim(),
       content: value.content.trim(),
       location: getSkillMdPath(value.name),
-      isExternal: true,
-      source: sourceKey,
-      createdAt: now,
-      updatedAt: now,
       files: skillFiles,
     });
   } catch (error) {

--- a/packages/shared/src/id/index.test.ts
+++ b/packages/shared/src/id/index.test.ts
@@ -19,7 +19,6 @@ import {
   createAgendaListId,
   createAgendaItemId,
   createTodoId,
-  createSkillId,
   extractTimestamp,
 } from './index';
 
@@ -41,7 +40,6 @@ const ALL_FACTORIES = [
   { create: createAgendaListId, prefix: ID_PREFIXES.agendaList },
   { create: createAgendaItemId, prefix: ID_PREFIXES.agendaItem },
   { create: createTodoId, prefix: ID_PREFIXES.todo },
-  { create: createSkillId, prefix: ID_PREFIXES.skill },
 ] as const;
 
 describe('id factories', () => {

--- a/packages/shared/src/id/index.ts
+++ b/packages/shared/src/id/index.ts
@@ -18,7 +18,6 @@ export const ID_PREFIXES = {
   agendaList: 'alist',
   agendaItem: 'aitm',
   todo: 'todo',
-  skill: 'skill',
 } as const;
 
 export type IdPrefix = (typeof ID_PREFIXES)[keyof typeof ID_PREFIXES];
@@ -81,7 +80,6 @@ export const createRecordingAnalysisId = createIdFactory(ID_PREFIXES.recordingAn
 export const createAgendaListId = createIdFactory(ID_PREFIXES.agendaList);
 export const createAgendaItemId = createIdFactory(ID_PREFIXES.agendaItem);
 export const createTodoId = createIdFactory(ID_PREFIXES.todo);
-export const createSkillId = createIdFactory(ID_PREFIXES.skill);
 
 export function extractTimestamp(id: string): number {
   const prefix = id.split('_')[0];

--- a/packages/shared/src/skills/types.ts
+++ b/packages/shared/src/skills/types.ts
@@ -1,19 +1,10 @@
 import { z } from 'zod';
 
-import type { PrefixedString } from '@stitch/shared/id';
-
-export type SkillId = PrefixedString<'skill'>;
-
 export type Skill = {
-  id: SkillId;
   name: string;
   description: string;
   content: string;
   location: string;
-  isExternal: boolean;
-  source: string | null;
-  createdAt: number;
-  updatedAt: number;
   files: string[];
 };
 


### PR DESCRIPTION
## 🚀 Change Summary

Skills are now resolved purely from the filesystem. The `skill_metadata` database table has been removed along with all associated metadata fields — skills are identified and operated on by their directory name.

### ✨ New Features
- **Name-based skill resolution**: `PUT` and `DELETE` routes now use `/:name` instead of `/:id`, matching the filesystem's natural key

### 🛠 Improvements & Refactors
- **Removed `skill_metadata` DB table**: All skill state lives in the `SKILL.md` file and directory structure on disk
- **Simplified `Skill` type**: Dropped `id`, `isExternal`, `source`, `createdAt`, `updatedAt` — none were meaningfully used
- **`syncBuiltInSkills` now skips existing directories**: Users can modify built-in skills without having them overwritten on restart
- **Removed `createSkillId` and `skill` ID prefix** from the shared id module
- **Simplified service**: All Drizzle/DB calls removed from the skills service
