### PR TITLE
chore(web): deepen server-request module and consolidate queries

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -170,5 +170,9 @@ export async function serverRequest<T>(path: string, init?: RequestInit): Promis
     }
     throw new Error(errorMsg);
   }
+
+  if (res.status === 204) {
+    return undefined as T;
+  }
   return res.json() as Promise<T>;
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -157,16 +157,11 @@ export async function serverRequest<T>(path: string, init?: RequestInit): Promis
     let errorMsg = `Request failed with status ${res.status}`;
     try {
       const errJson = await res.json();
-      if (
-        errJson &&
-        typeof errJson === 'object' &&
-        'error' in errJson &&
-        typeof errJson.error === 'string'
-      ) {
+      if (errJson?.error) {
         errorMsg = errJson.error;
       }
     } catch {
-      // JSON parsing failed or wasn't an object; use status code fallback
+      // JSON parsing failed; use status code fallback
     }
     throw new Error(errorMsg);
   }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -150,3 +150,25 @@ export async function serverFetch(path: string, init?: RequestInit): Promise<Res
   const baseUrl = await getServerUrl();
   return fetch(`${baseUrl}${path}`, init);
 }
+
+export async function serverRequest<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await serverFetch(path, init);
+  if (!res.ok) {
+    let errorMsg = `Request failed with status ${res.status}`;
+    try {
+      const errJson = await res.json();
+      if (
+        errJson &&
+        typeof errJson === 'object' &&
+        'error' in errJson &&
+        typeof errJson.error === 'string'
+      ) {
+        errorMsg = errJson.error;
+      }
+    } catch {
+      // JSON parsing failed or wasn't an object; use status code fallback
+    }
+    throw new Error(errorMsg);
+  }
+  return res.json() as Promise<T>;
+}

--- a/apps/web/src/lib/queries/agenda.ts
+++ b/apps/web/src/lib/queries/agenda.ts
@@ -9,7 +9,7 @@ import type {
   ListAgendaItemsResponse,
 } from '@stitch/shared/agenda/types';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 const agendaKeys = {
   all: ['agenda'] as const,
@@ -23,12 +23,10 @@ const agendaKeys = {
 export function agendaListsQueryOptions(includeArchived = false) {
   return queryOptions({
     queryKey: [...agendaKeys.lists(), includeArchived],
-    queryFn: async (): Promise<{ lists: AgendaListWithCounts[] }> => {
+    queryFn: () => {
       const params = new URLSearchParams();
       if (includeArchived) params.set('includeArchived', 'true');
-      const res = await serverFetch(`/agenda/lists?${params.toString()}`);
-      if (!res.ok) throw new Error('Failed to fetch agenda lists');
-      return res.json() as Promise<{ lists: AgendaListWithCounts[] }>;
+      return serverRequest<{ lists: AgendaListWithCounts[] }>(`/agenda/lists?${params.toString()}`);
     },
   });
 }
@@ -49,7 +47,7 @@ export function agendaItemsQueryOptions(input: {
       input.page,
       input.pageSize,
     ],
-    queryFn: async (): Promise<ListAgendaItemsResponse> => {
+    queryFn: () => {
       const params = new URLSearchParams({
         page: String(input.page),
         pageSize: String(input.pageSize),
@@ -57,9 +55,7 @@ export function agendaItemsQueryOptions(input: {
       if (input.listId) params.set('listId', input.listId);
       if (input.status) params.set('status', input.status);
       if (input.priority) params.set('priority', input.priority);
-      const res = await serverFetch(`/agenda/items?${params.toString()}`);
-      if (!res.ok) throw new Error('Failed to fetch agenda items');
-      return res.json() as Promise<ListAgendaItemsResponse>;
+      return serverRequest<ListAgendaItemsResponse>(`/agenda/items?${params.toString()}`);
     },
   });
 }
@@ -68,18 +64,12 @@ export function useCreateAgendaList() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: { name: string; description?: string; color?: string }) => {
-      const res = await serverFetch('/agenda/lists', {
+    mutationFn: (input: { name: string; description?: string; color?: string }) =>
+      serverRequest<unknown>('/agenda/lists', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to create list');
-      }
-      return res.json();
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: agendaKeys.lists() });
       toast.success('List created');
@@ -92,21 +82,15 @@ export function useUpdateAgendaList() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: {
+    mutationFn: (input: {
       id: string;
       updates: { name?: string; description?: string; color?: string | null; isArchived?: boolean };
-    }) => {
-      const res = await serverFetch(`/agenda/lists/${input.id}`, {
+    }) =>
+      serverRequest<unknown>(`/agenda/lists/${input.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input.updates),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to update list');
-      }
-      return res.json();
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: agendaKeys.lists() });
       toast.success('List updated');
@@ -119,13 +103,7 @@ export function useDeleteAgendaList() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (id: string) => {
-      const res = await serverFetch(`/agenda/lists/${id}`, { method: 'DELETE' });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to delete list');
-      }
-    },
+    mutationFn: (id: string) => serverRequest<void>(`/agenda/lists/${id}`, { method: 'DELETE' }),
     onSuccess: () => {
       // Items are cascade-deleted, so both caches are stale
       void queryClient.invalidateQueries({ queryKey: agendaKeys.all });
@@ -139,7 +117,7 @@ export function useCreateAgendaItem() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: {
+    mutationFn: (input: {
       title: string;
       description?: string;
       status?: AgendaItemStatus;
@@ -147,18 +125,12 @@ export function useCreateAgendaItem() {
       dueAt?: number | null;
       listId?: string;
       listName?: string;
-    }) => {
-      const res = await serverFetch('/agenda/items', {
+    }) =>
+      serverRequest<unknown>('/agenda/items', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to create item');
-      }
-      return res.json();
-    },
+      }),
     onSuccess: () => {
       // New item changes both item list and list counts
       void queryClient.invalidateQueries({ queryKey: agendaKeys.all });
@@ -172,7 +144,7 @@ export function useUpdateAgendaItem() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: {
+    mutationFn: (input: {
       id: string;
       updates: {
         title?: string;
@@ -182,18 +154,12 @@ export function useUpdateAgendaItem() {
         dueAt?: number | null;
         listId?: string;
       };
-    }) => {
-      const res = await serverFetch(`/agenda/items/${input.id}`, {
+    }) =>
+      serverRequest<unknown>(`/agenda/items/${input.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input.updates),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to update item');
-      }
-      return res.json();
-    },
+      }),
     onSuccess: (_data, variables) => {
       // Status changes affect list counts; listId moves affect both caches
       const touchesListCounts =
@@ -213,13 +179,7 @@ export function useDeleteAgendaItem() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (id: string) => {
-      const res = await serverFetch(`/agenda/items/${id}`, { method: 'DELETE' });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to delete item');
-      }
-    },
+    mutationFn: (id: string) => serverRequest<void>(`/agenda/items/${id}`, { method: 'DELETE' }),
     onSuccess: () => {
       // Deleted item changes both item list and list counts
       void queryClient.invalidateQueries({ queryKey: agendaKeys.all });
@@ -233,18 +193,12 @@ export function useMergeAgendaLists() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: { targetId: string; sourceId: string }) => {
-      const res = await serverFetch(`/agenda/lists/${input.targetId}/merge`, {
+    mutationFn: (input: { targetId: string; sourceId: string }) =>
+      serverRequest<unknown>(`/agenda/lists/${input.targetId}/merge`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sourceId: input.sourceId }),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to merge lists');
-      }
-      return res.json();
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: agendaKeys.all });
       toast.success('Lists merged');
@@ -257,17 +211,12 @@ export function useReorderAgendaItems() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (orderedIds: string[]) => {
-      const res = await serverFetch('/agenda/items/reorder', {
+    mutationFn: (orderedIds: string[]) =>
+      serverRequest<void>('/agenda/items/reorder', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ orderedIds }),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to reorder items');
-      }
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: agendaKeys.items() });
     },
@@ -279,17 +228,12 @@ export function useReorderAgendaLists() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (orderedIds: string[]) => {
-      const res = await serverFetch('/agenda/lists/reorder', {
+    mutationFn: (orderedIds: string[]) =>
+      serverRequest<void>('/agenda/lists/reorder', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ orderedIds }),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to reorder lists');
-      }
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: agendaKeys.lists() });
     },

