### PR TITLE
improvement: decouple STT model types

### DIFF
--- a/apps/web/src/lib/queries/providers.ts
+++ b/apps/web/src/lib/queries/providers.ts
@@ -2,6 +2,7 @@ import { queryOptions } from '@tanstack/react-query';
 
 import type { EmbeddingProviderModels } from '@stitch/shared/embedding/types';
 import { buildDefaultVisibleSet, isModelVisible } from '@stitch/shared/providers/model-visibility';
+import type { SttProviderModels } from '@stitch/shared/stt/types';
 
 import { serverRequest } from '@/lib/api';
 
@@ -36,18 +37,6 @@ export type ProviderModels = {
   providerId: string;
   providerName: string;
   models: ModelSummary[];
-};
-
-type SttModelSummary = {
-  id: string;
-  name: string;
-  sampleRateHz: number;
-};
-
-type SttProviderModels = {
-  providerId: string;
-  providerName: string;
-  models: SttModelSummary[];
 };
 
 type ProviderCredentials = Record<string, unknown>;

--- a/packages/server/src/provider/service.ts
+++ b/packages/server/src/provider/service.ts
@@ -1,3 +1,5 @@
+import type { SttProviderModels } from '@stitch/shared/stt/types';
+
 import { getDb } from '@/db/client.js';
 import { providerConfig } from '@/db/schema/providers.js';
 import { ok } from '@/lib/service-result.js';
@@ -14,18 +16,6 @@ export type ProviderWithCapabilities = {
   api: string | undefined;
   enabled: boolean;
   capabilities: ProviderCapability[];
-};
-
-type SttModelSummary = {
-  id: string;
-  name: string;
-  sampleRateHz: number;
-};
-
-type SttProviderModelsSummary = {
-  providerId: string;
-  providerName: string;
-  models: SttModelSummary[];
 };
 
 export async function listProvidersWithCapabilities(): Promise<
@@ -109,7 +99,7 @@ export async function listProvidersWithCapabilities(): Promise<
   return ok(results);
 }
 
-export async function listEnabledSttModels(): Promise<ServiceResult<SttProviderModelsSummary[]>> {
+export async function listEnabledSttModels(): Promise<ServiceResult<SttProviderModels[]>> {
   const db = getDb();
   const [configs, sttCatalog, llmProviders] = await Promise.all([
     db.select({ providerId: providerConfig.providerId }).from(providerConfig),
@@ -118,7 +108,7 @@ export async function listEnabledSttModels(): Promise<ServiceResult<SttProviderM
   ]);
   const enabledIds = new Set(configs.map((row) => row.providerId));
 
-  const results: SttProviderModelsSummary[] = [];
+  const results: SttProviderModels[] = [];
   for (const entry of sttCatalog) {
     if (!enabledIds.has(entry.providerId)) continue;
     const providerName = llmProviders[entry.providerId]?.name ?? entry.providerId;

--- a/packages/shared/src/stt/types.ts
+++ b/packages/shared/src/stt/types.ts
@@ -138,3 +138,15 @@ export type SttOutboundMessage =
   | SttTranscriptMessage
   | SttErrorMessage
   | SttDoneMessage;
+
+export type SttModelSummary = {
+  id: string;
+  name: string;
+  sampleRateHz: number;
+};
+
+export type SttProviderModels = {
+  providerId: string;
+  providerName: string;
+  models: SttModelSummary[];
+};


### PR DESCRIPTION
## 🚀 Change Summary

Follows the same pattern established in #353 for embedding models — moves `SttModelSummary` and `SttProviderModels` out of file-local type definitions and into the shared package so the contract between server and frontend is defined in one place.

### 🛠 Improvements & Refactors
- **Shared STT provider types**: Added `SttModelSummary` and `SttProviderModels` to `packages/shared/src/stt/types.ts`
- **Server**: Removed local `SttModelSummary`/`SttProviderModelsSummary` type definitions from `provider/service.ts`; import `SttProviderModels` from `@stitch/shared/stt/types`
- **Frontend**: Removed local `SttModelSummary`/`SttProviderModels` type definitions from `lib/queries/providers.ts`; import `SttProviderModels` from `@stitch/shared/stt/types`
