### PR TITLE
chore(release): add macOS signing diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -224,10 +224,31 @@ jobs:
           echo -n "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
           echo "APPLE_API_KEY=$KEY_PATH" >> "$GITHUB_ENV"
 
+      - name: Diagnose Bun sidecar signatures (macOS)
+        if: matrix.os == 'macos'
+        working-directory: apps/desktop
+        run: |
+          # Build the Bun-compiled sidecar binaries up front so we can inspect
+          # their embedded signatures before electron-builder signs the bundle.
+          # A truncated/invalid signature here points at the Bun --compile bug
+          # (oven-sh/bun#29120), where waiting on codesign will never finish.
+          bun run build:sidecar
+
+          for bin in ../../packages/server/dist/stitch-server ../../packages/server/dist/stitch-sandbox; do
+            echo "::group::codesign -dvvv $bin"
+            codesign -dvvv "$bin" 2>&1 || true
+            echo "::endgroup::"
+
+            echo "::group::otool LC_CODE_SIGNATURE $bin"
+            otool -l "$bin" | grep -A3 LC_CODE_SIGNATURE || echo "no LC_CODE_SIGNATURE load command"
+            echo "::endgroup::"
+          done
+
       - name: Build desktop package
         working-directory: apps/desktop
         env:
           GH_TOKEN: ${{ github.token }}
+          DEBUG: ${{ matrix.os == 'macos' && 'electron-builder,@electron/osx-sign*,electron-notarize*' || '' }}
           CSC_LINK: ${{ matrix.os == 'macos' && secrets.CSC_LINK || '' }}
           CSC_KEY_PASSWORD: ${{ matrix.os == 'macos' && secrets.CSC_KEY_PASSWORD || '' }}
           APPLE_API_KEY_ID: ${{ matrix.os == 'macos' && secrets.APPLE_API_KEY_ID || '' }}


### PR DESCRIPTION
## 🚀 Change Summary

Adds diagnostics to the macOS release build so we can pinpoint why Apple code signing stalls. The job currently hangs right after electron-builder prints the `signing file=...Stitch.app` line — i.e. during `codesign`, before notarization ever starts. This PR makes the next release surface enough detail to tell whether the stall is the Bun `--compile` signature bug or genuine codesign throughput. No signing behavior is changed.

### 🛠 Improvements & Refactors
- **Sidecar signature diagnostics**: builds the Bun-compiled `stitch-server` / `stitch-sandbox` binaries up front and dumps `codesign -dvvv` + `otool -l ... LC_CODE_SIGNATURE` for each. A truncated/invalid signature indicates the Bun `--compile` bug ([oven-sh/bun#29120](https://github.com/oven-sh/bun/issues/29120)), where waiting on codesign would never complete.
- **Verbose signing logs**: sets `DEBUG=electron-builder,@electron/osx-sign*,electron-notarize*` on the macOS build step so per-file signing progress is visible in the logs.

### How to read the results
- `code object is not signed at all` / tiny `datasize` → Bun #29120; the fix is `BUN_NO_CODESIGN_MACHO_BINARY=1` on the sidecar build (follow-up PR).
- Valid signature but slow per-file output → codesign throughput on large binaries; candidates are `strictVerify: false` and/or parallel signing (follow-up PR).