--- a/apps/web/src/lib/queries/automations.ts
+++ b/apps/web/src/lib/queries/automations.ts
@@ -9,7 +9,7 @@ import type {
 } from '@stitch/shared/automations/types';
 import type { Session } from '@stitch/shared/chat/messages';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 const automationKeys = {
   all: ['automations'] as const,
@@ -24,14 +24,12 @@ export function automationsPageQueryOptions(input: { page: number; pageSize: num
   return queryOptions({
     queryKey: automationKeys.page(input.page, input.pageSize),
     staleTime: Infinity,
-    queryFn: async (): Promise<ListAutomationsResponse> => {
+    queryFn: () => {
       const params = new URLSearchParams({
         page: String(input.page),
         pageSize: String(input.pageSize),
       });
-      const res = await serverFetch(`/automations?${params.toString()}`);
-      if (!res.ok) throw new Error('Failed to fetch automations');
-      return res.json() as Promise<ListAutomationsResponse>;
+      return serverRequest<ListAutomationsResponse>(`/automations?${params.toString()}`);
     },
   });
 }
@@ -41,9 +39,7 @@ export const automationsSidebarListQueryOptions = queryOptions({
   staleTime: Infinity,
   queryFn: async (): Promise<Automation[]> => {
     const params = new URLSearchParams({ page: '1', pageSize: '100' });
-    const res = await serverFetch(`/automations?${params.toString()}`);
-    if (!res.ok) throw new Error('Failed to fetch automations');
-    const data = (await res.json()) as ListAutomationsResponse;
+    const data = await serverRequest<ListAutomationsResponse>(`/automations?${params.toString()}`);
     return data.automations;
   },
 });
@@ -52,30 +48,18 @@ export const automationQueryOptions = (automationId: string) =>
   queryOptions({
     queryKey: automationKeys.detail(automationId),
     staleTime: Infinity,
-    queryFn: async (): Promise<Automation> => {
-      const res = await serverFetch(`/automations/${automationId}`);
-      if (!res.ok) throw new Error('Failed to fetch automation');
-      return res.json() as Promise<Automation>;
-    },
+    queryFn: () => serverRequest<Automation>(`/automations/${automationId}`),
   });
 
 export function useCreateAutomation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: CreateAutomationInput): Promise<Automation> => {
-      const res = await serverFetch('/automations', {
+    mutationFn: (input: CreateAutomationInput) =>
+      serverRequest<Automation>('/automations', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to create automation');
-      }
-
-      return res.json() as Promise<Automation>;
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: automationKeys.all });
     },
@@ -85,26 +69,12 @@ export function useCreateAutomation() {
 export function useUpdateAutomation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({
-      automationId,
-      input,
-    }: {
-      automationId: string;
-      input: UpdateAutomationInput;
-    }): Promise<Automation> => {
-      const res = await serverFetch(`/automations/${automationId}`, {
+    mutationFn: ({ automationId, input }: { automationId: string; input: UpdateAutomationInput }) =>
+      serverRequest<Automation>(`/automations/${automationId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to update automation');
-      }
-
-      return res.json() as Promise<Automation>;
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: automationKeys.all });
     },
@@ -114,14 +84,8 @@ export function useUpdateAutomation() {
 export function useDeleteAutomation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (automationId: string): Promise<void> => {
-      const res = await serverFetch(`/automations/${automationId}`, { method: 'DELETE' });
-
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to delete automation');
-      }
-    },
+    mutationFn: (automationId: string) =>
+      serverRequest<void>(`/automations/${automationId}`, { method: 'DELETE' }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: automationKeys.all });
     },
@@ -131,29 +95,17 @@ export function useDeleteAutomation() {
 export const automationSessionsQueryOptions = (automationId: string) =>
   queryOptions({
     queryKey: automationKeys.sessions(automationId),
-    queryFn: async (): Promise<Session[]> => {
-      const res = await serverFetch(`/automations/${automationId}/sessions`);
-      if (!res.ok) throw new Error('Failed to fetch automation sessions');
-      return res.json() as Promise<Session[]>;
-    },
+    queryFn: () => serverRequest<Session[]>(`/automations/${automationId}/sessions`),
     staleTime: 30_000,
   });
 
 export function useRunAutomation() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (automationId: string): Promise<RunAutomationResponse> => {
-      const res = await serverFetch(`/automations/${automationId}/run`, {
+    mutationFn: (automationId: string) =>
+      serverRequest<RunAutomationResponse>(`/automations/${automationId}/run`, {
         method: 'POST',
-      });
-
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to run automation');
-      }
-
-      return res.json() as Promise<RunAutomationResponse>;
-    },
+      }),
     onSuccess: (_data, automationId) => {
       void queryClient.invalidateQueries({ queryKey: automationKeys.sessions(automationId) });
       void queryClient.invalidateQueries({ queryKey: automationKeys.all });

--- a/apps/web/src/lib/queries/browser.ts
+++ b/apps/web/src/lib/queries/browser.ts
@@ -2,7 +2,7 @@ import { toast } from 'sonner';
 
 import { queryOptions, type MutationOptions, type QueryClient } from '@tanstack/react-query';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 type ChromeProfile = {
   id: string;
@@ -23,29 +23,19 @@ const browserKeys = {
 
 export const chromeProfilesQueryOptions = queryOptions({
   queryKey: browserKeys.profiles(),
-  queryFn: async (): Promise<ChromeProfile[]> => {
-    const res = await serverFetch('/browser/profiles');
-    if (!res.ok) throw new Error('Failed to fetch Chrome profiles');
-    return res.json() as Promise<ChromeProfile[]>;
-  },
+  queryFn: () => serverRequest<ChromeProfile[]>('/browser/profiles'),
 });
 
 export function importProfileMutationOptions(
   queryClient: QueryClient,
 ): MutationOptions<ImportResult, Error, string> {
   return {
-    mutationFn: async (profileId: string) => {
-      const res = await serverFetch('/browser/import-profile', {
+    mutationFn: (profileId: string) =>
+      serverRequest<ImportResult>('/browser/import-profile', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ profileId }),
-      });
-      const data = (await res.json()) as ImportResult;
-      if (!res.ok) {
-        throw new Error(data.error ?? 'Import failed');
-      }
-      return data;
-    },
+      }),
     onSuccess: (data) => {
       void queryClient.invalidateQueries({ queryKey: ['settings'] });
       toast.success(`Chrome profile imported: ${data.profile ?? 'done'}`);

--- a/apps/web/src/lib/queries/chat.ts
+++ b/apps/web/src/lib/queries/chat.ts
@@ -20,7 +20,7 @@ import type {
 import type { PrefixedString } from '@stitch/shared/id';
 import { createMessageId, createPartId } from '@stitch/shared/id';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 const EMPTY_USAGE: LanguageModelUsage = {
   inputTokens: 0,
@@ -48,7 +48,7 @@ const SESSION_PAGE_SIZE = 30;
 export const sessionsInfiniteQueryOptions = (search: string) =>
   infiniteQueryOptions({
     queryKey: sessionKeys.infiniteList(search),
-    queryFn: async ({ pageParam }): Promise<SessionsPage> => {
+    queryFn: ({ pageParam }): Promise<SessionsPage> => {
       const params = new URLSearchParams({
         type: 'chat',
         limit: String(SESSION_PAGE_SIZE),
@@ -60,9 +60,7 @@ export const sessionsInfiniteQueryOptions = (search: string) =>
         params.set('cursor', String(pageParam));
       }
 
-      const res = await serverFetch(`/chat/sessions?${params.toString()}`);
-      if (!res.ok) throw new Error('Failed to fetch sessions');
-      return res.json() as Promise<SessionsPage>;
+      return serverRequest<SessionsPage>(`/chat/sessions?${params.toString()}`);
     },
     initialPageParam: undefined as number | undefined,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
@@ -79,11 +77,7 @@ export const sessionsInfiniteQueryOptions = (search: string) =>
 export const sessionQueryOptions = (id: string) =>
   queryOptions({
     queryKey: sessionKeys.detail(id),
-    queryFn: async (): Promise<Session> => {
-      const res = await serverFetch(`/chat/sessions/${id}`);
-      if (!res.ok) throw new Error('Failed to fetch session');
-      return res.json() as Promise<Session>;
-    },
+    queryFn: () => serverRequest<Session>(`/chat/sessions/${id}`),
     staleTime: Infinity,
   });
 
@@ -122,11 +116,7 @@ export async function loadSessionRoute(queryClient: QueryClient, id: string): Pr
 export const sessionStatsQueryOptions = (id: string) =>
   queryOptions({
     queryKey: sessionKeys.stats(id),
-    queryFn: async (): Promise<SessionStats> => {
-      const res = await serverFetch(`/chat/sessions/${id}/stats`);
-      if (!res.ok) throw new Error('Failed to fetch session stats');
-      return res.json() as Promise<SessionStats>;
-    },
+    queryFn: () => serverRequest<SessionStats>(`/chat/sessions/${id}/stats`),
     staleTime: 30_000,
   });
 
@@ -135,14 +125,12 @@ const PAGE_SIZE = 50;
 export const sessionMessagesInfiniteQueryOptions = (id: string) =>
   infiniteQueryOptions({
     queryKey: sessionKeys.messages(id),
-    queryFn: async ({ pageParam }): Promise<MessagesPage> => {
+    queryFn: ({ pageParam }): Promise<MessagesPage> => {
       const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
       if (pageParam !== undefined) {
         params.set('cursor', String(pageParam));
       }
-      const res = await serverFetch(`/chat/sessions/${id}/messages?${params.toString()}`);
-      if (!res.ok) throw new Error('Failed to fetch messages');
-      return res.json() as Promise<MessagesPage>;
+      return serverRequest<MessagesPage>(`/chat/sessions/${id}/messages?${params.toString()}`);
     },
     initialPageParam: undefined as number | undefined,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
@@ -197,15 +185,12 @@ type SendMessageResult = {
 export function useCreateSession() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: CreateSessionInput): Promise<Session> => {
-      const res = await serverFetch('/chat/sessions', {
+    mutationFn: (input: CreateSessionInput) =>
+      serverRequest<Session>('/chat/sessions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) throw new Error('Failed to create session');
-      return res.json() as Promise<Session>;
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: sessionKeys.list() });
     },
@@ -229,15 +214,12 @@ type DoomLoopResponseInput = {
 export function useRenameSession() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: RenameSessionInput): Promise<Session> => {
-      const res = await serverFetch(`/chat/sessions/${input.sessionId}`, {
+    mutationFn: (input: RenameSessionInput) =>
+      serverRequest<Session>(`/chat/sessions/${input.sessionId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ title: input.title }),
-      });
-      if (!res.ok) throw new Error('Failed to rename session');
-      return res.json() as Promise<Session>;
-    },
+      }),
     onSuccess: (_data, input) => {
       void queryClient.invalidateQueries({ queryKey: sessionKeys.detail(input.sessionId) });
       void queryClient.invalidateQueries({ queryKey: sessionKeys.list() });
@@ -258,13 +240,10 @@ type SplitSessionResult = {
 export function useSplitSession() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: SplitSessionInput): Promise<SplitSessionResult> => {
-      const res = await serverFetch(`/chat/sessions/${input.sessionId}/split/${input.msgId}`, {
+    mutationFn: (input: SplitSessionInput) =>
+      serverRequest<SplitSessionResult>(`/chat/sessions/${input.sessionId}/split/${input.msgId}`, {
         method: 'POST',
-      });
-      if (!res.ok) throw new Error('Failed to split session');
-      return res.json() as Promise<SplitSessionResult>;
-    },
+      }),
     onSuccess: (data) => {
       queryClient.setQueryData<Session[]>(sessionKeys.list(), (prev) =>
         prev ? [...prev, data.session] : [data.session],
@@ -277,12 +256,10 @@ export function useSplitSession() {
 export function useDeleteSession() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: DeleteSessionInput): Promise<void> => {
-      const res = await serverFetch(`/chat/sessions/${input.sessionId}`, {
+    mutationFn: (input: DeleteSessionInput) =>
+      serverRequest<void>(`/chat/sessions/${input.sessionId}`, {
         method: 'DELETE',
-      });
-      if (!res.ok) throw new Error('Failed to delete session');
-    },
+      }),
     onSuccess: (_data, input) => {
       void queryClient.invalidateQueries({ queryKey: sessionKeys.list() });
       queryClient.removeQueries({ queryKey: sessionKeys.detail(input.sessionId) });
@@ -294,10 +271,11 @@ export function useDeleteSession() {
 export function useMarkSessionRead() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (sessionId: string): Promise<void> => {
-      const res = await serverFetch(`/chat/sessions/${sessionId}/read`, { method: 'PATCH' });
-      if (!res.ok && res.status !== 404) throw new Error('Failed to mark session as read');
-    },
+    mutationFn: (sessionId: string) =>
+      serverRequest<void>(`/chat/sessions/${sessionId}/read`, { method: 'PATCH' }).catch((err) => {
+        if (err instanceof Error && err.message.includes('status 404')) return;
+        throw err;
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: sessionKeys.list() });
     },
@@ -306,14 +284,12 @@ export function useMarkSessionRead() {
 
 export function useRespondDoomLoop() {
   return useMutation({
-    mutationFn: async (input: DoomLoopResponseInput): Promise<void> => {
-      const res = await serverFetch(`/chat/sessions/${input.sessionId}/doom-loop-response`, {
+    mutationFn: (input: DoomLoopResponseInput) =>
+      serverRequest<void>(`/chat/sessions/${input.sessionId}/doom-loop-response`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ response: input.response }),
-      });
-      if (!res.ok) throw new Error('Failed to respond to repeated action');
-    },
+      }),
     onError: (error) => {
       console.error('Failed to respond to repeated action:', error);
     },
@@ -323,17 +299,10 @@ export function useRespondDoomLoop() {
 export function useGenerateAutomationDraft() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (sessionId: string): Promise<GeneratedAutomationDraft> => {
-      const res = await serverFetch(`/chat/sessions/${sessionId}/generate-automation`, {
+    mutationFn: (sessionId: string) =>
+      serverRequest<GeneratedAutomationDraft>(`/chat/sessions/${sessionId}/generate-automation`, {
         method: 'POST',
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to generate automation draft');
-      }
-
-      return res.json() as Promise<GeneratedAutomationDraft>;
-    },
+      }),
     onSuccess: (_data, sessionId) => {
       void queryClient.invalidateQueries({ queryKey: sessionKeys.messages(sessionId) });
     },
@@ -343,8 +312,8 @@ export function useGenerateAutomationDraft() {
 export function useSendMessage() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: SendMessageInput): Promise<SendMessageResult> => {
-      const res = await serverFetch(`/chat/sessions/${input.sessionId}/messages`, {
+    mutationFn: (input: SendMessageInput) =>
+      serverRequest<SendMessageResult>(`/chat/sessions/${input.sessionId}/messages`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -358,10 +327,7 @@ export function useSendMessage() {
           modelId: input.modelId,
           assistantMessageId: input.assistantMessageId,
         }),
-      });
-      if (!res.ok) throw new Error('Failed to send message');
-      return res.json() as Promise<SendMessageResult>;
-    },
+      }),
     onMutate: async (input) => {
       const queryKey = sessionKeys.messages(input.sessionId);
       await queryClient.cancelQueries({ queryKey });

--- a/apps/web/src/lib/queries/connectors.ts
+++ b/apps/web/src/lib/queries/connectors.ts
@@ -2,7 +2,7 @@ import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query
 
 import type { ConnectorDefinition, ConnectorInstanceSafe } from '@stitch/shared/connectors/types';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 const connectorKeys = {
   all: ['connectors'] as const,
@@ -14,11 +14,7 @@ const connectorKeys = {
 export const connectorDefinitionsQueryOptions = queryOptions({
   queryKey: connectorKeys.definitions(),
   staleTime: Infinity,
-  queryFn: async (): Promise<ConnectorDefinition[]> => {
-    const res = await serverFetch('/connectors/definitions');
-    if (!res.ok) throw new Error('Failed to fetch connector definitions');
-    return res.json() as Promise<ConnectorDefinition[]>;
-  },
+  queryFn: () => serverRequest<ConnectorDefinition[]>('/connectors/definitions'),
 });
 
 export const connectorInstancesQueryOptions = queryOptions({
@@ -28,34 +24,24 @@ export const connectorInstancesQueryOptions = queryOptions({
     const data = query.state.data;
     return data?.some((instance) => instance.status === 'awaiting_auth') ? 2000 : false;
   },
-  queryFn: async (): Promise<ConnectorInstanceSafe[]> => {
-    const res = await serverFetch('/connectors/instances');
-    if (!res.ok) throw new Error('Failed to fetch connector instances');
-    return res.json() as Promise<ConnectorInstanceSafe[]>;
-  },
+  queryFn: () => serverRequest<ConnectorInstanceSafe[]>('/connectors/instances'),
 });
 
 export function useCreateOAuthConnector() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: {
+    mutationFn: (input: {
       connectorId: string;
       label: string;
       clientId: string;
       clientSecret: string;
       scopes: string[];
-    }): Promise<ConnectorInstanceSafe> => {
-      const res = await serverFetch('/connectors/instances/oauth', {
+    }) =>
+      serverRequest<ConnectorInstanceSafe>('/connectors/instances/oauth', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to create connector');
-      }
-      return res.json() as Promise<ConnectorInstanceSafe>;
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: connectorKeys.all });
     },
@@ -65,22 +51,12 @@ export function useCreateOAuthConnector() {
 export function useCreateApiKeyConnector() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: {
-      connectorId: string;
-      label: string;
-      apiKey: string;
-    }): Promise<ConnectorInstanceSafe> => {
-      const res = await serverFetch('/connectors/instances/api-key', {
+    mutationFn: (input: { connectorId: string; label: string; apiKey: string }) =>
+      serverRequest<ConnectorInstanceSafe>('/connectors/instances/api-key', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to create connector');
-      }
-      return res.json() as Promise<ConnectorInstanceSafe>;
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: connectorKeys.all });
     },
@@ -90,16 +66,10 @@ export function useCreateApiKeyConnector() {
 export function useAuthorizeConnector() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (instanceId: string): Promise<{ authUrl: string }> => {
-      const res = await serverFetch(`/connectors/instances/${instanceId}/authorize`, {
+    mutationFn: (instanceId: string) =>
+      serverRequest<{ authUrl: string }>(`/connectors/instances/${instanceId}/authorize`, {
         method: 'POST',
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to start authorization');
-      }
-      return res.json() as Promise<{ authUrl: string }>;
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: connectorKeys.all });
     },
@@ -109,15 +79,10 @@ export function useAuthorizeConnector() {
 export function useDeleteConnector() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (instanceId: string) => {
-      const res = await serverFetch(`/connectors/instances/${instanceId}`, {
+    mutationFn: (instanceId: string) =>
+      serverRequest<void>(`/connectors/instances/${instanceId}`, {
         method: 'DELETE',
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to delete connector');
-      }
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: connectorKeys.all });
     },
@@ -127,16 +92,10 @@ export function useDeleteConnector() {
 export function useTestConnector() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (instanceId: string): Promise<{ success: boolean }> => {
-      const res = await serverFetch(`/connectors/instances/${instanceId}/test`, {
+    mutationFn: (instanceId: string) =>
+      serverRequest<{ success: boolean }>(`/connectors/instances/${instanceId}/test`, {
         method: 'POST',
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Connection test failed');
-      }
-      return res.json() as Promise<{ success: boolean }>;
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: connectorKeys.all });
     },
@@ -146,21 +105,15 @@ export function useTestConnector() {
 export function useUpgradeConnector() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: {
-      instanceId: string;
-      apiKey?: string;
-    }): Promise<{ type: 'reauthorize'; authUrl: string } | { type: 'updated' }> => {
-      const res = await serverFetch(`/connectors/instances/${input.instanceId}/upgrade`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ apiKey: input.apiKey }),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Upgrade failed');
-      }
-      return res.json() as Promise<{ type: 'reauthorize'; authUrl: string } | { type: 'updated' }>;
-    },
+    mutationFn: (input: { instanceId: string; apiKey?: string }) =>
+      serverRequest<{ type: 'reauthorize'; authUrl: string } | { type: 'updated' }>(
+        `/connectors/instances/${input.instanceId}/upgrade`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ apiKey: input.apiKey }),
+        },
+      ),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: connectorKeys.all });
     },

--- a/apps/web/src/lib/queries/mcp.ts
+++ b/apps/web/src/lib/queries/mcp.ts
@@ -8,7 +8,7 @@ import type {
   McpTransport,
 } from '@stitch/shared/mcp/types';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 import { toolKeys } from '@/lib/queries/tools';
 
 const mcpKeys = {
@@ -21,11 +21,7 @@ const mcpKeys = {
 export const mcpServersQueryOptions = queryOptions({
   queryKey: mcpKeys.list(),
   staleTime: Infinity,
-  queryFn: async (): Promise<McpServer[]> => {
-    const res = await serverFetch('/mcp');
-    if (!res.ok) throw new Error('Failed to fetch MCP servers');
-    return res.json() as Promise<McpServer[]>;
-  },
+  queryFn: () => serverRequest<McpServer[]>('/mcp'),
 });
 
 export const mcpToolsQueryOptions = (id: string) =>
@@ -33,49 +29,29 @@ export const mcpToolsQueryOptions = (id: string) =>
     queryKey: mcpKeys.tools(id),
     staleTime: 0,
     retry: false,
-    queryFn: async (): Promise<McpTool[]> => {
-      const res = await serverFetch(`/mcp/${id}/tools`);
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? 'Failed to fetch MCP tools');
-      }
-      return res.json() as Promise<McpTool[]>;
-    },
+    queryFn: () => serverRequest<McpTool[]>(`/mcp/${id}/tools`),
   });
 
 export const mcpRegistryQueryOptions = queryOptions({
   queryKey: mcpKeys.registry(),
   staleTime: 5 * 60 * 1000,
-  queryFn: async (): Promise<McpRegistryServer[]> => {
-    const res = await serverFetch('/mcp/registry');
-    if (!res.ok) {
-      const err = (await res.json().catch(() => ({}))) as { error?: string };
-      throw new Error(err.error ?? 'Failed to fetch MCP registry');
-    }
-    return res.json() as Promise<McpRegistryServer[]>;
-  },
+  queryFn: () => serverRequest<McpRegistryServer[]>('/mcp/registry'),
 });
 
 export function useAddMcpServer() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: {
+    mutationFn: (input: {
       name: string;
       transport: McpTransport;
       url: string;
       authConfig: McpAuthConfig;
-    }): Promise<{ id: string }> => {
-      const res = await serverFetch('/mcp', {
+    }) =>
+      serverRequest<{ id: string }>('/mcp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to add MCP server');
-      }
-      return res.json() as Promise<{ id: string }>;
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: mcpKeys.all });
       void queryClient.invalidateQueries({ queryKey: toolKeys.all });
@@ -86,13 +62,7 @@ export function useAddMcpServer() {
 export function useDeleteMcpServer() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: string) => {
-      const res = await serverFetch(`/mcp/${id}`, { method: 'DELETE' });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to delete MCP server');
-      }
-    },
+    mutationFn: (id: string) => serverRequest<void>(`/mcp/${id}`, { method: 'DELETE' }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: mcpKeys.all });
       void queryClient.invalidateQueries({ queryKey: toolKeys.all });
@@ -103,13 +73,7 @@ export function useDeleteMcpServer() {
 export function useRefreshMcpServers() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async () => {
-      const res = await serverFetch('/mcp/refresh', { method: 'POST' });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to refresh MCP servers');
-      }
-    },
+    mutationFn: () => serverRequest<void>('/mcp/refresh', { method: 'POST' }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: mcpKeys.all });
       void queryClient.invalidateQueries({ queryKey: toolKeys.all });
@@ -120,13 +84,7 @@ export function useRefreshMcpServers() {
 export function useRefreshMcpRegistry() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async () => {
-      const res = await serverFetch('/mcp/registry/refresh', { method: 'POST' });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to refresh MCP registry');
-      }
-    },
+    mutationFn: () => serverRequest<void>('/mcp/registry/refresh', { method: 'POST' }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: mcpKeys.registry() });
     },

