### PR TITLE
fix: allow window to close during app quit

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -42,6 +42,7 @@ if (!gotTheLock) {
 let mainWindow: BrowserWindow | null = null;
 let isQuitting = false;
 let isShuttingDown = false;
+let updateCheckInterval: NodeJS.Timeout | null = null;
 
 // Shared mutable server state — passed by reference to IPC handlers that own it.
 const serverState = {
@@ -74,6 +75,10 @@ async function resolveServerUrl(): Promise<string> {
 async function shutdownRuntime(): Promise<void> {
   if (isShuttingDown) return;
   isShuttingDown = true;
+  if (updateCheckInterval) {
+    clearInterval(updateCheckInterval);
+    updateCheckInterval = null;
+  }
   destroyTray();
   stopMeetingDetection();
   await stopRecordingCapture().catch(() => null);
@@ -116,7 +121,9 @@ function onContextMenu(params: Electron.ContextMenuParams): void {
 
 async function spawnMainWindow(): Promise<BrowserWindow> {
   return createWindow(onContextMenu, () => {
-    if (!isQuitting) mainWindow?.hide();
+    if (isQuitting) return 'allow';
+    mainWindow?.hide();
+    return 'prevent';
   });
 }
 
@@ -160,7 +167,10 @@ void app.whenReady().then(async () => {
     if (process.platform !== 'darwin') {
       updater.init();
       setTimeout(() => void updater.checkForUpdates(), 15_000);
-      setInterval(() => void updater.checkForUpdates(), UPDATE_CHECK_INTERVAL_MS);
+      updateCheckInterval = setInterval(
+        () => void updater.checkForUpdates(),
+        UPDATE_CHECK_INTERVAL_MS,
+      );
     }
 
     initTray(() => mainWindow);

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -37,7 +37,7 @@ function resolveWindowIcon(): Electron.NativeImage | undefined {
 
 export async function createWindow(
   onContextMenu: (params: Electron.ContextMenuParams) => void,
-  onClose: () => void,
+  onClose: () => 'allow' | 'prevent',
 ): Promise<BrowserWindow> {
   const isMac = process.platform === 'darwin';
   const windowIcon = resolveWindowIcon();
@@ -74,8 +74,9 @@ export async function createWindow(
   });
 
   win.on('close', (event) => {
-    event.preventDefault();
-    onClose();
+    if (onClose() === 'prevent') {
+      event.preventDefault();
+    }
   });
 
   win.webContents.on('context-menu', (_e, params) => {


### PR DESCRIPTION
## 🚀 Change Summary

Fixes a bug where the packaged desktop app would not fully quit — the Electron process and its `stitch-server` sidecar remained running after hitting Quit, requiring a manual kill via Task Manager. Reproduced on both Windows and macOS.

### 🐛 Bug Fixes
- **App fails to quit / ghost processes**: The window`s `close` handler unconditionally called `event.preventDefault()` to support hide-to-tray. Per Electron lifecycle semantics, any window canceling its `close` event aborts the entire `app.quit()`, leaving a non-destroyed window that keeps the process alive indefinitely. The `close` handler now only prevents default when hiding to tray; during quit it allows the window to close so `app.quit()` completes and `shutdownRuntime()` tears down the sidecar.

### 🛠 Improvements & Refactors
- Track the updater `setInterval` handle and clear it in `shutdownRuntime()` to remove a lingering event-loop reference during shutdown.