### PR TITLE
refactor(server): centralize prompt config type and remove nullable defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,10 @@ Naming Conventions
 - Only catch errors when you can handle them meaningfully (e.g., return null, retry, log and continue)
 - Let errors bubble up when there's no recovery strategy
 
+### TypeScript Types
+
+- Never add `?` or `| null` to a type field by default — only when the value is genuinely absent at runtime. If a field is always provided, make it required. Nullable types are a last resort, not a safety blanket.
+
 ### Do Not
 
 - Use `var` - always `const` or `let`

--- a/packages/server/src/automations/generation.ts
+++ b/packages/server/src/automations/generation.ts
@@ -12,9 +12,9 @@ import { messages, sessions } from '@/db/schema/sessions.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { buildHistoryMessages } from '@/llm/history-messages.js';
+import { getPromptUserContext } from '@/llm/prompt/builder.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
-import { getSettings } from '@/settings/service.js';
 import { listToolsets } from '@/tools/toolsets/registry.js';
 import { recordLlmUsage } from '@/usage/ledger.js';
 
@@ -96,17 +96,6 @@ function collectToolsetContext(messageList: GenerationMessageContext[]): {
     usedToolNames: dedupeStrings(toolNames),
     inferredToolsets: [...inferredToolsets].sort(),
     availableToolsets,
-  };
-}
-
-async function getPromptUserContext(): Promise<{
-  userName: string | null;
-  userTimezone: string | null;
-}> {
-  const s = await getSettings(['profile.name', 'profile.timezone'] as const);
-  return {
-    userName: s['profile.name'] || null,
-    userTimezone: s['profile.timezone'] || null,
   };
 }
 