--- a/apps/web/src/lib/queries/memories.ts
+++ b/apps/web/src/lib/queries/memories.ts
@@ -2,7 +2,7 @@ import { toast } from 'sonner';
 
 import { queryOptions, type MutationOptions, type QueryClient } from '@tanstack/react-query';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 export type {
   MemoryCategory,
@@ -37,11 +37,7 @@ type MemoryHealthStats = {
 
 export const memoryStatsQueryOptions = queryOptions({
   queryKey: memoriesKeys.stats(),
-  queryFn: async (): Promise<MemoryHealthStats> => {
-    const res = await serverFetch(`/memory/stats`);
-    if (!res.ok) throw new Error('Failed to fetch memory stats');
-    return res.json() as Promise<MemoryHealthStats>;
-  },
+  queryFn: () => serverRequest<MemoryHealthStats>(`/memory/stats`),
 });
 
 export const semanticMemoriesQueryOptions = (input: {
@@ -58,19 +54,15 @@ export const semanticMemoriesQueryOptions = (input: {
       input.page,
       input.pageSize,
     ],
-    queryFn: async (): Promise<
-      import('@stitch/shared/memory/types').ListSemanticMemoriesResponse
-    > => {
+    queryFn: () => {
       const params = new URLSearchParams();
       params.set('page', String(input.page));
       params.set('pageSize', String(input.pageSize));
       if (input.source) params.set('source', input.source);
       if (input.category) params.set('category', input.category);
-      const res = await serverFetch(`/memory/semantic?${params.toString()}`);
-      if (!res.ok) throw new Error('Failed to fetch memories');
-      return res.json() as Promise<
-        import('@stitch/shared/memory/types').ListSemanticMemoriesResponse
-      >;
+      return serverRequest<import('@stitch/shared/memory/types').ListSemanticMemoriesResponse>(
+        `/memory/semantic?${params.toString()}`,
+      );
     },
   });
 
@@ -89,9 +81,7 @@ export const semanticMemorySearchQueryOptions = (input: {
       input.page,
       input.pageSize,
     ],
-    queryFn: async (): Promise<
-      import('@stitch/shared/memory/types').SearchSemanticMemoriesResponse
-    > => {
+    queryFn: () => {
       const params = new URLSearchParams({
         q: input.q,
         page: String(input.page),
@@ -99,11 +89,9 @@ export const semanticMemorySearchQueryOptions = (input: {
       });
       if (input.source) params.set('source', input.source);
       if (input.category) params.set('category', input.category);
-      const res = await serverFetch(`/memory/semantic?${params.toString()}`);
-      if (!res.ok) throw new Error('Failed to search memories');
-      return res.json() as Promise<
-        import('@stitch/shared/memory/types').SearchSemanticMemoriesResponse
-      >;
+      return serverRequest<import('@stitch/shared/memory/types').SearchSemanticMemoriesResponse>(
+        `/memory/semantic?${params.toString()}`,
+      );
     },
     enabled: input.q.trim().length > 0,
   });
@@ -112,14 +100,12 @@ export function updateMemoryMutationOptions(
   queryClient: QueryClient,
 ): MutationOptions<void, Error, { id: string; updates: SemanticMemoryUpdate }> {
   return {
-    mutationFn: async ({ id, updates }) => {
-      const res = await serverFetch(`/memory/semantic/${id}`, {
+    mutationFn: ({ id, updates }) =>
+      serverRequest<void>(`/memory/semantic/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(updates),
-      });
-      if (!res.ok) throw new Error('Failed to update memory');
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: memoriesKeys.all });
       toast.success('Memory updated');
@@ -132,14 +118,12 @@ export function pinMemoryMutationOptions(
   queryClient: QueryClient,
 ): MutationOptions<void, Error, { id: string; pinned: boolean }> {
   return {
-    mutationFn: async ({ id, pinned }) => {
-      const res = await serverFetch(`/memory/semantic/${id}/pin`, {
+    mutationFn: ({ id, pinned }) =>
+      serverRequest<void>(`/memory/semantic/${id}/pin`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ pinned }),
-      });
-      if (!res.ok) throw new Error('Failed to pin memory');
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: memoriesKeys.all });
     },
@@ -151,10 +135,7 @@ export function pruneMemoriesMutationOptions(
   queryClient: QueryClient,
 ): MutationOptions<void, Error, void> {
   return {
-    mutationFn: async () => {
-      const res = await serverFetch('/memory/prune', { method: 'POST' });
-      if (!res.ok) throw new Error('Failed to prune memories');
-    },
+    mutationFn: () => serverRequest<void>('/memory/prune', { method: 'POST' }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: memoriesKeys.all });
       toast.success('Stale memories pruned');
@@ -167,10 +148,7 @@ export function deleteMemoryMutationOptions(
   queryClient: QueryClient,
 ): MutationOptions<void, Error, string> {
   return {
-    mutationFn: async (id) => {
-      const res = await serverFetch(`/memory/semantic/${id}`, { method: 'DELETE' });
-      if (!res.ok) throw new Error('Failed to delete memory');
-    },
+    mutationFn: (id) => serverRequest<void>(`/memory/semantic/${id}`, { method: 'DELETE' }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: memoriesKeys.all });
       toast.success('Memory deleted');
@@ -183,14 +161,12 @@ export function bulkDeleteMemoriesMutationOptions(
   queryClient: QueryClient,
 ): MutationOptions<void, Error, string[]> {
   return {
-    mutationFn: async (ids) => {
-      const res = await serverFetch('/memory/semantic', {
+    mutationFn: (ids) =>
+      serverRequest<void>('/memory/semantic', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ ids }),
-      });
-      if (!res.ok) throw new Error('Failed to delete memories');
-    },
+      }),
     onSuccess: (_, ids) => {
       void queryClient.invalidateQueries({ queryKey: memoriesKeys.all });
       toast.success(`${ids.length} ${ids.length === 1 ? 'memory' : 'memories'} deleted`);
@@ -209,11 +185,7 @@ export function runMaintenanceMutationOptions(
   queryClient: QueryClient,
 ): MutationOptions<MaintenanceResult, Error, void> {
   return {
-    mutationFn: async () => {
-      const res = await serverFetch('/memory/maintenance', { method: 'POST' });
-      if (!res.ok) throw new Error('Failed to run memory maintenance');
-      return res.json() as Promise<MaintenanceResult>;
-    },
+    mutationFn: () => serverRequest<MaintenanceResult>('/memory/maintenance', { method: 'POST' }),
     onSuccess: (result) => {
       void queryClient.invalidateQueries({ queryKey: memoriesKeys.all });
       const parts: string[] = [];
@@ -233,10 +205,7 @@ export function resetMemoriesMutationOptions(
   queryClient: QueryClient,
 ): MutationOptions<void, Error, void> {
   return {
-    mutationFn: async () => {
-      const res = await serverFetch('/memory/reset', { method: 'POST' });
-      if (!res.ok) throw new Error('Failed to reset memories');
-    },
+    mutationFn: () => serverRequest<void>('/memory/reset', { method: 'POST' }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: memoriesKeys.all });
     },

--- a/apps/web/src/lib/queries/model-visibility.ts
+++ b/apps/web/src/lib/queries/model-visibility.ts
@@ -1,6 +1,6 @@
 import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 import { providerKeys } from '@/lib/queries/providers';
 
 type VisibilityOverride = {
@@ -17,17 +17,13 @@ const modelVisibilityKeys = {
 export const modelVisibilityQueryOptions = queryOptions({
   queryKey: modelVisibilityKeys.list(),
   staleTime: Infinity,
-  queryFn: async (): Promise<VisibilityOverride[]> => {
-    const res = await serverFetch('/llm/models/visibility');
-    if (!res.ok) throw new Error('Failed to fetch model visibility overrides');
-    return res.json() as Promise<VisibilityOverride[]>;
-  },
+  queryFn: () => serverRequest<VisibilityOverride[]>('/llm/models/visibility'),
 });
 
 export function useSetModelVisibility() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({
+    mutationFn: ({
       providerId,
       modelId,
       visibility,
@@ -35,20 +31,15 @@ export function useSetModelVisibility() {
       providerId: string;
       modelId: string;
       visibility: 'show' | 'hide';
-    }) => {
-      const res = await serverFetch(
+    }) =>
+      serverRequest<void>(
         `/llm/models/visibility/${encodeURIComponent(providerId)}/${encodeURIComponent(modelId)}`,
         {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ visibility }),
         },
-      );
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? 'Failed to update model visibility');
-      }
-    },
+      ),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: modelVisibilityKeys.all });
       void queryClient.invalidateQueries({ queryKey: providerKeys.visibleModels() });
@@ -59,16 +50,14 @@ export function useSetModelVisibility() {
 export function useResetModelVisibility() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ providerId, modelId }: { providerId: string; modelId: string }) => {
-      const res = await serverFetch(
+    mutationFn: ({ providerId, modelId }: { providerId: string; modelId: string }) =>
+      serverRequest<void>(
         `/llm/models/visibility/${encodeURIComponent(providerId)}/${encodeURIComponent(modelId)}`,
         { method: 'DELETE' },
-      );
-      if (!res.ok && res.status !== 404) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(body.error ?? 'Failed to reset model visibility');
-      }
-    },
+      ).catch((err) => {
+        if (err instanceof Error && err.message.includes('status 404')) return;
+        throw err;
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: modelVisibilityKeys.all });
       void queryClient.invalidateQueries({ queryKey: providerKeys.visibleModels() });

--- a/apps/web/src/lib/queries/ollama-models.ts
+++ b/apps/web/src/lib/queries/ollama-models.ts
@@ -1,6 +1,6 @@
 import { queryOptions } from '@tanstack/react-query';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 export type OllamaModality = 'text' | 'audio' | 'image' | 'video' | 'pdf';
 
@@ -53,24 +53,15 @@ export const ollamaModelKeys = {
 
 export const ollamaModelsQueryOptions = queryOptions({
   queryKey: ollamaModelKeys.list(),
-  queryFn: async (): Promise<OllamaModel[]> => {
-    const res = await serverFetch('/llm/ollama/models');
-    if (!res.ok) throw new Error('Failed to fetch Ollama models');
-    return res.json() as Promise<OllamaModel[]>;
-  },
+  queryFn: () => serverRequest<OllamaModel[]>('/llm/ollama/models'),
 });
 
 export const discoverOllamaModelsQueryOptions = (baseURL?: string) =>
   queryOptions({
     queryKey: ollamaModelKeys.discover(baseURL),
     enabled: false,
-    queryFn: async (): Promise<DiscoveredModel[]> => {
+    queryFn: () => {
       const params = baseURL ? `?baseURL=${encodeURIComponent(baseURL)}` : '';
-      const res = await serverFetch(`/llm/ollama/models/discover${params}`);
-      if (!res.ok) {
-        const payload = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(payload.error ?? 'Failed to discover Ollama models');
-      }
-      return res.json() as Promise<DiscoveredModel[]>;
+      return serverRequest<DiscoveredModel[]>(`/llm/ollama/models/discover${params}`);
     },
   });

--- a/apps/web/src/lib/queries/permissions.ts
+++ b/apps/web/src/lib/queries/permissions.ts
@@ -2,7 +2,7 @@ import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query
 
 import type { PermissionResponse } from '@stitch/shared/permissions/types';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 export const permissionResponseKeys = {
   all: ['permission-responses'] as const,
@@ -12,11 +12,8 @@ export const permissionResponseKeys = {
 export function permissionResponsesQueryOptions(sessionId: string) {
   return queryOptions({
     queryKey: permissionResponseKeys.list(sessionId),
-    queryFn: async (): Promise<PermissionResponse[]> => {
-      const res = await serverFetch(`/chat/sessions/${sessionId}/permission-responses`);
-      if (!res.ok) throw new Error('Failed to fetch permission responses');
-      return res.json() as Promise<PermissionResponse[]>;
-    },
+    queryFn: () =>
+      serverRequest<PermissionResponse[]>(`/chat/sessions/${sessionId}/permission-responses`),
   });
 }
 
@@ -37,18 +34,15 @@ export function useAllowPermissionResponse() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: PermissionBaseInput) => {
-      const res = await serverFetch(
+    mutationFn: (input: PermissionBaseInput) =>
+      serverRequest<unknown>(
         `/chat/sessions/${input.sessionId}/permission-responses/${input.permissionResponseId}/allow`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ setPermission: input.setPermission }),
         },
-      );
-      if (!res.ok) throw new Error('Failed to allow tool');
-      return res.json();
-    },
+      ),
     onSuccess: (_data, input) => {
       void queryClient.invalidateQueries({
         queryKey: permissionResponseKeys.list(input.sessionId),
@@ -61,18 +55,15 @@ export function useRejectPermissionResponse() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: PermissionBaseInput) => {
-      const res = await serverFetch(
+    mutationFn: (input: PermissionBaseInput) =>
+      serverRequest<unknown>(
         `/chat/sessions/${input.sessionId}/permission-responses/${input.permissionResponseId}/reject`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ setPermission: input.setPermission }),
         },
-      );
-      if (!res.ok) throw new Error('Failed to reject tool');
-      return res.json();
-    },
+      ),
     onSuccess: (_data, input) => {
       void queryClient.invalidateQueries({
         queryKey: permissionResponseKeys.list(input.sessionId),
@@ -85,18 +76,15 @@ export function useAlternativePermissionResponse() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: PermissionAlternativeInput) => {
-      const res = await serverFetch(
+    mutationFn: (input: PermissionAlternativeInput) =>
+      serverRequest<unknown>(
         `/chat/sessions/${input.sessionId}/permission-responses/${input.permissionResponseId}/alternative`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ entry: input.entry }),
         },
-      );
-      if (!res.ok) throw new Error('Failed to submit alternative action');
-      return res.json();
-    },
+      ),
     onSuccess: (_data, input) => {
       void queryClient.invalidateQueries({
         queryKey: permissionResponseKeys.list(input.sessionId),

--- a/apps/web/src/lib/queries/providers.ts
+++ b/apps/web/src/lib/queries/providers.ts
@@ -2,7 +2,7 @@ import { queryOptions } from '@tanstack/react-query';
 
 import { buildDefaultVisibleSet, isModelVisible } from '@stitch/shared/providers/model-visibility';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 export type ProviderCapability = 'llm' | 'stt' | 'embedding';
 
@@ -66,11 +66,7 @@ export const providersQueryOptions = queryOptions({
   queryKey: providerKeys.list(),
   staleTime: 60 * 60 * 1000,
   refetchOnWindowFocus: true,
-  queryFn: async (): Promise<ProviderSummary[]> => {
-    const res = await serverFetch('/providers');
-    if (!res.ok) throw new Error('Failed to fetch providers');
-    return res.json() as Promise<ProviderSummary[]>;
-  },
+  queryFn: () => serverRequest<ProviderSummary[]>('/providers'),
 });
 
 export const enabledProviderModelsQueryOptions = queryOptions({
@@ -78,19 +74,19 @@ export const enabledProviderModelsQueryOptions = queryOptions({
   staleTime: 60 * 60 * 1000,
   refetchOnWindowFocus: true,
   queryFn: async (): Promise<ProviderModels[]> => {
-    const providersRes = await serverFetch('/providers');
-    if (!providersRes.ok) throw new Error('Failed to fetch providers');
-    const providers = (await providersRes.json()) as ProviderSummary[];
+    const providers = await serverRequest<ProviderSummary[]>('/providers');
     const enabled = providers.filter((p) => p.enabled && p.capabilities.includes('llm'));
 
     if (enabled.length === 0) return [];
 
     const results = await Promise.all(
       enabled.map(async (provider) => {
-        const res = await serverFetch(`/llm/provider/${provider.id}/models`);
-        if (!res.ok) return { providerId: provider.id, providerName: provider.name, models: [] };
-        const models = (await res.json()) as ModelSummary[];
-        return { providerId: provider.id, providerName: provider.name, models };
+        try {
+          const models = await serverRequest<ModelSummary[]>(`/llm/provider/${provider.id}/models`);
+          return { providerId: provider.id, providerName: provider.name, models };
+        } catch {
+          return { providerId: provider.id, providerName: provider.name, models: [] };
+        }
       }),
     );
     return results.filter((r) => r.models.length > 0);
@@ -102,34 +98,32 @@ export const visibleProviderModelsQueryOptions = queryOptions({
   staleTime: 60 * 60 * 1000,
   refetchOnWindowFocus: true,
   queryFn: async (): Promise<ProviderModels[]> => {
-    const [providersRes, visibilityRes] = await Promise.all([
-      serverFetch('/providers'),
-      serverFetch('/llm/models/visibility'),
+    const [providers, overridesList] = await Promise.all([
+      serverRequest<ProviderSummary[]>('/providers'),
+      serverRequest<
+        Array<{
+          providerId: string;
+          modelId: string;
+          visibility: 'show' | 'hide';
+        }>
+      >('/llm/models/visibility'),
     ]);
-    if (!providersRes.ok) throw new Error('Failed to fetch providers');
-    if (!visibilityRes.ok) throw new Error('Failed to fetch model visibility');
-
-    const providers = (await providersRes.json()) as ProviderSummary[];
-    const overridesList = (await visibilityRes.json()) as Array<{
-      providerId: string;
-      modelId: string;
-      visibility: 'show' | 'hide';
-    }>;
 
     const enabled = providers.filter((p) => p.enabled && p.capabilities.includes('llm'));
     if (enabled.length === 0) return [];
 
     const allProviderModels = await Promise.all(
       enabled.map(async (provider) => {
-        const res = await serverFetch(`/llm/provider/${provider.id}/models`);
-        if (!res.ok)
+        try {
+          const models = await serverRequest<ModelSummary[]>(`/llm/provider/${provider.id}/models`);
+          return { providerId: provider.id, providerName: provider.name, models };
+        } catch {
           return {
             providerId: provider.id,
             providerName: provider.name,
             models: [] as ModelSummary[],
           };
-        const models = (await res.json()) as ModelSummary[];
-        return { providerId: provider.id, providerName: provider.name, models };
+        }
       }),
     );
 
@@ -159,32 +153,25 @@ export const providerConfigQueryOptions = (providerId: string) =>
   queryOptions({
     queryKey: providerKeys.config(providerId),
     staleTime: Infinity,
-    queryFn: async (): Promise<ProviderCredentials | null> => {
-      const res = await serverFetch(`/llm/provider/${providerId}/config`);
-      if (res.status === 404) return null;
-      if (!res.ok) throw new Error('Failed to fetch provider config');
-      return res.json() as Promise<ProviderCredentials>;
-    },
+    queryFn: () =>
+      serverRequest<ProviderCredentials | null>(`/llm/provider/${providerId}/config`).catch(
+        (err) => {
+          if (err instanceof Error && err.message.includes('status 404')) return null;
+          throw err;
+        },
+      ),
   });
 
 export const embeddingProviderModelsQueryOptions = queryOptions({
   queryKey: providerKeys.embeddingModels(),
   staleTime: 60 * 60 * 1000,
   refetchOnWindowFocus: true,
-  queryFn: async (): Promise<ProviderModels[]> => {
-    const res = await serverFetch('/llm/provider/embedding-models');
-    if (!res.ok) throw new Error('Failed to fetch embedding models');
-    return res.json() as Promise<ProviderModels[]>;
-  },
+  queryFn: () => serverRequest<ProviderModels[]>('/llm/provider/embedding-models'),
 });
 
 export const sttProviderModelsQueryOptions = queryOptions({
   queryKey: providerKeys.sttModels(),
   staleTime: 60 * 60 * 1000,
   refetchOnWindowFocus: true,
-  queryFn: async (): Promise<SttProviderModels[]> => {
-    const res = await serverFetch('/providers/stt/models');
-    if (!res.ok) throw new Error('Failed to fetch STT models');
-    return res.json() as Promise<SttProviderModels[]>;
-  },
+  queryFn: () => serverRequest<SttProviderModels[]>('/providers/stt/models'),
 });

--- a/apps/web/src/lib/queries/questions.ts
+++ b/apps/web/src/lib/queries/questions.ts
@@ -2,7 +2,7 @@ import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query
 
 import type { QuestionRequest } from '@stitch/shared/questions/types';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 export const questionKeys = {
   all: ['questions'] as const,
@@ -12,11 +12,7 @@ export const questionKeys = {
 export function questionsQueryOptions(sessionId: string) {
   return queryOptions({
     queryKey: questionKeys.list(sessionId),
-    queryFn: async (): Promise<QuestionRequest[]> => {
-      const res = await serverFetch(`/chat/sessions/${sessionId}/questions`);
-      if (!res.ok) throw new Error('Failed to fetch questions');
-      return res.json() as Promise<QuestionRequest[]>;
-    },
+    queryFn: () => serverRequest<QuestionRequest[]>(`/chat/sessions/${sessionId}/questions`),
   });
 }
 
@@ -35,18 +31,15 @@ export function useReplyQuestion() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: ReplyQuestionInput) => {
-      const res = await serverFetch(
+    mutationFn: (input: ReplyQuestionInput) =>
+      serverRequest<unknown>(
         `/chat/sessions/${input.sessionId}/questions/${input.questionId}/reply`,
         {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ answers: input.answers }),
         },
-      );
-      if (!res.ok) throw new Error('Failed to reply to question');
-      return res.json();
-    },
+      ),
     onSuccess: (_data, input) => {
       void queryClient.invalidateQueries({ queryKey: questionKeys.list(input.sessionId) });
     },
@@ -57,16 +50,13 @@ export function useRejectQuestion() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: RejectQuestionInput) => {
-      const res = await serverFetch(
+    mutationFn: (input: RejectQuestionInput) =>
+      serverRequest<unknown>(
         `/chat/sessions/${input.sessionId}/questions/${input.questionId}/reject`,
         {
           method: 'POST',
         },
-      );
-      if (!res.ok) throw new Error('Failed to reject question');
-      return res.json();
-    },
+      ),
     onSuccess: (_data, input) => {
       void queryClient.invalidateQueries({ queryKey: questionKeys.list(input.sessionId) });
     },

--- a/apps/web/src/lib/queries/recordings.ts
+++ b/apps/web/src/lib/queries/recordings.ts
@@ -9,7 +9,7 @@ import type {
   StopRecordingResponse,
 } from '@stitch/shared/recordings/types';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 const recordingsKeys = {
   all: ['recordings'] as const,
@@ -22,14 +22,12 @@ const recordingsKeys = {
 export function recordingsQueryOptions(input: { page: number; pageSize: number }) {
   return queryOptions({
     queryKey: recordingsKeys.list(input.page, input.pageSize),
-    queryFn: async (): Promise<ListRecordingsResponse> => {
+    queryFn: () => {
       const params = new URLSearchParams({
         page: String(input.page),
         pageSize: String(input.pageSize),
       });
-      const res = await serverFetch(`/recordings?${params.toString()}`);
-      if (!res.ok) throw new Error('Failed to fetch recordings');
-      return res.json() as Promise<ListRecordingsResponse>;
+      return serverRequest<ListRecordingsResponse>(`/recordings?${params.toString()}`);
     },
   });
 }
@@ -138,18 +136,11 @@ export function useStartRecording() {
         return window.api.recording.start(input);
       }
 
-      const res = await serverFetch('/recordings/start', {
+      return serverRequest<StartRecordingResponse>('/recordings/start', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
       });
-
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to start recording');
-      }
-
-      return res.json() as Promise<StartRecordingResponse>;
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: recordingsKeys.lists() });
@@ -161,21 +152,16 @@ export function useStopRecording() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (): Promise<StopRecordingResponse> => {
+    mutationFn: (): Promise<StopRecordingResponse> => {
       if (window.api?.recording?.stop) {
         return window.api.recording.stop();
       }
 
-      const res = await serverFetch('/recordings/stop', {
+      return serverRequest<StopRecordingResponse>('/recordings/stop', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ durationMs: null, fileSizeBytes: null }),
       });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to stop recording');
-      }
-      return res.json() as Promise<StopRecordingResponse>;
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: recordingsKeys.lists() });
@@ -187,13 +173,8 @@ export function useDeleteRecording() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (recordingId: string): Promise<void> => {
-      const res = await serverFetch(`/recordings/${recordingId}`, { method: 'DELETE' });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to delete recording');
-      }
-    },
+    mutationFn: (recordingId: string) =>
+      serverRequest<void>(`/recordings/${recordingId}`, { method: 'DELETE' }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: recordingsKeys.lists() });
     },
@@ -203,11 +184,7 @@ export function useDeleteRecording() {
 export function recordingAnalysisQueryOptions(recordingId: string) {
   return queryOptions({
     queryKey: recordingsKeys.analysis(recordingId),
-    queryFn: async (): Promise<RecordingAnalysisResponse> => {
-      const res = await serverFetch(`/recordings/${recordingId}/analysis`);
-      if (!res.ok) throw new Error('Failed to fetch recording analysis');
-      return res.json() as Promise<RecordingAnalysisResponse>;
-    },
+    queryFn: () => serverRequest<RecordingAnalysisResponse>(`/recordings/${recordingId}/analysis`),
   });
 }
 
@@ -215,24 +192,16 @@ export function useStartRecordingAnalysis() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: {
-      recordingId: string;
-      force?: boolean;
-    }): Promise<StartRecordingAnalysisResponse> => {
+    mutationFn: (input: { recordingId: string; force?: boolean }) => {
       const params = new URLSearchParams();
       if (input.force) {
         params.set('force', '1');
       }
       const suffix = params.toString();
-      const res = await serverFetch(
+      return serverRequest<StartRecordingAnalysisResponse>(
         `/recordings/${input.recordingId}/analyze${suffix ? `?${suffix}` : ''}`,
         { method: 'POST' },
       );
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to start recording analysis');
-      }
-      return res.json() as Promise<StartRecordingAnalysisResponse>;
     },
     onSuccess: (_, variables) => {
       void queryClient.invalidateQueries({
@@ -246,15 +215,10 @@ export function useCancelRecordingAnalysis() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (recordingId: string): Promise<void> => {
-      const res = await serverFetch(`/recordings/${recordingId}/analysis/cancel`, {
+    mutationFn: (recordingId: string) =>
+      serverRequest<void>(`/recordings/${recordingId}/analysis/cancel`, {
         method: 'POST',
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to cancel recording analysis');
-      }
-    },
+      }),
     onSuccess: (_, recordingId) => {
       void queryClient.invalidateQueries({ queryKey: recordingsKeys.analysis(recordingId) });
     },

--- a/apps/web/src/lib/queries/settings.ts
+++ b/apps/web/src/lib/queries/settings.ts
@@ -2,7 +2,7 @@ import { toast } from 'sonner';
 
 import { queryOptions, type QueryClient, type MutationOptions } from '@tanstack/react-query';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 type UserSettings = Record<string, string>;
 
@@ -14,11 +14,7 @@ const settingsKeys = {
 export const settingsQueryOptions = queryOptions({
   queryKey: settingsKeys.list(),
   staleTime: Infinity,
-  queryFn: async (): Promise<UserSettings> => {
-    const res = await serverFetch('/settings');
-    if (!res.ok) throw new Error('Failed to fetch settings');
-    return res.json() as Promise<UserSettings>;
-  },
+  queryFn: () => serverRequest<UserSettings>('/settings'),
 });
 
 export function saveSettingMutationOptions(
@@ -27,17 +23,12 @@ export function saveSettingMutationOptions(
   options?: { silent?: boolean },
 ): MutationOptions<void, Error, string> {
   return {
-    mutationFn: async (value: string) => {
-      const res = await serverFetch(`/settings/${key}`, {
+    mutationFn: (value: string) =>
+      serverRequest<void>(`/settings/${key}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ value }),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to save');
-      }
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: settingsKeys.all });
       if (!options?.silent) toast.success('Model preference saved');
@@ -52,10 +43,11 @@ export function deleteSettingMutationOptions(
   options?: { silent?: boolean },
 ): MutationOptions<void, Error, void> {
   return {
-    mutationFn: async () => {
-      const res = await serverFetch(`/settings/${key}`, { method: 'DELETE' });
-      if (!res.ok && res.status !== 404) throw new Error('Failed to reset');
-    },
+    mutationFn: () =>
+      serverRequest<void>(`/settings/${key}`, { method: 'DELETE' }).catch((err) => {
+        if (err instanceof Error && err.message.includes('status 404')) return;
+        throw err;
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: settingsKeys.all });
       if (!options?.silent) toast.success('Model preference reset');

--- a/apps/web/src/lib/queries/shortcuts.ts
+++ b/apps/web/src/lib/queries/shortcuts.ts
@@ -2,7 +2,7 @@ import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query
 
 import type { ShortcutCategory } from '@stitch/shared/shortcuts/types';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 export interface ShortcutEntry {
   actionId: string;
@@ -20,24 +20,18 @@ const shortcutKeys = {
 export const shortcutsQueryOptions = queryOptions({
   queryKey: shortcutKeys.list(),
   staleTime: Infinity,
-  queryFn: async (): Promise<ShortcutEntry[]> => {
-    const res = await serverFetch('/shortcuts');
-    if (!res.ok) throw new Error('Failed to fetch shortcuts');
-    return res.json() as Promise<ShortcutEntry[]>;
-  },
+  queryFn: () => serverRequest<ShortcutEntry[]>('/shortcuts'),
 });
 
 export function useSaveShortcut() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ actionId, hotkey }: { actionId: string; hotkey: string | null }) => {
-      const res = await serverFetch(`/shortcuts/${actionId}`, {
+    mutationFn: ({ actionId, hotkey }: { actionId: string; hotkey: string | null }) =>
+      serverRequest<void>(`/shortcuts/${actionId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ hotkey }),
-      });
-      if (!res.ok) throw new Error('Failed to save shortcut');
-    },
+      }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: shortcutKeys.all }),
   });
 }
@@ -45,10 +39,11 @@ export function useSaveShortcut() {
 export function useDeleteShortcut() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (actionId: string) => {
-      const res = await serverFetch(`/shortcuts/${actionId}`, { method: 'DELETE' });
-      if (!res.ok && res.status !== 404) throw new Error('Failed to delete shortcut');
-    },
+    mutationFn: (actionId: string) =>
+      serverRequest<void>(`/shortcuts/${actionId}`, { method: 'DELETE' }).catch((err) => {
+        if (err instanceof Error && err.message.includes('status 404')) return;
+        throw err;
+      }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: shortcutKeys.all }),
   });
 }
@@ -56,10 +51,7 @@ export function useDeleteShortcut() {
 export function useResetAllShortcuts() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async () => {
-      const res = await serverFetch('/shortcuts', { method: 'DELETE' });
-      if (!res.ok) throw new Error('Failed to reset shortcuts');
-    },
+    mutationFn: () => serverRequest<void>('/shortcuts', { method: 'DELETE' }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: shortcutKeys.all }),
   });
 }

--- a/apps/web/src/lib/queries/skills.ts
+++ b/apps/web/src/lib/queries/skills.ts
@@ -11,7 +11,7 @@ import type {
   SkillUpdateInput,
 } from '@stitch/shared/skills/types';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 const skillKeys = {
   all: ['skills'] as const,
@@ -22,11 +22,7 @@ const skillKeys = {
 export const skillsQueryOptions = queryOptions({
   queryKey: skillKeys.list(),
   staleTime: Infinity,
-  queryFn: async (): Promise<Skill[]> => {
-    const res = await serverFetch('/skills');
-    if (!res.ok) throw new Error('Failed to fetch skills');
-    return res.json() as Promise<Skill[]>;
-  },
+  queryFn: () => serverRequest<Skill[]>('/skills'),
 });
 
 export function useSearchSkills(query: string) {
@@ -41,31 +37,20 @@ export function useSearchSkills(query: string) {
   return useQuery({
     queryKey: skillKeys.search(debouncedQuery),
     enabled: debouncedQuery.length >= 2,
-    queryFn: async (): Promise<SkillSearchResult[]> => {
-      const res = await serverFetch(`/skills/search?q=${encodeURIComponent(debouncedQuery)}`);
-      if (!res.ok) throw await parseError(res, 'Failed to search skills');
-      return res.json() as Promise<SkillSearchResult[]>;
-    },
+    queryFn: () =>
+      serverRequest<SkillSearchResult[]>(`/skills/search?q=${encodeURIComponent(debouncedQuery)}`),
   });
-}
-
-async function parseError(res: Response, fallback: string): Promise<Error> {
-  const body = (await res.json().catch(() => ({}))) as { error?: string };
-  return new Error(body.error ?? fallback);
 }
 
 export function useCreateSkill() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: SkillCreateInput) => {
-      const res = await serverFetch('/skills', {
+    mutationFn: (input: SkillCreateInput) =>
+      serverRequest<Skill>('/skills', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) throw await parseError(res, 'Failed to create skill');
-      return res.json() as Promise<Skill>;
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: skillKeys.all });
       toast.success('Skill created');
@@ -77,15 +62,12 @@ export function useCreateSkill() {
 export function useUpdateSkill() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ name, input }: { name: string; input: SkillUpdateInput }) => {
-      const res = await serverFetch(`/skills/${encodeURIComponent(name)}`, {
+    mutationFn: ({ name, input }: { name: string; input: SkillUpdateInput }) =>
+      serverRequest<Skill>(`/skills/${encodeURIComponent(name)}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) throw await parseError(res, 'Failed to update skill');
-      return res.json() as Promise<Skill>;
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: skillKeys.all });
       toast.success('Skill saved');
@@ -97,10 +79,8 @@ export function useUpdateSkill() {
 export function useDeleteSkill() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (name: string) => {
-      const res = await serverFetch(`/skills/${encodeURIComponent(name)}`, { method: 'DELETE' });
-      if (!res.ok) throw await parseError(res, 'Failed to delete skill');
-    },
+    mutationFn: (name: string) =>
+      serverRequest<void>(`/skills/${encodeURIComponent(name)}`, { method: 'DELETE' }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: skillKeys.all });
       toast.success('Skill deleted');
@@ -112,15 +92,12 @@ export function useDeleteSkill() {
 export function useImportSkill() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: SkillImportInput) => {
-      const res = await serverFetch('/skills/import', {
+    mutationFn: (input: SkillImportInput) =>
+      serverRequest<Skill>('/skills/import', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) throw await parseError(res, 'Failed to import skill');
-      return res.json() as Promise<Skill>;
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: skillKeys.all });
       toast.success('Skill imported');

--- a/apps/web/src/lib/queries/todos.ts
+++ b/apps/web/src/lib/queries/todos.ts
@@ -2,7 +2,7 @@ import { queryOptions } from '@tanstack/react-query';
 
 import type { SessionTodo } from '@stitch/shared/todos/types';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 export const todoKeys = {
   all: ['todos'] as const,
@@ -12,10 +12,6 @@ export const todoKeys = {
 export function sessionTodosQueryOptions(sessionId: string) {
   return queryOptions({
     queryKey: todoKeys.list(sessionId),
-    queryFn: async (): Promise<SessionTodo[]> => {
-      const res = await serverFetch(`/chat/sessions/${sessionId}/todos`);
-      if (!res.ok) throw new Error('Failed to fetch todos');
-      return res.json() as Promise<SessionTodo[]>;
-    },
+    queryFn: () => serverRequest<SessionTodo[]>(`/chat/sessions/${sessionId}/todos`),
   });
 }

--- a/apps/web/src/lib/queries/tools.ts
+++ b/apps/web/src/lib/queries/tools.ts
@@ -4,7 +4,7 @@ import type { ConnectorIconSource } from '@stitch/shared/connectors/types';
 import type { ToolPermission, ToolPermissionValue } from '@stitch/shared/permissions/types';
 import type { ToolEnabledScope, ToolEnabledState, ToolType } from '@stitch/shared/tools/types';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 type KnownTool = {
   toolType: ToolType;
@@ -46,9 +46,7 @@ export const knownToolsQueryOptions = queryOptions({
   queryKey: toolKeys.knownTools(),
   staleTime: Infinity,
   queryFn: async (): Promise<KnownTool[]> => {
-    const res = await serverFetch('/config/tools');
-    if (!res.ok) throw new Error('Failed to fetch tools');
-    const data = (await res.json()) as { tools: KnownTool[] };
+    const data = await serverRequest<{ tools: KnownTool[] }>('/config/tools');
     return data.tools;
   },
 });
@@ -57,9 +55,7 @@ export const knownMcpToolsQueryOptions = queryOptions({
   queryKey: toolKeys.knownMcpTools(),
   staleTime: Infinity,
   queryFn: async (): Promise<KnownMcpTool[]> => {
-    const res = await serverFetch('/config/mcp-tools');
-    if (!res.ok) throw new Error('Failed to fetch MCP tools');
-    const data = (await res.json()) as { tools: KnownMcpTool[] };
+    const data = await serverRequest<{ tools: KnownMcpTool[] }>('/config/mcp-tools');
     return data.tools;
   },
 });
@@ -68,9 +64,7 @@ export const knownToolsetsQueryOptions = queryOptions({
   queryKey: toolKeys.knownToolsets(),
   staleTime: Infinity,
   queryFn: async (): Promise<KnownToolset[]> => {
-    const res = await serverFetch('/config/toolsets');
-    if (!res.ok) throw new Error('Failed to fetch toolsets');
-    const data = (await res.json()) as { toolsets: KnownToolset[] };
+    const data = await serverRequest<{ toolsets: KnownToolset[] }>('/config/toolsets');
     return data.toolsets;
   },
 });
@@ -78,20 +72,14 @@ export const knownToolsetsQueryOptions = queryOptions({
 export const toolPermissionsQueryOptions = queryOptions({
   queryKey: toolKeys.permissions(),
   staleTime: Infinity,
-  queryFn: async (): Promise<ToolPermission[]> => {
-    const res = await serverFetch('/config/permissions');
-    if (!res.ok) throw new Error('Failed to fetch permissions');
-    return res.json() as Promise<ToolPermission[]>;
-  },
+  queryFn: () => serverRequest<ToolPermission[]>('/config/permissions'),
 });
 
 export const toolEnabledStatesQueryOptions = queryOptions({
   queryKey: toolKeys.enabledStates(),
   staleTime: Infinity,
   queryFn: async (): Promise<ToolEnabledState[]> => {
-    const res = await serverFetch('/config/tools/enabled');
-    if (!res.ok) throw new Error('Failed to fetch tool enabled states');
-    const data = (await res.json()) as { states: ToolEnabledState[] };
+    const data = await serverRequest<{ states: ToolEnabledState[] }>('/config/tools/enabled');
     return data.states;
   },
 });
@@ -99,21 +87,16 @@ export const toolEnabledStatesQueryOptions = queryOptions({
 export function useUpsertToolPermission() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: {
+    mutationFn: (input: {
       toolName: string;
       pattern: string | null;
       permission: ToolPermissionValue;
-    }) => {
-      const res = await serverFetch('/config/permissions', {
+    }) =>
+      serverRequest<void>('/config/permissions', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to update permission');
-      }
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: toolKeys.permissions() });
     },
@@ -123,15 +106,10 @@ export function useUpsertToolPermission() {
 export function useDeleteToolPermission() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (permissionId: string) => {
-      const res = await serverFetch(`/config/permissions/${permissionId}`, {
+    mutationFn: (permissionId: string) =>
+      serverRequest<void>(`/config/permissions/${permissionId}`, {
         method: 'DELETE',
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to delete permission');
-      }
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: toolKeys.permissions() });
     },
@@ -141,21 +119,12 @@ export function useDeleteToolPermission() {
 export function useSetToolEnabledState() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (input: {
-      scope: ToolEnabledScope;
-      identifier: string;
-      enabled: boolean;
-    }) => {
-      const res = await serverFetch('/config/tools/enabled', {
+    mutationFn: (input: { scope: ToolEnabledScope; identifier: string; enabled: boolean }) =>
+      serverRequest<void>('/config/tools/enabled', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(err.error ?? 'Failed to update tool state');
-      }
-    },
+      }),
     onSuccess: () => {
       void Promise.all([
         queryClient.invalidateQueries({ queryKey: toolKeys.enabledStates() }),

--- a/apps/web/src/lib/queries/usage.ts
+++ b/apps/web/src/lib/queries/usage.ts
@@ -6,7 +6,7 @@ import type {
   UsageDateRange,
 } from '@stitch/shared/usage/types';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 
 type UsageDashboardFilters = {
   providerId?: string;
@@ -38,13 +38,11 @@ function buildQueryString(filters: UsageDashboardFilters): string {
 export const usageDashboardQueryOptions = (filters: UsageDashboardFilters) =>
   queryOptions({
     queryKey: usageKeys.dashboard(filters),
-    queryFn: async (): Promise<UsageDashboardResponse> => {
+    queryFn: () => {
       const query = buildQueryString(filters);
       const path = query.length > 0 ? `/usage?${query}` : '/usage';
 
-      const res = await serverFetch(path);
-      if (!res.ok) throw new Error('Failed to fetch usage dashboard');
-      return res.json() as Promise<UsageDashboardResponse>;
+      return serverRequest<UsageDashboardResponse>(path);
     },
     staleTime: 30_000,
   });
@@ -52,13 +50,11 @@ export const usageDashboardQueryOptions = (filters: UsageDashboardFilters) =>
 export const sttUsageDashboardQueryOptions = (filters: UsageDashboardFilters) =>
   queryOptions({
     queryKey: usageKeys.sttDashboard(filters),
-    queryFn: async (): Promise<SttUsageDashboardResponse> => {
+    queryFn: () => {
       const query = buildQueryString(filters);
       const path = query.length > 0 ? `/usage/stt?${query}` : '/usage/stt';
 
-      const res = await serverFetch(path);
-      if (!res.ok) throw new Error('Failed to fetch STT usage dashboard');
-      return res.json() as Promise<SttUsageDashboardResponse>;
+      return serverRequest<SttUsageDashboardResponse>(path);
     },
     staleTime: 30_000,
   });


### PR DESCRIPTION
## 🚀 Change Summary

This PR deepens the network layer of the web application by implementing a robust, type-safe, and generic `serverRequest<T>` utility. By centralizing error-message parsing and empty/successful response handling (specifically supporting `204 No Content` responses from the Hono backend), we have consolidated all API calls across all 20 query modules, eliminating more than 400 lines of repetitive boilerplate code.

Closes #335

### ✨ New Features
- **Generic Server Request Wrapper**: Introduced `serverRequest<T>` in `apps/web/src/lib/api.ts` to seamlessly handle network fetching, response parsing, Hono-aligned status-checking, and automatic error extraction.

### 🛠 Improvements & Refactors
- **Consolidated All Query Modules**: Migrated all 20 files under `apps/web/src/lib/queries/` to use `serverRequest<T>`, removing duplicated `.ok` checks, manual JSON parsing, and `as Promise<T>` type casting.
- **Hono-Aligned No-Content Response Logic**: Added direct bypass of JSON parsing on `204 No Content` status codes, preventing runtime JSON parsing exceptions while maintaining robust error handling.
- **Modernized Error Extraction**: Simplified defensive JSON-error parsing into a clean optional-chaining expression (`errJson?.error`).

### 🐛 Bug Fixes
- Avoided `Failed to execute 'json' on 'Response': Unexpected end of JSON input` errors on PUT/PATCH/DELETE mutations returning empty bodies (status `204`).
