### PR TITLE
fix(web): eliminate blocking round trips for session type in route loaders

### DIFF
--- a/apps/web/src/lib/queries/chat.ts
+++ b/apps/web/src/lib/queries/chat.ts
@@ -5,7 +5,7 @@ import {
   useMutation,
   useQueryClient,
 } from '@tanstack/react-query';
-import type { InfiniteData } from '@tanstack/react-query';
+import type { InfiniteData, QueryClient } from '@tanstack/react-query';
 
 import type { GeneratedAutomationDraft } from '@stitch/shared/automations/types';
 import type {
@@ -86,6 +86,38 @@ export const sessionQueryOptions = (id: string) =>
     },
     staleTime: Infinity,
   });
+
+function findSessionInListCache(queryClient: QueryClient, id: string): Session | undefined {
+  const cacheEntries = queryClient.getQueriesData<InfiniteData<SessionsPage>>({
+    queryKey: sessionKeys.list(),
+  });
+  for (const [, data] of cacheEntries) {
+    if (!data) continue;
+    for (const page of data.pages) {
+      const found = page.sessions.find((s) => s.id === id);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
+export async function loadSessionRoute(queryClient: QueryClient, id: string): Promise<Session> {
+  let session = queryClient.getQueryData<Session>(sessionKeys.detail(id));
+
+  if (!session) {
+    const fromList = findSessionInListCache(queryClient, id);
+    if (fromList) {
+      queryClient.setQueryData(sessionKeys.detail(id), fromList);
+      session = fromList;
+    }
+  }
+
+  if (!session) {
+    session = await queryClient.ensureQueryData(sessionQueryOptions(id));
+  }
+
+  return session;
+}
 
 export const sessionStatsQueryOptions = (id: string) =>
   queryOptions({

--- a/apps/web/src/routes/automations/sessions/$id.tsx
+++ b/apps/web/src/routes/automations/sessions/$id.tsx
@@ -2,20 +2,25 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 
 import { SessionPage } from '@/components/session/session-page';
 import { useActions } from '@/lib/actions';
-import { sessionMessagesInfiniteQueryOptions, sessionQueryOptions } from '@/lib/queries/chat';
+import { loadSessionRoute, sessionMessagesInfiniteQueryOptions } from '@/lib/queries/chat';
+import { visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
+import { sessionTodosQueryOptions } from '@/lib/queries/todos';
 import { useSessionHotkeys } from '@/lib/use-session-hotkeys';
 
 export const Route = createFileRoute('/automations/sessions/$id')({
-  loader: async ({ context, params }) => {
-    const session = await context.queryClient.ensureQueryData(sessionQueryOptions(params.id));
+  beforeLoad: async ({ context, params }) => {
+    const session = await loadSessionRoute(context.queryClient, params.id);
 
     if (session.type !== 'automation') {
       throw redirect({ to: '/session/$id', params: { id: params.id } });
     }
-
-    await context.queryClient.ensureInfiniteQueryData(
-      sessionMessagesInfiniteQueryOptions(params.id),
-    );
+  },
+  loader: ({ context, params }) => {
+    void Promise.all([
+      context.queryClient.ensureInfiniteQueryData(sessionMessagesInfiniteQueryOptions(params.id)),
+      context.queryClient.ensureQueryData(visibleProviderModelsQueryOptions),
+      context.queryClient.ensureQueryData(sessionTodosQueryOptions(params.id)),
+    ]);
   },
   component: RouteComponent,
 });

--- a/apps/web/src/routes/session.$id.tsx
+++ b/apps/web/src/routes/session.$id.tsx
@@ -4,20 +4,20 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 
 import { SessionPage } from '@/components/session/session-page';
 import { useActions } from '@/lib/actions';
-import { sessionQueryOptions, sessionMessagesInfiniteQueryOptions } from '@/lib/queries/chat';
+import { loadSessionRoute, sessionMessagesInfiniteQueryOptions } from '@/lib/queries/chat';
 import { visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
 import { sessionTodosQueryOptions } from '@/lib/queries/todos';
 import { useSessionHotkeys } from '@/lib/use-session-hotkeys';
 
 export const Route = createFileRoute('/session/$id')({
-  loader: async ({ context, params }) => {
-    const session = await context.queryClient.ensureQueryData(sessionQueryOptions(params.id));
+  beforeLoad: async ({ context, params }) => {
+    const session = await loadSessionRoute(context.queryClient, params.id);
 
     if (session.type === 'automation') {
       throw redirect({ to: '/automations/sessions/$id', params: { id: params.id } });
     }
-
-    // Prefetch remaining data without blocking navigation
+  },
+  loader: ({ context, params }) => {
     void Promise.all([
       context.queryClient.ensureInfiniteQueryData(sessionMessagesInfiniteQueryOptions(params.id)),
       context.queryClient.ensureQueryData(visibleProviderModelsQueryOptions),


### PR DESCRIPTION
## 🚀 Change Summary

Eliminates unnecessary network round trips when navigating to session routes by resolving session type from the TanStack Query cache before falling back to a network fetch.

### ✨ New Features
- **Cache-first session resolution**: New \loadSessionRoute\ utility checks the detail cache, then seeds from the sidebar's infinite list cache, and only fetches from the network on a cold open (URL pasted directly with no prior cache)

### 🛠 Improvements & Refactors
- **Redirect moved to \eforeLoad\**: Per TanStack Router best practices, redirect/guard decisions belong in \eforeLoad\, not \loader\. \loader\ is now solely responsible for firing data prefetches
- **Parallel prefetches in automation route**: The automation sessions route previously awaited metadata then sequentially awaited messages (2 serial RTTs before paint). Messages, models, and todos now all fire in \Promise.all\ without blocking navigation
- **Shared utility**: Both \/session/\\ and \/automations/sessions/\\ routes share the same \loadSessionRoute\ logic

Closes #320