### PR TITLE
chore: delete the dead data-change SSE event (resolves #326)

### DIFF
--- a/packages/server/src/llm/compaction.ts
+++ b/packages/server/src/llm/compaction.ts
@@ -426,7 +426,6 @@ export async function compact(input: {
     );
 
     Events.emit('compaction-complete', { sessionId, summaryMessageId });
-    Events.emit('data-change', { queryKey: ['sessions', sessionId] });
 
     return 'continue';
   } catch (error) {

--- a/packages/shared/src/chat/realtime.ts
+++ b/packages/shared/src/chat/realtime.ts
@@ -30,10 +30,6 @@ export type StreamToolStatePayload = {
   error?: string;
 };
 
-export type DataChangePayload = {
-  queryKey: readonly unknown[];
-};
-
 export type PartUpdate =
   | TextStartPart
   | TextEndPart
@@ -190,7 +186,6 @@ export type RecordingTranscriptEntryPayload = {
 export const SSE_EVENT_NAMES = [
   'heartbeat',
   'connected',
-  'data-change',
   'session-title-update',
   'stream-start',
   'stream-part-update',
@@ -219,7 +214,6 @@ export type SseEventName = (typeof SSE_EVENT_NAMES)[number];
 export type SseEventPayloadMap = {
   heartbeat: { ts: number };
   connected: { ts: number };
-  'data-change': DataChangePayload;
   'session-title-update': SessionTitleUpdatePayload;
   'stream-start': StreamStartPayload;
   'stream-part-update': StreamPartUpdatePayload;


### PR DESCRIPTION
## 🚀 Change Summary

This PR removes the dead `data-change` SSE event end-to-end to clean up unused real-time events and remove the coupling between the server and the frontend's cache layout.

Closes #326

### 🛠 Improvements & Refactors
- **Remove dead `data-change` event**: Deleted `Events.emit('data-change', ...)` from the compaction flow.
- **Clean up Shared types**: Removed `data-change` from `SSE_EVENT_NAMES`, `SseEventPayloadMap`, and removed the unused `DataChangePayload` type.
