### PR TITLE
fix(server): remove mock.module from analysis-service tests via DI seam

### DIFF
--- a/packages/server/src/recordings/analysis-service.test.ts
+++ b/packages/server/src/recordings/analysis-service.test.ts
@@ -1,5 +1,5 @@
 import { MockLanguageModelV3 } from 'ai/test';
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { beforeEach, describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
 
 import type { PrefixedString } from '@stitch/shared/id';
@@ -7,6 +7,8 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { getDb } from '@/db/client.js';
 import { recordingAnalyses, recordings } from '@/db/schema/recordings.js';
 import { setupTestDb } from '@/db/test-helpers.js';
+import { ok } from '@/lib/service-result.js';
+import { cancelRecordingAnalysis, startRecordingAnalysis } from '@/recordings/analysis-service.js';
 import { ZERO_USAGE } from '@/utils/usage.js';
 
 let generateTextCalls = 0;
@@ -24,23 +26,6 @@ function createHangingAnalysisModel(): MockLanguageModelV3 {
     },
   });
 }
-
-void mock.module('@/llm/provider/provider.js', () => ({
-  createProvider: () => () => createHangingAnalysisModel(),
-}));
-
-void mock.module('@/llm/resolve-model.js', () => ({
-  resolveModel: async () => ({
-    data: {
-      providerId: 'test-provider',
-      modelId: 'test-model',
-      credentials: {
-        providerId: 'openai',
-        auth: { method: 'api-key', apiKey: 'test-key' },
-      },
-    },
-  }),
-}));
 
 setupTestDb();
 
@@ -118,10 +103,22 @@ describe('recording analysis reruns', () => {
   });
 
   test('keeps completed analysis while a forced rerun is cancelled', async () => {
-    const { cancelRecordingAnalysis, startRecordingAnalysis } =
-      await import('@/recordings/analysis-service.js');
-
-    const startResult = await startRecordingAnalysis(recordingId, { force: true });
+    const startResult = await startRecordingAnalysis(
+      recordingId,
+      { force: true },
+      {
+        resolveModel: async () =>
+          ok({
+            providerId: 'test-provider',
+            modelId: 'test-model',
+            credentials: {
+              providerId: 'openai',
+              auth: { method: 'api-key', apiKey: 'test-key' },
+            },
+          }),
+        createProvider: () => () => createHangingAnalysisModel(),
+      },
+    );
 
     await waitForAnalysisModelCall();
 

--- a/packages/server/src/recordings/analysis-service.ts
+++ b/packages/server/src/recordings/analysis-service.ts
@@ -26,6 +26,7 @@ import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { resolveModel } from '@/llm/resolve-model.js';
 import { recordLlmUsage } from '@/usage/ledger.js';
 import { ZERO_USAGE } from '@/utils/usage.js';
+import type { LanguageModel } from 'ai';
 
 const log = Log.create({ service: 'recordings-analysis' });
 const NOT_SPECIFIED_TEXT = 'not specified';
@@ -65,6 +66,13 @@ const analysisOutputSchema = z.object({
   summary: z.string(),
   topicSections: z.array(topicSectionSchema).default([]),
 });
+
+type AnalysisDeps = {
+  resolveModel: typeof resolveModel;
+  createProvider: (credentials: ProviderCredentials) => (modelId: string) => LanguageModel;
+};
+
+const defaultDeps: AnalysisDeps = { resolveModel, createProvider };
 
 type ActiveRun = {
   controller: AbortController;
@@ -184,6 +192,7 @@ export async function getRecordingAnalysis(
 export async function startRecordingAnalysis(
   recordingId: PrefixedString<'rec'>,
   input?: { force?: boolean },
+  deps: AnalysisDeps = defaultDeps,
 ): Promise<ServiceResult<StartRecordingAnalysisResponse>> {
   const db = getDb();
 
@@ -209,7 +218,7 @@ export async function startRecordingAnalysis(
     return err('No transcript available for this recording', 400);
   }
 
-  const analysisModel = await resolveModel({
+  const analysisModel = await deps.resolveModel({
     providerIdKey: 'recordings.analysis.providerId',
     modelIdKey: 'recordings.analysis.modelId',
   });
@@ -277,14 +286,18 @@ export async function startRecordingAnalysis(
     title: null,
   });
 
-  void runRecordingAnalysis(id, {
-    recordingId,
-    transcript,
-    analysisProviderId: analysisModel.data.providerId,
-    analysisModelId: analysisModel.data.modelId,
-    analysisCredentials: analysisModel.data.credentials,
-    preserveExistingUntilComplete,
-  });
+  void runRecordingAnalysis(
+    id,
+    {
+      recordingId,
+      transcript,
+      analysisProviderId: analysisModel.data.providerId,
+      analysisModelId: analysisModel.data.modelId,
+      analysisCredentials: analysisModel.data.credentials,
+      preserveExistingUntilComplete,
+    },
+    deps,
+  );
 
   const [created] = await db.select().from(recordingAnalyses).where(eq(recordingAnalyses.id, id));
   if (!created) {
@@ -369,6 +382,7 @@ async function runRecordingAnalysis(
     analysisCredentials: ProviderCredentials;
     preserveExistingUntilComplete: boolean;
   },
+  deps: AnalysisDeps,
 ): Promise<void> {
   const db = getDb();
   const startedAt = Date.now();
@@ -403,7 +417,7 @@ async function runRecordingAnalysis(
       title: null,
     });
 
-    const analysisModel = createProvider(input.analysisCredentials)(input.analysisModelId);
+    const analysisModel = deps.createProvider(input.analysisCredentials)(input.analysisModelId);
     const analysisRunId = `${analysisId}:analysis`;
     const analysisStart = Date.now();
     const analysisResult = await generateText({


### PR DESCRIPTION
## Change Summary

Fixes a flaky CI failure where 4 unrelated tests would fail with \SyntaxError: Export named 'ProviderCredentialsSchema' not found\ regardless of branch. The root cause was \mock.module\ in Bun running process-globally and permanently — the mock in \nalysis-service.test.ts\ only stubbed \createProvider\, stripping \ProviderCredentialsSchema\ from the module for all test files that ran after it.

### Bug Fixes
- **Eliminated global module-mock pollution**: Replaced both \mock.module\ calls in \nalysis-service.test.ts\ with a small DI seam on \startRecordingAnalysis\. Dependencies (\esolveModel\, \createProvider\) are now passed as an optional third argument defaulting to the real implementations — all production callers are unaffected. The test supplies fakes inline, scoped to the call, with no process-global side effects.