### PR TITLE
refactor: fetch embedding models from registry like STT models

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -157,7 +157,6 @@
         "@openrouter/ai-sdk-provider": "catalog:ai",
         "@stitch-connectors/google": "workspace:*",
         "@stitch-connectors/sdk": "workspace:*",
-        "@stitch/registry-embeddings": "workspace:*",
         "@stitch/sandbox": "workspace:*",
         "@stitch/scheduler": "workspace:*",
         "@stitch/shared": "workspace:*",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -29,7 +29,6 @@
     "@openrouter/ai-sdk-provider": "catalog:ai",
     "@stitch-connectors/google": "workspace:*",
     "@stitch-connectors/sdk": "workspace:*",
-    "@stitch/registry-embeddings": "workspace:*",
     "@stitch/sandbox": "workspace:*",
     "@stitch/scheduler": "workspace:*",
     "@stitch/shared": "workspace:*",

--- a/packages/server/src/llm/provider/embedding-registry.ts
+++ b/packages/server/src/llm/provider/embedding-registry.ts
@@ -1,10 +1,6 @@
-import googleRegistry from '@stitch/registry-embeddings/models/google.json';
-import openaiRegistry from '@stitch/registry-embeddings/models/openai.json';
-
 import { PATHS } from '@/lib/paths.js';
 import { createRegistryCache } from '@/lib/registry-cache.js';
 import {
-  EmbeddingProviderSchema,
   EmbeddingRegistryPayloadSchema,
   type EmbeddingModel,
   type EmbeddingProvider,
@@ -13,8 +9,6 @@ import {
 import type { RawModel, RawProvider } from '@/llm/provider/models.js';
 
 const DEFAULT_EMBEDDING_REGISTRY_URL = 'https://usestitch.ai/embedding-models.json';
-
-const registries = [googleRegistry, openaiRegistry] as const;
 
 function toRawModel(model: EmbeddingModel): RawModel {
   return {
@@ -62,21 +56,12 @@ function getRegistryUrl(): string {
   return process.env['STITCH_EMBEDDING_REGISTRY_URL']?.trim() || DEFAULT_EMBEDDING_REGISTRY_URL;
 }
 
-function getBundledRegistryPayload(): EmbeddingRegistryPayload {
-  return {
-    version: 1,
-    generatedAt: new Date(0).toISOString(),
-    providers: registries.map((registry) => EmbeddingProviderSchema.parse(registry)),
-  };
-}
-
 const embeddingRegistryCache = createRegistryCache<EmbeddingRegistryPayload>({
   cacheFilePath: PATHS.filePaths.embeddingModelsRegistry,
   get url() {
     return getRegistryUrl();
   },
   parse: (raw) => EmbeddingRegistryPayloadSchema.parse(raw),
-  fallback: getBundledRegistryPayload(),
 });
 
 export async function getEmbeddingModelsFromRegistry(
@@ -84,4 +69,8 @@ export async function getEmbeddingModelsFromRegistry(
 ): Promise<Record<string, RawProvider>> {
   const payload = await embeddingRegistryCache.get(fetchImpl);
   return toRawProviders(payload.providers);
+}
+
+export async function refresh(fetchImpl = fetch): Promise<void> {
+  await embeddingRegistryCache.refresh(fetchImpl);
 }

--- a/packages/server/src/scheduler/runtime.ts
+++ b/packages/server/src/scheduler/runtime.ts
@@ -3,6 +3,7 @@ import type { RegisteredJob } from '@stitch/scheduler';
 
 import { refreshExpiringTokens } from '@/connectors/auth/token-refresh.js';
 import * as Log from '@/lib/log.js';
+import * as EmbeddingRegistry from '@/llm/provider/embedding-registry.js';
 import * as ModelsDev from '@/llm/provider/models.js';
 import { refreshMcpRegistryCache } from '@/mcp/registry-service.js';
 import { refreshMcpToolsets } from '@/mcp/tool-executor.js';
@@ -18,6 +19,7 @@ const LOG_CLEANUP_INTERVAL_MS = 24 * HOUR_MS;
 const MEMORY_MAINTENANCE_INTERVAL_MS = 6 * HOUR_MS;
 const MODELS_REFRESH_INTERVAL_MS = 1 * HOUR_MS;
 const STT_REGISTRY_REFRESH_INTERVAL_MS = 6 * HOUR_MS;
+const EMBEDDING_REGISTRY_REFRESH_INTERVAL_MS = 6 * HOUR_MS;
 const TOOL_OUTPUT_CLEANUP_INTERVAL_MS = 1 * HOUR_MS;
 const MCP_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
 const MCP_REGISTRY_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
@@ -50,6 +52,12 @@ function getBuiltinJobs(): RegisteredJob[] {
       key: 'stt-registry-refresh',
       schedule: { type: 'interval', everyMs: STT_REGISTRY_REFRESH_INTERVAL_MS },
       callback: () => SttRegistry.refresh(),
+      immediate: true,
+    },
+    {
+      key: 'embedding-registry-refresh',
+      schedule: { type: 'interval', everyMs: EMBEDDING_REGISTRY_REFRESH_INTERVAL_MS },
+      callback: () => EmbeddingRegistry.refresh(),
       immediate: true,
     },
     {

--- a/scripts/build-website-registries.mjs
+++ b/scripts/build-website-registries.mjs
@@ -5,24 +5,8 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
 
-const registryDir = join(rootDir, 'registries', 'mcp');
-const serversDir = join(registryDir, 'servers');
-const schemaDir = join(registryDir, 'schema');
-const embeddingsRegistryDir = join(rootDir, 'registries', 'embeddings');
-const embeddingModelsDir = join(embeddingsRegistryDir, 'models');
-const embeddingSchemaDir = join(embeddingsRegistryDir, 'schema');
-const liveTranscriptionRegistryDir = join(rootDir, 'registries', 'live-transcription');
-const liveTranscriptionModelsDir = join(liveTranscriptionRegistryDir, 'models');
-const liveTranscriptionSchemaDir = join(liveTranscriptionRegistryDir, 'schema');
-const sttRegistryDir = join(rootDir, 'registries', 'stt');
-const sttModelsDir = join(sttRegistryDir, 'models');
-const sttSchemaDir = join(sttRegistryDir, 'schema');
+const WEBSITE_BASE_URL = 'https://usestitch.ai';
 const outputDir = join(rootDir, 'apps', 'website', 'dist');
-const outputFile = join(outputDir, 'mcp-registry.json');
-const embeddingOutputFile = join(outputDir, 'embedding-models.json');
-const liveTranscriptionOutputFile = join(outputDir, 'live-transcription-models.json');
-const sttOutputFile = join(outputDir, 'stt-models.json');
-const websiteBaseUrl = 'https://usestitch.ai';
 
 function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
@@ -34,19 +18,51 @@ function assert(condition, message) {
   }
 }
 
-function assertAuthConfig(authConfig, filePath) {
+// --- Validation helpers ---
+
+function assertNonEmptyString(value, filePath, field) {
+  assert(typeof value === 'string' && value.length > 0, `${filePath}: ${field} is required`);
+}
+
+function assertObject(value, filePath, field) {
+  assert(value && typeof value === 'object', `${filePath}: ${field} is required`);
+}
+
+function assertPositiveInt(value, filePath, field) {
+  assert(Number.isInteger(value) && value > 0, `${filePath}: ${field} must be a positive integer`);
+}
+
+function assertNonEmptyArray(value, filePath, field) {
   assert(
-    authConfig && typeof authConfig === 'object',
-    `${filePath}: install.authConfig is required`,
+    Array.isArray(value) && value.length > 0,
+    `${filePath}: ${field} must be a non-empty array`,
   );
+}
+
+function assertOneOf(value, allowed, filePath, field) {
+  assert(allowed.includes(value), `${filePath}: ${field} must be ${allowed.join(' or ')}`);
+}
+
+function assertOptionalNonEmptyArray(value, filePath, field) {
+  if (value === undefined) return;
+  assertNonEmptyArray(value, filePath, field);
+}
+
+function assertOptionalNumber(value, filePath, field) {
+  if (value === undefined) return;
+  assert(typeof value === 'number', `${filePath}: ${field} must be a number`);
+}
+
+// --- Auth config validation ---
+
+function assertAuthConfig(authConfig, filePath) {
+  assertObject(authConfig, filePath, 'install.authConfig');
   assert(
     typeof authConfig.type === 'string',
     `${filePath}: install.authConfig.type must be a string`,
   );
 
-  if (authConfig.type === 'none') {
-    return;
-  }
+  if (authConfig.type === 'none') return;
 
   if (authConfig.type === 'api_key') {
     assert(
@@ -74,46 +90,26 @@ function assertAuthConfig(authConfig, filePath) {
   throw new Error(`${filePath}: unsupported auth type ${String(authConfig.type)}`);
 }
 
+// --- MCP server validation ---
+
 function assertServerConfig(server, filePath) {
-  assert(server && typeof server === 'object', `${filePath}: config must be an object`);
-  assert(typeof server.id === 'string' && server.id.length > 0, `${filePath}: id is required`);
-  assert(
-    typeof server.name === 'string' && server.name.length > 0,
-    `${filePath}: name is required`,
-  );
-  assert(
-    typeof server.description === 'string' && server.description.length > 0,
-    `${filePath}: description is required`,
-  );
-  assert(
-    typeof server.docsUrl === 'string' && server.docsUrl.length > 0,
-    `${filePath}: docsUrl is required`,
-  );
+  assertObject(server, filePath, 'config');
+  assertNonEmptyString(server.id, filePath, 'id');
+  assertNonEmptyString(server.name, filePath, 'name');
+  assertNonEmptyString(server.description, filePath, 'description');
+  assertNonEmptyString(server.docsUrl, filePath, 'docsUrl');
+
   if (server.logoUrl !== undefined) {
-    assert(
-      typeof server.logoUrl === 'string' && server.logoUrl.length > 0,
-      `${filePath}: logoUrl must be a string`,
-    );
+    assertNonEmptyString(server.logoUrl, filePath, 'logoUrl');
   }
-  assert(
-    Array.isArray(server.tags) && server.tags.length > 0,
-    `${filePath}: tags must be a non-empty array`,
-  );
+
+  assertNonEmptyArray(server.tags, filePath, 'tags');
 
   const install = server.install;
-  assert(install && typeof install === 'object', `${filePath}: install is required`);
-  assert(
-    typeof install.name === 'string' && install.name.length > 0,
-    `${filePath}: install.name is required`,
-  );
-  assert(
-    install.transport === 'http' || install.transport === 'stdio',
-    `${filePath}: install.transport must be http or stdio`,
-  );
-  assert(
-    typeof install.url === 'string' && install.url.length > 0,
-    `${filePath}: install.url is required`,
-  );
+  assertObject(install, filePath, 'install');
+  assertNonEmptyString(install.name, filePath, 'install.name');
+  assertOneOf(install.transport, ['http', 'stdio'], filePath, 'install.transport');
+  assertNonEmptyString(install.url, filePath, 'install.url');
   assertAuthConfig(install.authConfig, filePath);
 
   if (install.optionalAuthConfigs !== undefined) {
@@ -127,223 +123,158 @@ function assertServerConfig(server, filePath) {
   }
 }
 
+// --- Embedding model validation ---
+
 function assertEmbeddingModel(model, filePath) {
-  assert(model && typeof model === 'object', `${filePath}: model must be an object`);
-  assert(typeof model.id === 'string' && model.id.length > 0, `${filePath}: model.id is required`);
-  assert(
-    typeof model.name === 'string' && model.name.length > 0,
-    `${filePath}: model.name is required`,
-  );
-  assert(
-    Number.isInteger(model.dimensions) && model.dimensions > 0,
-    `${filePath}: model.dimensions must be a positive integer`,
-  );
-  assert(
-    typeof model.release_date === 'string' && model.release_date.length > 0,
-    `${filePath}: model.release_date is required`,
-  );
-  assert(
-    Number.isInteger(model.context) && model.context > 0,
-    `${filePath}: model.context must be a positive integer`,
-  );
-  if (model.inputModalities !== undefined) {
-    assert(
-      Array.isArray(model.inputModalities) && model.inputModalities.length > 0,
-      `${filePath}: model.inputModalities must be a non-empty array`,
-    );
-  }
-  if (model.outputModalities !== undefined) {
-    assert(
-      Array.isArray(model.outputModalities) && model.outputModalities.length > 0,
-      `${filePath}: model.outputModalities must be a non-empty array`,
-    );
-  }
-  assert(model.cost && typeof model.cost === 'object', `${filePath}: model.cost is required`);
+  assertObject(model, filePath, 'model');
+  assertNonEmptyString(model.id, filePath, 'model.id');
+  assertNonEmptyString(model.name, filePath, 'model.name');
+  assertPositiveInt(model.dimensions, filePath, 'model.dimensions');
+  assertNonEmptyString(model.release_date, filePath, 'model.release_date');
+  assertPositiveInt(model.context, filePath, 'model.context');
+  assertOptionalNonEmptyArray(model.inputModalities, filePath, 'model.inputModalities');
+  assertOptionalNonEmptyArray(model.outputModalities, filePath, 'model.outputModalities');
+  assertObject(model.cost, filePath, 'model.cost');
   assert(typeof model.cost.input === 'number', `${filePath}: model.cost.input must be a number`);
-  if (model.cost.inputImage !== undefined) {
-    assert(
-      typeof model.cost.inputImage === 'number',
-      `${filePath}: model.cost.inputImage must be a number`,
-    );
-  }
-  if (model.cost.inputAudio !== undefined) {
-    assert(
-      typeof model.cost.inputAudio === 'number',
-      `${filePath}: model.cost.inputAudio must be a number`,
-    );
-  }
-  if (model.cost.inputVideo !== undefined) {
-    assert(
-      typeof model.cost.inputVideo === 'number',
-      `${filePath}: model.cost.inputVideo must be a number`,
-    );
-  }
+  assertOptionalNumber(model.cost.inputImage, filePath, 'model.cost.inputImage');
+  assertOptionalNumber(model.cost.inputAudio, filePath, 'model.cost.inputAudio');
+  assertOptionalNumber(model.cost.inputVideo, filePath, 'model.cost.inputVideo');
   assert(typeof model.cost.output === 'number', `${filePath}: model.cost.output must be a number`);
 }
 
 function assertEmbeddingProviderConfig(provider, filePath) {
-  assert(provider && typeof provider === 'object', `${filePath}: config must be an object`);
-  assert(
-    provider.providerId === 'google' || provider.providerId === 'openai',
-    `${filePath}: providerId must be google or openai`,
-  );
-  assert(
-    typeof provider.providerName === 'string' && provider.providerName.length > 0,
-    `${filePath}: providerName is required`,
-  );
-  assert(
-    Array.isArray(provider.models) && provider.models.length > 0,
-    `${filePath}: models must be a non-empty array`,
-  );
-
-  const ids = new Set();
+  assertObject(provider, filePath, 'config');
+  assertOneOf(provider.providerId, ['google', 'openai'], filePath, 'providerId');
+  assertNonEmptyString(provider.providerName, filePath, 'providerName');
+  assertNonEmptyArray(provider.models, filePath, 'models');
+  assertUniqueIds(provider.models, (m) => m.id, filePath);
   for (const model of provider.models) {
     assertEmbeddingModel(model, filePath);
-    assert(!ids.has(model.id), `${filePath}: duplicate model id ${model.id}`);
-    ids.add(model.id);
   }
 }
 
+// --- Live transcription model validation ---
+
 function assertLiveTranscriptionModel(model, filePath) {
-  assert(model && typeof model === 'object', `${filePath}: model must be an object`);
-  assert(typeof model.id === 'string' && model.id.length > 0, `${filePath}: model.id is required`);
-  assert(
-    typeof model.name === 'string' && model.name.length > 0,
-    `${filePath}: model.name is required`,
-  );
+  assertObject(model, filePath, 'model');
+  assertNonEmptyString(model.id, filePath, 'model.id');
+  assertNonEmptyString(model.name, filePath, 'model.name');
   assert(
     typeof model.endpoint === 'string' && model.endpoint.startsWith('wss://'),
     `${filePath}: model.endpoint must be a wss:// URL`,
   );
-  assert(model.audio && typeof model.audio === 'object', `${filePath}: model.audio is required`);
+  assertObject(model.audio, filePath, 'model.audio');
   assert(
     Number.isInteger(model.audio.sampleRate) && model.audio.sampleRate >= 8000,
     `${filePath}: model.audio.sampleRate must be an integer >= 8000`,
   );
-  assert(
-    Number.isInteger(model.audio.channels) && model.audio.channels >= 1,
-    `${filePath}: model.audio.channels must be a positive integer`,
-  );
+  assertPositiveInt(model.audio.channels, filePath, 'model.audio.channels');
   assert(
     model.audio.encoding === 'pcm_s16le',
     `${filePath}: model.audio.encoding must be pcm_s16le`,
   );
-  assert(
-    model.connection && typeof model.connection === 'object',
-    `${filePath}: model.connection is required`,
+  assertObject(model.connection, filePath, 'model.connection');
+  assertOneOf(model.connection.mode, ['per-source', 'single'], filePath, 'model.connection.mode');
+  assertOneOf(
+    model.connection.authMethod,
+    ['query-param', 'header'],
+    filePath,
+    'model.connection.authMethod',
   );
-  assert(
-    model.connection.mode === 'per-source' || model.connection.mode === 'single',
-    `${filePath}: model.connection.mode must be per-source or single`,
-  );
-  assert(
-    model.connection.authMethod === 'query-param' || model.connection.authMethod === 'header',
-    `${filePath}: model.connection.authMethod must be query-param or header`,
-  );
-  if (model.supportedLanguages !== undefined) {
-    assert(
-      Array.isArray(model.supportedLanguages) && model.supportedLanguages.length > 0,
-      `${filePath}: model.supportedLanguages must be a non-empty array`,
-    );
-  }
+  assertOptionalNonEmptyArray(model.supportedLanguages, filePath, 'model.supportedLanguages');
 }
 
 function assertLiveTranscriptionProviderConfig(provider, filePath) {
-  assert(provider && typeof provider === 'object', `${filePath}: config must be an object`);
-  assert(
-    provider.providerId === 'google' || provider.providerId === 'openai',
-    `${filePath}: providerId must be google or openai`,
-  );
-  assert(
-    typeof provider.providerName === 'string' && provider.providerName.length > 0,
-    `${filePath}: providerName is required`,
-  );
-  assert(
-    Array.isArray(provider.models) && provider.models.length > 0,
-    `${filePath}: models must be a non-empty array`,
-  );
-
-  const ids = new Set();
+  assertObject(provider, filePath, 'config');
+  assertOneOf(provider.providerId, ['google', 'openai'], filePath, 'providerId');
+  assertNonEmptyString(provider.providerName, filePath, 'providerName');
+  assertNonEmptyArray(provider.models, filePath, 'models');
+  assertUniqueIds(provider.models, (m) => m.id, filePath);
   for (const model of provider.models) {
     assertLiveTranscriptionModel(model, filePath);
-    assert(!ids.has(model.id), `${filePath}: duplicate model id ${model.id}`);
-    ids.add(model.id);
   }
 }
 
+// --- STT model validation ---
+
 function assertSttModel(model, filePath) {
-  assert(model && typeof model === 'object', `${filePath}: model must be an object`);
-  assert(
-    typeof model.modelId === 'string' && model.modelId.length > 0,
-    `${filePath}: model.modelId is required`,
-  );
-  assert(
-    typeof model.displayName === 'string' && model.displayName.length > 0,
-    `${filePath}: model.displayName is required`,
-  );
-  assert(
-    model.capabilities && typeof model.capabilities === 'object',
-    `${filePath}: model.capabilities is required`,
-  );
-  assert(
-    model.inputFormat && typeof model.inputFormat === 'object',
-    `${filePath}: model.inputFormat is required`,
-  );
-  assert(
-    model.inputFormat.encoding === 'pcm_s16le' || model.inputFormat.encoding === 'f32le',
-    `${filePath}: model.inputFormat.encoding must be pcm_s16le or f32le`,
+  assertObject(model, filePath, 'model');
+  assertNonEmptyString(model.modelId, filePath, 'model.modelId');
+  assertNonEmptyString(model.displayName, filePath, 'model.displayName');
+  assertObject(model.capabilities, filePath, 'model.capabilities');
+  assertObject(model.inputFormat, filePath, 'model.inputFormat');
+  assertOneOf(
+    model.inputFormat.encoding,
+    ['pcm_s16le', 'f32le'],
+    filePath,
+    'model.inputFormat.encoding',
   );
   assert(
     Number.isInteger(model.inputFormat.sampleRateHz) && model.inputFormat.sampleRateHz >= 8000,
     `${filePath}: model.inputFormat.sampleRateHz must be an integer >= 8000`,
   );
-  assert(
-    Number.isInteger(model.inputFormat.channels) && model.inputFormat.channels >= 1,
-    `${filePath}: model.inputFormat.channels must be a positive integer`,
+  assertPositiveInt(model.inputFormat.channels, filePath, 'model.inputFormat.channels');
+  assertOneOf(
+    model.partialStrategy,
+    ['cumulative', 'incremental'],
+    filePath,
+    'model.partialStrategy',
   );
-  assert(
-    model.partialStrategy === 'cumulative' || model.partialStrategy === 'incremental',
-    `${filePath}: model.partialStrategy must be cumulative or incremental`,
-  );
-  assert(model.buffer && typeof model.buffer === 'object', `${filePath}: model.buffer is required`);
-  assert(
-    model.reconnect && typeof model.reconnect === 'object',
-    `${filePath}: model.reconnect is required`,
-  );
-  assert(
-    model.pricing && typeof model.pricing === 'object',
-    `${filePath}: model.pricing is required`,
-  );
-  assert(
-    model.pricing.type === 'token' || model.pricing.type === 'duration',
-    `${filePath}: model.pricing.type must be token or duration`,
-  );
+  assertObject(model.buffer, filePath, 'model.buffer');
+  assertObject(model.reconnect, filePath, 'model.reconnect');
+  assertObject(model.pricing, filePath, 'model.pricing');
+  assertOneOf(model.pricing.type, ['token', 'duration'], filePath, 'model.pricing.type');
 }
 
 function assertSttProviderConfig(provider, filePath) {
-  assert(provider && typeof provider === 'object', `${filePath}: config must be an object`);
-  assert(
-    typeof provider.providerId === 'string' && provider.providerId.length > 0,
-    `${filePath}: providerId is required`,
-  );
-  assert(
-    typeof provider.providerName === 'string' && provider.providerName.length > 0,
-    `${filePath}: providerName is required`,
-  );
-  assert(
-    Array.isArray(provider.models) && provider.models.length > 0,
-    `${filePath}: models must be a non-empty array`,
-  );
-
-  const ids = new Set();
+  assertObject(provider, filePath, 'config');
+  assertNonEmptyString(provider.providerId, filePath, 'providerId');
+  assertNonEmptyString(provider.providerName, filePath, 'providerName');
+  assertNonEmptyArray(provider.models, filePath, 'models');
+  assertUniqueIds(provider.models, (m) => m.modelId, filePath);
   for (const model of provider.models) {
     assertSttModel(model, filePath);
-    assert(!ids.has(model.modelId), `${filePath}: duplicate model id ${model.modelId}`);
-    ids.add(model.modelId);
   }
 }
 
+// --- Generic loading helpers ---
+
+function assertUniqueIds(items, getId, filePath) {
+  const ids = new Set();
+  for (const item of items) {
+    const id = getId(item);
+    assert(!ids.has(id), `${filePath}: duplicate model id ${id}`);
+    ids.add(id);
+  }
+}
+
+function assertUniqueProviderIds(providers, label) {
+  const ids = new Set();
+  for (const provider of providers) {
+    assert(!ids.has(provider.providerId), `Duplicate ${label} provider id: ${provider.providerId}`);
+    ids.add(provider.providerId);
+  }
+}
+
+function loadProviderConfigs(modelsDir, validator, label) {
+  const files = readdirSync(modelsDir)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => join(modelsDir, name));
+
+  const providers = files.map((filePath) => {
+    const parsed = readJson(filePath);
+    validator(parsed, filePath);
+    return parsed;
+  });
+
+  assertUniqueProviderIds(providers, label);
+  return providers.toSorted((a, b) => a.providerName.localeCompare(b.providerName));
+}
+
+// --- MCP server loading ---
+
 function loadServerConfigs() {
+  const serversDir = join(rootDir, 'registries', 'mcp', 'servers');
   const entries = readdirSync(serversDir, { withFileTypes: true }).filter((entry) =>
     entry.isDirectory(),
   );
@@ -358,13 +289,11 @@ function loadServerConfigs() {
     assertServerConfig(parsed, filePath);
     assert(parsed.id === entry.name, `${filePath}: id must match directory name ${entry.name}`);
 
-    if (!existsSync(logoPath)) {
-      return parsed;
-    }
+    if (!existsSync(logoPath)) return parsed;
 
     return {
       ...parsed,
-      logoUrl: `${websiteBaseUrl}/mcp/servers/${parsed.id}/logo.svg`,
+      logoUrl: `${WEBSITE_BASE_URL}/mcp/servers/${parsed.id}/logo.svg`,
     };
   });
 
@@ -377,95 +306,48 @@ function loadServerConfigs() {
   return servers.toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
-function loadEmbeddingProviderConfigs() {
-  const files = readdirSync(embeddingModelsDir)
-    .filter((name) => name.endsWith('.json'))
-    .map((name) => join(embeddingModelsDir, name));
+// --- Output writing ---
 
-  const providers = files.map((filePath) => {
-    const parsed = readJson(filePath);
-    assertEmbeddingProviderConfig(parsed, filePath);
-    return parsed;
-  });
-
-  const ids = new Set();
-  for (const provider of providers) {
-    assert(
-      !ids.has(provider.providerId),
-      `Duplicate embedding provider id: ${provider.providerId}`,
-    );
-    ids.add(provider.providerId);
-  }
-
-  return providers.toSorted((a, b) => a.providerName.localeCompare(b.providerName));
+function writeRegistryJson(filePath, payload) {
+  writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 }
 
-function loadLiveTranscriptionProviderConfigs() {
-  const files = readdirSync(liveTranscriptionModelsDir)
-    .filter((name) => name.endsWith('.json'))
-    .map((name) => join(liveTranscriptionModelsDir, name));
+function copySchemas() {
+  const schemasOutputDir = join(outputDir, 'schemas');
+  mkdirSync(schemasOutputDir, { recursive: true });
 
-  const providers = files.map((filePath) => {
-    const parsed = readJson(filePath);
-    assertLiveTranscriptionProviderConfig(parsed, filePath);
-    return parsed;
-  });
+  const schemaCopies = [
+    {
+      src: join(rootDir, 'registries', 'mcp', 'schema', 'mcp-server.schema.json'),
+      dest: 'mcp-server.schema.json',
+    },
+    {
+      src: join(rootDir, 'registries', 'embeddings', 'schema', 'embedding-provider.schema.json'),
+      dest: 'embedding-provider.schema.json',
+    },
+    {
+      src: join(
+        rootDir,
+        'registries',
+        'live-transcription',
+        'schema',
+        'live-transcription-provider.schema.json',
+      ),
+      dest: 'live-transcription-provider.schema.json',
+    },
+    {
+      src: join(rootDir, 'registries', 'stt', 'schema', 'stt-provider.schema.json'),
+      dest: 'stt-provider.schema.json',
+    },
+  ];
 
-  const ids = new Set();
-  for (const provider of providers) {
-    assert(
-      !ids.has(provider.providerId),
-      `Duplicate live transcription provider id: ${provider.providerId}`,
-    );
-    ids.add(provider.providerId);
+  for (const { src, dest } of schemaCopies) {
+    cpSync(src, join(schemasOutputDir, dest));
   }
-
-  return providers.toSorted((a, b) => a.providerName.localeCompare(b.providerName));
 }
 
-function loadSttProviderConfigs() {
-  const files = readdirSync(sttModelsDir)
-    .filter((name) => name.endsWith('.json'))
-    .map((name) => join(sttModelsDir, name));
-
-  const providers = files.map((filePath) => {
-    const parsed = readJson(filePath);
-    assertSttProviderConfig(parsed, filePath);
-    return parsed;
-  });
-
-  const ids = new Set();
-  for (const provider of providers) {
-    assert(!ids.has(provider.providerId), `Duplicate STT provider id: ${provider.providerId}`);
-    ids.add(provider.providerId);
-  }
-
-  return providers.toSorted((a, b) => a.providerName.localeCompare(b.providerName));
-}
-
-function writeOutput(servers, embeddingProviders, liveTranscriptionProviders, sttProviders) {
-  mkdirSync(outputDir, { recursive: true });
-  mkdirSync(join(outputDir, 'schemas'), { recursive: true });
-  mkdirSync(join(outputDir, 'mcp', 'servers'), { recursive: true });
-
-  cpSync(join(rootDir, 'apps', 'website', 'index.html'), join(outputDir, 'index.html'));
-  cpSync(
-    join(schemaDir, 'mcp-server.schema.json'),
-    join(outputDir, 'schemas', 'mcp-server.schema.json'),
-  );
-  cpSync(
-    join(embeddingSchemaDir, 'embedding-provider.schema.json'),
-    join(outputDir, 'schemas', 'embedding-provider.schema.json'),
-  );
-  cpSync(
-    join(liveTranscriptionSchemaDir, 'live-transcription-provider.schema.json'),
-    join(outputDir, 'schemas', 'live-transcription-provider.schema.json'),
-  );
-  cpSync(
-    join(sttSchemaDir, 'stt-provider.schema.json'),
-    join(outputDir, 'schemas', 'stt-provider.schema.json'),
-  );
-
+function copyServerLogos(servers) {
+  const serversDir = join(rootDir, 'registries', 'mcp', 'servers');
   for (const server of servers) {
     if (!server.logoUrl) continue;
     const logoInputPath = join(serversDir, server.id, 'logo.svg');
@@ -473,58 +355,75 @@ function writeOutput(servers, embeddingProviders, liveTranscriptionProviders, st
     mkdirSync(logoOutputDir, { recursive: true });
     cpSync(logoInputPath, join(logoOutputDir, 'logo.svg'));
   }
+}
 
-  const payload = {
+function writeOutput(servers, embeddingProviders, liveTranscriptionProviders, sttProviders) {
+  mkdirSync(outputDir, { recursive: true });
+  mkdirSync(join(outputDir, 'mcp', 'servers'), { recursive: true });
+
+  cpSync(join(rootDir, 'apps', 'website', 'index.html'), join(outputDir, 'index.html'));
+  copySchemas();
+  copyServerLogos(servers);
+
+  writeRegistryJson(join(outputDir, 'mcp-registry.json'), {
     version: 1,
     generatedAt: new Date().toISOString(),
     servers,
-  };
+  });
 
-  writeFileSync(outputFile, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
-
-  const embeddingPayload = {
+  writeRegistryJson(join(outputDir, 'embedding-models.json'), {
     version: 1,
     generatedAt: new Date().toISOString(),
     providers: embeddingProviders,
-  };
+  });
 
-  writeFileSync(embeddingOutputFile, `${JSON.stringify(embeddingPayload, null, 2)}\n`, 'utf8');
-
-  const liveTranscriptionPayload = {
+  writeRegistryJson(join(outputDir, 'live-transcription-models.json'), {
     version: 1,
     generatedAt: new Date().toISOString(),
     providers: liveTranscriptionProviders,
-  };
+  });
 
-  writeFileSync(
-    liveTranscriptionOutputFile,
-    `${JSON.stringify(liveTranscriptionPayload, null, 2)}\n`,
-    'utf8',
-  );
-
-  const sttPayload = {
+  writeRegistryJson(join(outputDir, 'stt-models.json'), {
     version: 1,
     generatedAt: new Date().toISOString(),
     providers: sttProviders,
-  };
-
-  writeFileSync(sttOutputFile, `${JSON.stringify(sttPayload, null, 2)}\n`, 'utf8');
+  });
 }
+
+// --- Main ---
 
 function main() {
   const servers = loadServerConfigs();
-  const embeddingProviders = loadEmbeddingProviderConfigs();
-  const liveTranscriptionProviders = loadLiveTranscriptionProviderConfigs();
-  const sttProviders = loadSttProviderConfigs();
+  const embeddingProviders = loadProviderConfigs(
+    join(rootDir, 'registries', 'embeddings', 'models'),
+    assertEmbeddingProviderConfig,
+    'embedding',
+  );
+  const liveTranscriptionProviders = loadProviderConfigs(
+    join(rootDir, 'registries', 'live-transcription', 'models'),
+    assertLiveTranscriptionProviderConfig,
+    'live transcription',
+  );
+  const sttProviders = loadProviderConfigs(
+    join(rootDir, 'registries', 'stt', 'models'),
+    assertSttProviderConfig,
+    'STT',
+  );
+
   writeOutput(servers, embeddingProviders, liveTranscriptionProviders, sttProviders);
-  console.log(`Built MCP registry with ${servers.length} server(s): ${outputFile}`);
+
   console.log(
-    `Built embedding registry with ${embeddingProviders.length} provider(s): ${embeddingOutputFile}`,
+    `Built MCP registry with ${servers.length} server(s): ${join(outputDir, 'mcp-registry.json')}`,
   );
   console.log(
-    `Built live transcription registry with ${liveTranscriptionProviders.length} provider(s): ${liveTranscriptionOutputFile}`,
+    `Built embedding registry with ${embeddingProviders.length} provider(s): ${join(outputDir, 'embedding-models.json')}`,
   );
-  console.log(`Built STT registry with ${sttProviders.length} provider(s): ${sttOutputFile}`);
+  console.log(
+    `Built live transcription registry with ${liveTranscriptionProviders.length} provider(s): ${join(outputDir, 'live-transcription-models.json')}`,
+  );
+  console.log(
+    `Built STT registry with ${sttProviders.length} provider(s): ${join(outputDir, 'stt-models.json')}`,
+  );
 }
 
 main();


### PR DESCRIPTION
## 🚀 Change Summary

Fetches embedding models from the remote registry API instead of bundling them, with local caching and scheduled refresh — matching the pattern already used for STT models.

### ✨ New Features
- **Embedding registry refresh**: Scheduled job to refresh the embedding model registry every 6 hours (via the scheduler), so users get updated models without app updates

### 🛠 Improvements & Refactors
- **Remote embedding registry**: Replaces the bundled \@stitch/registry-embeddings\ package with API-fetched registry data, cached locally — aligns with STT registry approach from #305
- **Shared validation helpers**: Extracts common validation functions (\ssertNonEmptyString\, \ssertObject\, \ssertPositiveInt\, etc.) and a generic \loadProviderConfigs\ in \uild-website-registries.mjs\, reducing duplication across MCP, embedding, live transcription, and STT config loading
- **DRY output logic**: Consolidates registry JSON writing and schema/logo copying into reusable helpers