### PR TITLE
improvement: embedding model registry and type decoupling

### DIFF
--- a/apps/web/src/components/model-selectors/model-combobox.tsx
+++ b/apps/web/src/components/model-selectors/model-combobox.tsx
@@ -12,11 +12,16 @@ import {
   ComboboxList,
   ComboboxSeparator,
 } from '@/components/ui/combobox';
-import type { ProviderModels } from '@/lib/queries/providers';
 
 export type ModelSelection = {
   providerId: string;
   modelId: string;
+};
+
+type MinimalProviderModels = {
+  providerId: string;
+  providerName: string;
+  models: { id: string; name: string }[];
 };
 
 type ModelOption = {
@@ -31,7 +36,7 @@ type ModelGroup = {
   items: ModelOption[];
 };
 
-function buildGroups(providerModels: ProviderModels[]): ModelGroup[] {
+function buildGroups(providerModels: MinimalProviderModels[]): ModelGroup[] {
   return providerModels.map((provider) => ({
     value: provider.providerName,
     items: provider.models.map((model) => ({
@@ -48,7 +53,7 @@ function flattenGroups(groups: ModelGroup[]): ModelOption[] {
 }
 
 type ModelComboboxProps = {
-  providerModels: ProviderModels[];
+  providerModels: MinimalProviderModels[];
   value: ModelSelection | null;
   onValueChange: (value: ModelSelection | null) => void;
   placeholder?: string;
@@ -65,12 +70,10 @@ export function ModelCombobox({
   const groups = React.useMemo(() => buildGroups(providerModels), [providerModels]);
   const allOptions = React.useMemo(() => flattenGroups(groups), [groups]);
 
-  const selectedOption =
-    value
-      ? (allOptions.find(
-          (o) => o.providerId === value.providerId && o.modelId === value.modelId,
-        ) ?? null)
-      : null;
+  const selectedOption = value
+    ? (allOptions.find((o) => o.providerId === value.providerId && o.modelId === value.modelId) ??
+      null)
+    : null;
 
   const resolvedShowClear = showClear ?? !!value;
 

--- a/apps/web/src/components/onboarding/steps/memory-step.tsx
+++ b/apps/web/src/components/onboarding/steps/memory-step.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import type { EmbeddingProviderModels } from '@stitch/shared/embedding/types';
+
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import {
@@ -11,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { embeddingProviderModelsQueryOptions, type ProviderModels } from '@/lib/queries/providers';
+import { embeddingProviderModelsQueryOptions } from '@/lib/queries/providers';
 import { saveSettingMutationOptions, settingsQueryOptions } from '@/lib/queries/settings';
 
 type ModelOption = {
@@ -21,7 +23,7 @@ type ModelOption = {
   modelId: string;
 };
 
-function buildModelOptions(providerModels: ProviderModels[] | undefined): ModelOption[] {
+function buildModelOptions(providerModels: EmbeddingProviderModels[] | undefined): ModelOption[] {
   if (!providerModels) return [];
   const options: ModelOption[] = [];
   for (const provider of providerModels) {

--- a/apps/web/src/components/settings/memory.tsx
+++ b/apps/web/src/components/settings/memory.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 
+import type { EmbeddingProviderModels } from '@stitch/shared/embedding/types';
+
 import { ModelCombobox, type ModelSelection } from '@/components/model-selectors/model-combobox';
 import { SETTINGS_PAGE_BY_ID } from '@/components/settings/settings-metadata';
 import {
@@ -33,7 +35,7 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { resetMemoriesMutationOptions } from '@/lib/queries/memories';
-import { embeddingProviderModelsQueryOptions, type ProviderModels } from '@/lib/queries/providers';
+import { embeddingProviderModelsQueryOptions } from '@/lib/queries/providers';
 import { saveSettingMutationOptions, settingsQueryOptions } from '@/lib/queries/settings';
 
 const CONFIDENCE_FILTER_OPTIONS = [
@@ -49,7 +51,7 @@ function EmbeddingModelSelect({
 }: {
   currentProviderId: string | undefined;
   currentModelId: string | undefined;
-  providerModels: ProviderModels[];
+  providerModels: EmbeddingProviderModels[];
 }) {
   const queryClient = useQueryClient();
   const [pendingValue, setPendingValue] = React.useState<ModelSelection | null | undefined>(

--- a/apps/web/src/lib/queries/providers.ts
+++ b/apps/web/src/lib/queries/providers.ts
@@ -1,5 +1,6 @@
 import { queryOptions } from '@tanstack/react-query';
 
+import type { EmbeddingProviderModels } from '@stitch/shared/embedding/types';
 import { buildDefaultVisibleSet, isModelVisible } from '@stitch/shared/providers/model-visibility';
 
 import { serverRequest } from '@/lib/api';
@@ -165,7 +166,7 @@ export const embeddingProviderModelsQueryOptions = queryOptions({
   queryKey: providerKeys.embeddingModels(),
   staleTime: 60 * 60 * 1000,
   refetchOnWindowFocus: true,
-  queryFn: () => serverRequest<ProviderModels[]>('/llm/provider/embedding-models'),
+  queryFn: () => serverRequest<EmbeddingProviderModels[]>('/llm/provider/embedding-models'),
 });
 
 export const sttProviderModelsQueryOptions = queryOptions({

--- a/packages/server/src/llm/provider/service.ts
+++ b/packages/server/src/llm/provider/service.ts
@@ -1,9 +1,12 @@
 import { eq, count } from 'drizzle-orm';
 
+import type { EmbeddingProviderModels } from '@stitch/shared/embedding/types';
+
 import { getDb } from '@/db/client.js';
 import { providerConfig, ollamaModels } from '@/db/schema/providers.js';
 import { err, isServiceError, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
+import type { ResolvedEmbeddingModel } from '@/models/embedding/schema.js';
 import * as EmbeddingModels from '@/models/embedding/service.js';
 import * as OllamaModels from '@/models/llm/ollama.js';
 import { isAllowedProvider } from '@/models/llm/registry.js';
@@ -26,12 +29,6 @@ type ModelSummary = {
   cost: Models.RawModel['cost'];
   limit: Models.RawModel['limit'];
   modalities: Models.RawModel['modalities'];
-};
-
-type ProviderModelsSummary = {
-  providerId: string;
-  providerName: string;
-  models: ModelSummary[];
 };
 
 function toProviderSummary(provider: Models.RawProvider, enabled: boolean): ProviderSummary {
@@ -158,8 +155,20 @@ export async function listProviderModels(
   return ok(Object.values(providerResult.data.models).map(toModelSummary));
 }
 
+function toEmbeddingModelSummary(
+  model: ResolvedEmbeddingModel,
+): EmbeddingProviderModels['models'][number] {
+  return {
+    id: model.id,
+    name: model.name,
+    family: model.family,
+    dimensions: model.dimensions,
+    context: model.context,
+  };
+}
+
 export async function listEnabledProviderEmbeddingModels(): Promise<
-  ServiceResult<ProviderModelsSummary[]>
+  ServiceResult<EmbeddingProviderModels[]>
 > {
   const db = getDb();
   const [providers, configs] = await Promise.all([
@@ -174,7 +183,7 @@ export async function listEnabledProviderEmbeddingModels(): Promise<
       .map((provider) => ({
         providerId: provider.id,
         providerName: provider.name,
-        models: Object.values(provider.models).map(toModelSummary),
+        models: Object.values(provider.models).map(toEmbeddingModelSummary),
       })),
   );
 }

--- a/packages/server/src/memory/service.ts
+++ b/packages/server/src/memory/service.ts
@@ -4,8 +4,6 @@ import * as Log from '@/lib/log.js';
 import { computeTotalPages } from '@/lib/paginated-query.js';
 import { ok, err } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
-import type { MemoryEmbedder } from '@/memory/embedding/embedder.js';
-import { createEmbedder } from '@/memory/embedding/factory.js';
 import { getSemanticTable } from '@/memory/store/tables.js';
 import type {
   ListSemanticMemoriesResponse,
@@ -15,6 +13,8 @@ import type {
   MemorySource,
   ExtractedFact,
 } from '@/memory/types.js';
+import type { Embedder } from '@/models/embedding/embedder.js';
+import { createEmbedder } from '@/models/embedding/factory.js';
 import type { VectorQuery } from '@lancedb/lancedb';
 
 export type MemoryStats = {
@@ -35,7 +35,7 @@ function now(): string {
   return new Date().toISOString();
 }
 
-async function getEmbedder(): Promise<MemoryEmbedder> {
+async function getEmbedder(): Promise<Embedder> {
   return createEmbedder();
 }
 

--- a/packages/server/src/models/embedding/embedder.ts
+++ b/packages/server/src/models/embedding/embedder.ts
@@ -2,7 +2,7 @@
  * Abstract interface for generating text embeddings.
  * Implementations use remote API providers.
  */
-export interface MemoryEmbedder {
+export interface Embedder {
   /** Generate an embedding vector for a single text. */
   embed(text: string): Promise<number[]>;
   /** Generate embedding vectors for multiple texts in a batch. */

--- a/packages/server/src/models/embedding/factory.ts
+++ b/packages/server/src/models/embedding/factory.ts
@@ -9,14 +9,14 @@ import {
   hasConfiguredEmbeddingModel,
   invalidateMemoryConfig,
 } from '@/memory/config.js';
-import type { MemoryEmbedder } from '@/memory/embedding/embedder.js';
-import { ProviderEmbedder } from '@/memory/embedding/provider-embedder.js';
+import type { Embedder } from '@/models/embedding/embedder.js';
+import { ProviderEmbedder } from '@/models/embedding/provider-embedder.js';
 
-const log = Log.create({ service: 'memory-embedder' });
+const log = Log.create({ service: 'embedder' });
 
 const DEFAULT_DIMENSIONS = 1536;
 
-let cachedEmbedder: MemoryEmbedder | null = null;
+let cachedEmbedder: Embedder | null = null;
 
 export function resetEmbedder(): void {
   cachedEmbedder = null;
@@ -24,14 +24,14 @@ export function resetEmbedder(): void {
 }
 
 /**
- * Create a MemoryEmbedder based on the user's settings.
+ * Create an Embedder based on the user's settings.
  *
  * Uses the configured provider embedding model via AI SDK.
  *
  * The embedder is cached as a singleton and only recreated when settings change.
  * Reads embedding config from the already-cached MemoryConfig to avoid a duplicate DB query.
  */
-export async function createEmbedder(): Promise<MemoryEmbedder> {
+export async function createEmbedder(): Promise<Embedder> {
   if (cachedEmbedder) return cachedEmbedder;
 
   const config = await getMemoryConfig();

--- a/packages/server/src/models/embedding/provider-embedder.ts
+++ b/packages/server/src/models/embedding/provider-embedder.ts
@@ -2,13 +2,13 @@ import { embed, embedMany, type EmbeddingModel } from 'ai';
 
 import { createProvider } from '@/llm/provider/provider.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
-import type { MemoryEmbedder } from '@/memory/embedding/embedder.js';
+import type { Embedder } from '@/models/embedding/embedder.js';
 
 /**
  * Embedding implementation using AI SDK providers (OpenAI, Google, etc.).
- * Wraps the AI SDK embed()/embedMany() functions into the MemoryEmbedder interface.
+ * Wraps the AI SDK embed()/embedMany() functions into the Embedder interface.
  */
-export class ProviderEmbedder implements MemoryEmbedder {
+export class ProviderEmbedder implements Embedder {
   readonly dimensions: number;
   private readonly model: EmbeddingModel;
 

--- a/packages/server/src/models/embedding/registry.ts
+++ b/packages/server/src/models/embedding/registry.ts
@@ -5,50 +5,46 @@ import {
   type EmbeddingModel,
   type EmbeddingProvider,
   type EmbeddingRegistryPayload,
+  type ResolvedEmbeddingModel,
+  type ResolvedEmbeddingProvider,
 } from '@/models/embedding/schema.js';
-import type { RawModel, RawProvider } from '@/models/llm/registry.js';
 
 const DEFAULT_EMBEDDING_REGISTRY_URL = 'https://usestitch.ai/embedding-models.json';
 
-function toRawModel(model: EmbeddingModel): RawModel {
+function toResolvedModel(model: EmbeddingModel): ResolvedEmbeddingModel {
   return {
     id: model.id,
     name: model.name,
     family: model.family,
     release_date: model.release_date,
-    attachment: false,
-    reasoning: false,
-    temperature: false,
-    tool_call: false,
+    dimensions: model.dimensions,
+    context: model.context,
     cost: model.cost,
-    limit: {
-      context: model.context,
-      output: model.dimensions,
-    },
     modalities: {
       input: model.inputModalities ?? ['text'],
       output: model.outputModalities ?? ['text'],
     },
-    options: {},
   };
 }
 
-function toRawProvider(provider: EmbeddingProvider): RawProvider {
-  const models = Object.fromEntries(provider.models.map((model) => [model.id, toRawModel(model)]));
+function toResolvedProvider(provider: EmbeddingProvider): ResolvedEmbeddingProvider {
+  const models = Object.fromEntries(
+    provider.models.map((model) => [model.id, toResolvedModel(model)]),
+  );
 
   return {
     id: provider.providerId,
     name: provider.providerName,
     api: provider.api,
-    npm: provider.npm,
-    env: provider.env ?? [],
     models,
   };
 }
 
-function toRawProviders(providers: EmbeddingProvider[]): Record<string, RawProvider> {
+function toResolvedProviders(
+  providers: EmbeddingProvider[],
+): Record<string, ResolvedEmbeddingProvider> {
   return Object.fromEntries(
-    providers.map((provider) => [provider.providerId, toRawProvider(provider)]),
+    providers.map((provider) => [provider.providerId, toResolvedProvider(provider)]),
   );
 }
 
@@ -75,9 +71,9 @@ const embeddingRegistryCache = createRegistryCache<EmbeddingRegistryPayload>({
 
 export async function getEmbeddingModelsFromRegistry(
   fetchImpl = fetch,
-): Promise<Record<string, RawProvider>> {
+): Promise<Record<string, ResolvedEmbeddingProvider>> {
   const payload = await embeddingRegistryCache.get(fetchImpl);
-  return toRawProviders(payload.providers);
+  return toResolvedProviders(payload.providers);
 }
 
 export async function refresh(fetchImpl = fetch): Promise<void> {

--- a/packages/server/src/models/embedding/schema.ts
+++ b/packages/server/src/models/embedding/schema.ts
@@ -1,7 +1,5 @@
 import z from 'zod';
 
-const embeddingProviderIdSchema = z.enum(['google', 'openai']);
-
 export const EmbeddingModelSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
@@ -29,7 +27,7 @@ export const EmbeddingModelSchema = z.object({
 
 export const EmbeddingProviderSchema = z.object({
   $schema: z.string().optional(),
-  providerId: embeddingProviderIdSchema,
+  providerId: z.string().min(1),
   providerName: z.string().min(1),
   api: z.string().optional(),
   npm: z.string().optional(),

--- a/packages/server/src/models/embedding/schema.ts
+++ b/packages/server/src/models/embedding/schema.ts
@@ -31,7 +31,6 @@ export const EmbeddingProviderSchema = z.object({
   providerName: z.string().min(1),
   api: z.string().optional(),
   npm: z.string().optional(),
-  env: z.array(z.string().min(1)).optional(),
   models: z.array(EmbeddingModelSchema).min(1),
 });
 
@@ -44,3 +43,26 @@ export const EmbeddingRegistryPayloadSchema = z.object({
 export type EmbeddingProvider = z.infer<typeof EmbeddingProviderSchema>;
 export type EmbeddingModel = z.infer<typeof EmbeddingModelSchema>;
 export type EmbeddingRegistryPayload = z.infer<typeof EmbeddingRegistryPayloadSchema>;
+
+/** Resolved embedding model ready for consumption by services. */
+export type ResolvedEmbeddingModel = {
+  id: string;
+  name: string;
+  family: string | undefined;
+  release_date: string;
+  dimensions: number;
+  context: number;
+  cost: EmbeddingModel['cost'];
+  modalities: {
+    input: string[];
+    output: string[];
+  };
+};
+
+/** Resolved embedding provider with its models keyed by ID. */
+export type ResolvedEmbeddingProvider = {
+  id: string;
+  name: string;
+  api: string | undefined;
+  models: Record<string, ResolvedEmbeddingModel>;
+};

--- a/packages/server/src/models/embedding/service.ts
+++ b/packages/server/src/models/embedding/service.ts
@@ -1,12 +1,15 @@
 import { getEmbeddingModelsFromRegistry } from '@/models/embedding/registry.js';
-import type { RawProvider, RawModel } from '@/models/llm/registry.js';
+import type {
+  ResolvedEmbeddingModel,
+  ResolvedEmbeddingProvider,
+} from '@/models/embedding/schema.js';
 
 /** Returns embedding models from the Stitch embedding registry. */
-export async function getEmbeddingModels(): Promise<Record<string, RawProvider>> {
+export async function getEmbeddingModels(): Promise<Record<string, ResolvedEmbeddingProvider>> {
   return await getEmbeddingModelsFromRegistry();
 }
 
 /** Returns the output dimension of an embedding model, or undefined if unknown. */
-export function getEmbeddingDimensions(model: RawModel): number | undefined {
-  return model.limit?.output;
+export function getEmbeddingDimensions(model: ResolvedEmbeddingModel): number | undefined {
+  return model.dimensions;
 }

--- a/packages/server/src/routes/memory.ts
+++ b/packages/server/src/routes/memory.ts
@@ -5,7 +5,6 @@ import { z } from 'zod';
 import { unwrapResult } from '@/lib/route-helpers.js';
 import { paginationQuerySchema } from '@/lib/route-schemas.js';
 import { getMemoryConfig, isMemoryActive } from '@/memory/config.js';
-import { resetEmbedder } from '@/memory/embedding/factory.js';
 import { runMemoryMaintenance } from '@/memory/maintenance.js';
 import {
   getAllSemanticMemories,
@@ -19,6 +18,7 @@ import {
 } from '@/memory/service.js';
 import { dropSemanticTable } from '@/memory/store/tables.js';
 import { MEMORY_CATEGORIES, MEMORY_CONFIDENCES, MEMORY_SOURCES } from '@/memory/types.js';
+import { resetEmbedder } from '@/models/embedding/factory.js';
 import type { Context } from 'hono';
 
 const semanticQuerySchema = paginationQuerySchema({ pageSize: 20 }).extend({

--- a/packages/server/src/settings/service.ts
+++ b/packages/server/src/settings/service.ts
@@ -10,7 +10,7 @@ import { err, isServiceError, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { listEnabledProviderEmbeddingModels } from '@/llm/provider/service.js';
 import { getMemoryConfig, hasConfiguredEmbeddingModel } from '@/memory/config.js';
-import { resetEmbedder } from '@/memory/embedding/factory.js';
+import { resetEmbedder } from '@/models/embedding/factory.js';
 import type { z } from 'zod';
 
 type SettingValue<K extends SettingsKey> = z.infer<(typeof SETTINGS_SCHEMAS)[K]>;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -37,6 +37,7 @@
     "./tools/types": "./src/tools/types.ts",
     "./usage/types": "./src/usage/types.ts",
     "./connectors/types": "./src/connectors/types.ts",
+    "./embedding/types": "./src/embedding/types.ts",
     "./memory/types": "./src/memory/types.ts",
     "./agenda/types": "./src/agenda/types.ts",
     "./skills/types": "./src/skills/types.ts",

--- a/packages/shared/src/embedding/types.ts
+++ b/packages/shared/src/embedding/types.ts
@@ -1,0 +1,13 @@
+export type EmbeddingModelSummary = {
+  id: string;
+  name: string;
+  family?: string;
+  dimensions: number;
+  context: number;
+};
+
+export type EmbeddingProviderModels = {
+  providerId: string;
+  providerName: string;
+  models: EmbeddingModelSummary[];
+};

--- a/registries/embeddings/models/google.json
+++ b/registries/embeddings/models/google.json
@@ -3,7 +3,6 @@
   "providerId": "google",
   "providerName": "Google",
   "npm": "@ai-sdk/google",
-  "env": ["GOOGLE_API_KEY", "GOOGLE_GENERATIVE_AI_API_KEY", "GEMINI_API_KEY"],
   "models": [
     {
       "id": "gemini-embedding-2",

--- a/registries/embeddings/models/nvidia.json
+++ b/registries/embeddings/models/nvidia.json
@@ -5,21 +5,6 @@
   "env": ["NVIDIA_API_KEY"],
   "models": [
     {
-      "id": "nvidia/nv-embedcode-7b-v1",
-      "name": "NV-EmbedCode 7B v1",
-      "family": "nv-embed",
-      "deprecated": false,
-      "dimensions": 4096,
-      "release_date": "2025-05-01",
-      "context": 131072,
-      "inputModalities": ["text"],
-      "outputModalities": ["text"],
-      "cost": {
-        "input": 0,
-        "output": 0
-      }
-    },
-    {
       "id": "nvidia/nv-embed-v1",
       "name": "NV-Embed v1",
       "family": "nv-embed",
@@ -27,21 +12,6 @@
       "dimensions": 4096,
       "release_date": "2024-05-01",
       "context": 32768,
-      "inputModalities": ["text"],
-      "outputModalities": ["text"],
-      "cost": {
-        "input": 0,
-        "output": 0
-      }
-    },
-    {
-      "id": "meta/esm2-650m",
-      "name": "ESM2 650M",
-      "family": "esm2",
-      "deprecated": false,
-      "dimensions": 1280,
-      "release_date": "2023-01-01",
-      "context": 1024,
       "inputModalities": ["text"],
       "outputModalities": ["text"],
       "cost": {

--- a/registries/embeddings/models/nvidia.json
+++ b/registries/embeddings/models/nvidia.json
@@ -2,7 +2,6 @@
   "$schema": "https://usestitch.ai/schemas/embedding-provider.schema.json",
   "providerId": "nvidia",
   "providerName": "NVIDIA",
-  "env": ["NVIDIA_API_KEY"],
   "models": [
     {
       "id": "nvidia/nv-embed-v1",

--- a/registries/embeddings/models/nvidia.json
+++ b/registries/embeddings/models/nvidia.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://usestitch.ai/schemas/embedding-provider.schema.json",
+  "providerId": "nvidia",
+  "providerName": "NVIDIA",
+  "env": ["NVIDIA_API_KEY"],
+  "models": [
+    {
+      "id": "nvidia/nv-embedcode-7b-v1",
+      "name": "NV-EmbedCode 7B v1",
+      "family": "nv-embed",
+      "deprecated": false,
+      "dimensions": 4096,
+      "release_date": "2025-05-01",
+      "context": 131072,
+      "inputModalities": ["text"],
+      "outputModalities": ["text"],
+      "cost": {
+        "input": 0,
+        "output": 0
+      }
+    },
+    {
+      "id": "nvidia/nv-embed-v1",
+      "name": "NV-Embed v1",
+      "family": "nv-embed",
+      "deprecated": false,
+      "dimensions": 4096,
+      "release_date": "2024-05-01",
+      "context": 32768,
+      "inputModalities": ["text"],
+      "outputModalities": ["text"],
+      "cost": {
+        "input": 0,
+        "output": 0
+      }
+    },
+    {
+      "id": "meta/esm2-650m",
+      "name": "ESM2 650M",
+      "family": "esm2",
+      "deprecated": false,
+      "dimensions": 1280,
+      "release_date": "2023-01-01",
+      "context": 1024,
+      "inputModalities": ["text"],
+      "outputModalities": ["text"],
+      "cost": {
+        "input": 0,
+        "output": 0
+      }
+    }
+  ]
+}

--- a/registries/embeddings/models/openai.json
+++ b/registries/embeddings/models/openai.json
@@ -3,7 +3,6 @@
   "providerId": "openai",
   "providerName": "OpenAI",
   "npm": "@ai-sdk/openai",
-  "env": ["OPENAI_API_KEY"],
   "models": [
     {
       "id": "text-embedding-3-large",

--- a/registries/embeddings/models/openrouter.json
+++ b/registries/embeddings/models/openrouter.json
@@ -3,7 +3,6 @@
   "providerId": "openrouter",
   "providerName": "OpenRouter",
   "npm": "@openrouter/ai-sdk-provider",
-  "env": ["OPENROUTER_API_KEY"],
   "models": [
     {
       "id": "nvidia/llama-nemotron-embed-vl-1b-v2:free",

--- a/registries/embeddings/models/openrouter.json
+++ b/registries/embeddings/models/openrouter.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://usestitch.ai/schemas/embedding-provider.schema.json",
+  "providerId": "openrouter",
+  "providerName": "OpenRouter",
+  "npm": "@openrouter/ai-sdk-provider",
+  "env": ["OPENROUTER_API_KEY"],
+  "models": [
+    {
+      "id": "nvidia/llama-nemotron-embed-vl-1b-v2:free",
+      "name": "Llama Nemotron Embed VL 1B V2",
+      "family": "llama-nemotron",
+      "deprecated": false,
+      "dimensions": 2048,
+      "release_date": "2025-02-01",
+      "context": 131072,
+      "inputModalities": ["text", "image"],
+      "outputModalities": ["text"],
+      "cost": {
+        "input": 0,
+        "output": 0
+      }
+    }
+  ]
+}

--- a/registries/embeddings/package.json
+++ b/registries/embeddings/package.json
@@ -4,6 +4,8 @@
   "type": "module",
   "exports": {
     "./models/google.json": "./models/google.json",
-    "./models/openai.json": "./models/openai.json"
+    "./models/nvidia.json": "./models/nvidia.json",
+    "./models/openai.json": "./models/openai.json",
+    "./models/openrouter.json": "./models/openrouter.json"
   }
 }

--- a/registries/embeddings/schema/embedding-provider.schema.json
+++ b/registries/embeddings/schema/embedding-provider.schema.json
@@ -12,7 +12,7 @@
     },
     "providerId": {
       "type": "string",
-      "enum": ["google", "openai"]
+      "minLength": 1
     },
     "providerName": {
       "type": "string",

--- a/registries/embeddings/schema/embedding-provider.schema.json
+++ b/registries/embeddings/schema/embedding-provider.schema.json
@@ -24,13 +24,6 @@
     "npm": {
       "type": "string"
     },
-    "env": {
-      "type": "array",
-      "items": {
-        "type": "string",
-        "minLength": 1
-      }
-    },
     "models": {
       "type": "array",
       "minItems": 1,

--- a/scripts/build-website-registries.mjs
+++ b/scripts/build-website-registries.mjs
@@ -144,7 +144,7 @@ function assertEmbeddingModel(model, filePath) {
 
 function assertEmbeddingProviderConfig(provider, filePath) {
   assertObject(provider, filePath, 'config');
-  assertOneOf(provider.providerId, ['google', 'openai'], filePath, 'providerId');
+  assertNonEmptyString(provider.providerId, filePath, 'providerId');
   assertNonEmptyString(provider.providerName, filePath, 'providerName');
   assertNonEmptyArray(provider.models, filePath, 'models');
   assertUniqueIds(provider.models, (m) => m.id, filePath);


### PR DESCRIPTION
## Change Summary

Improves the embedding model system by adding new free models, decoupling embedding types from the LLM registry, and relocating embedding infrastructure to its proper home.

### New Features
- **Free embedding models**: Added OpenRouter (nvidia/llama-nemotron-embed-vl-1b-v2:free) and NVIDIA (nvidia/nv-embed-v1) to the embedding registry

### Improvements & Refactors
- **Decoupled embedding types from LLM registry**: Embedding models no longer reuse RawModel/RawProvider from the LLM module, using dedicated ResolvedEmbeddingModel/Provider types instead
- **Shared embedding types**: Created EmbeddingProviderModels/EmbeddingModelSummary in @stitch/shared for frontend/server contract
- **Relocated embedding infrastructure**: Moved embedder, provider-embedder, and factory from memory/embedding/ to models/embedding/ since embeddings are a general-purpose capability
- **Renamed MemoryEmbedder to Embedder** to reflect its general-purpose nature
- **Relaxed providerId**: Changed from a fixed enum to any non-empty string so new providers don't require schema changes
- **Removed env field**: Dropped unused env arrays from embedding registry (auth is handled internally)
- **ModelCombobox accepts minimal generic shape**: No longer coupled to ProviderModels type
