### PR TITLE
feat: add STT usage tab to usage dashboard

### DIFF
--- a/apps/web/src/components/usage/stt-usage-cost-chart.tsx
+++ b/apps/web/src/components/usage/stt-usage-cost-chart.tsx
@@ -1,0 +1,220 @@
+import {
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  type ScriptableContext,
+  Tooltip,
+  type TooltipItem,
+} from 'chart.js';
+import { BarChart3Icon } from 'lucide-react';
+import * as React from 'react';
+import { Bar } from 'react-chartjs-2';
+
+import type { SttUsageDashboardResponse } from '@stitch/shared/usage/types';
+
+import { formatCost } from '@/components/usage/usage-dashboard-utils';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+const SERVICE_COLOR_CONFIG: Record<string, { cssVar: string; fallback: string }> = {
+  'chat-input': { cssVar: '--chart-1', fallback: '#f97316' },
+  'meeting-recording': { cssVar: '--chart-2', fallback: '#10b981' },
+};
+
+const FALLBACK_SERVICE_COLORS = ['#f97316', '#10b981', '#3b82f6', '#f59e0b', '#ec4899', '#14b8a6'];
+
+const SERVICE_LABELS: Record<string, string> = {
+  'chat-input': 'Chat Input',
+  'meeting-recording': 'Meeting Recording',
+};
+
+function getServiceLabel(service: string): string {
+  return SERVICE_LABELS[service] ?? service.replaceAll('-', ' ');
+}
+
+function resolveCssVar(varName: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback;
+  const value = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
+  return value.length > 0 ? value : fallback;
+}
+
+function hashService(service: string): number {
+  let hash = 0;
+  for (let i = 0; i < service.length; i += 1) {
+    hash = (hash * 31 + service.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+function getServiceColor(service: string): string {
+  const configured = SERVICE_COLOR_CONFIG[service];
+  if (configured) {
+    return resolveCssVar(configured.cssVar, configured.fallback);
+  }
+
+  const fallback = FALLBACK_SERVICE_COLORS[hashService(service) % FALLBACK_SERVICE_COLORS.length];
+  return fallback ?? '#6b7280';
+}
+
+function getNumericValue(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function getStackSegmentRadius(ctx: ScriptableContext<'bar'>, radius = 5) {
+  const datasetIndex = ctx.datasetIndex;
+  const dataIndex = ctx.dataIndex;
+  const datasets = ctx.chart.data.datasets;
+
+  const hasAbove = datasets
+    .slice(datasetIndex + 1)
+    .some((dataset) => getNumericValue(dataset.data?.[dataIndex]) > 0);
+  const hasBelow = datasets
+    .slice(0, datasetIndex)
+    .some((dataset) => getNumericValue(dataset.data?.[dataIndex]) > 0);
+
+  return {
+    topLeft: hasAbove ? 0 : radius,
+    topRight: hasAbove ? 0 : radius,
+    bottomLeft: hasBelow ? 0 : radius,
+    bottomRight: hasBelow ? 0 : radius,
+  };
+}
+
+function useChartTheme() {
+  return React.useMemo(() => {
+    const tickColor = resolveCssVar('--muted-foreground', '#71717a');
+    const gridColor = resolveCssVar('--border', '#27272a');
+    return { tickColor, gridColor };
+  }, []);
+}
+
+function EmptyChart({ message }: { message: string }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+      <BarChart3Icon className="size-8 text-muted-foreground/40" />
+      <div>
+        <p className="text-sm font-medium text-foreground/60">No data</p>
+        <p className="text-xs text-muted-foreground">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+type SttUsageCostChartProps = {
+  usageData: SttUsageDashboardResponse | undefined;
+};
+
+export function SttUsageCostChart({ usageData }: SttUsageCostChartProps) {
+  const services = React.useMemo(
+    () => [...(usageData?.services ?? [])].sort((a, b) => a.localeCompare(b)),
+    [usageData?.services],
+  );
+  const serviceColors = React.useMemo(
+    () => Object.fromEntries(services.map((service) => [service, getServiceColor(service)])),
+    [services],
+  );
+  const { tickColor, gridColor } = useChartTheme();
+  const hasData = !!usageData && usageData.buckets.length > 0;
+
+  const chartData = React.useMemo(
+    () => ({
+      labels: usageData?.buckets.map((b) => b.label) ?? [],
+      datasets: services.map((service) => ({
+        label: getServiceLabel(service),
+        data: usageData?.buckets.map((b) => b.costUsdByService[service] ?? 0) ?? [],
+        backgroundColor: serviceColors[service] ?? '#6b7280',
+        borderRadius: (ctx: ScriptableContext<'bar'>) => getStackSegmentRadius(ctx),
+        borderSkipped: false,
+        inflateAmount: 0,
+      })),
+    }),
+    [serviceColors, services, usageData],
+  );
+
+  const baseScales = React.useMemo(
+    () => ({
+      x: {
+        stacked: true,
+        grid: { display: false },
+        ticks: { color: tickColor },
+        border: { color: gridColor },
+      },
+      y: {
+        stacked: true,
+        beginAtZero: true,
+        grid: { color: gridColor },
+        ticks: { color: tickColor },
+        border: { display: false },
+      },
+    }),
+    [gridColor, tickColor],
+  );
+
+  const baseLegend = React.useMemo(
+    () => ({
+      position: 'bottom' as const,
+      labels: {
+        usePointStyle: true,
+        pointStyle: 'rectRounded' as const,
+        color: tickColor,
+        padding: 16,
+        font: { size: 12 },
+      },
+    }),
+    [tickColor],
+  );
+
+  const chartOptions = React.useMemo(
+    () => ({
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index' as const, intersect: false },
+      plugins: {
+        legend: baseLegend,
+        tooltip: {
+          callbacks: {
+            label: (ctx: TooltipItem<'bar'>) => {
+              const value = Number(ctx.raw ?? 0);
+              if (value === 0) return [];
+              return `${ctx.dataset.label}: ${formatCost(value)}`;
+            },
+          },
+        },
+      },
+      scales: {
+        ...baseScales,
+        y: {
+          ...baseScales.y,
+          ticks: {
+            ...baseScales.y.ticks,
+            callback: (value: string | number) => formatCost(Number(value)),
+          },
+        },
+      },
+    }),
+    [baseScales, baseLegend],
+  );
+
+  return (
+    <div className="rounded-xl bg-muted/20 p-4">
+      <div className="mb-4">
+        <p className="text-sm font-medium">Cost over time</p>
+        <p className="text-xs text-muted-foreground">Stacked by service</p>
+      </div>
+      <div className="h-64 md:h-96">
+        {hasData ? (
+          <Bar data={chartData} options={chartOptions} />
+        ) : (
+          <EmptyChart message="No STT usage data for the selected filters." />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/usage/stt-usage-summary-cards.tsx
+++ b/apps/web/src/components/usage/stt-usage-summary-cards.tsx
@@ -1,0 +1,50 @@
+import type { SttUsageDashboardResponse } from '@stitch/shared/usage/types';
+
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatCost } from '@/components/usage/usage-dashboard-utils';
+
+type SttUsageSummaryCardsProps = {
+  rangeLabel: string;
+  usageData: SttUsageDashboardResponse | undefined;
+};
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
+export function SttUsageSummaryCards({ rangeLabel, usageData }: SttUsageSummaryCardsProps) {
+  const granularityLabel = usageData?.range.granularity ?? 'day';
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <Card className="shadow-sm">
+        <CardHeader>
+          <CardDescription>Total Cost</CardDescription>
+          <CardTitle className="text-3xl font-bold tabular-nums">
+            {formatCost(usageData?.totals.costUsd ?? 0)}
+          </CardTitle>
+          <p className="text-xs text-muted-foreground capitalize">
+            {rangeLabel} · {granularityLabel} buckets
+          </p>
+        </CardHeader>
+      </Card>
+
+      <Card className="shadow-sm">
+        <CardHeader>
+          <CardDescription>Total Duration</CardDescription>
+          <CardTitle className="text-3xl font-bold tabular-nums">
+            {formatDuration(usageData?.totals.durationMs ?? 0)}
+          </CardTitle>
+          <p className="text-xs text-muted-foreground">Audio transcribed</p>
+        </CardHeader>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/components/usage/usage-dashboard-page.tsx
+++ b/apps/web/src/components/usage/usage-dashboard-page.tsx
@@ -9,13 +9,18 @@ import {
   PageIcon,
   PageTitle,
 } from '@/components/ui/page';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { SttUsageCostChart } from '@/components/usage/stt-usage-cost-chart';
+import { SttUsageSummaryCards } from '@/components/usage/stt-usage-summary-cards';
 import { UsageDashboardCostChart } from '@/components/usage/usage-dashboard-cost-chart';
 import { UsageDashboardFilters } from '@/components/usage/usage-dashboard-filters';
 import { UsageDashboardSummaryCards } from '@/components/usage/usage-dashboard-summary-cards';
+import { useSttUsageDashboardData } from '@/components/usage/use-stt-usage-dashboard-data';
 import { useUsageDashboardData } from '@/components/usage/use-usage-dashboard-data';
 
 export function UsageDashboardPage() {
-  const dashboard = useUsageDashboardData();
+  const llm = useUsageDashboardData();
+  const stt = useSttUsageDashboardData(llm.filters.range);
 
   return (
     <Page className="thin-scrollbar">
@@ -34,23 +39,42 @@ export function UsageDashboardPage() {
           </PageHeaderContent>
         </PageHeader>
 
-        <UsageDashboardFilters
-          availableModels={dashboard.availableModels}
-          availableProviders={dashboard.availableProviders}
-          filters={dashboard.filters}
-          labels={dashboard.labels}
-          isFetching={dashboard.isFetching}
-          onModelChange={dashboard.setModelFilter}
-          onProviderChange={dashboard.setProviderFilter}
-          onRangeChange={dashboard.setRangeFilter}
-        />
+        <Tabs defaultValue="llm">
+          <TabsList variant="line">
+            <TabsTrigger value="llm">LLM</TabsTrigger>
+            <TabsTrigger value="stt">Speech-to-Text</TabsTrigger>
+          </TabsList>
 
-        <UsageDashboardSummaryCards
-          rangeLabel={dashboard.labels.range}
-          usageData={dashboard.usageData}
-        />
+          <TabsContent value="llm" className="mt-4 flex flex-col gap-4">
+            <UsageDashboardFilters
+              availableModels={llm.availableModels}
+              availableProviders={llm.availableProviders}
+              filters={llm.filters}
+              labels={llm.labels}
+              isFetching={llm.isFetching}
+              onModelChange={llm.setModelFilter}
+              onProviderChange={llm.setProviderFilter}
+              onRangeChange={llm.setRangeFilter}
+            />
+            <UsageDashboardSummaryCards rangeLabel={llm.labels.range} usageData={llm.usageData} />
+            <UsageDashboardCostChart usageData={llm.usageData} />
+          </TabsContent>
 
-        <UsageDashboardCostChart usageData={dashboard.usageData} />
+          <TabsContent value="stt" className="mt-4 flex flex-col gap-4">
+            <UsageDashboardFilters
+              availableModels={stt.availableModels}
+              availableProviders={stt.availableProviders}
+              filters={stt.filters}
+              labels={stt.labels}
+              isFetching={stt.isFetching}
+              onModelChange={stt.setModelFilter}
+              onProviderChange={stt.setProviderFilter}
+              onRangeChange={llm.setRangeFilter}
+            />
+            <SttUsageSummaryCards rangeLabel={stt.labels.range} usageData={stt.usageData} />
+            <SttUsageCostChart usageData={stt.usageData} />
+          </TabsContent>
+        </Tabs>
       </PageContent>
     </Page>
   );

--- a/apps/web/src/components/usage/use-stt-usage-dashboard-data.ts
+++ b/apps/web/src/components/usage/use-stt-usage-dashboard-data.ts
@@ -1,0 +1,154 @@
+import * as React from 'react';
+
+import { keepPreviousData, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+
+import type { UsageDateRange } from '@stitch/shared/usage/types';
+
+import {
+  ALL_FILTER,
+  RANGE_LABELS,
+  encodeModelFilter,
+  decodeModelFilter,
+} from '@/components/usage/usage-dashboard-utils';
+import { sttProviderModelsQueryOptions } from '@/lib/queries/providers';
+import { sttUsageDashboardQueryOptions } from '@/lib/queries/usage';
+
+type SttProviderOption = {
+  providerId: string;
+  providerName: string;
+};
+
+type SttModelOption = {
+  label: string;
+  providerId: string;
+  providerName: string;
+  modelId: string;
+  modelName: string;
+};
+
+export function useSttUsageDashboardData(rangeFilter: UsageDateRange) {
+  const { data: sttProviderModels } = useSuspenseQuery(sttProviderModelsQueryOptions);
+
+  const [providerFilter, setProviderFilter] = React.useState<string>(ALL_FILTER);
+  const [modelFilter, setModelFilter] = React.useState<string>(ALL_FILTER);
+
+  const { data: usageRangeData } = useQuery({
+    ...sttUsageDashboardQueryOptions({ range: rangeFilter }),
+    placeholderData: keepPreviousData,
+  });
+
+  const providerById = React.useMemo(
+    () => new Map(sttProviderModels.map((p) => [p.providerId, p] as const)),
+    [sttProviderModels],
+  );
+
+  const modelNameByKey = React.useMemo(() => {
+    const map = new Map<string, string>();
+    for (const provider of sttProviderModels) {
+      for (const model of provider.models) {
+        map.set(encodeModelFilter(provider.providerId, model.id), model.name);
+      }
+    }
+    return map;
+  }, [sttProviderModels]);
+
+  const availableProviders = React.useMemo<SttProviderOption[]>(() => {
+    const used = new Set(usageRangeData?.usedProviders ?? []);
+    return sttProviderModels
+      .filter((p) => used.has(p.providerId))
+      .map((p) => ({ providerId: p.providerId, providerName: p.providerName }));
+  }, [sttProviderModels, usageRangeData?.usedProviders]);
+
+  const availableModels = React.useMemo<SttModelOption[]>(() => {
+    const usedModels = usageRangeData?.usedModels ?? [];
+    return usedModels
+      .filter((m) => providerFilter === ALL_FILTER || m.providerId === providerFilter)
+      .map((m) => {
+        const provider = providerById.get(m.providerId);
+        const key = encodeModelFilter(m.providerId, m.modelId);
+        const modelName = modelNameByKey.get(key) ?? m.modelId;
+        return {
+          label: modelName,
+          providerId: m.providerId,
+          providerName: provider?.providerName ?? m.providerId,
+          modelId: m.modelId,
+          modelName,
+        };
+      });
+  }, [modelNameByKey, providerById, providerFilter, usageRangeData?.usedModels]);
+
+  React.useEffect(() => {
+    if (providerFilter === ALL_FILTER) return;
+    const stillAvailable = availableProviders.some((p) => p.providerId === providerFilter);
+    if (!stillAvailable) {
+      setProviderFilter(ALL_FILTER);
+      setModelFilter(ALL_FILTER);
+    }
+  }, [availableProviders, providerFilter]);
+
+  React.useEffect(() => {
+    if (modelFilter === ALL_FILTER) return;
+    const isStillAvailable = availableModels.some(
+      (m) => encodeModelFilter(m.providerId, m.modelId) === modelFilter,
+    );
+    if (!isStillAvailable) setModelFilter(ALL_FILTER);
+  }, [availableModels, modelFilter]);
+
+  const usageFilters = React.useMemo(() => {
+    const decodedModel = modelFilter === ALL_FILTER ? null : decodeModelFilter(modelFilter);
+    const providerIdFromModel =
+      providerFilter === ALL_FILTER ? decodedModel?.providerId : providerFilter;
+    return {
+      range: rangeFilter,
+      providerId: providerIdFromModel,
+      modelId: decodedModel?.modelId,
+    };
+  }, [modelFilter, providerFilter, rangeFilter]);
+
+  const { data: usageData, isFetching } = useQuery({
+    ...sttUsageDashboardQueryOptions(usageFilters),
+    placeholderData: keepPreviousData,
+  });
+
+  const providerLabelById = React.useMemo(
+    () => new Map(availableProviders.map((p) => [p.providerId, p.providerName] as const)),
+    [availableProviders],
+  );
+
+  const modelLabelByValue = React.useMemo(
+    () =>
+      new Map(
+        availableModels.map(
+          (m) =>
+            [
+              encodeModelFilter(m.providerId, m.modelId),
+              `${m.providerName} · ${m.modelName}`,
+            ] as const,
+        ),
+      ),
+    [availableModels],
+  );
+
+  return {
+    availableModels,
+    availableProviders,
+    filters: {
+      provider: providerFilter,
+      model: modelFilter,
+      range: rangeFilter,
+    },
+    labels: {
+      provider:
+        providerFilter === ALL_FILTER
+          ? 'All providers'
+          : (providerLabelById.get(providerFilter) ?? 'Provider'),
+      model:
+        modelFilter === ALL_FILTER ? 'All models' : (modelLabelByValue.get(modelFilter) ?? 'Model'),
+      range: RANGE_LABELS[rangeFilter],
+    },
+    isFetching,
+    setModelFilter,
+    setProviderFilter,
+    usageData,
+  };
+}

--- a/apps/web/src/lib/queries/usage.ts
+++ b/apps/web/src/lib/queries/usage.ts
@@ -1,6 +1,10 @@
 import { queryOptions } from '@tanstack/react-query';
 
-import type { UsageDashboardResponse, UsageDateRange } from '@stitch/shared/usage/types';
+import type {
+  SttUsageDashboardResponse,
+  UsageDashboardResponse,
+  UsageDateRange,
+} from '@stitch/shared/usage/types';
 
 import { serverFetch } from '@/lib/api';
 
@@ -15,26 +19,46 @@ type UsageDashboardFilters = {
 const usageKeys = {
   all: ['usage'] as const,
   dashboard: (filters: UsageDashboardFilters) => [...usageKeys.all, 'dashboard', filters] as const,
+  sttDashboard: (filters: UsageDashboardFilters) =>
+    [...usageKeys.all, 'stt-dashboard', filters] as const,
 };
+
+function buildQueryString(filters: UsageDashboardFilters): string {
+  const params = new URLSearchParams();
+
+  if (filters.providerId) params.set('providerId', filters.providerId);
+  if (filters.modelId) params.set('modelId', filters.modelId);
+  if (filters.range) params.set('range', filters.range);
+  if (filters.from) params.set('from', String(filters.from));
+  if (filters.to) params.set('to', String(filters.to));
+
+  return params.toString();
+}
 
 export const usageDashboardQueryOptions = (filters: UsageDashboardFilters) =>
   queryOptions({
     queryKey: usageKeys.dashboard(filters),
     queryFn: async (): Promise<UsageDashboardResponse> => {
-      const params = new URLSearchParams();
-
-      if (filters.providerId) params.set('providerId', filters.providerId);
-      if (filters.modelId) params.set('modelId', filters.modelId);
-      if (filters.range) params.set('range', filters.range);
-      if (filters.from) params.set('from', String(filters.from));
-      if (filters.to) params.set('to', String(filters.to));
-
-      const query = params.toString();
+      const query = buildQueryString(filters);
       const path = query.length > 0 ? `/usage?${query}` : '/usage';
 
       const res = await serverFetch(path);
       if (!res.ok) throw new Error('Failed to fetch usage dashboard');
       return res.json() as Promise<UsageDashboardResponse>;
+    },
+    staleTime: 30_000,
+  });
+
+export const sttUsageDashboardQueryOptions = (filters: UsageDashboardFilters) =>
+  queryOptions({
+    queryKey: usageKeys.sttDashboard(filters),
+    queryFn: async (): Promise<SttUsageDashboardResponse> => {
+      const query = buildQueryString(filters);
+      const path = query.length > 0 ? `/usage/stt?${query}` : '/usage/stt';
+
+      const res = await serverFetch(path);
+      if (!res.ok) throw new Error('Failed to fetch STT usage dashboard');
+      return res.json() as Promise<SttUsageDashboardResponse>;
     },
     staleTime: 30_000,
   });

--- a/packages/server/src/routes/usage.ts
+++ b/packages/server/src/routes/usage.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { USAGE_DATE_RANGES } from '@stitch/shared/usage/types';
 
 import { unwrapResult } from '@/lib/route-helpers.js';
-import { getUsageDashboard } from '@/usage/service.js';
+import { getSttUsageDashboard, getUsageDashboard } from '@/usage/service.js';
 
 const usageQuerySchema = z.object({
   providerId: z.string().optional(),
@@ -21,5 +21,12 @@ usageRouter.get('/', zValidator('query', usageQuerySchema), async (c) => {
   const { providerId, modelId, range, from, to } = c.req.valid('query');
 
   const result = await getUsageDashboard({ providerId, modelId, range, from, to });
+  return unwrapResult(c, result);
+});
+
+usageRouter.get('/stt', zValidator('query', usageQuerySchema), async (c) => {
+  const { providerId, modelId, range, from, to } = c.req.valid('query');
+
+  const result = await getSttUsageDashboard({ providerId, modelId, range, from, to });
   return unwrapResult(c, result);
 });

--- a/packages/server/src/usage/service.ts
+++ b/packages/server/src/usage/service.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, gte, isNotNull, lt } from 'drizzle-orm';
 
 import {
   USAGE_SOURCES,
+  type SttUsageDashboardResponse,
   type UsageDashboardResponse,
   type UsageBucketGranularity,
   type UsageDateRange,
@@ -12,7 +13,7 @@ import {
 import { getDb } from '@/db/client.js';
 import { recordingAnalyses } from '@/db/schema/recordings.js';
 import { sessions } from '@/db/schema/sessions.js';
-import { llmUsageEvents } from '@/db/schema/usage.js';
+import { llmUsageEvents, sttUsageEvents } from '@/db/schema/usage.js';
 import { ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import type { LanguageModelUsage } from 'ai';
@@ -500,6 +501,111 @@ export async function getUsageDashboard(
     totals: {
       costUsd: totalCostUsd,
       tokenMetrics: totalTokenMetrics,
+    },
+    buckets,
+  });
+}
+
+export async function getSttUsageDashboard(
+  input: GetUsageDashboardInput,
+): Promise<ServiceResult<SttUsageDashboardResponse>> {
+  const db = getDb();
+  const window = await resolveWindow(input);
+  const granularity = inferGranularity(window);
+  const bucketRanges = buildBucketRanges(window, granularity);
+
+  const buckets = bucketRanges.map((range) => ({
+    start: range.start,
+    end: range.end,
+    label: formatBucketLabel(range, granularity),
+    costUsdByService: {} as Record<string, number>,
+    durationMsByService: {} as Record<string, number>,
+  }));
+
+  const bucketIndexByStart = new Map(bucketRanges.map((range, index) => [range.start, index]));
+
+  const serviceSet = new Set<string>();
+  let totalCostUsd = 0;
+  let totalDurationMs = 0;
+
+  const usedProviderIds = new Set<string>();
+  const usedModelKeys = new Set<string>();
+
+  const conditions = [
+    gte(sttUsageEvents.startedAt, window.from),
+    lt(sttUsageEvents.startedAt, window.to),
+  ];
+  if (input.providerId) {
+    conditions.push(eq(sttUsageEvents.providerId, input.providerId));
+  }
+  if (input.modelId) {
+    conditions.push(eq(sttUsageEvents.modelId, input.modelId));
+  }
+
+  const rows = await db
+    .select({
+      startedAt: sttUsageEvents.startedAt,
+      providerId: sttUsageEvents.providerId,
+      modelId: sttUsageEvents.modelId,
+      service: sttUsageEvents.service,
+      costUsd: sttUsageEvents.costUsd,
+      rawData: sttUsageEvents.rawData,
+    })
+    .from(sttUsageEvents)
+    .where(and(...conditions));
+
+  for (const row of rows) {
+    usedProviderIds.add(row.providerId);
+    usedModelKeys.add(`${row.providerId}::${row.modelId}`);
+
+    const service = row.service;
+    const costUsd = row.costUsd ?? 0;
+    const durationMs = row.rawData?.durationMs ?? 0;
+
+    serviceSet.add(service);
+    totalCostUsd += costUsd;
+    totalDurationMs += durationMs;
+
+    const bucketStart = floorToGranularity(row.startedAt, granularity);
+    const bucketIndex = bucketIndexByStart.get(bucketStart);
+    if (bucketIndex === undefined) continue;
+
+    const bucket = buckets[bucketIndex];
+    if (!bucket) continue;
+
+    bucket.costUsdByService[service] = (bucket.costUsdByService[service] ?? 0) + costUsd;
+    bucket.durationMsByService[service] = (bucket.durationMsByService[service] ?? 0) + durationMs;
+  }
+
+  const services = Array.from(serviceSet).sort((a, b) => a.localeCompare(b));
+
+  return ok({
+    range: {
+      from: window.from,
+      to: window.to,
+      granularity,
+      bucketCount: buckets.length,
+    },
+    filters: {
+      providerId: input.providerId ?? null,
+      modelId: input.modelId ?? null,
+    },
+    usedProviders: Array.from(usedProviderIds).sort((a, b) => a.localeCompare(b)),
+    usedModels: Array.from(usedModelKeys)
+      .map((key) => {
+        const separator = key.indexOf('::');
+        return {
+          providerId: key.slice(0, separator),
+          modelId: key.slice(separator + 2),
+        };
+      })
+      .sort(
+        (a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId),
+      ),
+    services,
+    totals: {
+      costUsd: totalCostUsd,
+      durationMs: totalDurationMs,
     },
     buckets,
   });

--- a/packages/shared/src/usage/types.ts
+++ b/packages/shared/src/usage/types.ts
@@ -52,3 +52,32 @@ export type UsageDashboardResponse = {
   };
   buckets: UsageBucket[];
 };
+
+export type SttUsageBucket = {
+  start: number;
+  end: number;
+  label: string;
+  costUsdByService: Record<string, number>;
+  durationMsByService: Record<string, number>;
+};
+
+export type SttUsageDashboardResponse = {
+  range: {
+    from: number;
+    to: number;
+    granularity: UsageBucketGranularity;
+    bucketCount: number;
+  };
+  filters: {
+    providerId: string | null;
+    modelId: string | null;
+  };
+  usedProviders: string[];
+  usedModels: Array<{ providerId: string; modelId: string }>;
+  services: string[];
+  totals: {
+    costUsd: number;
+    durationMs: number;
+  };
+  buckets: SttUsageBucket[];
+};


### PR DESCRIPTION
## 🚀 Change Summary

Adds a Speech-to-Text tab to the usage dashboard so STT consumption can be monitored alongside LLM usage.

### ✨ New Features
- **STT Usage Tab**: New tab on the usage dashboard displaying cost and audio duration totals for STT events, broken down by service (\chat-input\, \meeting-recording\)
- **STT-specific filters**: The STT tab has its own provider/model filter dropdowns populated from STT models (via \/providers/stt/models\), independent of the LLM tab filters
- **Line-variant tabs**: Both tabs use the \line\ tab variant as requested

### 🛠 Improvements & Refactors
- Extracted \uildQueryString\ helper in the usage query file to avoid duplication between LLM and STT query options
- Shared date range filter state across both tabs (changing range on one tab applies to the other)