### PR TITLE
fix(ci): restore bun setup required by wrangler-action in deploy-cloudflare

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
       - name: Build website registry artifacts
         run: node scripts/build-website-registries.mjs
 


### PR DESCRIPTION
## 🐛 Bug Fixes

- **Restore bun setup step**: \cloudflare/wrangler-action@v3\ requires \un\ in PATH. This was removed in #286 causing the deploy workflow to fail with \Unable to locate executable file: bun\.

Fixes: https://github.com/UseStitch/stitch/actions/runs/27153720224/job/80151077892