### PR TITLE
fix(ci): populate release notes (range against HEAD, not unborn tag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,10 +323,16 @@ jobs:
         env:
           TAG: ${{ needs.version.outputs.tag }}
         run: |
+          set -euo pipefail
+
+          # The new tag does not exist yet (it is created by `gh release create`),
+          # so range against the checked-out release commit (HEAD) instead of TAG.
           prev=$(git tag --sort=-version:refname | grep -v "^${TAG}$" | head -n1)
           from=${prev:-$(git rev-list --max-parents=0 HEAD)}
 
-          declare -a feats fixes improvements docs chores other
+          subjects=$(git log "${from}..HEAD" --pretty=format:"%s")
+
+          feats=() fixes=() improvements=() docs=() chores=() other=()
 
           re_bump='^chore(\([^)]*\))?!?:\ bump\ version'
           re_feat='^feat(\([^)]*\))?!?:\ (.*)'
@@ -352,7 +358,7 @@ jobs:
             else
               other+=("- ${subject}")
             fi
-          done < <(git log "${from}..${TAG}" --pretty=format:"%s")
+          done <<< "$subjects"
 
           {
             if [ ${#feats[@]} -gt 0 ]; then


### PR DESCRIPTION
## 🚀 Change Summary

Fixes the release workflow so GitHub release notes are actually populated. The last three releases (`v0.4.11`, `v0.5.0`, `v0.5.1`) shipped with empty release bodies.

### 🐛 Bug Fixes
- **Release notes were always empty**: The "Generate release notes" step ran `git log "${from}..${TAG}"`, but the tag (`vX.Y.Z`) does not exist yet at that point — it is only created later by `gh release create`. The `git log` therefore failed with `fatal: unknown revision`. Because the command was inside a process substitution (`done < <(git log ...)`), its non-zero exit was swallowed, the loop read nothing, and `release-notes.md` was written empty while the step still exited 0.

### 🛠 Improvements & Refactors
- Range commits against the checked-out release commit (`HEAD`) instead of the not-yet-created tag.
- Read `git log` output into a variable consumed via a here-string so failures surface instead of being hidden by process substitution.
- Add `set -euo pipefail` and explicitly initialize the category arrays so the step fails loudly on real errors.

Verified locally against the `v0.5.0`/`v0.5.1` ranges: the step now emits correctly categorized New Features / Bug Fixes / Improvements / Chores sections.
