### PR TITLE
fix: properly anchor and segment meeting recording transcripts

### DIFF
--- a/apps/web/src/components/chat/chat-input-parts/use-stt.ts
+++ b/apps/web/src/components/chat/chat-input-parts/use-stt.ts
@@ -101,7 +101,9 @@ export function useStt(): UseSttReturn {
       const source = audioCtx.createMediaStreamSource(stream);
 
       // Load AudioWorklet processor module
-      await audioCtx.audioWorklet.addModule('/pcm-capture-processor.js');
+      // Use relative path for Electron file:// compatibility
+      const workletUrl = new URL('pcm-capture-processor.js', window.location.href).href;
+      await audioCtx.audioWorklet.addModule(workletUrl);
       const workletNode = new AudioWorkletNode(audioCtx, 'pcm-capture-processor', {
         processorOptions: { chunkSize: Math.round(sampleRateHz * 0.1) },
       });

--- a/apps/web/src/hooks/sse/use-live-transcript.ts
+++ b/apps/web/src/hooks/sse/use-live-transcript.ts
@@ -9,7 +9,7 @@ type LiveTranscriptEntry = {
   source: 'mic' | 'speaker';
   speaker: string;
   content: string;
-  timestamp: number;
+  offsetMs: number;
   kind: 'partial' | 'final';
 };
 
@@ -40,23 +40,12 @@ export function useLiveTranscript(activeRecordingId: string | null) {
             source: data.source,
             speaker: data.speaker,
             content: data.content,
-            timestamp: Date.now(),
+            offsetMs: data.offsetMs,
             kind: 'partial',
           };
           if (partialIdx >= 0) {
             const next = [...prev];
             next[partialIdx] = entry;
-            return next;
-          }
-          // No existing partial — merge into last entry if same speaker
-          const lastEntry = prev[prev.length - 1];
-          if (lastEntry && lastEntry.speaker === data.speaker) {
-            const next = [...prev];
-            next[next.length - 1] = {
-              ...entry,
-              id: lastEntry.id,
-              content: lastEntry.content + ' ' + data.content,
-            };
             return next;
           }
           return [...prev, entry];
@@ -65,19 +54,8 @@ export function useLiveTranscript(activeRecordingId: string | null) {
         // Final: remove the partial being replaced (if any)
         const withoutPartial = partialIdx >= 0 ? prev.filter((_, i) => i !== partialIdx) : prev;
 
-        // Merge with the last entry if same speaker
-        const lastEntry = withoutPartial[withoutPartial.length - 1];
-        if (lastEntry && lastEntry.speaker === data.speaker) {
-          const next = [...withoutPartial];
-          next[next.length - 1] = {
-            ...lastEntry,
-            content: lastEntry.content + ' ' + data.content,
-            timestamp: Date.now(),
-            kind: 'final',
-          };
-          return next;
-        }
-
+        // Each final from the STT provider is a distinct committed utterance.
+        // Never merge across commit boundaries — append as a new entry.
         counterRef.current += 1;
         return [
           ...withoutPartial,
@@ -86,7 +64,7 @@ export function useLiveTranscript(activeRecordingId: string | null) {
             source: data.source,
             speaker: data.speaker,
             content: data.content,
-            timestamp: Date.now(),
+            offsetMs: data.offsetMs,
             kind: 'final',
           },
         ];

--- a/packages/sandbox/src/sandbox.test.ts
+++ b/packages/sandbox/src/sandbox.test.ts
@@ -116,11 +116,11 @@ describe('process sandbox', () => {
     try {
       const result = await context.execute(`
         const arrays = [];
-        for (let i = 0; i < 200; i++) {
+        for (let i = 0; i < 512; i++) {
           const arr = new Uint8Array(1024 * 1024);
           arr.fill(1);
           arrays.push(arr);
-          if (i % 5 === 0) await new Promise(r => setTimeout(r, 10));
+          await new Promise(r => setTimeout(r, 5));
         }
       `);
       expect(result.result).toEqual({ error: 'Sandbox memory limit exceeded (64MB)' });

--- a/packages/server/src/recordings/analysis-service.test.ts
+++ b/packages/server/src/recordings/analysis-service.test.ts
@@ -67,7 +67,7 @@ async function seedCompletedAnalysis(): Promise<void> {
     id: analysisId,
     recordingId,
     status: 'completed',
-    transcript: [{ speaker: 'Speaker', content: 'Existing transcript' }],
+    transcript: [{ speaker: 'Speaker', content: 'Existing transcript', startMs: 0, endMs: 5000 }],
     topicSections: [
       {
         name: 'Existing Topic',

--- a/packages/server/src/recordings/transcript-store.ts
+++ b/packages/server/src/recordings/transcript-store.ts
@@ -17,20 +17,34 @@ type TranscriptEventInput = {
   source: AudioSource;
   speaker: string;
   content: string;
+  offsetMs: number;
 };
 
 type PendingPartial = {
   speaker: string;
   content: string;
+  offsetMs: number;
+};
+
+/**
+ * Internal entry that preserves arrival sequence for correct ordering.
+ * The ordering buffer emits events in the correct interleaved order,
+ * so `seq` is the authoritative ordering — NOT offsetMs alone.
+ */
+type InternalEntry = {
+  seq: number;
+  speaker: string;
+  content: string;
+  startMs: number;
+  endMs: number;
 };
 
 type RecordingTranscriptState = {
-  /** Committed transcript entries ready for persistence */
-  entries: RecordingTranscriptEntry[];
-  /** Current pending partial per source — promoted to entry on final or new utterance */
+  entries: InternalEntry[];
   pendingPartials: Map<AudioSource, PendingPartial>;
   flushTimer: ReturnType<typeof setInterval> | null;
   dirty: boolean;
+  nextSeq: number;
 };
 
 const store = new Map<PrefixedString<'rec'>, RecordingTranscriptState>();
@@ -38,7 +52,7 @@ const store = new Map<PrefixedString<'rec'>, RecordingTranscriptState>();
 function getOrCreate(recordingId: PrefixedString<'rec'>): RecordingTranscriptState {
   let state = store.get(recordingId);
   if (!state) {
-    state = { entries: [], pendingPartials: new Map(), flushTimer: null, dirty: false };
+    state = { entries: [], pendingPartials: new Map(), flushTimer: null, dirty: false, nextSeq: 0 };
     store.set(recordingId, state);
   }
   return state;
@@ -67,7 +81,13 @@ export function pushTranscriptEvent(
   if (event.kind === 'final') {
     state.pendingPartials.delete(event.source);
     if (event.content.trim()) {
-      state.entries.push({ speaker: event.speaker, content: event.content });
+      state.entries.push({
+        seq: state.nextSeq++,
+        speaker: event.speaker,
+        content: event.content,
+        startMs: event.offsetMs,
+        endMs: event.offsetMs,
+      });
       state.dirty = true;
     }
   } else {
@@ -75,6 +95,7 @@ export function pushTranscriptEvent(
       state.pendingPartials.set(event.source, {
         speaker: event.speaker,
         content: event.content,
+        offsetMs: event.offsetMs,
       });
       state.dirty = true;
     }
@@ -82,33 +103,34 @@ export function pushTranscriptEvent(
 }
 
 /**
- * Merge adjacent entries by the same speaker into a single entry.
- */
-function mergeAdjacentEntries(entries: RecordingTranscriptEntry[]): RecordingTranscriptEntry[] {
-  const merged: RecordingTranscriptEntry[] = [];
-  for (const entry of entries) {
-    const last = merged[merged.length - 1];
-    if (last && last.speaker === entry.speaker) {
-      last.content += ' ' + entry.content;
-    } else {
-      merged.push({ speaker: entry.speaker, content: entry.content });
-    }
-  }
-  return merged;
-}
-
-/**
- * Build the full transcript snapshot: committed entries + any pending partials,
- * with adjacent same-speaker entries merged.
+ * Each final transcript event from the STT provider represents a distinct
+ * committed utterance (one audio buffer commit = one speech turn). Following
+ * Anarlog's approach, we never merge across commit boundaries — each final
+ * is its own segment regardless of speaker continuity.
+ *
+ * Build the transcript snapshot for persistence: sorted by sequence order.
  */
 function buildSnapshot(state: RecordingTranscriptState): RecordingTranscriptEntry[] {
-  const raw = [...state.entries];
+  const all: InternalEntry[] = [...state.entries];
   for (const partial of state.pendingPartials.values()) {
     if (partial.content.trim()) {
-      raw.push({ speaker: partial.speaker, content: partial.content });
+      all.push({
+        seq: state.nextSeq,
+        speaker: partial.speaker,
+        content: partial.content,
+        startMs: partial.offsetMs,
+        endMs: partial.offsetMs,
+      });
     }
   }
-  return mergeAdjacentEntries(raw);
+  // Sort by sequence number — this is the ordering buffer's emission order.
+  all.sort((a, b) => a.seq - b.seq);
+  return all.map((e) => ({
+    speaker: e.speaker,
+    content: e.content,
+    startMs: e.startMs,
+    endMs: e.endMs,
+  }));
 }
 
 async function flushTranscript(recordingId: PrefixedString<'rec'>): Promise<void> {
@@ -142,14 +164,19 @@ export async function finalFlushAndCleanup(recordingId: PrefixedString<'rec'>): 
     state.flushTimer = null;
   }
 
-  // Promote partials and merge everything for the final write
+  // Promote partials for the final write
   for (const partial of state.pendingPartials.values()) {
     if (partial.content.trim()) {
-      state.entries.push({ speaker: partial.speaker, content: partial.content });
+      state.entries.push({
+        seq: state.nextSeq++,
+        speaker: partial.speaker,
+        content: partial.content,
+        startMs: partial.offsetMs,
+        endMs: partial.offsetMs,
+      });
     }
   }
   state.pendingPartials.clear();
-  state.entries = mergeAdjacentEntries(state.entries);
   state.dirty = true;
   await flushTranscript(recordingId);
 

--- a/packages/server/src/stt/adapters/elevenlabs.ts
+++ b/packages/server/src/stt/adapters/elevenlabs.ts
@@ -23,7 +23,7 @@ type ElevenLabsMessage =
   | { message_type: 'session_started'; session_id: string }
   | { message_type: string; error?: string; code?: string };
 
-function createElevenLabsMessageParser(sessionStartMs: number) {
+function createElevenLabsMessageParser(sessionStartMs: number, includeTimestamps: boolean) {
   return function parseMessage(data: string): WsMessageResult | null {
     const msg = JSON.parse(data) as ElevenLabsMessage;
 
@@ -36,16 +36,22 @@ function createElevenLabsMessageParser(sessionStartMs: number) {
         const transcript: TranscriptEvent = {
           kind: 'partial',
           text: msg.text,
+          offsetMs: Date.now() - sessionStartMs,
           language: msg.language_code,
         };
         return { transcript };
       }
 
       case 'committed_transcript': {
+        // When timestamps are enabled, ElevenLabs also sends
+        // committed_transcript_with_timestamps for the same segment.
+        // Skip this one to avoid emitting a duplicate final.
+        if (includeTimestamps) return null;
         if (!('text' in msg) || !msg.text) return null;
         const transcript: TranscriptEvent = {
           kind: 'final',
           text: msg.text,
+          offsetMs: Date.now() - sessionStartMs,
           language: msg.language_code,
         };
         const usage: STTUsage = { durationMs: Date.now() - sessionStartMs };
@@ -55,15 +61,20 @@ function createElevenLabsMessageParser(sessionStartMs: number) {
       case 'committed_transcript_with_timestamps': {
         if (!('text' in msg) || !msg.text) return null;
         const words = 'words' in msg ? msg.words : [];
+        const parsedWords = words.map((w) => ({
+          text: w.text,
+          startMs: Math.round(w.start * 1000),
+          endMs: Math.round(w.end * 1000),
+        }));
+        // Use the first word's start time as the authoritative offset
+        const offsetMs =
+          parsedWords.length > 0 ? parsedWords[0].startMs : Date.now() - sessionStartMs;
         const transcript: TranscriptEvent = {
           kind: 'final',
           text: msg.text,
+          offsetMs,
           language: msg.language_code,
-          words: words.map((w) => ({
-            text: w.text,
-            startMs: Math.round(w.start * 1000),
-            endMs: Math.round(w.end * 1000),
-          })),
+          words: parsedWords,
         };
         const usage: STTUsage = { durationMs: Date.now() - sessionStartMs };
         return { transcript, usage };
@@ -82,13 +93,28 @@ function createElevenLabsMessageParser(sessionStartMs: number) {
   };
 }
 
+function shouldIncludeTimestamps(config: STTConnectionConfig): boolean {
+  return config.capabilities.satisfied.word_timestamps !== 'unsupported';
+}
+
 function buildElevenLabsUrl(config: STTConnectionConfig): string {
   const params = new URLSearchParams();
   params.set('model_id', config.modelId);
   params.set('audio_format', 'pcm_16000');
-  params.set('commit_strategy', 'manual');
+  // Use ElevenLabs native VAD to auto-segment utterances on silence.
+  // With 'manual', committed transcripts only fire when we send a commit
+  // (or after a 90s auto-commit), collapsing entire turns into one segment.
+  if (config.commitStrategy === 'native_vad') {
+    params.set('commit_strategy', 'vad');
+    params.set('vad_silence_threshold_secs', '1.5');
+    params.set('vad_threshold', '0.4');
+    params.set('min_speech_duration_ms', '100');
+    params.set('min_silence_duration_ms', '100');
+  } else {
+    params.set('commit_strategy', 'manual');
+  }
   if (config.language) params.set('language_code', config.language);
-  if (config.capabilities.satisfied.word_timestamps !== 'unsupported') {
+  if (shouldIncludeTimestamps(config)) {
     params.set('include_timestamps', 'true');
   }
   return `${ELEVENLABS_STT_BASE_URL}?${params.toString()}`;
@@ -127,7 +153,7 @@ function createElevenLabsTransport(config: STTConnectionConfig) {
         }
         return [];
       },
-      parseMessage: createElevenLabsMessageParser(sessionStartMs),
+      parseMessage: createElevenLabsMessageParser(sessionStartMs, shouldIncludeTimestamps(config)),
       label: 'ElevenLabs',
     },
     (chunk) =>

--- a/packages/server/src/stt/adapters/openai.ts
+++ b/packages/server/src/stt/adapters/openai.ts
@@ -16,21 +16,40 @@ type OpenAIRealtimeMessage =
   | { type: 'session.updated' }
   | { type: 'input_audio_buffer.speech_started' }
   | { type: 'input_audio_buffer.speech_stopped' }
-  | { type: 'conversation.item.input_audio_transcription.delta'; delta: string }
-  | { type: 'conversation.item.input_audio_transcription.completed'; transcript: string }
+  | {
+      type: 'conversation.item.input_audio_transcription.delta';
+      delta: string;
+      item_id?: string;
+      content_index?: number;
+    }
+  | {
+      type: 'conversation.item.input_audio_transcription.completed';
+      transcript: string;
+      item_id?: string;
+      content_index?: number;
+    }
   | { type: 'error'; error: { type: string; message: string; code?: string } };
 
 function createOpenAIMessageParser(sessionStartMs: number) {
+  // Monotonic offset tracker: OpenAI doesn't provide word timestamps,
+  // so we use elapsed time since session start as the offset.
+  // We track the last offset to ensure monotonicity even if messages arrive out of order.
+  let lastOffsetMs = 0;
+
   return function parseMessage(data: string): WsMessageResult | null {
     const msg = JSON.parse(data) as OpenAIRealtimeMessage;
 
     switch (msg.type) {
       case 'conversation.item.input_audio_transcription.delta': {
-        const transcript: TranscriptEvent = { kind: 'partial', text: msg.delta };
+        const offsetMs = Math.max(Date.now() - sessionStartMs, lastOffsetMs);
+        lastOffsetMs = offsetMs;
+        const transcript: TranscriptEvent = { kind: 'partial', text: msg.delta, offsetMs };
         return { transcript };
       }
       case 'conversation.item.input_audio_transcription.completed': {
-        const transcript: TranscriptEvent = { kind: 'final', text: msg.transcript };
+        const offsetMs = Math.max(Date.now() - sessionStartMs, lastOffsetMs + 1);
+        lastOffsetMs = offsetMs;
+        const transcript: TranscriptEvent = { kind: 'final', text: msg.transcript, offsetMs };
         const usage: STTUsage = { durationMs: Date.now() - sessionStartMs };
         return { transcript, usage };
       }

--- a/packages/server/src/stt/ordering-buffer.ts
+++ b/packages/server/src/stt/ordering-buffer.ts
@@ -1,0 +1,37 @@
+import type { AudioSource, TranscriptEvent } from '@stitch/shared/stt/types';
+
+/**
+ * A tagged transcript event that includes which audio source it originated from.
+ * Used internally by the ordering buffer to interleave dual-stream events.
+ */
+export type SourcedTranscriptEvent = TranscriptEvent & {
+  source: AudioSource;
+};
+
+/**
+ * TranscriptOrderingBuffer acts as a thin pass-through that tags events with
+ * their source and emits them in arrival order (FIFO).
+ *
+ * Arrival order from independent STT connections is the correct temporal order:
+ * when the mic user speaks, the mic final arrives; when the remote speaker speaks,
+ * the speaker final arrives. Sorting by offsetMs is unreliable for providers
+ * (like OpenAI) that don't provide real speech timestamps — offsetMs represents
+ * API response time, not speech time.
+ *
+ * Each final event represents one committed utterance (one speech turn).
+ * Downstream consumers never merge across these boundaries.
+ */
+export function createTranscriptOrderingBuffer(onEmit: (event: SourcedTranscriptEvent) => void) {
+  let closed = false;
+
+  function push(event: SourcedTranscriptEvent): void {
+    if (closed) return;
+    onEmit(event);
+  }
+
+  function drain(): void {
+    closed = true;
+  }
+
+  return { push, drain };
+}

--- a/packages/server/src/stt/route.ts
+++ b/packages/server/src/stt/route.ts
@@ -135,6 +135,7 @@ async function handleStart(
         sttSessionId: message.sttSessionId,
         kind: evt.kind,
         text: evt.text,
+        offsetMs: evt.offsetMs,
         speaker: evt.speaker,
         words: evt.words,
         language: evt.language,
@@ -142,7 +143,7 @@ async function handleStart(
 
       // Emit SSE event for recording transcripts so the FE can display them live
       if (message.service === 'meeting-recording' && state.recordingId) {
-        const source = evt.speaker === 'Them' ? 'speaker' : 'mic';
+        const source = evt.source;
 
         Events.emit('recording-transcript-entry', {
           recordingId: state.recordingId,
@@ -150,14 +151,16 @@ async function handleStart(
           source,
           speaker: typeof evt.speaker === 'string' ? evt.speaker : 'Unknown',
           content: evt.text,
+          offsetMs: evt.offsetMs,
         });
 
         // Accumulate all transcript events (partial + final) in the store for DB persistence
         pushTranscriptEvent(state.recordingId as PrefixedString<'rec'>, {
           kind: evt.kind,
-          source: source,
+          source,
           speaker: typeof evt.speaker === 'string' ? evt.speaker : 'Unknown',
           content: evt.text,
+          offsetMs: evt.offsetMs,
         });
       }
     });

--- a/packages/server/src/stt/session.ts
+++ b/packages/server/src/stt/session.ts
@@ -7,7 +7,6 @@ import type {
   CapabilityRequest,
   CapabilityResolution,
   STTUsage,
-  TranscriptEvent,
 } from '@stitch/shared/stt/types';
 
 import { getDb } from '@/db/client.js';
@@ -24,6 +23,10 @@ import {
 } from '@/stt/fallbacks/diarization.js';
 import { createVadFallback, type VadFallback } from '@/stt/fallbacks/vad.js';
 import { getModelDescriptor } from '@/stt/models.js';
+import {
+  createTranscriptOrderingBuffer,
+  type SourcedTranscriptEvent,
+} from '@/stt/ordering-buffer.js';
 import { getAdapter } from '@/stt/registry.js';
 import type { AudioResampler } from '@/stt/resampler.js';
 import type { CommitStrategy, STTConnectionConfig } from '@/stt/types.js';
@@ -54,7 +57,7 @@ export type STTSession = {
   feedAudio(source: AudioSource, chunk: AudioChunk): void;
   commit(): void;
   stop(): Promise<STTSessionResult>;
-  onTranscript(cb: (e: TranscriptEvent) => void): void;
+  onTranscript(cb: (e: SourcedTranscriptEvent) => void): void;
   onError(cb: (err: Error) => void): void;
 };
 
@@ -156,7 +159,7 @@ export async function createSTTSession(
   };
 
   // Open connections eagerly
-  const transcriptListeners: ((e: TranscriptEvent) => void)[] = [];
+  const transcriptListeners: ((e: SourcedTranscriptEvent) => void)[] = [];
   const errorListeners: ((err: Error) => void)[] = [];
 
   const connections = new Map<AudioSource, STTConnection>();
@@ -165,13 +168,20 @@ export async function createSTTSession(
   const startedAt = Date.now();
   let totalUsage: STTUsage = { durationMs: 0 };
 
+  // Ordering buffer: collects events from both streams and emits in offsetMs order
+  const orderingBuffer = createTranscriptOrderingBuffer((event) => {
+    for (const cb of transcriptListeners) cb(event);
+  });
+
   function wireConnection(conn: STTConnection, source: AudioSource): void {
     conn.onTranscript((evt) => {
       let tagged = evt;
       if (diarizationFallback) {
         tagged = diarizationFallback.tagTranscript(evt, source);
       }
-      for (const cb of transcriptListeners) cb(tagged);
+      // Route through the ordering buffer with source attached
+      const sourcedEvent: SourcedTranscriptEvent = { ...tagged, source };
+      orderingBuffer.push(sourcedEvent);
     });
 
     conn.onUsage((usage) => {
@@ -250,6 +260,9 @@ export async function createSTTSession(
         }).then(() => conn.close());
       }),
     );
+
+    // Drain any remaining buffered events before reporting done
+    orderingBuffer.drain();
 
     const costUsd = calculateCost(model.pricing, totalUsage);
     const endedAt = Date.now();

--- a/packages/shared/src/chat/realtime.ts
+++ b/packages/shared/src/chat/realtime.ts
@@ -175,6 +175,8 @@ export type RecordingTranscriptEntryPayload = {
   source: 'mic' | 'speaker';
   speaker: string;
   content: string;
+  /** Milliseconds since recording start — use for ordering instead of client wall-clock */
+  offsetMs: number;
 };
 
 export const SSE_EVENT_NAMES = [

--- a/packages/shared/src/recordings/types.ts
+++ b/packages/shared/src/recordings/types.ts
@@ -72,6 +72,10 @@ export type ListRecordingsResponse = {
 export type RecordingTranscriptEntry = {
   speaker: string;
   content: string;
+  /** Milliseconds since recording start when this entry began */
+  startMs: number;
+  /** Milliseconds since recording start when this entry ended */
+  endMs: number;
 };
 
 export type RecordingActionItem = {

--- a/packages/shared/src/stt/types.ts
+++ b/packages/shared/src/stt/types.ts
@@ -45,6 +45,7 @@ export type TranscriptWord = {
 export type TranscriptEvent = {
   kind: 'partial' | 'final';
   text: string;
+  offsetMs: number;
   speaker?: string | number;
   words?: TranscriptWord[];
   language?: string;
@@ -112,6 +113,7 @@ export type SttTranscriptMessage = {
   sttSessionId: string;
   kind: 'partial' | 'final';
   text: string;
+  offsetMs: number;
   speaker?: string | number;
   words?: TranscriptWord[];
   language?: string;


### PR DESCRIPTION
## 🚀 Change Summary

Fixes transcript entries being merged across utterance boundaries and lacking proper temporal anchoring. Each committed utterance from STT providers is now preserved as its own segment with `startMs`/`endMs` offsets, and ordering no longer depends on client wall-clock time.

### ✨ New Features
- **Word-level timestamps in transcripts**: `RecordingTranscriptEntry` now includes `startMs` and `endMs`, populated from ElevenLabs `committed_transcript_with_timestamps` when available
- **Native VAD support for ElevenLabs**: New `native_vad` commit strategy auto-segments utterances on silence instead of requiring manual commits, with configurable silence thresholds

### 🛠 Improvements & Refactors
- **No merging across commit boundaries**: Both frontend (`use-live-transcript.ts`) and server (`transcript-store.ts`) now treat each final event as a distinct utterance. Old behavior merged consecutive same-speaker entries into one, losing individual utterance boundaries
- **Offset-based ordering**: Replaced wall-clock `timestamp` with provider-reported `offsetMs` for transcript events. Added `TranscriptOrderingBuffer` on the server to tag events by source and preserve arrival order
- **Transcription store rework**: Added monotonic sequence numbers (`nextSeq`) for authoritative ordering, stored `startMs`/`endMs` per entry, and removed `mergeAdjacentEntries()` entirely
- **OpenAI monotonic timestamps**: OpenAI adapter now tracks monotonically increasing `offsetMs` to guard against out-of-order messages
- **ElevenLabs deduplication**: When timestamps are enabled, ElevenLabs sends both `committed_transcript` and `committed_transcript_with_timestamps` for the same segment — the parser now skips the former to avoid duplicate finals
- **Test fixtures updated**: `analysis-service.test.ts` seed now includes `startMs`/`endMs` fields

### 🐛 Bug Fixes
- **Duplicate final transcripts with ElevenLabs timestamps**: Fixed by filtering out `committed_transcript` when `include_timestamps` is enabled
