### PR TITLE
improvement(desktop): enable auto-updates on macOS

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -164,14 +164,12 @@ void app.whenReady().then(async () => {
       });
     }
 
-    if (process.platform !== 'darwin') {
-      updater.init();
-      setTimeout(() => void updater.checkForUpdates(), 15_000);
-      updateCheckInterval = setInterval(
-        () => void updater.checkForUpdates(),
-        UPDATE_CHECK_INTERVAL_MS,
-      );
-    }
+    updater.init();
+    setTimeout(() => void updater.checkForUpdates(), 15_000);
+    updateCheckInterval = setInterval(
+      () => void updater.checkForUpdates(),
+      UPDATE_CHECK_INTERVAL_MS,
+    );
 
     initTray(() => mainWindow);
 

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,10 +1,5 @@
 import { app, shell } from 'electron';
 import { autoUpdater, type ProgressInfo, type UpdateInfo } from 'electron-updater';
-import { createWriteStream } from 'node:fs';
-import { mkdir, rename, rm } from 'node:fs/promises';
-import path from 'node:path';
-import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
 
 import type { UpdaterStatePayload } from './ipc-types.js';
 
@@ -19,38 +14,9 @@ const NETWORK_ERROR_CODES = [
 ];
 
 const RELEASES_URL = 'https://github.com/UseStitch/stitch/releases/latest';
-const RELEASE_DOWNLOAD_BASE_URL = 'https://github.com/UseStitch/stitch/releases/latest/download';
 
 function isNetworkError(error: Error): boolean {
   return NETWORK_ERROR_CODES.some((code) => error.message.includes(code));
-}
-
-async function downloadLatestMacDmg(): Promise<string> {
-  const downloadsDir = app.getPath('downloads');
-  await mkdir(downloadsDir, { recursive: true });
-
-  const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
-  const fileName = `Stitch-macos-${arch}.dmg`;
-  const filePath = path.join(downloadsDir, fileName);
-  const partialPath = `${filePath}.download`;
-  const downloadUrl = `${RELEASE_DOWNLOAD_BASE_URL}/${fileName}`;
-
-  const response = await fetch(downloadUrl, {
-    headers: { 'User-Agent': 'Stitch Desktop' },
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to download ${fileName}: ${response.status} ${response.statusText}`);
-  }
-  if (!response.body) {
-    throw new Error(`Failed to download ${fileName}: response body was empty`);
-  }
-
-  await rm(partialPath, { force: true });
-  await pipeline(Readable.fromWeb(response.body), createWriteStream(partialPath));
-  await rename(partialPath, filePath);
-
-  return filePath;
 }
 
 type UpdaterOptions = {
@@ -139,15 +105,7 @@ export function createUpdater(options: UpdaterOptions) {
   }
 
   async function openManualUpdateAndQuit(): Promise<boolean> {
-    const filePath = process.platform === 'darwin' ? await downloadLatestMacDmg() : null;
-
-    if (filePath) {
-      const error = await shell.openPath(filePath);
-      if (error) throw new Error(error);
-    } else {
-      await shell.openExternal(RELEASES_URL);
-    }
-
+    await shell.openExternal(RELEASES_URL);
     await options.prepareForInstall();
     app.quit();
     return true;

--- a/apps/web/src/components/settings/general.tsx
+++ b/apps/web/src/components/settings/general.tsx
@@ -168,9 +168,6 @@ const UPDATER_STATUS_LABELS: Record<string, string> = {
   installing: 'Installing update and restarting...',
 };
 
-const MAC_MANUAL_UPDATE_DESCRIPTION =
-  'Download the latest macOS installer, open it, then quit Stitch so you can replace the app safely.';
-
 function updaterStatusLabel(status: string, progress?: number): string {
   if (status === 'downloading') {
     return `Downloading update${progress ? ` (${Math.round(progress)}%)` : '...'}`;
@@ -179,58 +176,7 @@ function updaterStatusLabel(status: string, progress?: number): string {
 }
 
 function AppUpdatesContent() {
-  const isMac = window.electron?.platform === 'darwin';
-
-  if (isMac) {
-    return <MacManualUpdatesContent />;
-  }
-
   return <AutoUpdatesContent />;
-}
-
-function MacManualUpdatesContent() {
-  const [quitPending, setQuitPending] = React.useState(false);
-  const [error, setError] = React.useState<string | null>(null);
-
-  async function handleManualUpdate() {
-    const openManualUpdateAndQuit = window.api?.updater?.openManualUpdateAndQuit;
-    if (!openManualUpdateAndQuit) return;
-
-    setQuitPending(true);
-    setError(null);
-    try {
-      await openManualUpdateAndQuit();
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
-    } finally {
-      setQuitPending(false);
-    }
-  }
-
-  return (
-    <SettingRows>
-      <SettingRow label="Desktop app updates" description={MAC_MANUAL_UPDATE_DESCRIPTION}>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="shrink-0"
-          onClick={handleManualUpdate}
-          disabled={quitPending}
-        >
-          {quitPending ? (
-            <>
-              <LoaderIcon className="size-3.5 animate-spin" />
-              Downloading...
-            </>
-          ) : (
-            'Download and quit'
-          )}
-        </Button>
-      </SettingRow>
-      {error ? <p className="pb-2 text-xs text-destructive">{error}</p> : null}
-    </SettingRows>
-  );
 }
 
 function AutoUpdatesContent() {


### PR DESCRIPTION
## Change Summary

Now that Mac releases are code-signed and notarized, this PR enables the native electron-updater auto-update flow on macOS - the same mechanism already used on Windows.

### Improvements & Refactors
- **Unified auto-update on all platforms**: Removed the Darwin platform guard that skipped updater initialization on macOS. The auto-updater now runs identically on Windows and macOS (background check, auto-download, restart to install).
- **Removed manual DMG download fallback**: The downloadLatestMacDmg function is no longer needed since electron-updater handles the update natively via the signed zip artifact.
- **Unified settings UI**: Removed the MacManualUpdatesContent component and the platform-specific branching. Both platforms now show the same Check for updates / Restart to update controls.
