### PR TITLE
fix: reconnect SSE when window becomes visible after hide

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -6,6 +6,7 @@ import type { UpdaterStatePayload } from '@stitch/shared/ipc/types';
 const NETWORK_ERROR_CODES = [
   'ERR_INTERNET_DISCONNECTED',
   'ERR_NETWORK_CHANGED',
+  'ERR_NETWORK_IO_SUSPENDED',
   'ERR_NAME_NOT_RESOLVED',
   'ERR_CONNECTION_REFUSED',
   'ERR_CONNECTION_TIMED_OUT',

--- a/apps/web/src/hooks/sse/sse-context.tsx
+++ b/apps/web/src/hooks/sse/sse-context.tsx
@@ -112,6 +112,16 @@ export function SseProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   React.useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        setConnectionVersion((version) => version + 1);
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, []);
+
+  React.useEffect(() => {
     let eventSource: EventSource | null = null;
     let cancelled = false;
 


### PR DESCRIPTION
## Change Summary

Fixes 
et::ERR_NETWORK_IO_SUSPENDED errors that occurred after hiding the app to the tray and reopening it.

When the Electron window is hidden, Chromium suspends the renderer's network I/O. The EventSource SSE connection would fire onerror and go dead — but connectionVersion was never incremented, so the SSE never reconnected. On reopen, the stale connection and any in-flight requests would fail with ERR_NETWORK_IO_SUSPENDED.

### Bug Fixes

- **SSE reconnect on visibility change**: SseProvider now listens for document.visibilitychange and increments connectionVersion when the page becomes visible, triggering a fresh EventSource connection
- **Updater error handling**: Added ERR_NETWORK_IO_SUSPENDED to the list of transient network errors so the updater silently ignores it rather than surfacing an error state
