### PR TITLE
introduce tool catalog: unify all four tool sources under listKnownTools

### DIFF
--- a/packages/server/src/lib/browser/tool-config.ts
+++ b/packages/server/src/lib/browser/tool-config.ts
@@ -1,18 +1,6 @@
 import { readFileSync } from 'node:fs';
 
-import type { ToolType } from '@stitch/shared/tools/types';
-
 import { resolveRuntimeAssetPath } from '@/lib/runtime-assets.js';
-
-type KnownTool = {
-  toolType: ToolType;
-  toolName: string;
-  displayName: string;
-};
-
-const BROWSER_KNOWN_TOOLS: KnownTool[] = [
-  { toolType: 'plugin', toolName: 'browser', displayName: 'Browser' },
-];
 
 export const BROWSER_TOOL_INSTRUCTIONS = readFileSync(
   resolveRuntimeAssetPath(
@@ -21,7 +9,3 @@ export const BROWSER_TOOL_INSTRUCTIONS = readFileSync(
   ),
   'utf8',
 ).trim();
-
-export function getBrowserKnownTools(): KnownTool[] {
-  return BROWSER_KNOWN_TOOLS;
-}

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -6,12 +6,11 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { formatMcpToolName } from '@stitch/shared/mcp/types';
 import { TOOL_ENABLED_SCOPES } from '@stitch/shared/tools/types';
 
-import { getBrowserKnownTools } from '@/lib/browser/tool-config.js';
 import { getMcpServersWithCachedTools } from '@/mcp/service.js';
 import { getMcpServerPresentation } from '@/mcp/tool-executor.js';
 import { deletePerm, getPerms, upsertPerm } from '@/permission/service.js';
+import { listKnownTools } from '@/tools/catalog.js';
 import { getToolEnabledStates, setToolEnabledState } from '@/tools/enabled-service.js';
-import { STITCH_KNOWN_TOOLS } from '@/tools/runtime/registry.js';
 import { listToolsets } from '@/tools/toolsets/registry.js';
 import type { ToolsetKind } from '@/tools/toolsets/types.js';
 import { toToolsetView } from '@/tools/toolsets/view.js';
@@ -34,21 +33,8 @@ export function getToolsetSource(toolset: { kind: ToolsetKind }): ToolsetKind {
   return toolset.kind;
 }
 
-configRouter.get('/tools', async (c) => {
-  const mcpServersWithTools = await getMcpServersWithCachedTools();
-  const mcpKnownTools = mcpServersWithTools.flatMap((server) =>
-    (server.tools ?? []).map((tool) => {
-      const presentation = getMcpServerPresentation(server.id);
-      const toolPresentation = presentation?.tools[tool.name];
-      return {
-        toolType: 'mcp' as const,
-        toolName: formatMcpToolName(server.id, tool.name),
-        displayName: toolPresentation?.title ?? tool.title ?? tool.annotations?.title ?? tool.name,
-      };
-    }),
-  );
-
-  return c.json({ tools: [...STITCH_KNOWN_TOOLS, ...mcpKnownTools, ...getBrowserKnownTools()] });
+configRouter.get('/tools', (c) => {
+  return c.json({ tools: listKnownTools() });
 });
 
 configRouter.get('/mcp-tools', async (c) => {

--- a/packages/server/src/tools/catalog.test.ts
+++ b/packages/server/src/tools/catalog.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { listKnownTools } from '@/tools/catalog.js';
+import { STITCH_KNOWN_TOOLS } from '@/tools/runtime/registry.js';
+import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
+import type { Toolset } from '@/tools/toolsets/types.js';
+
+function clearToolsets(): void {
+  for (const id of listToolsetIds()) {
+    unregisterToolset(id);
+  }
+}
+
+function makeToolset(overrides: Partial<Toolset>): Toolset {
+  return {
+    id: 'test',
+    kind: 'native',
+    name: 'Test',
+    description: 'Test toolset',
+    tools: () => [],
+    activate: async () => ({}),
+    ...overrides,
+  };
+}
+
+describe('listKnownTools', () => {
+  beforeEach(() => {
+    clearToolsets();
+  });
+
+  test('returns built-in stitch tools', () => {
+    const tools = listKnownTools();
+    const stitchTools = tools.filter((t) => t.toolType === 'stitch');
+    expect(stitchTools.length).toBe(STITCH_KNOWN_TOOLS.length);
+    expect(stitchTools.map((t) => t.toolName)).toEqual(STITCH_KNOWN_TOOLS.map((t) => t.toolName));
+  });
+
+  test('includes tools from a registered native toolset', () => {
+    registerToolset(
+      makeToolset({
+        id: 'browser',
+        kind: 'native',
+        name: 'Browser',
+        description: 'Browser toolset',
+        tools: () => [
+          { name: 'browser_navigate', description: 'Navigate to a URL' },
+          { name: 'browser_screenshot', description: 'Take a screenshot' },
+        ],
+      }),
+    );
+
+    const tools = listKnownTools();
+    const browserTools = tools.filter((t) => t.toolName.startsWith('browser_'));
+    expect(browserTools.length).toBe(2);
+    expect(browserTools.map((t) => t.toolType)).toEqual(['plugin', 'plugin']);
+    expect(browserTools.map((t) => t.toolName)).toEqual(['browser_navigate', 'browser_screenshot']);
+  });
+
+  test('includes tools from a connector toolset', () => {
+    registerToolset(
+      makeToolset({
+        id: 'connector:google:gmail',
+        kind: 'connector',
+        name: 'Gmail',
+        description: 'Gmail connector',
+        tools: () => [{ name: 'gmail_send_message', description: 'Send an email' }],
+      }),
+    );
+
+    const tools = listKnownTools();
+    const connectorTool = tools.find((t) => t.toolName === 'gmail_send_message');
+    expect(connectorTool).toBeDefined();
+    expect(connectorTool?.toolType).toBe('plugin');
+    expect(connectorTool?.displayName).toBe('Gmail Send Message');
+  });
+
+  test('includes tools from an MCP toolset with formatted names', () => {
+    const serverId = 'mcp_abcdefghijklmnopqrstuvwxyz';
+    const formattedName = `${serverId}_list_files`;
+
+    registerToolset(
+      makeToolset({
+        id: `mcp:${serverId}`,
+        kind: 'mcp',
+        name: 'My MCP Server',
+        description: 'MCP server',
+        tools: () => [{ name: formattedName, description: 'List files' }],
+      }),
+    );
+
+    const tools = listKnownTools();
+    const mcpTool = tools.find((t) => t.toolName === formattedName);
+    expect(mcpTool).toBeDefined();
+    expect(mcpTool?.toolType).toBe('mcp');
+  });
+
+  test('uses MCP presentation title when available', () => {
+    const serverId = 'mcp_abcdefghijklmnopqrstuvwxyz';
+    const rawToolName = 'send_email';
+    const formattedName = `${serverId}_${rawToolName}`;
+
+    registerToolset(
+      makeToolset({
+        id: `mcp:${serverId}`,
+        kind: 'mcp',
+        name: 'Mail Server',
+        description: 'Mail MCP server',
+        tools: () => [{ name: formattedName, description: 'Send an email' }],
+        presentation: {
+          serverId,
+          name: 'Mail Server',
+          tools: {
+            [rawToolName]: { title: 'Send Email Message' },
+          },
+        },
+      }),
+    );
+
+    const tools = listKnownTools();
+    const mcpTool = tools.find((t) => t.toolName === formattedName);
+    expect(mcpTool?.displayName).toBe('Send Email Message');
+  });
+
+  test('falls back to humanized name for MCP tool without presentation title', () => {
+    const serverId = 'mcp_abcdefghijklmnopqrstuvwxyz';
+    const rawToolName = 'list_files';
+    const formattedName = `${serverId}_${rawToolName}`;
+
+    registerToolset(
+      makeToolset({
+        id: `mcp:${serverId}`,
+        kind: 'mcp',
+        name: 'FS Server',
+        description: 'FS MCP server',
+        tools: () => [{ name: formattedName, description: 'List files' }],
+      }),
+    );
+
+    const tools = listKnownTools();
+    const mcpTool = tools.find((t) => t.toolName === formattedName);
+    expect(mcpTool?.displayName).toBe('List Files');
+  });
+
+  test('returns only built-in tools when no toolsets are registered', () => {
+    const tools = listKnownTools();
+    expect(tools.length).toBe(STITCH_KNOWN_TOOLS.length);
+    expect(tools.every((t) => t.toolType === 'stitch')).toBe(true);
+  });
+
+  test('connector toolset unregistered after being registered', () => {
+    registerToolset(
+      makeToolset({
+        id: 'connector:google:calendar',
+        kind: 'connector',
+        name: 'Calendar',
+        description: 'Calendar connector',
+        tools: () => [{ name: 'calendar_create_event', description: 'Create a calendar event' }],
+      }),
+    );
+
+    unregisterToolset('connector:google:calendar');
+
+    const tools = listKnownTools();
+    const calendarTool = tools.find((t) => t.toolName === 'calendar_create_event');
+    expect(calendarTool).toBeUndefined();
+  });
+});

--- a/packages/server/src/tools/catalog.ts
+++ b/packages/server/src/tools/catalog.ts
@@ -1,0 +1,37 @@
+import { parseMcpToolName } from '@stitch/shared/mcp/types';
+import { humanizeToolName } from '@stitch/shared/tools/display';
+import type { ToolType } from '@stitch/shared/tools/types';
+
+import { STITCH_KNOWN_TOOLS } from '@/tools/runtime/registry.js';
+import { listToolsets } from '@/tools/toolsets/registry.js';
+
+type CatalogTool = {
+  toolType: ToolType;
+  toolName: string;
+  displayName: string;
+};
+
+function displayNameForMcpTool(
+  formattedName: string,
+  presentation: { tools: Record<string, { title?: string }> } | undefined,
+): string {
+  const parsed = parseMcpToolName(formattedName);
+  if (!parsed) return humanizeToolName(formattedName);
+  return presentation?.tools[parsed.toolName]?.title ?? humanizeToolName(formattedName);
+}
+
+/** Returns the full catalog of known tools across all four sources. */
+export function listKnownTools(): CatalogTool[] {
+  const toolsetTools: CatalogTool[] = listToolsets().flatMap((toolset) =>
+    toolset.tools().map((tool) => ({
+      toolType: (toolset.kind === 'mcp' ? 'mcp' : 'plugin') as ToolType,
+      toolName: tool.name,
+      displayName:
+        toolset.kind === 'mcp'
+          ? displayNameForMcpTool(tool.name, toolset.presentation)
+          : humanizeToolName(tool.name),
+    })),
+  );
+
+  return [...STITCH_KNOWN_TOOLS, ...toolsetTools];
+}


### PR DESCRIPTION
## Change Summary

Introduces a `tools/catalog.ts` module as the single source of truth for "what tools exist", replacing the hand-rolled aggregation in the `/tools` route that missed connector tools entirely and used a legacy browser placeholder instead of the real `browser_*` tool list.

Closes #313

### New Features
- **Tool catalog (`tools/catalog.ts`)**: `listKnownTools()` covers all four sources — built-in core tools, MCP toolsets, browser toolset, and connector toolsets — with a single naming and metadata convention

### Improvements & Refactors
- `/tools` route is now a one-line pass-through to `listKnownTools()`; direct imports of `STITCH_KNOWN_TOOLS`, `getMcpServersWithCachedTools`, `getMcpServerPresentation`, and `getBrowserKnownTools` removed from the route
- MCP tool metadata now flows through a single path (toolset registry `presentation`) instead of two parallel paths
- Connector and real `browser_*` tools are now reachable through the catalog interface
- Removed legacy `getBrowserKnownTools` placeholder from `lib/browser/tool-config.ts`
