### PR TITLE
feat(web): add error boundary to memories route

### DIFF
--- a/apps/web/src/routes/memories.tsx
+++ b/apps/web/src/routes/memories.tsx
@@ -1,7 +1,32 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { BrainIcon } from 'lucide-react';
+
+import { Link, createFileRoute } from '@tanstack/react-router';
 
 import { MemoriesPage } from '@/components/memories/memories-page';
+import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
+import { Page, PageContent } from '@/components/ui/page';
 import { memoryStatsQueryOptions, semanticMemoriesQueryOptions } from '@/lib/queries/memories';
+
+function MemoriesErrorComponent({ error }: { error: Error }) {
+  return (
+    <Page>
+      <PageContent>
+        <Empty className="mt-16">
+          <EmptyMedia>
+            <BrainIcon className="size-10 text-muted-foreground/30" />
+          </EmptyMedia>
+          <EmptyTitle>Memory unavailable</EmptyTitle>
+          <EmptyDescription>
+            {error.message}{' '}
+            <Link to="/settings/memory" className="underline underline-offset-4 hover:text-primary">
+              Go to Memory settings
+            </Link>
+          </EmptyDescription>
+        </Empty>
+      </PageContent>
+    </Page>
+  );
+}
 
 export const Route = createFileRoute('/memories')({
   loader: ({ context }) =>
@@ -10,4 +35,5 @@ export const Route = createFileRoute('/memories')({
       context.queryClient.ensureQueryData(semanticMemoriesQueryOptions({ page: 1, pageSize: 12 })),
     ]),
   component: MemoriesPage,
+  errorComponent: MemoriesErrorComponent,
 });


### PR DESCRIPTION
## Change Summary

Adds a route-level error boundary to the memories page so that navigating to /memories without a configured embedding provider shows a graceful error state instead of crashing to the root error boundary.

### New Features
- **Memories error boundary**: When the memories loader throws (e.g. 409 from the server when memory is not configured), a full-page empty state is rendered with the error message and a direct link to Memory settings.