@@ -195,6 +184,8 @@ export async function generateAutomationDraft(
     systemPrompt: null,
     userName: promptUserContext.userName,
     userTimezone: promptUserContext.userTimezone,
+    memoryContext: null,
+    todoContext: null,
   });
 
   const resolved = await resolveCheapModel({

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -347,7 +347,10 @@ export async function sendMessage(
 
   await db.update(sessions).set({ updatedAt: Date.now() }).where(eq(sessions.id, input.sessionId));
 
-  const llmMessages = await buildCompactedHistory(input.sessionId);
+  const llmMessages = await buildCompactedHistory(input.sessionId, {
+    useBasePrompt: true,
+    systemPrompt: null,
+  });
   const assistantMessageId = input.assistantMessageId as PrefixedString<'msg'>;
   const abortSignal = AbortRegistry.register(input.sessionId);
 

--- a/packages/server/src/llm/compaction.test.ts
+++ b/packages/server/src/llm/compaction.test.ts
@@ -170,14 +170,24 @@ describe('buildHistoryMessages', () => {
   }
 
   test('keeps matched tool-call and tool-result pairs', () => {
-    const result = buildHistoryMessages([
+    const result = buildHistoryMessages(
+      [
+        {
+          role: 'assistant',
+          isSummary: false,
+          modelId: 'test-model',
+          parts: [toolCallPart('tc_1'), toolResultPart('tc_1', { ok: true })],
+        },
+      ],
       {
-        role: 'assistant',
-        isSummary: false,
-        modelId: 'test-model',
-        parts: [toolCallPart('tc_1'), toolResultPart('tc_1', { ok: true })],
+        useBasePrompt: true,
+        systemPrompt: null,
+        userName: '',
+        userTimezone: '',
+        memoryContext: null,
+        todoContext: null,
       },
-    ]);
+    );
 
     expect(result).toHaveLength(3);
     expect(result[0]).toMatchObject({ role: 'system' });
@@ -192,28 +202,48 @@ describe('buildHistoryMessages', () => {
   });
 
   test('drops unmatched tool-call parts from history', () => {
-    const result = buildHistoryMessages([
+    const result = buildHistoryMessages(
+      [
+        {
+          role: 'assistant',
+          isSummary: false,
+          modelId: 'test-model',
+          parts: [toolCallPart('tc_missing')],
+        },
+      ],
       {
-        role: 'assistant',
-        isSummary: false,
-        modelId: 'test-model',
-        parts: [toolCallPart('tc_missing')],
+        useBasePrompt: true,
+        systemPrompt: null,
+        userName: '',
+        userTimezone: '',
+        memoryContext: null,
+        todoContext: null,
       },
-    ]);
+    );
 
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ role: 'system' });
   });
 
   test('keeps assistant text even when tool-call is unmatched', () => {
-    const result = buildHistoryMessages([
+    const result = buildHistoryMessages(
+      [
+        {
+          role: 'assistant',
+          isSummary: false,
+          modelId: 'test-model',
+          parts: [textPart('hello'), toolCallPart('tc_missing')],
+        },
+      ],
       {
-        role: 'assistant',
-        isSummary: false,
-        modelId: 'test-model',
-        parts: [textPart('hello'), toolCallPart('tc_missing')],
+        useBasePrompt: true,
+        systemPrompt: null,
+        userName: '',
+        userTimezone: '',
+        memoryContext: null,
+        todoContext: null,
       },
-    ]);
+    );
 
     expect(result).toHaveLength(2);
     expect(result[0]).toMatchObject({ role: 'system' });
@@ -224,14 +254,27 @@ describe('buildHistoryMessages', () => {
   });
 
   test('maps error outputs to error-json tool results', () => {
-    const result = buildHistoryMessages([
+    const result = buildHistoryMessages(
+      [
+        {
+          role: 'assistant',
+          isSummary: false,
+          modelId: 'test-model',
+          parts: [
+            toolCallPart('tc_err'),
+            toolResultPart('tc_err', { error: 'Command was aborted' }),
+          ],
+        },
+      ],
       {
-        role: 'assistant',
-        isSummary: false,
-        modelId: 'test-model',
-        parts: [toolCallPart('tc_err'), toolResultPart('tc_err', { error: 'Command was aborted' })],
+        useBasePrompt: true,
+        systemPrompt: null,
+        userName: '',
+        userTimezone: '',
+        memoryContext: null,
+        todoContext: null,
       },
-    ]);
+    );
 
     expect(result[2]).toMatchObject({
       role: 'tool',
@@ -246,14 +289,24 @@ describe('buildHistoryMessages', () => {
   });
 
   test('adds system prompt with environment', () => {
-    const result = buildHistoryMessages([
+    const result = buildHistoryMessages(
+      [
+        {
+          role: 'user',
+          isSummary: false,
+          modelId: 'openai/gpt-5.3-codex',
+          parts: [textPart('hello')],
+        },
+      ],
       {
-        role: 'user',
-        isSummary: false,
-        modelId: 'openai/gpt-5.3-codex',
-        parts: [textPart('hello')],
+        useBasePrompt: true,
+        systemPrompt: null,
+        userName: '',
+        userTimezone: '',
+        memoryContext: null,
+        todoContext: null,
       },
-    ]);
+    );
 
     expect(result[0]).toMatchObject({ role: 'system' });
     expect(typeof result[0]?.content).toBe('string');
@@ -275,6 +328,10 @@ describe('buildHistoryMessages', () => {
       {
         useBasePrompt: false,
         systemPrompt: 'Custom system prompt for testing',
+        userName: '',
+        userTimezone: '',
+        memoryContext: null,
+        todoContext: null,
       },
     );
 
@@ -297,6 +354,10 @@ describe('buildHistoryMessages', () => {
       {
         useBasePrompt: true,
         systemPrompt: 'Extra user instruction',
+        userName: '',
+        userTimezone: '',
+        memoryContext: null,
+        todoContext: null,
       },
     );
 
@@ -320,6 +381,9 @@ describe('buildHistoryMessages', () => {
         useBasePrompt: true,
         systemPrompt: null,
         userName: 'Jane',
+        userTimezone: '',
+        memoryContext: null,
+        todoContext: null,
       },
     );
 
@@ -341,7 +405,10 @@ describe('buildHistoryMessages', () => {
       {
         useBasePrompt: true,
         systemPrompt: null,
+        userName: '',
         userTimezone: 'America/New_York',
+        memoryContext: null,
+        todoContext: null,
       },
     );
 
@@ -351,9 +418,16 @@ describe('buildHistoryMessages', () => {
   });
 
   test('throws when called with empty history', () => {
-    expect(() => buildHistoryMessages([])).toThrow(
-      'buildHistoryMessages requires at least one message',
-    );
+    expect(() =>
+      buildHistoryMessages([], {
+        useBasePrompt: true,
+        systemPrompt: null,
+        userName: '',
+        userTimezone: '',
+        memoryContext: null,
+        todoContext: null,
+      }),
+    ).toThrow('buildHistoryMessages requires at least one message');
   });
 
   function imagePart(dataUrl = 'data:image/png;base64,AAAA', mime = 'image/png'): StoredPart {
@@ -404,7 +478,14 @@ describe('buildHistoryMessages', () => {
       assistantMsg('Done'),
     ];
 
-    const result = buildHistoryMessages(msgs);
+    const result = buildHistoryMessages(msgs, {
+      useBasePrompt: true,
+      systemPrompt: null,
+      userName: '',
+      userTimezone: '',
+      memoryContext: null,
+      todoContext: null,
+    });
     const userMessages = result.filter((m) => m.role === 'user');
 
     for (const um of userMessages) {
@@ -433,7 +514,14 @@ describe('buildHistoryMessages', () => {
       assistantMsg('turn 4'),
     ];
 
-    const result = buildHistoryMessages(msgs);
+    const result = buildHistoryMessages(msgs, {
+      useBasePrompt: true,
+      systemPrompt: null,
+      userName: '',
+      userTimezone: '',
+      memoryContext: null,
+      todoContext: null,
+    });
     const userMessages = result.filter((m) => m.role === 'user');
 
     const firstUserContent = userMessages[0].content as Array<{ type: string; text?: string }>;
@@ -460,7 +548,14 @@ describe('buildHistoryMessages', () => {
       assistantMsg('turn 4'),
     ];
 
-    const result = buildHistoryMessages(msgs);
+    const result = buildHistoryMessages(msgs, {
+      useBasePrompt: true,
+      systemPrompt: null,
+      userName: '',
+      userTimezone: '',
+      memoryContext: null,
+      todoContext: null,
+    });
     const userMessages = result.filter((m) => m.role === 'user');
 
     const firstUserContent = userMessages[0].content as Array<{ type: string; text?: string }>;
@@ -478,7 +573,14 @@ describe('buildHistoryMessages', () => {
       assistantMsg('turn 2'),
     ];
 
-    const result = buildHistoryMessages(msgs);
+    const result = buildHistoryMessages(msgs, {
+      useBasePrompt: true,
+      systemPrompt: null,
+      userName: '',
+      userTimezone: '',
+      memoryContext: null,
+      todoContext: null,
+    });
     const userMessages = result.filter((m) => m.role === 'user');
 
     const firstContent = userMessages[0].content as Array<{ type: string }>;

--- a/packages/server/src/llm/compaction.ts
+++ b/packages/server/src/llm/compaction.ts
@@ -13,6 +13,8 @@ import * as Log from '@/lib/log.js';
 import { isServiceError } from '@/lib/service-result.js';
 import { addCacheControlToMessages, getProviderOptions } from '@/llm/cache-control.js';
 import { buildHistoryMessages } from '@/llm/history-messages.js';
+import { getPromptUserContext } from '@/llm/prompt/builder.js';
+import type { PromptConfig } from '@/llm/prompt/builder.js';
 import * as Models from '@/llm/provider/models.js';
 import * as OllamaModels from '@/llm/provider/ollama-models.js';
 import { createProvider } from '@/llm/provider/provider.js';
@@ -55,17 +57,6 @@ export async function getCompactionSettings(): Promise<CompactionSettings> {
     auto: s['compaction.auto'],
     prune: s['compaction.prune'],
     reserved: s['compaction.reserved'],
-  };
-}
-
-async function getPromptUserContext(): Promise<{
-  userName: string | null;
-  userTimezone: string | null;
-}> {
-  const s = await getSettings(['profile.name', 'profile.timezone'] as const);
-  return {
-    userName: s['profile.name'] || null,
-    userTimezone: s['profile.timezone'] || null,
   };
 }
 
@@ -326,6 +317,7 @@ export async function compact(input: {
       systemPrompt: null,
       userName: promptUserContext.userName,
       userTimezone: promptUserContext.userTimezone,
+      memoryContext: null,
       todoContext,
     });
 
@@ -479,13 +471,7 @@ export async function compact(input: {
  */
 export async function buildCompactedHistory(
   sessionId: PrefixedString<'ses'>,
-  promptConfig?: {
-    useBasePrompt: boolean;
-    systemPrompt: string | null;
-    userName?: string | null;
-    userTimezone?: string | null;
-    codeModePrompt?: string | null;
-  },
+  promptConfig: Pick<PromptConfig, 'useBasePrompt' | 'systemPrompt'>,
 ): Promise<ModelMessage[]> {
   const db = getDb();
 
@@ -495,12 +481,7 @@ export async function buildCompactedHistory(
       .from(messages)
       .where(eq(messages.sessionId, sessionId))
       .orderBy(asc(messages.createdAt)),
-    promptConfig?.userName !== undefined && promptConfig?.userTimezone !== undefined
-      ? Promise.resolve({
-          userName: promptConfig.userName ?? null,
-          userTimezone: promptConfig.userTimezone ?? null,
-        })
-      : getPromptUserContext(),
+    getPromptUserContext(),
     db.select({ type: sessions.type }).from(sessions).where(eq(sessions.id, sessionId)).limit(1),
     getSessionTodosPromptBlock(sessionId),
   ]);
@@ -532,13 +513,12 @@ export async function buildCompactedHistory(
   }
 
   const historyMessages = buildHistoryMessages(msgs.slice(startIndex), {
-    useBasePrompt: promptConfig?.useBasePrompt ?? true,
-    systemPrompt: promptConfig?.systemPrompt ?? null,
+    useBasePrompt: promptConfig.useBasePrompt,
+    systemPrompt: promptConfig.systemPrompt,
     userName: promptUserContext.userName,
     userTimezone: promptUserContext.userTimezone,
     memoryContext,
     todoContext,
-    codeModePrompt: promptConfig?.codeModePrompt ?? null,
   });
 
   const instructionsBlock = buildActiveToolsetInstructionsBlock(sessionId);

--- a/packages/server/src/llm/history-messages.ts
+++ b/packages/server/src/llm/history-messages.ts
@@ -2,6 +2,7 @@ import type { Message, StoredPart } from '@stitch/shared/chat/messages';
 
 import * as Log from '@/lib/log.js';
 import { buildSystemPrompt } from '@/llm/prompt/builder.js';
+import type { PromptConfig } from '@/llm/prompt/builder.js';
 import { estimate } from '@/utils/token.js';
 import type { ModelMessage } from 'ai';
 
@@ -63,15 +64,7 @@ function compactToolResultOutput(part: StoredPart & { type: 'tool-result' }): un
 
 export function buildHistoryMessages(
   msgs: Array<Pick<Message, 'role' | 'parts' | 'isSummary' | 'modelId'>>,
-  promptConfig?: {
-    useBasePrompt: boolean;
-    systemPrompt: string | null;
-    userName?: string | null;
-    userTimezone?: string | null;
-    memoryContext?: string | null;
-    todoContext?: string | null;
-    codeModePrompt?: string | null;
-  },
+  promptConfig: PromptConfig,
 ): ModelMessage[] {
   if (msgs.length === 0) {
     throw new Error('buildHistoryMessages requires at least one message');
@@ -271,16 +264,7 @@ export function buildHistoryMessages(
   if (llmMessages[0]?.role !== 'system') {
     llmMessages.unshift({
       role: 'system',
-      content: buildSystemPrompt({
-        useBasePrompt: promptConfig?.useBasePrompt ?? true,
-        systemPrompt: promptConfig?.systemPrompt ?? null,
-        userName: promptConfig?.userName ?? null,
-        userTimezone: promptConfig?.userTimezone ?? null,
-        memoryContext: promptConfig?.memoryContext ?? null,
-        todoContext: promptConfig?.todoContext ?? null,
-        codeModePrompt: promptConfig?.codeModePrompt ?? null,
-        liquidUiPromptSection: null,
-      }),
+      content: buildSystemPrompt(promptConfig),
     });
   }
 

--- a/packages/server/src/llm/prompt/builder.ts
+++ b/packages/server/src/llm/prompt/builder.ts
@@ -4,8 +4,29 @@ import { buildLiquidUiCatalogPrompt } from '@stitch/shared/liquid-ui/catalog';
 
 import { resolveRuntimeAssetPath } from '@/lib/runtime-assets.js';
 import { buildPromptEnvironment } from '@/llm/prompt/env.js';
+import { getSettings } from '@/settings/service.js';
 
-const identity = (userName: string | null) => {
+export type PromptConfig = {
+  useBasePrompt: boolean;
+  systemPrompt: string | null;
+  userName: string;
+  userTimezone: string;
+  memoryContext: string | null;
+  todoContext: string | null;
+};
+
+export async function getPromptUserContext(): Promise<{
+  userName: string;
+  userTimezone: string;
+}> {
+  const s = await getSettings(['profile.name', 'profile.timezone'] as const);
+  return {
+    userName: s['profile.name'],
+    userTimezone: s['profile.timezone'],
+  };
+}
+
+const identity = (userName: string) => {
   const identityLine = userName
     ? `You are Stitch, a local machine assistant that helps ${userName} with day-to-day tasks on their computer.`
     : 'You are Stitch, a local machine assistant that helps users with day-to-day tasks on their computer.';
@@ -88,19 +109,8 @@ function buildEnforcementGuidance(): string {
 - Act, don't ask: act immediately when the request has an obvious safe default. Ask at most one focused question only when truly blocked.`;
 }
 
-export function buildSystemPrompt(input: {
-  useBasePrompt: boolean;
-  systemPrompt: string | null;
-  userName?: string | null;
-  userTimezone?: string | null;
-  memoryContext?: string | null;
-  todoContext?: string | null;
-  codeModePrompt?: string | null;
-  liquidUiPromptSection?: string | null;
-}): string {
+export function buildSystemPrompt(input: PromptConfig): string {
   const userPrompt = input.systemPrompt?.trim() ?? '';
-  const userName = input.userName?.trim() || null;
-  const userTimezone = input.userTimezone?.trim() || null;
 
   let promptBody = userPrompt;
   if (input.useBasePrompt) {
@@ -110,17 +120,11 @@ export function buildSystemPrompt(input: {
     }
   }
 
-  let result = `${identity(userName)}\n\n${buildPromptEnvironment({ userTimezone })}\n\n${promptBody}`;
+  let result = `${identity(input.userName)}\n\n${buildPromptEnvironment({ userTimezone: input.userTimezone })}\n\n${promptBody}`;
 
   result = `${result}\n\n${buildEnforcementGuidance()}`;
 
-  if (input.codeModePrompt?.trim()) {
-    result = `${result}\n\n${input.codeModePrompt.trim()}`;
-  }
-
-  if (!input.codeModePrompt?.trim()) {
-    result = `${result}\n\n${input.liquidUiPromptSection?.trim() || buildLiquidUiPromptSection()}`;
-  }
+  result = `${result}\n\n${buildLiquidUiPromptSection()}`;
 
   if (input.memoryContext) {
     result = `${result}\n\n<memory>\n${input.memoryContext}\n</memory>`;

--- a/packages/server/src/tools/core/inspect-image.ts
+++ b/packages/server/src/tools/core/inspect-image.ts
@@ -174,7 +174,10 @@ export function createInspectImageTool(context: ToolContext, deps: InspectImageT
         duration: null,
       });
 
-      const llmMessages = await buildCompactedHistory(childSessionId);
+      const llmMessages = await buildCompactedHistory(childSessionId, {
+        useBasePrompt: true,
+        systemPrompt: null,
+      });
       const assistantMessageId = createMessageId();
 
       const childAbortSignal = AbortRegistry.register(childSessionId);

--- a/packages/server/src/tools/core/task.ts
+++ b/packages/server/src/tools/core/task.ts
@@ -124,7 +124,10 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
       });
 
       // Build history (just the system prompt + user message)
-      const llmMessages = await buildCompactedHistory(childSessionId);
+      const llmMessages = await buildCompactedHistory(childSessionId, {
+        useBasePrompt: true,
+        systemPrompt: null,
+      });
       const assistantMessageId = createMessageId();
 
       // Create a child abort controller linked to the parent


### PR DESCRIPTION
## Change Summary

Centralizes prompt config into a single `PromptConfig` type in `builder.ts`, removes dead fields, eliminates duplicate `getPromptUserContext` implementations, and enforces that prompt config is always passed explicitly with no hidden defaults or unnecessary nullability.

### Improvements & Refactors

- **Centralized `PromptConfig` type**: Single source of truth exported from `llm/prompt/builder.ts` — replaces three separate inline object types across `builder.ts`, `history-messages.ts`, and `compaction.ts`
- **Exported `getPromptUserContext`**: Removed two private duplicate implementations in `compaction.ts` and `generation.ts`; both now import from `builder.ts`
- **Removed dead prompt fields**: `codeModePrompt` and `liquidUiPromptSection` removed from `PromptConfig` — code mode is injected via `runner.ts` `promptAdditions`, liquid UI prompt is always built internally by the builder
- **Required prompt config params**: `buildHistoryMessages` and `buildCompactedHistory` now require their `promptConfig` argument — no optional params, no internal fallback defaults; all call sites pass config explicitly
- **Cleaner nullability**: `userName` and `userTimezone` are `string` (not `string | null`) reflecting that onboarding ensures they are set; `memoryContext` and `todoContext` remain `string | null` as they are genuinely absent at times
- **AGENTS.md**: Added TypeScript types guideline — `?` and `| null` are a last resort, not the default

Closes #345