### PR TITLE
chore(models): remove unused fields from ModelSchema and ProviderSchema

### DIFF
--- a/packages/server/src/models/llm/registry.ts
+++ b/packages/server/src/models/llm/registry.ts
@@ -20,20 +20,7 @@ export const ModelSchema = z.object({
   name: z.string(),
   family: z.string().optional(),
   release_date: z.string(),
-  attachment: z.boolean().optional().default(false),
-  reasoning: z.boolean().optional().default(false),
-  temperature: z.boolean().optional().default(false),
-  tool_call: z.boolean().optional().default(false),
-  interleaved: z
-    .union([
-      z.literal(true),
-      z
-        .object({
-          field: z.enum(['reasoning_content', 'reasoning_details']),
-        })
-        .strict(),
-    ])
-    .optional(),
+  status: z.enum(['alpha', 'beta', 'deprecated']).optional(),
   cost: z
     .object({
       input: z.number(),
@@ -61,19 +48,11 @@ export const ModelSchema = z.object({
       output: z.array(z.enum(['text', 'audio', 'image', 'video', 'pdf'])),
     })
     .optional(),
-  experimental: z.unknown().optional(),
-  status: z.enum(['alpha', 'beta', 'deprecated']).optional(),
-  options: z.record(z.string(), z.any()).optional().default({}),
-  headers: z.record(z.string(), z.string()).optional(),
-  provider: z.object({ npm: z.string().optional(), api: z.string().optional() }).optional(),
-  variants: z.record(z.string(), z.record(z.string(), z.any())).optional(),
 });
 export const ProviderSchema = z.object({
   api: z.string().optional(),
   name: z.string(),
-  env: z.array(z.string()),
   id: z.string(),
-  npm: z.string().optional(),
   models: z.record(z.string(), ModelSchema),
 });
 


### PR DESCRIPTION
## 🚀 Change Summary

Removes fields from `ModelSchema` and `ProviderSchema` in the models.dev registry that are parsed from the API but never read anywhere in the codebase.

### 🛠 Improvements & Refactors

- **`ModelSchema`**: Removed `attachment`, `reasoning`, `temperature`, `tool_call`, `interleaved`, `experimental`, `options`, `headers`, `provider`, and `variants` — none of these were accessed after parsing
- **`ProviderSchema`**: Removed `env` and `npm` — neither field was read at runtime
