### PR TITLE
Extract STT model registry and fetch from API with local cache

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -158,6 +158,7 @@
         "@stitch-connectors/google": "workspace:*",
         "@stitch-connectors/sdk": "workspace:*",
         "@stitch/registry-embeddings": "workspace:*",
+        "@stitch/registry-stt": "workspace:*",
         "@stitch/sandbox": "workspace:*",
         "@stitch/scheduler": "workspace:*",
         "@stitch/shared": "workspace:*",
@@ -196,6 +197,9 @@
     },
     "registries/mcp": {
       "name": "@stitch/registry-mcp",
+    },
+    "registries/stt": {
+      "name": "@stitch/registry-stt",
     },
   },
   "catalog": {
@@ -911,6 +915,8 @@
     "@stitch/registry-live-transcription": ["@stitch/registry-live-transcription@workspace:registries/live-transcription"],
 
     "@stitch/registry-mcp": ["@stitch/registry-mcp@workspace:registries/mcp"],
+
+    "@stitch/registry-stt": ["@stitch/registry-stt@workspace:registries/stt"],
 
     "@stitch/sandbox": ["@stitch/sandbox@workspace:packages/sandbox"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -158,7 +158,6 @@
         "@stitch-connectors/google": "workspace:*",
         "@stitch-connectors/sdk": "workspace:*",
         "@stitch/registry-embeddings": "workspace:*",
-        "@stitch/registry-stt": "workspace:*",
         "@stitch/sandbox": "workspace:*",
         "@stitch/scheduler": "workspace:*",
         "@stitch/shared": "workspace:*",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,7 +30,6 @@
     "@stitch-connectors/google": "workspace:*",
     "@stitch-connectors/sdk": "workspace:*",
     "@stitch/registry-embeddings": "workspace:*",
-    "@stitch/registry-stt": "workspace:*",
     "@stitch/sandbox": "workspace:*",
     "@stitch/scheduler": "workspace:*",
     "@stitch/shared": "workspace:*",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,6 +30,7 @@
     "@stitch-connectors/google": "workspace:*",
     "@stitch-connectors/sdk": "workspace:*",
     "@stitch/registry-embeddings": "workspace:*",
+    "@stitch/registry-stt": "workspace:*",
     "@stitch/sandbox": "workspace:*",
     "@stitch/scheduler": "workspace:*",
     "@stitch/shared": "workspace:*",

--- a/packages/server/src/lib/paths.ts
+++ b/packages/server/src/lib/paths.ts
@@ -88,6 +88,7 @@ export const PATHS = {
     models: path.join(paths.cache, 'models.json'),
     embeddingModelsRegistry: path.join(paths.cache, 'embedding-models-registry.json'),
     transcriptionModelsRegistry: path.join(paths.cache, 'transcription-models-registry.json'),
+    sttModelsRegistry: path.join(paths.cache, 'stt-models-registry.json'),
     mcpRegistry: path.join(paths.cache, 'mcp-registry.json'),
   },
 

--- a/packages/server/src/provider/service.ts
+++ b/packages/server/src/provider/service.ts
@@ -5,7 +5,7 @@ import type { ServiceResult } from '@/lib/service-result.js';
 import * as EmbeddingModels from '@/llm/provider/embedding-models.js';
 import * as Models from '@/llm/provider/models.js';
 import * as TranscriptionModels from '@/llm/provider/transcription-models.js';
-import { MODEL_CATALOG } from '@/stt/models.js';
+import { getModelCatalog } from '@/stt/models.js';
 
 export type ProviderCapability = 'llm' | 'stt' | 'embedding' | 'transcription';
 
@@ -33,12 +33,14 @@ export async function listProvidersWithCapabilities(): Promise<
   ServiceResult<ProviderWithCapabilities[]>
 > {
   const db = getDb();
-  const [llmProviders, embeddingProviders, transcriptionProviders, configs] = await Promise.all([
-    Models.get(),
-    EmbeddingModels.getEmbeddingModels(),
-    TranscriptionModels.getTranscriptionModels(),
-    db.select({ providerId: providerConfig.providerId }).from(providerConfig),
-  ]);
+  const [llmProviders, embeddingProviders, transcriptionProviders, sttCatalog, configs] =
+    await Promise.all([
+      Models.get(),
+      EmbeddingModels.getEmbeddingModels(),
+      TranscriptionModels.getTranscriptionModels(),
+      getModelCatalog(),
+      db.select({ providerId: providerConfig.providerId }).from(providerConfig),
+    ]);
 
   const enabledIds = new Set(configs.map((row) => row.providerId));
 
@@ -61,7 +63,7 @@ export async function listProvidersWithCapabilities(): Promise<
     ensureEntry(provider.providerId).add('transcription');
   }
 
-  for (const entry of MODEL_CATALOG) {
+  for (const entry of sttCatalog) {
     ensureEntry(entry.providerId).add('stt');
   }
 
@@ -123,13 +125,15 @@ export async function listProvidersWithCapabilities(): Promise<
 
 export async function listEnabledSttModels(): Promise<ServiceResult<SttProviderModelsSummary[]>> {
   const db = getDb();
-  const configs = await db.select({ providerId: providerConfig.providerId }).from(providerConfig);
+  const [configs, sttCatalog, llmProviders] = await Promise.all([
+    db.select({ providerId: providerConfig.providerId }).from(providerConfig),
+    getModelCatalog(),
+    Models.get(),
+  ]);
   const enabledIds = new Set(configs.map((row) => row.providerId));
 
-  const llmProviders = await Models.get();
-
   const results: SttProviderModelsSummary[] = [];
-  for (const entry of MODEL_CATALOG) {
+  for (const entry of sttCatalog) {
     if (!enabledIds.has(entry.providerId)) continue;
     const providerName = llmProviders[entry.providerId]?.name ?? entry.providerId;
     results.push({

--- a/packages/server/src/scheduler/runtime.ts
+++ b/packages/server/src/scheduler/runtime.ts
@@ -8,6 +8,7 @@ import { refreshMcpRegistryCache } from '@/mcp/registry-service.js';
 import { refreshMcpToolsets } from '@/mcp/tool-executor.js';
 import { runMemoryMaintenance } from '@/memory/maintenance.js';
 import { createSchedulerStore } from '@/scheduler/store.js';
+import * as SttRegistry from '@/stt/stt-registry.js';
 import * as ToolTruncation from '@/tools/runtime/truncation.js';
 
 const log = Log.create({ service: 'scheduler' });
@@ -16,6 +17,7 @@ const HOUR_MS = 60 * 60 * 1000;
 const LOG_CLEANUP_INTERVAL_MS = 24 * HOUR_MS;
 const MEMORY_MAINTENANCE_INTERVAL_MS = 6 * HOUR_MS;
 const MODELS_REFRESH_INTERVAL_MS = 1 * HOUR_MS;
+const STT_REGISTRY_REFRESH_INTERVAL_MS = 6 * HOUR_MS;
 const TOOL_OUTPUT_CLEANUP_INTERVAL_MS = 1 * HOUR_MS;
 const MCP_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
 const MCP_REGISTRY_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
@@ -42,6 +44,12 @@ function getBuiltinJobs(): RegisteredJob[] {
       key: 'models-refresh',
       schedule: { type: 'interval', everyMs: MODELS_REFRESH_INTERVAL_MS },
       callback: () => ModelsDev.refresh(),
+      immediate: true,
+    },
+    {
+      key: 'stt-registry-refresh',
+      schedule: { type: 'interval', everyMs: STT_REGISTRY_REFRESH_INTERVAL_MS },
+      callback: () => SttRegistry.refresh(),
       immediate: true,
     },
     {

--- a/packages/server/src/stt/adapter-iface.ts
+++ b/packages/server/src/stt/adapter-iface.ts
@@ -28,6 +28,6 @@ export type STTTransport = {
 
 export type STTAdapter = {
   readonly providerId: string;
-  readonly models: ModelDescriptor[];
+  models(): Promise<ModelDescriptor[]>;
   connect(config: STTConnectionConfig): Promise<STTConnection>;
 };

--- a/packages/server/src/stt/adapters/elevenlabs.ts
+++ b/packages/server/src/stt/adapters/elevenlabs.ts
@@ -144,10 +144,9 @@ function createElevenLabsTransport(config: STTConnectionConfig) {
 export const elevenlabsAdapter: STTAdapter = {
   providerId: 'elevenlabs',
 
-  get models(): ModelDescriptor[] {
-    return [getModelDescriptor('elevenlabs', 'scribe_v2_realtime')].filter(
-      (m): m is ModelDescriptor => m !== null,
-    );
+  async models(): Promise<ModelDescriptor[]> {
+    const descriptor = await getModelDescriptor('elevenlabs', 'scribe_v2_realtime');
+    return descriptor ? [descriptor] : [];
   },
 
   async connect(config: STTConnectionConfig): Promise<STTConnection> {

--- a/packages/server/src/stt/adapters/openai.ts
+++ b/packages/server/src/stt/adapters/openai.ts
@@ -101,10 +101,9 @@ function createOpenAITransport(config: STTConnectionConfig) {
 export const openaiAdapter: STTAdapter = {
   providerId: 'openai',
 
-  get models(): ModelDescriptor[] {
-    return [getModelDescriptor('openai', 'gpt-realtime-whisper')].filter(
-      (m): m is ModelDescriptor => m !== null,
-    );
+  async models(): Promise<ModelDescriptor[]> {
+    const descriptor = await getModelDescriptor('openai', 'gpt-realtime-whisper');
+    return descriptor ? [descriptor] : [];
   },
 
   async connect(config: STTConnectionConfig): Promise<STTConnection> {

--- a/packages/server/src/stt/models.ts
+++ b/packages/server/src/stt/models.ts
@@ -1,68 +1,43 @@
+import elevenlabsRegistry from '@stitch/registry-stt/models/elevenlabs.json';
+import openaiRegistry from '@stitch/registry-stt/models/openai.json';
+
 import type { ModelDescriptor } from '@/stt/types.js';
+
+type RegistryModel = {
+  modelId: string;
+  displayName: string;
+  capabilities: Record<string, boolean>;
+  inputFormat: { encoding: string; sampleRateHz: number; channels: number };
+  partialStrategy: string;
+  buffer: {
+    maxChunkBytes: number;
+    flushIntervalMs: number;
+    maxBufferedMs: number;
+    paceRealtime: boolean;
+  };
+  reconnect: { enabled: boolean; maxRetries: number; backoffMs: number; rotateBeforeMs?: number };
+  pricing:
+    | { type: 'token'; perMillionTokens: { audioInput: number; textOutput: number } }
+    | { type: 'duration'; perMinuteUsd: number };
+};
+
+type RegistryProvider = {
+  providerId: string;
+  providerName: string;
+  models: RegistryModel[];
+};
 
 type CatalogEntry = {
   providerId: string;
   models: ModelDescriptor[];
 };
 
-export const MODEL_CATALOG: CatalogEntry[] = [
-  {
-    providerId: 'openai',
-    models: [
-      {
-        modelId: 'gpt-realtime-whisper',
-        displayName: 'GPT Realtime Whisper',
-        capabilities: {
-          partials: true,
-          word_timestamps: false,
-          utterance_timestamps: false,
-          diarization: false,
-          native_vad: false,
-          language_detection: true,
-          keyterm_biasing: false,
-        },
-        inputFormat: { encoding: 'pcm_s16le', sampleRateHz: 24000, channels: 1 },
-        partialStrategy: 'incremental',
-        buffer: {
-          maxChunkBytes: 65_536,
-          flushIntervalMs: 100,
-          maxBufferedMs: 30_000,
-          paceRealtime: false,
-        },
-        reconnect: { enabled: true, maxRetries: 5, backoffMs: 500, rotateBeforeMs: 29 * 60 * 1000 },
-        pricing: { type: 'token', perMillionTokens: { audioInput: 40, textOutput: 10 } },
-      },
-    ],
-  },
-  {
-    providerId: 'elevenlabs',
-    models: [
-      {
-        modelId: 'scribe_v2_realtime',
-        displayName: 'Scribe v2 Realtime',
-        capabilities: {
-          partials: true,
-          word_timestamps: true,
-          utterance_timestamps: true,
-          diarization: false,
-          native_vad: true,
-          language_detection: true,
-          keyterm_biasing: true,
-        },
-        inputFormat: { encoding: 'pcm_s16le', sampleRateHz: 16000, channels: 1 },
-        partialStrategy: 'cumulative',
-        buffer: {
-          maxChunkBytes: 32_768,
-          flushIntervalMs: 80,
-          maxBufferedMs: 20_000,
-          paceRealtime: false,
-        },
-        reconnect: { enabled: true, maxRetries: 5, backoffMs: 500 },
-        pricing: { type: 'duration', perMinuteUsd: 0.007 },
-      },
-    ],
-  },
-];
+const registries = [openaiRegistry, elevenlabsRegistry] as unknown as RegistryProvider[];
+
+export const MODEL_CATALOG: CatalogEntry[] = registries.map((registry) => ({
+  providerId: registry.providerId,
+  models: registry.models as unknown as ModelDescriptor[],
+}));
 
 export function getModelDescriptor(providerId: string, modelId: string): ModelDescriptor | null {
   const entry = MODEL_CATALOG.find((e) => e.providerId === providerId);

--- a/packages/server/src/stt/models.ts
+++ b/packages/server/src/stt/models.ts
@@ -1,46 +1,34 @@
-import elevenlabsRegistry from '@stitch/registry-stt/models/elevenlabs.json';
-import openaiRegistry from '@stitch/registry-stt/models/openai.json';
-
+import { getSttProvidersFromRegistry } from '@/stt/stt-registry.js';
+import type { SttModel, SttProvider } from '@/stt/stt-schema.js';
 import type { ModelDescriptor } from '@/stt/types.js';
-
-type RegistryModel = {
-  modelId: string;
-  displayName: string;
-  capabilities: Record<string, boolean>;
-  inputFormat: { encoding: string; sampleRateHz: number; channels: number };
-  partialStrategy: string;
-  buffer: {
-    maxChunkBytes: number;
-    flushIntervalMs: number;
-    maxBufferedMs: number;
-    paceRealtime: boolean;
-  };
-  reconnect: { enabled: boolean; maxRetries: number; backoffMs: number; rotateBeforeMs?: number };
-  pricing:
-    | { type: 'token'; perMillionTokens: { audioInput: number; textOutput: number } }
-    | { type: 'duration'; perMinuteUsd: number };
-};
-
-type RegistryProvider = {
-  providerId: string;
-  providerName: string;
-  models: RegistryModel[];
-};
 
 type CatalogEntry = {
   providerId: string;
   models: ModelDescriptor[];
 };
 
-const registries = [openaiRegistry, elevenlabsRegistry] as unknown as RegistryProvider[];
+function toModelDescriptor(model: SttModel): ModelDescriptor {
+  return model as unknown as ModelDescriptor;
+}
 
-export const MODEL_CATALOG: CatalogEntry[] = registries.map((registry) => ({
-  providerId: registry.providerId,
-  models: registry.models as unknown as ModelDescriptor[],
-}));
+function toCatalogEntry(provider: SttProvider): CatalogEntry {
+  return {
+    providerId: provider.providerId,
+    models: provider.models.map(toModelDescriptor),
+  };
+}
 
-export function getModelDescriptor(providerId: string, modelId: string): ModelDescriptor | null {
-  const entry = MODEL_CATALOG.find((e) => e.providerId === providerId);
+export async function getModelCatalog(): Promise<CatalogEntry[]> {
+  const providers = await getSttProvidersFromRegistry();
+  return providers.map(toCatalogEntry);
+}
+
+export async function getModelDescriptor(
+  providerId: string,
+  modelId: string,
+): Promise<ModelDescriptor | null> {
+  const catalog = await getModelCatalog();
+  const entry = catalog.find((e) => e.providerId === providerId);
   if (!entry) return null;
   return entry.models.find((m) => m.modelId === modelId) ?? null;
 }

--- a/packages/server/src/stt/session.ts
+++ b/packages/server/src/stt/session.ts
@@ -88,7 +88,7 @@ export async function createSTTSession(
   }
 
   // Resolve model
-  const maybeModel = getModelDescriptor(providerId, modelId);
+  const maybeModel = await getModelDescriptor(providerId, modelId);
   if (!maybeModel) {
     throw new STTSessionError(`Unknown STT model: ${modelId}`, 'unknown_model');
   }

--- a/packages/server/src/stt/stt-registry.ts
+++ b/packages/server/src/stt/stt-registry.ts
@@ -1,0 +1,30 @@
+import { PATHS } from '@/lib/paths.js';
+import { createRegistryCache } from '@/lib/registry-cache.js';
+import {
+  SttRegistryPayloadSchema,
+  type SttProvider,
+  type SttRegistryPayload,
+} from '@/stt/stt-schema.js';
+
+const DEFAULT_STT_REGISTRY_URL = 'https://usestitch.ai/stt-models.json';
+
+function getRegistryUrl(): string {
+  return process.env['STITCH_STT_REGISTRY_URL']?.trim() || DEFAULT_STT_REGISTRY_URL;
+}
+
+const sttRegistryCache = createRegistryCache<SttRegistryPayload>({
+  cacheFilePath: PATHS.filePaths.sttModelsRegistry,
+  get url() {
+    return getRegistryUrl();
+  },
+  parse: (raw) => SttRegistryPayloadSchema.parse(raw),
+});
+
+export async function getSttProvidersFromRegistry(fetchImpl = fetch): Promise<SttProvider[]> {
+  const payload = await sttRegistryCache.get(fetchImpl);
+  return payload.providers;
+}
+
+export async function refresh(fetchImpl = fetch): Promise<void> {
+  await sttRegistryCache.refresh(fetchImpl);
+}

--- a/packages/server/src/stt/stt-schema.ts
+++ b/packages/server/src/stt/stt-schema.ts
@@ -1,0 +1,78 @@
+import z from 'zod';
+
+const SttCapabilitySchema = z.enum([
+  'partials',
+  'word_timestamps',
+  'utterance_timestamps',
+  'diarization',
+  'native_vad',
+  'language_detection',
+  'keyterm_biasing',
+]);
+
+const AudioEncodingSchema = z.enum(['pcm_s16le', 'f32le']);
+
+const InputFormatSchema = z.object({
+  encoding: AudioEncodingSchema,
+  sampleRateHz: z.number().int().min(8000),
+  channels: z.number().int().positive(),
+});
+
+const BufferConfigSchema = z.object({
+  maxChunkBytes: z.number().int().positive(),
+  flushIntervalMs: z.number().int().positive(),
+  maxBufferedMs: z.number().int().positive(),
+  paceRealtime: z.boolean(),
+});
+
+const ReconnectConfigSchema = z.object({
+  enabled: z.boolean(),
+  maxRetries: z.number().int().nonnegative(),
+  backoffMs: z.number().int().nonnegative(),
+  rotateBeforeMs: z.number().int().positive().optional(),
+});
+
+const TokenPricingSchema = z.object({
+  type: z.literal('token'),
+  perMillionTokens: z.object({
+    audioInput: z.number().nonnegative(),
+    textOutput: z.number().nonnegative(),
+  }),
+});
+
+const DurationPricingSchema = z.object({
+  type: z.literal('duration'),
+  perMinuteUsd: z.number().nonnegative(),
+});
+
+const PricingSchema = z.discriminatedUnion('type', [TokenPricingSchema, DurationPricingSchema]);
+
+const PartialStrategySchema = z.enum(['cumulative', 'incremental']);
+
+export const SttModelSchema = z.object({
+  modelId: z.string().min(1),
+  displayName: z.string().min(1),
+  capabilities: z.record(SttCapabilitySchema, z.boolean()),
+  inputFormat: InputFormatSchema,
+  partialStrategy: PartialStrategySchema,
+  buffer: BufferConfigSchema,
+  reconnect: ReconnectConfigSchema,
+  pricing: PricingSchema,
+});
+
+export const SttProviderSchema = z.object({
+  $schema: z.string().optional(),
+  providerId: z.string().min(1),
+  providerName: z.string().min(1),
+  models: z.array(SttModelSchema).min(1),
+});
+
+export const SttRegistryPayloadSchema = z.object({
+  version: z.number().int().positive(),
+  generatedAt: z.string().datetime({ offset: true }),
+  providers: z.array(SttProviderSchema).min(1),
+});
+
+export type SttModel = z.infer<typeof SttModelSchema>;
+export type SttProvider = z.infer<typeof SttProviderSchema>;
+export type SttRegistryPayload = z.infer<typeof SttRegistryPayloadSchema>;

--- a/registries/stt/models/elevenlabs.json
+++ b/registries/stt/models/elevenlabs.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "../schema/stt-provider.schema.json",
+  "providerId": "elevenlabs",
+  "providerName": "ElevenLabs",
+  "models": [
+    {
+      "modelId": "scribe_v2_realtime",
+      "displayName": "Scribe v2 Realtime",
+      "capabilities": {
+        "partials": true,
+        "word_timestamps": true,
+        "utterance_timestamps": true,
+        "diarization": false,
+        "native_vad": true,
+        "language_detection": true,
+        "keyterm_biasing": true
+      },
+      "inputFormat": {
+        "encoding": "pcm_s16le",
+        "sampleRateHz": 16000,
+        "channels": 1
+      },
+      "partialStrategy": "cumulative",
+      "buffer": {
+        "maxChunkBytes": 32768,
+        "flushIntervalMs": 80,
+        "maxBufferedMs": 20000,
+        "paceRealtime": false
+      },
+      "reconnect": {
+        "enabled": true,
+        "maxRetries": 5,
+        "backoffMs": 500
+      },
+      "pricing": {
+        "type": "duration",
+        "perMinuteUsd": 0.007
+      }
+    }
+  ]
+}

--- a/registries/stt/models/openai.json
+++ b/registries/stt/models/openai.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "../schema/stt-provider.schema.json",
+  "providerId": "openai",
+  "providerName": "OpenAI",
+  "models": [
+    {
+      "modelId": "gpt-realtime-whisper",
+      "displayName": "GPT Realtime Whisper",
+      "capabilities": {
+        "partials": true,
+        "word_timestamps": false,
+        "utterance_timestamps": false,
+        "diarization": false,
+        "native_vad": false,
+        "language_detection": true,
+        "keyterm_biasing": false
+      },
+      "inputFormat": {
+        "encoding": "pcm_s16le",
+        "sampleRateHz": 24000,
+        "channels": 1
+      },
+      "partialStrategy": "incremental",
+      "buffer": {
+        "maxChunkBytes": 65536,
+        "flushIntervalMs": 100,
+        "maxBufferedMs": 30000,
+        "paceRealtime": false
+      },
+      "reconnect": {
+        "enabled": true,
+        "maxRetries": 5,
+        "backoffMs": 500,
+        "rotateBeforeMs": 1740000
+      },
+      "pricing": {
+        "type": "token",
+        "perMillionTokens": {
+          "audioInput": 40,
+          "textOutput": 10
+        }
+      }
+    }
+  ]
+}

--- a/registries/stt/package.json
+++ b/registries/stt/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@stitch/registry-stt",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./models/openai.json": "./models/openai.json",
+    "./models/elevenlabs.json": "./models/elevenlabs.json"
+  }
+}

--- a/registries/stt/schema/stt-provider.schema.json
+++ b/registries/stt/schema/stt-provider.schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://usestitch.ai/schemas/stt-provider.schema.json",
+  "title": "Stitch STT Provider Registry Entry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["providerId", "providerName", "models"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Optional JSON Schema reference for editor tooling"
+    },
+    "providerId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "providerName": {
+      "type": "string",
+      "minLength": 1
+    },
+    "models": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "modelId",
+          "displayName",
+          "capabilities",
+          "inputFormat",
+          "partialStrategy",
+          "buffer",
+          "reconnect",
+          "pricing"
+        ],
+        "properties": {
+          "modelId": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Unique model identifier"
+          },
+          "displayName": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Human-readable model name"
+          },
+          "capabilities": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "partials",
+              "word_timestamps",
+              "utterance_timestamps",
+              "diarization",
+              "native_vad",
+              "language_detection",
+              "keyterm_biasing"
+            ],
+            "properties": {
+              "partials": { "type": "boolean" },
+              "word_timestamps": { "type": "boolean" },
+              "utterance_timestamps": { "type": "boolean" },
+              "diarization": { "type": "boolean" },
+              "native_vad": { "type": "boolean" },
+              "language_detection": { "type": "boolean" },
+              "keyterm_biasing": { "type": "boolean" }
+            }
+          },
+          "inputFormat": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["encoding", "sampleRateHz", "channels"],
+            "properties": {
+              "encoding": {
+                "type": "string",
+                "enum": ["pcm_s16le", "f32le"]
+              },
+              "sampleRateHz": {
+                "type": "integer",
+                "minimum": 8000
+              },
+              "channels": {
+                "type": "integer",
+                "minimum": 1
+              }
+            }
+          },
+          "partialStrategy": {
+            "type": "string",
+            "enum": ["cumulative", "incremental"]
+          },
+          "buffer": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["maxChunkBytes", "flushIntervalMs", "maxBufferedMs", "paceRealtime"],
+            "properties": {
+              "maxChunkBytes": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "flushIntervalMs": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "maxBufferedMs": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "paceRealtime": {
+                "type": "boolean"
+              }
+            }
+          },
+          "reconnect": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["enabled", "maxRetries", "backoffMs"],
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "maxRetries": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "backoffMs": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "rotateBeforeMs": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Proactively rotate the connection before this many milliseconds elapse"
+              }
+            }
+          },
+          "pricing": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "description": "Cost information for this model",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["token", "duration"]
+              },
+              "perMillionTokens": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "Cost in USD per 1M tokens. Used when type=token.",
+                "properties": {
+                  "audioInput": {
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "textOutput": {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                }
+              },
+              "perMinuteUsd": {
+                "type": "number",
+                "minimum": 0,
+                "description": "Cost in USD per minute of audio. Used when type=duration."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/build-website-registries.mjs
+++ b/scripts/build-website-registries.mjs
@@ -14,10 +14,14 @@ const embeddingSchemaDir = join(embeddingsRegistryDir, 'schema');
 const liveTranscriptionRegistryDir = join(rootDir, 'registries', 'live-transcription');
 const liveTranscriptionModelsDir = join(liveTranscriptionRegistryDir, 'models');
 const liveTranscriptionSchemaDir = join(liveTranscriptionRegistryDir, 'schema');
+const sttRegistryDir = join(rootDir, 'registries', 'stt');
+const sttModelsDir = join(sttRegistryDir, 'models');
+const sttSchemaDir = join(sttRegistryDir, 'schema');
 const outputDir = join(rootDir, 'apps', 'website', 'dist');
 const outputFile = join(outputDir, 'mcp-registry.json');
 const embeddingOutputFile = join(outputDir, 'embedding-models.json');
 const liveTranscriptionOutputFile = join(outputDir, 'live-transcription-models.json');
+const sttOutputFile = join(outputDir, 'stt-models.json');
 const websiteBaseUrl = 'https://usestitch.ai';
 
 function readJson(path) {
@@ -267,6 +271,78 @@ function assertLiveTranscriptionProviderConfig(provider, filePath) {
   }
 }
 
+function assertSttModel(model, filePath) {
+  assert(model && typeof model === 'object', `${filePath}: model must be an object`);
+  assert(
+    typeof model.modelId === 'string' && model.modelId.length > 0,
+    `${filePath}: model.modelId is required`,
+  );
+  assert(
+    typeof model.displayName === 'string' && model.displayName.length > 0,
+    `${filePath}: model.displayName is required`,
+  );
+  assert(
+    model.capabilities && typeof model.capabilities === 'object',
+    `${filePath}: model.capabilities is required`,
+  );
+  assert(
+    model.inputFormat && typeof model.inputFormat === 'object',
+    `${filePath}: model.inputFormat is required`,
+  );
+  assert(
+    model.inputFormat.encoding === 'pcm_s16le' || model.inputFormat.encoding === 'f32le',
+    `${filePath}: model.inputFormat.encoding must be pcm_s16le or f32le`,
+  );
+  assert(
+    Number.isInteger(model.inputFormat.sampleRateHz) && model.inputFormat.sampleRateHz >= 8000,
+    `${filePath}: model.inputFormat.sampleRateHz must be an integer >= 8000`,
+  );
+  assert(
+    Number.isInteger(model.inputFormat.channels) && model.inputFormat.channels >= 1,
+    `${filePath}: model.inputFormat.channels must be a positive integer`,
+  );
+  assert(
+    model.partialStrategy === 'cumulative' || model.partialStrategy === 'incremental',
+    `${filePath}: model.partialStrategy must be cumulative or incremental`,
+  );
+  assert(model.buffer && typeof model.buffer === 'object', `${filePath}: model.buffer is required`);
+  assert(
+    model.reconnect && typeof model.reconnect === 'object',
+    `${filePath}: model.reconnect is required`,
+  );
+  assert(
+    model.pricing && typeof model.pricing === 'object',
+    `${filePath}: model.pricing is required`,
+  );
+  assert(
+    model.pricing.type === 'token' || model.pricing.type === 'duration',
+    `${filePath}: model.pricing.type must be token or duration`,
+  );
+}
+
+function assertSttProviderConfig(provider, filePath) {
+  assert(provider && typeof provider === 'object', `${filePath}: config must be an object`);
+  assert(
+    typeof provider.providerId === 'string' && provider.providerId.length > 0,
+    `${filePath}: providerId is required`,
+  );
+  assert(
+    typeof provider.providerName === 'string' && provider.providerName.length > 0,
+    `${filePath}: providerName is required`,
+  );
+  assert(
+    Array.isArray(provider.models) && provider.models.length > 0,
+    `${filePath}: models must be a non-empty array`,
+  );
+
+  const ids = new Set();
+  for (const model of provider.models) {
+    assertSttModel(model, filePath);
+    assert(!ids.has(model.modelId), `${filePath}: duplicate model id ${model.modelId}`);
+    ids.add(model.modelId);
+  }
+}
+
 function loadServerConfigs() {
   const entries = readdirSync(serversDir, { withFileTypes: true }).filter((entry) =>
     entry.isDirectory(),
@@ -347,7 +423,27 @@ function loadLiveTranscriptionProviderConfigs() {
   return providers.toSorted((a, b) => a.providerName.localeCompare(b.providerName));
 }
 
-function writeOutput(servers, embeddingProviders, liveTranscriptionProviders) {
+function loadSttProviderConfigs() {
+  const files = readdirSync(sttModelsDir)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => join(sttModelsDir, name));
+
+  const providers = files.map((filePath) => {
+    const parsed = readJson(filePath);
+    assertSttProviderConfig(parsed, filePath);
+    return parsed;
+  });
+
+  const ids = new Set();
+  for (const provider of providers) {
+    assert(!ids.has(provider.providerId), `Duplicate STT provider id: ${provider.providerId}`);
+    ids.add(provider.providerId);
+  }
+
+  return providers.toSorted((a, b) => a.providerName.localeCompare(b.providerName));
+}
+
+function writeOutput(servers, embeddingProviders, liveTranscriptionProviders, sttProviders) {
   mkdirSync(outputDir, { recursive: true });
   mkdirSync(join(outputDir, 'schemas'), { recursive: true });
   mkdirSync(join(outputDir, 'mcp', 'servers'), { recursive: true });
@@ -364,6 +460,10 @@ function writeOutput(servers, embeddingProviders, liveTranscriptionProviders) {
   cpSync(
     join(liveTranscriptionSchemaDir, 'live-transcription-provider.schema.json'),
     join(outputDir, 'schemas', 'live-transcription-provider.schema.json'),
+  );
+  cpSync(
+    join(sttSchemaDir, 'stt-provider.schema.json'),
+    join(outputDir, 'schemas', 'stt-provider.schema.json'),
   );
 
   for (const server of servers) {
@@ -401,13 +501,22 @@ function writeOutput(servers, embeddingProviders, liveTranscriptionProviders) {
     `${JSON.stringify(liveTranscriptionPayload, null, 2)}\n`,
     'utf8',
   );
+
+  const sttPayload = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    providers: sttProviders,
+  };
+
+  writeFileSync(sttOutputFile, `${JSON.stringify(sttPayload, null, 2)}\n`, 'utf8');
 }
 
 function main() {
   const servers = loadServerConfigs();
   const embeddingProviders = loadEmbeddingProviderConfigs();
   const liveTranscriptionProviders = loadLiveTranscriptionProviderConfigs();
-  writeOutput(servers, embeddingProviders, liveTranscriptionProviders);
+  const sttProviders = loadSttProviderConfigs();
+  writeOutput(servers, embeddingProviders, liveTranscriptionProviders, sttProviders);
   console.log(`Built MCP registry with ${servers.length} server(s): ${outputFile}`);
   console.log(
     `Built embedding registry with ${embeddingProviders.length} provider(s): ${embeddingOutputFile}`,
@@ -415,6 +524,7 @@ function main() {
   console.log(
     `Built live transcription registry with ${liveTranscriptionProviders.length} provider(s): ${liveTranscriptionOutputFile}`,
   );
+  console.log(`Built STT registry with ${sttProviders.length} provider(s): ${sttOutputFile}`);
 }
 
 main();


### PR DESCRIPTION
## 🚀 Change Summary

Move STT model definitions from a hardcoded server package import to a JSON-based registry hosted on the website, fetched at runtime and cached locally with periodic refresh — following the same pattern as embeddings and live-transcription registries.

### ✨ New Features
- **STT Registry (registries/stt/)**: JSON model definition files for OpenAI and ElevenLabs STT providers, with JSON Schema validation
- **API-based model fetching**: Server fetches \stt-models.json\ from the website API at startup and caches to disk, eliminating the need for a workspace package dependency
- **Scheduled refresh**: STT registry auto-refreshes every 6 hours via the scheduler

### 🛠 Improvements & Refactors
- \models.ts\ now exports async \getModelCatalog()\ and \getModelDescriptor()\ backed by \createRegistryCache\
- Added Zod schema (\stt-schema.ts\) for runtime validation of the registry payload
- \STTAdapter.models\ changed from sync getter to async method
- \provider/service.ts\ parallelizes STT catalog fetch alongside other provider queries
- Build script validates and outputs \stt-models.json\ for the website