### PR TITLE
feat(desktop): sign and notarize macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,10 +215,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-electron-
 
+      - name: Prepare Apple API key for notarization
+        if: matrix.os == 'macos'
+        env:
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          KEY_PATH="$RUNNER_TEMP/apple_api_key.p8"
+          echo -n "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          echo "APPLE_API_KEY=$KEY_PATH" >> "$GITHUB_ENV"
+
       - name: Build desktop package
         working-directory: apps/desktop
         env:
           GH_TOKEN: ${{ github.token }}
+          CSC_LINK: ${{ matrix.os == 'macos' && secrets.CSC_LINK || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos' && secrets.CSC_KEY_PASSWORD || '' }}
+          APPLE_API_KEY_ID: ${{ matrix.os == 'macos' && secrets.APPLE_API_KEY_ID || '' }}
+          APPLE_API_ISSUER: ${{ matrix.os == 'macos' && secrets.APPLE_API_ISSUER || '' }}
+          APPLE_TEAM_ID: ${{ matrix.os == 'macos' && secrets.APPLE_TEAM_ID || '' }}
         run: bun run ${{ matrix.package_script || 'package' }}
 
       - name: Upload desktop artifacts

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -15,6 +15,10 @@ const audioCaptureResource = {
 
 const hasAudioCaptureResource = existsSync(audioCaptureResource.from);
 
+const shouldNotarize = Boolean(
+  process.env.APPLE_API_KEY && process.env.APPLE_API_KEY_ID && process.env.APPLE_API_ISSUER,
+);
+
 const config: Configuration = {
   appId: 'com.stitch.desktop',
   productName: 'Stitch',
@@ -78,6 +82,9 @@ const config: Configuration = {
     artifactName: '${productName}-macos-${arch}.${ext}',
     icon: 'resources/icon.icns',
     category: 'public.app-category.developer-tools',
+    hardenedRuntime: true,
+    gatekeeperAssess: false,
+    notarize: shouldNotarize,
     entitlements: 'resources/entitlements.mac.plist',
     entitlementsInherit: 'resources/entitlements.mac.inherit.plist',
     binaries: [


### PR DESCRIPTION
## 🚀 Change Summary

Enables macOS code signing and notarization for desktop release builds so the shipped DMG/ZIP pass Gatekeeper and support auto-update without warnings.

### ✨ New Features
- **Signed & notarized macOS builds**: The release workflow now signs the macOS app with a Developer ID Application certificate and notarizes it via the App Store Connect API. Signing/notarization env vars are scoped to the macOS matrix entry so the Windows build is unaffected.

### 🛠 Improvements & Refactors
- electron-builder `mac` config now sets `hardenedRuntime` and `gatekeeperAssess: false`, and gates notarization on the presence of App Store Connect API credentials so local builds still work without them.