### PR TITLE
Add desktop notifications

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -14,6 +14,12 @@ import {
   startMeetingDetection,
   stopMeetingDetection,
 } from './meeting-detection.js';
+import {
+  destroyNotificationWindow,
+  dismissDesktopNotification,
+  registerNotificationHandlers,
+  showDesktopNotification,
+} from './notifications.js';
 import { configureRecordingCaptureEnv, stopRecordingCapture } from './recording-capture.js';
 import { readServerConnectionConfig, type ServerConnectionConfig } from './server-config.js';
 import { findAvailablePort, killServer, spawnServer } from './sidecar.js';
@@ -80,6 +86,7 @@ async function shutdownRuntime(): Promise<void> {
     updateCheckInterval = null;
   }
   destroyTray();
+  destroyNotificationWindow();
   stopMeetingDetection();
   await stopRecordingCapture().catch(() => null);
   await killServer();
@@ -105,6 +112,7 @@ function registerAllIpcHandlers(): void {
   registerRecordingHandlers(getServerUrl, getWindow);
   registerServerHandlers(serverState, startLocalServer, getWindow);
   registerUpdaterHandlers(updater, getWindow);
+  registerNotificationHandlers();
 }
 
 function onContextMenu(params: Electron.ContextMenuParams): void {
@@ -151,7 +159,21 @@ void app.whenReady().then(async () => {
     const permissionsWereReset = await resetTccPermissionsIfVersionChanged();
 
     mainWindow = await spawnMainWindow();
-    startMeetingDetection(() => mainWindow);
+    startMeetingDetection(
+      () => mainWindow,
+      (payload) => {
+        void showDesktopNotification({
+          id: `meeting:${payload.key}`,
+          type: 'meeting-detected',
+          createdAt: Date.now(),
+          autoDismissMs: null,
+          payload,
+        });
+      },
+      (payload) => {
+        dismissDesktopNotification(`meeting:${payload.key}`);
+      },
+    );
 
     if (permissionsWereReset) {
       void dialog.showMessageBox(mainWindow, {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,6 +4,7 @@ import { registerDevtoolsHandlers } from './ipc/devtools.js';
 import { registerFilesHandlers } from './ipc/files.js';
 import { registerPermissionsHandlers } from './ipc/permissions.js';
 import { registerRecordingHandlers } from './ipc/recording.js';
+import { registerIpcHandler } from './ipc/register.js';
 import { registerServerHandlers } from './ipc/server.js';
 import { registerShellHandlers } from './ipc/shell.js';
 import { registerSpellcheckHandlers } from './ipc/spellcheck.js';
@@ -112,7 +113,19 @@ function registerAllIpcHandlers(): void {
   registerRecordingHandlers(getServerUrl, getWindow);
   registerServerHandlers(serverState, startLocalServer, getWindow);
   registerUpdaterHandlers(updater, getWindow);
-  registerNotificationHandlers();
+  registerNotificationHandlers((event) => {
+    if (event.type === 'meeting-detected') {
+      dismissMeetingCall(event.payload.key);
+    }
+  });
+  registerIpcHandler('meeting:call-dismiss', (_event, key) => {
+    dismissMeetingCall(key);
+  });
+}
+
+function dismissMeetingCall(key: string): void {
+  mainWindow?.webContents.send('meeting:call-dismissed', { key });
+  dismissDesktopNotification(`meeting:${key}`);
 }
 
 function onContextMenu(params: Electron.ContextMenuParams): void {

--- a/apps/desktop/src/main/meeting-detection.ts
+++ b/apps/desktop/src/main/meeting-detection.ts
@@ -22,7 +22,11 @@ export function configureMeetingDetectionEnv(): void {
   process.env.STITCH_MEETING_WATCH_BIN = resolveMeetingWatcherBinaryPath();
 }
 
-export function startMeetingDetection(getWindow: () => BrowserWindow | null): void {
+export function startMeetingDetection(
+  getWindow: () => BrowserWindow | null,
+  onCallDetected?: (payload: MeetingCallDetectedPayload) => void,
+  onCallEnded?: (payload: MeetingCallEndedPayload) => void,
+): void {
   if (started) {
     return;
   }
@@ -30,16 +34,16 @@ export function startMeetingDetection(getWindow: () => BrowserWindow | null): vo
   started = true;
   unsubscribe = detector.subscribe((event) => {
     const webContents = getWindow()?.webContents;
-    if (!webContents || webContents.isDestroyed()) {
-      return;
-    }
 
     if (event.type === 'ended') {
       const payload: MeetingCallEndedPayload = {
         key: event.key,
         endedAt: event.endedAt,
       };
-      webContents.send('meeting:call-ended', payload);
+      if (webContents && !webContents.isDestroyed()) {
+        webContents.send('meeting:call-ended', payload);
+      }
+      onCallEnded?.(payload);
       return;
     }
 
@@ -52,7 +56,10 @@ export function startMeetingDetection(getWindow: () => BrowserWindow | null): vo
       windowTitle: event.detection.windowTitle,
       detectedAt: event.detectedAt,
     };
-    webContents.send('meeting:call-detected', payload);
+    if (webContents && !webContents.isDestroyed()) {
+      webContents.send('meeting:call-detected', payload);
+    }
+    onCallDetected?.(payload);
   });
 
   detector.start();

--- a/apps/desktop/src/main/notifications.ts
+++ b/apps/desktop/src/main/notifications.ts
@@ -1,0 +1,227 @@
+import { app, BrowserWindow, screen, shell } from 'electron';
+import { join } from 'node:path';
+
+import type { DesktopNotificationEvent } from '@stitch/shared/ipc/types';
+
+import { registerIpcHandler } from './ipc/register.js';
+import { loadRendererWindow } from './window.js';
+
+const NOTIFICATION_HASH = '/desktop-notifications';
+const NOTIFICATION_WIDTH = 360;
+const NOTIFICATION_DEFAULT_HEIGHT = 92;
+const NOTIFICATION_MARGIN = 16;
+const NOTIFICATION_GAP = 8;
+const EXIT_ANIMATION_MS = 220;
+
+type NotificationEntry = {
+  event: DesktopNotificationEvent;
+  win: BrowserWindow;
+  height: number;
+  destroyTimer: NodeJS.Timeout | null;
+};
+
+const entries = new Map<string, NotificationEntry>();
+const orderedIds: string[] = [];
+let displayId: number | null = null;
+let screenListenersRegistered = false;
+
+function getActiveDisplay(): Electron.Display {
+  const cursorDisplay = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+  if (displayId === null) {
+    displayId = cursorDisplay.id;
+  }
+
+  return screen.getAllDisplays().find((display) => display.id === displayId) ?? cursorDisplay;
+}
+
+function resetActiveDisplay(): void {
+  displayId = screen.getDisplayNearestPoint(screen.getCursorScreenPoint()).id;
+}
+
+function getBounds(
+  display: Electron.Display,
+  stackIndex: number,
+  height: number,
+): Electron.Rectangle {
+  const previousHeight = orderedIds.slice(0, stackIndex).reduce((total, id) => {
+    const entry = entries.get(id);
+    return total + (entry?.height ?? NOTIFICATION_DEFAULT_HEIGHT) + NOTIFICATION_GAP;
+  }, 0);
+
+  return {
+    width: NOTIFICATION_WIDTH,
+    height,
+    x: display.workArea.x + display.workArea.width - NOTIFICATION_WIDTH - NOTIFICATION_MARGIN,
+    y: display.workArea.y + display.workArea.height - height - NOTIFICATION_MARGIN - previousHeight,
+  };
+}
+
+function relayoutNotifications(): void {
+  const display = getActiveDisplay();
+
+  orderedIds.forEach((id, index) => {
+    const entry = entries.get(id);
+    if (!entry || entry.win.isDestroyed()) return;
+
+    entry.win.setBounds(getBounds(display, index, entry.height), false);
+    entry.win.showInactive();
+  });
+}
+
+function removeOrderedId(id: string): void {
+  const index = orderedIds.indexOf(id);
+  if (index !== -1) {
+    orderedIds.splice(index, 1);
+  }
+}
+
+function destroyNotification(id: string): void {
+  const entry = entries.get(id);
+  if (!entry) return;
+
+  if (entry.destroyTimer) {
+    clearTimeout(entry.destroyTimer);
+  }
+  entries.delete(id);
+  removeOrderedId(id);
+
+  if (!entry.win.isDestroyed()) {
+    entry.win.destroy();
+  }
+
+  relayoutNotifications();
+}
+
+function animateOutNotification(id: string): void {
+  const entry = entries.get(id);
+  if (!entry || entry.destroyTimer) return;
+
+  if (!entry.win.isDestroyed()) {
+    entry.win.webContents.send('notifications:dismissed', id);
+  }
+
+  entry.destroyTimer = setTimeout(() => destroyNotification(id), EXIT_ANIMATION_MS);
+}
+
+function registerScreenListeners(): void {
+  if (screenListenersRegistered) return;
+  screenListenersRegistered = true;
+
+  screen.on('display-metrics-changed', () => {
+    relayoutNotifications();
+  });
+  screen.on('display-removed', () => {
+    resetActiveDisplay();
+    relayoutNotifications();
+  });
+}
+
+function createNotificationWindow(event: DesktopNotificationEvent): BrowserWindow {
+  const display = getActiveDisplay();
+  const stackIndex = orderedIds.length;
+  const win = new BrowserWindow({
+    ...getBounds(display, stackIndex, NOTIFICATION_DEFAULT_HEIGHT),
+    title: 'Notification',
+    frame: false,
+    transparent: true,
+    resizable: false,
+    movable: false,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    skipTaskbar: true,
+    alwaysOnTop: true,
+    show: false,
+    focusable: false,
+    hiddenInMissionControl: true,
+    roundedCorners: false,
+    hasShadow: false,
+    backgroundColor: '#00000000',
+    titleBarStyle: 'hidden',
+    trafficLightPosition: { x: -15, y: -16 },
+    ...(process.platform === 'darwin' ? { type: 'panel' as const } : {}),
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      devTools: !app.isPackaged,
+    },
+  });
+
+  win.setAlwaysOnTop(true, 'screen-saver');
+  if (process.platform === 'darwin') {
+    win.setVisibleOnAllWorkspaces(true, {
+      visibleOnFullScreen: true,
+      skipTransformProcessType: true,
+    });
+  }
+
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    void shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  win.once('ready-to-show', () => {
+    relayoutNotifications();
+    win.showInactive();
+  });
+
+  win.on('closed', () => {
+    const entry = entries.get(event.id);
+    if (entry?.win !== win) return;
+
+    entries.delete(event.id);
+    removeOrderedId(event.id);
+    relayoutNotifications();
+  });
+
+  return win;
+}
+
+export function registerNotificationHandlers(): void {
+  registerScreenListeners();
+
+  registerIpcHandler('notifications:dismiss', (_event, id) => {
+    animateOutNotification(id);
+  });
+
+  registerIpcHandler('notifications:set-height', (event, height) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (!win || win.isDestroyed()) return;
+
+    const entry = [...entries.values()].find((item) => item.win === win);
+    if (!entry) return;
+
+    entry.height = Math.max(1, Math.ceil(height));
+    relayoutNotifications();
+  });
+}
+
+export async function showDesktopNotification(event: DesktopNotificationEvent): Promise<void> {
+  if (entries.has(event.id)) return;
+
+  resetActiveDisplay();
+  const win = createNotificationWindow(event);
+  entries.set(event.id, {
+    event,
+    win,
+    height: NOTIFICATION_DEFAULT_HEIGHT,
+    destroyTimer: null,
+  });
+  orderedIds.push(event.id);
+
+  const notification = encodeURIComponent(JSON.stringify(event));
+  await loadRendererWindow(win, `${NOTIFICATION_HASH}?notification=${notification}`);
+}
+
+export function dismissDesktopNotification(id: string): void {
+  animateOutNotification(id);
+}
+
+export function destroyNotificationWindow(): void {
+  while (orderedIds.length > 0) {
+    const id = orderedIds[0];
+    if (!id) return;
+    destroyNotification(id);
+  }
+}

--- a/apps/desktop/src/main/notifications.ts
+++ b/apps/desktop/src/main/notifications.ts
@@ -178,10 +178,16 @@ function createNotificationWindow(event: DesktopNotificationEvent): BrowserWindo
   return win;
 }
 
-export function registerNotificationHandlers(): void {
+export function registerNotificationHandlers(
+  onDismiss?: (event: DesktopNotificationEvent) => void,
+): void {
   registerScreenListeners();
 
   registerIpcHandler('notifications:dismiss', (_event, id) => {
+    const entry = entries.get(id);
+    if (entry) {
+      onDismiss?.(entry.event);
+    }
     animateOutNotification(id);
   });
 

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -35,6 +35,21 @@ function resolveWindowIcon(): Electron.NativeImage | undefined {
     .find((image) => !image.isEmpty());
 }
 
+export async function loadRendererWindow(win: BrowserWindow, hash?: string): Promise<void> {
+  const devUrl = process.env['ELECTRON_RENDERER_URL'] ?? WEB_DEV_URL;
+  if (!app.isPackaged) {
+    await waitForDevServer(devUrl);
+    const url = new URL(devUrl);
+    if (hash) {
+      url.hash = hash;
+    }
+    await win.loadURL(url.toString());
+    return;
+  }
+
+  await win.loadFile(getPackagedWebDistPath(), hash ? { hash } : undefined);
+}
+
 export async function createWindow(
   onContextMenu: (params: Electron.ContextMenuParams) => void,
   onClose: () => 'allow' | 'prevent',
@@ -91,13 +106,10 @@ export async function createWindow(
     win.webContents.send('window:fullscreen-changed', false);
   });
 
-  const devUrl = process.env['ELECTRON_RENDERER_URL'] ?? WEB_DEV_URL;
+  await loadRendererWindow(win);
+
   if (!app.isPackaged) {
-    await waitForDevServer(devUrl);
-    void win.loadURL(devUrl);
     win.webContents.openDevTools();
-  } else {
-    void win.loadFile(getPackagedWebDistPath());
   }
 
   return win;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -4,6 +4,7 @@ import type {
   IpcContract,
   IpcEventContract,
   DesktopNotificationEvent,
+  MeetingCallDismissedPayload,
   MeetingCallDetectedPayload,
   MeetingCallEndedPayload,
   RecordingDeviceChangedPayload,
@@ -83,10 +84,13 @@ const api = {
     openScreenCaptureSettings: () => invokeIpc('permissions:openScreenCaptureSettings'),
   },
   meeting: {
+    dismissCall: (key: string) => invokeIpc('meeting:call-dismiss', key),
     onCallDetected: (callback: (payload: MeetingCallDetectedPayload) => void) =>
       onIpc('meeting:call-detected', callback),
     onCallEnded: (callback: (payload: MeetingCallEndedPayload) => void) =>
       onIpc('meeting:call-ended', callback),
+    onCallDismissed: (callback: (payload: MeetingCallDismissedPayload) => void) =>
+      onIpc('meeting:call-dismissed', callback),
   },
   recording: {
     start: (input: StartRecordingInput) => invokeIpc('recording:start', input),

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -3,6 +3,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 import type {
   IpcContract,
   IpcEventContract,
+  DesktopNotificationEvent,
   MeetingCallDetectedPayload,
   MeetingCallEndedPayload,
   RecordingDeviceChangedPayload,
@@ -96,6 +97,13 @@ const api = {
       onIpc('recording:warning', callback),
     onDeviceChanged: (callback: (payload: RecordingDeviceChangedPayload) => void) =>
       onIpc('recording:device-changed', callback),
+  },
+  notifications: {
+    dismiss: (id: string) => invokeIpc('notifications:dismiss', id),
+    setHeight: (height: number) => invokeIpc('notifications:set-height', height),
+    onShow: (callback: (event: DesktopNotificationEvent) => void) =>
+      onIpc('notifications:show', callback),
+    onDismissed: (callback: (id: string) => void) => onIpc('notifications:dismissed', callback),
   },
 };
 

--- a/apps/web/src/components/desktop-notifications/desktop-notification-root.tsx
+++ b/apps/web/src/components/desktop-notifications/desktop-notification-root.tsx
@@ -1,8 +1,20 @@
 import * as React from 'react';
 
+import { useQuery } from '@tanstack/react-query';
+
+import type { AppearanceMode } from '@stitch/shared/appearance/types';
 import type { DesktopNotificationEvent } from '@stitch/shared/ipc/types';
 
 import { MeetingDetectedNotification } from './meeting-detected-notification';
+
+import { settingsQueryOptions } from '@/lib/queries/settings';
+import {
+  applyAppearanceMode,
+  DEFAULT_MODE,
+  DEFAULT_THEME,
+  getTheme,
+  injectThemeCss,
+} from '@/lib/theme';
 
 const EXIT_ANIMATION_MS = 220;
 const NOTIFICATION_HASH_PREFIX = '#/desktop-notifications?';
@@ -32,6 +44,8 @@ export function DesktopNotificationRoot() {
     document.body.classList.add('desktop-notifications-window');
     return () => document.body.classList.remove('desktop-notifications-window');
   }, []);
+
+  useDesktopNotificationTheme();
 
   React.useEffect(() => {
     const element = contentRef.current;
@@ -77,4 +91,25 @@ export function DesktopNotificationRoot() {
       </div>
     </div>
   );
+}
+
+function useDesktopNotificationTheme(): void {
+  const { data: settings } = useQuery(settingsQueryOptions);
+  const themeName = settings?.['appearance.theme'] ?? DEFAULT_THEME;
+  const mode = (settings?.['appearance.mode'] as AppearanceMode | undefined) ?? DEFAULT_MODE;
+
+  React.useEffect(() => {
+    injectThemeCss(getTheme(themeName));
+  }, [themeName]);
+
+  React.useEffect(() => {
+    applyAppearanceMode(mode);
+
+    if (mode !== 'system') return;
+
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = () => applyAppearanceMode('system');
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [mode]);
 }

--- a/apps/web/src/components/desktop-notifications/desktop-notification-root.tsx
+++ b/apps/web/src/components/desktop-notifications/desktop-notification-root.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+
+import type { DesktopNotificationEvent } from '@stitch/shared/ipc/types';
+
+import { MeetingDetectedNotification } from './meeting-detected-notification';
+
+const EXIT_ANIMATION_MS = 220;
+const NOTIFICATION_HASH_PREFIX = '#/desktop-notifications?';
+
+function readInitialNotification(): DesktopNotificationEvent | null {
+  if (!window.location.hash.startsWith(NOTIFICATION_HASH_PREFIX)) return null;
+
+  const params = new URLSearchParams(window.location.hash.slice(NOTIFICATION_HASH_PREFIX.length));
+  const value = params.get('notification');
+  if (!value) return null;
+
+  try {
+    return JSON.parse(value) as DesktopNotificationEvent;
+  } catch {
+    return null;
+  }
+}
+
+export function DesktopNotificationRoot() {
+  const contentRef = React.useRef<HTMLDivElement | null>(null);
+  const [notification, setNotification] = React.useState<DesktopNotificationEvent | null>(() =>
+    readInitialNotification(),
+  );
+  const [exiting, setExiting] = React.useState(false);
+
+  React.useEffect(() => {
+    document.body.classList.add('desktop-notifications-window');
+    return () => document.body.classList.remove('desktop-notifications-window');
+  }, []);
+
+  React.useEffect(() => {
+    const element = contentRef.current;
+    if (!element) return;
+
+    const observer = new ResizeObserver(([entry]) => {
+      const height = entry?.contentRect.height ?? 0;
+      void window.api?.notifications?.setHeight(height);
+    });
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  React.useEffect(() => {
+    return window.api?.notifications?.onDismissed((id) => {
+      setNotification((current) => {
+        if (!current || current.id !== id) return current;
+
+        setExiting(true);
+        window.setTimeout(() => setNotification(null), EXIT_ANIMATION_MS);
+        return current;
+      });
+    });
+  }, []);
+
+  function dismiss(id: string): void {
+    if (window.api?.notifications?.dismiss) {
+      void window.api.notifications.dismiss(id);
+      return;
+    }
+
+    setExiting(true);
+    window.setTimeout(() => setNotification(null), EXIT_ANIMATION_MS);
+  }
+
+  return (
+    <div className="min-h-screen bg-transparent p-0">
+      <div ref={contentRef} className="w-full overflow-hidden">
+        {notification?.type === 'meeting-detected' ? (
+          <MeetingDetectedNotification event={notification} exiting={exiting} onDismiss={dismiss} />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/desktop-notifications/desktop-notification.tsx
+++ b/apps/web/src/components/desktop-notifications/desktop-notification.tsx
@@ -1,0 +1,86 @@
+import { XIcon } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { ReactNode } from 'react';
+
+type DesktopNotificationProps = {
+  children: ReactNode;
+  exiting?: boolean;
+  onDismiss: () => void;
+};
+
+function DesktopNotificationRoot({ children, exiting, onDismiss }: DesktopNotificationProps) {
+  return (
+    <article
+      className={cn(
+        'desktop-notification-surface group relative box-border flex w-full min-w-0 gap-2 overflow-hidden rounded-xl border p-3 shadow-lg shadow-black/15 transition-all duration-200 ease-out',
+        exiting ? 'translate-x-8 opacity-0' : 'translate-x-0 opacity-100',
+      )}
+    >
+      {children}
+      <button
+        type="button"
+        aria-label="Dismiss notification"
+        onClick={onDismiss}
+        className="absolute top-1.5 right-1.5 flex size-6 items-center justify-center rounded-full text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:bg-muted hover:text-foreground"
+      >
+        <XIcon className="size-3.5" />
+      </button>
+    </article>
+  );
+}
+
+function DesktopNotificationIcon({ children }: { children: ReactNode }) {
+  return (
+    <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary ring-1 ring-primary/20">
+      {children}
+    </div>
+  );
+}
+
+function DesktopNotificationContent({ children }: { children: ReactNode }) {
+  return <div className="min-w-0 flex-1 overflow-hidden pr-5">{children}</div>;
+}
+
+function DesktopNotificationTitle({ children }: { children: ReactNode }) {
+  return <h2 className="truncate text-sm font-medium text-foreground">{children}</h2>;
+}
+
+function DesktopNotificationDescription({ children }: { children: ReactNode }) {
+  return <p className="mt-0.5 text-xs leading-4 break-words text-muted-foreground">{children}</p>;
+}
+
+function DesktopNotificationActions({ children }: { children: ReactNode }) {
+  return <div className="mt-2 flex min-w-0 items-center gap-2 overflow-hidden">{children}</div>;
+}
+
+function DesktopNotificationAction({
+  children,
+  onClick,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      size="sm"
+      onClick={onClick}
+      className="h-7 min-w-0 px-2 text-xs shadow-sm"
+    >
+      {children}
+    </Button>
+  );
+}
+
+const DesktopNotification = Object.assign(DesktopNotificationRoot, {
+  Icon: DesktopNotificationIcon,
+  Content: DesktopNotificationContent,
+  Title: DesktopNotificationTitle,
+  Description: DesktopNotificationDescription,
+  Actions: DesktopNotificationActions,
+  Action: DesktopNotificationAction,
+});
+
+export { DesktopNotification };

--- a/apps/web/src/components/desktop-notifications/desktop-notification.tsx
+++ b/apps/web/src/components/desktop-notifications/desktop-notification.tsx
@@ -48,7 +48,9 @@ function DesktopNotificationTitle({ children }: { children: ReactNode }) {
 }
 
 function DesktopNotificationDescription({ children }: { children: ReactNode }) {
-  return <p className="mt-0.5 text-xs leading-4 break-words text-muted-foreground">{children}</p>;
+  return (
+    <p className="mt-0.5 text-xs leading-4 wrap-break-word text-muted-foreground">{children}</p>
+  );
 }
 
 function DesktopNotificationActions({ children }: { children: ReactNode }) {

--- a/apps/web/src/components/desktop-notifications/desktop-notification.tsx
+++ b/apps/web/src/components/desktop-notifications/desktop-notification.tsx
@@ -58,14 +58,17 @@ function DesktopNotificationActions({ children }: { children: ReactNode }) {
 function DesktopNotificationAction({
   children,
   onClick,
+  variant = 'default',
 }: {
   children: ReactNode;
   onClick: () => void;
+  variant?: 'default' | 'ghost';
 }) {
   return (
     <Button
       type="button"
       size="sm"
+      variant={variant}
       onClick={onClick}
       className="h-7 min-w-0 px-2 text-xs shadow-sm"
     >

--- a/apps/web/src/components/desktop-notifications/meeting-detected-notification.tsx
+++ b/apps/web/src/components/desktop-notifications/meeting-detected-notification.tsx
@@ -53,6 +53,9 @@ export function MeetingDetectedNotification({
           >
             {startRecording.isPending ? 'Starting...' : 'Start recording'}
           </DesktopNotification.Action>
+          <DesktopNotification.Action variant="ghost" onClick={() => onDismiss(event.id)}>
+            Dismiss
+          </DesktopNotification.Action>
         </DesktopNotification.Actions>
       </DesktopNotification.Content>
     </DesktopNotification>

--- a/apps/web/src/components/desktop-notifications/meeting-detected-notification.tsx
+++ b/apps/web/src/components/desktop-notifications/meeting-detected-notification.tsx
@@ -1,0 +1,60 @@
+import { VideoIcon } from 'lucide-react';
+import * as React from 'react';
+
+import type { DesktopNotificationEvent } from '@stitch/shared/ipc/types';
+
+import { DesktopNotification } from './desktop-notification';
+
+import { PLATFORM_CONFIG } from '@/components/recordings/shared/formatting';
+import { useStartRecording } from '@/lib/queries/recordings';
+
+type MeetingDetectedNotificationProps = {
+  event: DesktopNotificationEvent;
+  exiting?: boolean;
+  onDismiss: (id: string) => void;
+};
+
+export function MeetingDetectedNotification({
+  event,
+  exiting,
+  onDismiss,
+}: MeetingDetectedNotificationProps) {
+  const [error, setError] = React.useState<string | null>(null);
+  const startRecording = useStartRecording();
+  const platformLabel = PLATFORM_CONFIG[event.payload.platform].label;
+
+  return (
+    <DesktopNotification exiting={exiting} onDismiss={() => onDismiss(event.id)}>
+      <DesktopNotification.Icon>
+        <VideoIcon className="size-4" />
+      </DesktopNotification.Icon>
+      <DesktopNotification.Content>
+        <DesktopNotification.Title>Meeting detected</DesktopNotification.Title>
+        <DesktopNotification.Description>
+          Active call detected in{' '}
+          <span className="font-medium text-foreground">{platformLabel}</span>.
+        </DesktopNotification.Description>
+        {error ? (
+          <p className="mt-1.5 text-xs leading-4 wrap-break-word text-destructive">{error}</p>
+        ) : null}
+        <DesktopNotification.Actions>
+          <DesktopNotification.Action
+            onClick={() => {
+              setError(null);
+              void startRecording.mutateAsync({ platform: event.payload.platform }).then(
+                () => onDismiss(event.id),
+                (nextError: unknown) => {
+                  setError(
+                    nextError instanceof Error ? nextError.message : 'Failed to start recording',
+                  );
+                },
+              );
+            }}
+          >
+            {startRecording.isPending ? 'Starting...' : 'Start recording'}
+          </DesktopNotification.Action>
+        </DesktopNotification.Actions>
+      </DesktopNotification.Content>
+    </DesktopNotification>
+  );
+}

--- a/apps/web/src/components/recordings/meeting-recording-banner.tsx
+++ b/apps/web/src/components/recordings/meeting-recording-banner.tsx
@@ -50,6 +50,30 @@ export function MeetingRecordingBanner() {
   const dismissedKeysRef = React.useRef(dismissedKeys);
   dismissedKeysRef.current = dismissedKeys;
 
+  function dismissMeeting(key: string): void {
+    setDismissedKeys((current) => {
+      if (current.has(key)) return current;
+
+      const next = new Set(current);
+      next.add(key);
+      return next;
+    });
+    setDetection((current) => {
+      if (!current || current.key !== key) return current;
+
+      return null;
+    });
+  }
+
+  function requestDismissMeeting(key: string): void {
+    if (window.api?.meeting?.dismissCall) {
+      void window.api.meeting.dismissCall(key);
+      return;
+    }
+
+    dismissMeeting(key);
+  }
+
   React.useEffect(() => {
     const unsubscribeDetected = window.api?.meeting?.onCallDetected((payload) => {
       if (activeRecordingIdRef.current) {
@@ -82,10 +106,14 @@ export function MeetingRecordingBanner() {
         return next;
       });
     });
+    const unsubscribeDismissed = window.api?.meeting?.onCallDismissed(({ key }) => {
+      dismissMeeting(key);
+    });
 
     return () => {
       unsubscribeDetected?.();
       unsubscribeEnded?.();
+      unsubscribeDismissed?.();
     };
   }, []);
 
@@ -125,7 +153,7 @@ export function MeetingRecordingBanner() {
             onClick={() => {
               void startRecording.mutateAsync({ platform: detection.platform }).then(
                 () => {
-                  setDetection(null);
+                  requestDismissMeeting(detection.key);
                   toast.success('Recording started');
                 },
                 (error: unknown) => {
@@ -143,12 +171,7 @@ export function MeetingRecordingBanner() {
             size="sm"
             variant="ghost"
             onClick={() => {
-              setDismissedKeys((current) => {
-                const next = new Set(current);
-                next.add(detection.key);
-                return next;
-              });
-              setDetection(null);
+              requestDismissMeeting(detection.key);
             }}
             className="text-muted-foreground hover:bg-muted hover:text-foreground"
           >

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,7 +5,9 @@ import { HotkeysProvider } from '@tanstack/react-hotkeys';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, createHashHistory, createRouter } from '@tanstack/react-router';
 
+import { DesktopNotificationRoot } from '@/components/desktop-notifications/desktop-notification-root';
 import { SseProvider } from '@/hooks/sse/sse-context';
+import { applyAppearanceMode, DEFAULT_THEME, getTheme, injectThemeCss } from '@/lib/theme';
 import { routeTree } from '@/routeTree.gen';
 import '@/styles/global.css';
 
@@ -34,15 +36,25 @@ declare module '@tanstack/react-router' {
 }
 
 const rootElement = document.getElementById('root')!;
+const isDesktopNotificationWindow = window.location.hash.startsWith('#/desktop-notifications');
+
+if (isDesktopNotificationWindow) {
+  injectThemeCss(getTheme(DEFAULT_THEME));
+  applyAppearanceMode('light');
+}
 
 ReactDOM.createRoot(rootElement).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <HotkeysProvider>
-        <SseProvider>
-          <RouterProvider router={router} />
-        </SseProvider>
-      </HotkeysProvider>
+      {isDesktopNotificationWindow ? (
+        <DesktopNotificationRoot />
+      ) : (
+        <HotkeysProvider>
+          <SseProvider>
+            <RouterProvider router={router} />
+          </SseProvider>
+        </HotkeysProvider>
+      )}
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,7 +7,13 @@ import { RouterProvider, createHashHistory, createRouter } from '@tanstack/react
 
 import { DesktopNotificationRoot } from '@/components/desktop-notifications/desktop-notification-root';
 import { SseProvider } from '@/hooks/sse/sse-context';
-import { applyAppearanceMode, DEFAULT_THEME, getTheme, injectThemeCss } from '@/lib/theme';
+import {
+  applyAppearanceMode,
+  DEFAULT_MODE,
+  DEFAULT_THEME,
+  getTheme,
+  injectThemeCss,
+} from '@/lib/theme';
 import { routeTree } from '@/routeTree.gen';
 import '@/styles/global.css';
 
@@ -40,7 +46,7 @@ const isDesktopNotificationWindow = window.location.hash.startsWith('#/desktop-n
 
 if (isDesktopNotificationWindow) {
   injectThemeCss(getTheme(DEFAULT_THEME));
-  applyAppearanceMode('light');
+  applyAppearanceMode(DEFAULT_MODE);
 }
 
 ReactDOM.createRoot(rootElement).render(

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -115,6 +115,10 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  body.desktop-notifications-window {
+    @apply overflow-hidden bg-transparent;
+  }
 }
 
 @layer utilities {
@@ -155,5 +159,11 @@
 
   .shadow-info-glow {
     box-shadow: 0 0 8px var(--info);
+  }
+
+  .desktop-notification-surface {
+    background: var(--card, oklch(1 0 0));
+    color: var(--card-foreground, oklch(0.145 0 0));
+    border-color: var(--border, oklch(0.922 0 0));
   }
 }

--- a/packages/shared/src/ipc/types.ts
+++ b/packages/shared/src/ipc/types.ts
@@ -47,6 +47,10 @@ export type RecordingPermissionsPayload = {
   screenCapture: 'granted' | 'denied' | 'unknown';
 };
 
+export type MeetingCallDismissedPayload = {
+  key: string;
+};
+
 export type MeetingDetectedNotificationPayload = MeetingCallDetectedPayload;
 
 export type DesktopNotificationEvent = {
@@ -83,6 +87,7 @@ export interface IpcContract {
   'permissions:requestMicrophone': { args: []; return: boolean };
   'permissions:getScreenCaptureStatus': { args: []; return: string };
   'permissions:openScreenCaptureSettings': { args: []; return: void };
+  'meeting:call-dismiss': { args: [key: string]; return: void };
   'recording:start': { args: [input: StartRecordingInput]; return: StartRecordingResponse };
   'recording:stop': { args: []; return: StopRecordingResponse };
   'recording:listDevices': { args: []; return: RecordingDevicesPayload };
@@ -95,6 +100,7 @@ export interface IpcEventContract {
   'server:config-changed': [config: ServerConfigPayload];
   'meeting:call-detected': [payload: MeetingCallDetectedPayload];
   'meeting:call-ended': [payload: MeetingCallEndedPayload];
+  'meeting:call-dismissed': [payload: MeetingCallDismissedPayload];
   'recording:warning': [payload: RecordingWarningPayload];
   'recording:device-changed': [payload: RecordingDeviceChangedPayload];
   'notifications:show': [event: DesktopNotificationEvent];

--- a/packages/shared/src/ipc/types.ts
+++ b/packages/shared/src/ipc/types.ts
@@ -47,6 +47,16 @@ export type RecordingPermissionsPayload = {
   screenCapture: 'granted' | 'denied' | 'unknown';
 };
 
+export type MeetingDetectedNotificationPayload = MeetingCallDetectedPayload;
+
+export type DesktopNotificationEvent = {
+  id: string;
+  type: 'meeting-detected';
+  createdAt: number;
+  autoDismissMs: number | null;
+  payload: MeetingDetectedNotificationPayload;
+};
+
 export interface IpcContract {
   'get-server-config': { args: []; return: ServerConfigPayload };
   'server:test-remote': { args: [url: string]; return: ServerTestRemoteResult };
@@ -77,6 +87,8 @@ export interface IpcContract {
   'recording:stop': { args: []; return: StopRecordingResponse };
   'recording:listDevices': { args: []; return: RecordingDevicesPayload };
   'recording:checkPermissions': { args: []; return: RecordingPermissionsPayload };
+  'notifications:dismiss': { args: [id: string]; return: void };
+  'notifications:set-height': { args: [height: number]; return: void };
 }
 
 export interface IpcEventContract {
@@ -85,4 +97,6 @@ export interface IpcEventContract {
   'meeting:call-ended': [payload: MeetingCallEndedPayload];
   'recording:warning': [payload: RecordingWarningPayload];
   'recording:device-changed': [payload: RecordingDeviceChangedPayload];
+  'notifications:show': [event: DesktopNotificationEvent];
+  'notifications:dismissed': [id: string];
 }


### PR DESCRIPTION
## 🚀 Change Summary

Adds a custom Electron desktop notification system for meeting detection using frameless notification windows that render the existing web bundle through a notification-specific hash route.

### ✨ New Features
- **Desktop Notifications**: Shows meeting-detected notifications in dedicated always-on-top Electron windows without stealing focus.
- **Stacked Toast Windows**: Uses one BrowserWindow per notification so empty space between notifications remains interactive with the desktop.
- **Reusable Notification UI**: Adds compound React notification components for consistent future notification designs.

### 🛠 Improvements & Refactors
- Loads renderer windows through a shared helper that supports notification-specific hashes in dev and packaged builds.
- Syncs notification appearance with the selected app theme and appearance mode.
- Centralizes meeting dismissal so desktop and in-app meeting prompts stay in sync.
