### PR TITLE
fix(recordings): live transcript disappearing and ordering bugs

### DIFF
--- a/apps/web/src/components/recordings/analysis/transcript-sidebar.tsx
+++ b/apps/web/src/components/recordings/analysis/transcript-sidebar.tsx
@@ -34,11 +34,12 @@ export function TranscriptSidebar({
   recordingId,
   isRecording,
 }: TranscriptSidebarProps) {
-  const liveEntries = useLiveTranscript(isRecording ? recordingId : null);
+  const liveEntries = useLiveTranscript(recordingId, isRecording);
   const scrollParentRef = React.useRef<HTMLDivElement>(null);
 
   const staticTranscript = analysis?.transcript;
-  const showLive = isRecording && liveEntries.length > 0;
+  const hasStaticTranscript = staticTranscript && staticTranscript.length > 0;
+  const showLive = liveEntries.length > 0 && !hasStaticTranscript;
   const entries = React.useMemo<TranscriptEntryView[]>(() => {
     if (showLive) {
       return liveEntries.map((entry) => ({

--- a/apps/web/src/hooks/sse/use-live-transcript.ts
+++ b/apps/web/src/hooks/sse/use-live-transcript.ts
@@ -11,18 +11,40 @@ type LiveTranscriptEntry = {
   kind: 'partial' | 'final';
 };
 
-export function useLiveTranscript(activeRecordingId: string | null) {
+const FLUSH_GRACE_MS = 2000;
+
+export function useLiveTranscript(recordingId: string, isRecording: boolean) {
   const [entries, setEntries] = React.useState<LiveTranscriptEntry[]>([]);
   const counterRef = React.useRef(0);
+  const prevRecordingIdRef = React.useRef(recordingId);
 
+  // Clear entries when switching to a different recording
   React.useEffect(() => {
-    if (!activeRecordingId) {
+    const prev = prevRecordingIdRef.current;
+    prevRecordingIdRef.current = recordingId;
+
+    if (recordingId !== prev) {
       setEntries([]);
       counterRef.current = 0;
     }
-  }, [activeRecordingId]);
+  }, [recordingId]);
 
-  useRecordingEvents(activeRecordingId, {
+  // After recording stops, wait for flush then promote remaining partials
+  React.useEffect(() => {
+    if (isRecording) return;
+
+    const timer = setTimeout(() => {
+      setEntries((current) => {
+        if (!current.some((e) => e.kind === 'partial')) return current;
+        return current.map((e) => (e.kind === 'partial' ? { ...e, kind: 'final' as const } : e));
+      });
+    }, FLUSH_GRACE_MS);
+
+    return () => clearTimeout(timer);
+  }, [isRecording]);
+
+  // Keep subscribing with the recordingId so we receive post-stop flush events
+  useRecordingEvents(recordingId, {
     'recording-transcript-entry': (data) => {
       setEntries((prev) => {
         // Find existing partial from same source to replace
@@ -47,23 +69,25 @@ export function useLiveTranscript(activeRecordingId: string | null) {
           return [...prev, entry];
         }
 
-        // Final: remove the partial being replaced (if any)
-        const withoutPartial = partialIdx >= 0 ? prev.filter((_, i) => i !== partialIdx) : prev;
-
-        // Each final from the STT provider is a distinct committed utterance.
-        // Never merge across commit boundaries — append as a new entry.
+        // Final: replace the partial in-place to preserve chronological order,
+        // or append if there was no partial for this source.
         counterRef.current += 1;
-        return [
-          ...withoutPartial,
-          {
-            id: counterRef.current,
-            source: data.source,
-            speaker: data.speaker,
-            content: data.content,
-            offsetMs: data.offsetMs,
-            kind: 'final',
-          },
-        ];
+        const finalEntry: LiveTranscriptEntry = {
+          id: counterRef.current,
+          source: data.source,
+          speaker: data.speaker,
+          content: data.content,
+          offsetMs: data.offsetMs,
+          kind: 'final',
+        };
+
+        if (partialIdx >= 0) {
+          const next = [...prev];
+          next[partialIdx] = finalEntry;
+          return next;
+        }
+
+        return [...prev, finalEntry];
       });
     },
   });


### PR DESCRIPTION
## Change Summary

Fixes three related bugs on the live transcript sidebar in the recording analysis page.

### Bug Fixes
- **Transcript disappearing on stop**: Live transcript entries no longer vanish when recording stops — they remain visible until the static transcript from analysis arrives
- **Bubble ordering**: Final entries now replace their partial in-place instead of being appended to the end, preserving chronological order during interleaved multi-source transcription
- **Partials stuck after stop**: SSE subscription stays active after recording stops to receive the backend's final flush events, with a 2s grace period before promoting any remaining partials to final
