### PR TITLE
improvement(mcp): polish MCP Settings UI

### DIFF
--- a/apps/web/src/components/settings/mcp-servers/add-custom-mcp-server.tsx
+++ b/apps/web/src/components/settings/mcp-servers/add-custom-mcp-server.tsx
@@ -74,13 +74,34 @@ export function AddCustomMcpServer({ onBack }: { onBack: () => void }) {
       backLabel="Back to MCP servers"
     >
       <div className="space-y-4">
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-muted-foreground">Name</Label>
-          <Input
-            value={form.name}
-            onChange={(e) => set('name', e.target.value)}
-            placeholder="e.g. GitHub MCP"
-          />
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label className="text-xs font-medium text-muted-foreground">Name</Label>
+            <Input
+              value={form.name}
+              onChange={(e) => set('name', e.target.value)}
+              placeholder="e.g. GitHub MCP"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label className="text-xs font-medium text-muted-foreground">Authentication</Label>
+            <Select
+              value={form.authType}
+              onValueChange={(v) => set('authType', v as AddFormState['authType'])}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue>{AUTH_TYPE_LABELS[form.authType].label}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {MCP_AUTH_TYPES.map((type) => (
+                  <SelectItem key={type} value={type}>
+                    {AUTH_TYPE_LABELS[type].label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </div>
 
         <div className="space-y-1.5">
@@ -91,30 +112,6 @@ export function AddCustomMcpServer({ onBack }: { onBack: () => void }) {
             placeholder="https://mcp.example.com"
             type="url"
           />
-        </div>
-
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-muted-foreground">Authentication</Label>
-          <Select
-            value={form.authType}
-            onValueChange={(v) => set('authType', v as AddFormState['authType'])}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue>{AUTH_TYPE_LABELS[form.authType].label}</SelectValue>
-            </SelectTrigger>
-            <SelectContent className="w-72" alignItemWithTrigger={false}>
-              {MCP_AUTH_TYPES.map((type) => (
-                <SelectItem key={type} value={type} className="items-start py-2">
-                  <div className="flex flex-col gap-0.5">
-                    <span className="font-medium">{AUTH_TYPE_LABELS[type].label}</span>
-                    <span className="text-xs leading-snug text-muted-foreground">
-                      {AUTH_TYPE_LABELS[type].description}
-                    </span>
-                  </div>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
         </div>
 
         {form.authType === 'api_key' && (

--- a/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
+++ b/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
@@ -163,13 +163,8 @@ export function InstallRegistryMcpServer({
                 </SelectTrigger>
                 <SelectContent>
                   {MCP_AUTH_TYPES.map((type) => (
-                    <SelectItem key={type} value={type} className="items-start py-2">
-                      <div className="flex flex-col gap-0.5">
-                        <span className="font-medium">{AUTH_TYPE_LABELS[type].label}</span>
-                        <span className="text-xs leading-snug text-muted-foreground">
-                          {AUTH_TYPE_LABELS[type].description}
-                        </span>
-                      </div>
+                    <SelectItem key={type} value={type}>
+                      {AUTH_TYPE_LABELS[type].label}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
+++ b/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
@@ -14,7 +14,6 @@ import {
 } from './shared';
 
 import { SettingSubPage } from '@/components/settings/settings-ui';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -115,21 +114,21 @@ export function InstallRegistryMcpServer({
   return (
     <SettingSubPage
       title={`Install ${server.name}`}
-      description="Review connection settings before adding."
+      description={server.description}
       onBack={onBack}
       backLabel="Back to marketplace"
+      actions={
+        <a
+          href={server.docsUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="text-xs text-muted-foreground underline hover:text-foreground"
+        >
+          View docs
+        </a>
+      }
     >
       <div className="space-y-4">
-        <div className="rounded-lg border border-border/60 px-3 py-2.5 text-xs text-muted-foreground">
-          <p>{server.description}</p>
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            <Badge variant="secondary">{server.install.transport.toUpperCase()}</Badge>
-            <a href={server.docsUrl} target="_blank" rel="noreferrer" className="underline">
-              View docs
-            </a>
-          </div>
-        </div>
-
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-1.5">
             <Label className="text-xs font-medium text-muted-foreground">Name</Label>

--- a/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
+++ b/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
@@ -130,56 +130,58 @@ export function InstallRegistryMcpServer({
           </div>
         </div>
 
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-muted-foreground">Name</Label>
-          <Input value={form.name} onChange={(e) => set('name', e.target.value)} />
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label className="text-xs font-medium text-muted-foreground">Name</Label>
+            <Input value={form.name} onChange={(e) => set('name', e.target.value)} />
+          </div>
+
+          {authOptions.length > 1 ? (
+            <div className="space-y-1.5">
+              <Label className="text-xs font-medium text-muted-foreground">Auth preset</Label>
+              <Select value={selectedAuthId} onValueChange={handleAuthPresetChange}>
+                <SelectTrigger className="w-full">
+                  <SelectValue>{selectedAuthOption?.label ?? 'Select auth preset'}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {authOptions.map((option) => (
+                    <SelectItem key={option.id} value={option.id}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              <Label className="text-xs font-medium text-muted-foreground">Authentication</Label>
+              <Select
+                value={form.authType}
+                onValueChange={(v) => set('authType', v as AddFormState['authType'])}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue>{AUTH_TYPE_LABELS[form.authType].label}</SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {MCP_AUTH_TYPES.map((type) => (
+                    <SelectItem key={type} value={type} className="items-start py-2">
+                      <div className="flex flex-col gap-0.5">
+                        <span className="font-medium">{AUTH_TYPE_LABELS[type].label}</span>
+                        <span className="text-xs leading-snug text-muted-foreground">
+                          {AUTH_TYPE_LABELS[type].description}
+                        </span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
         </div>
 
         <div className="space-y-1.5">
           <Label className="text-xs font-medium text-muted-foreground">URL</Label>
           <Input value={form.url} onChange={(e) => set('url', e.target.value)} type="url" />
-        </div>
-
-        {authOptions.length > 1 && (
-          <div className="space-y-1.5">
-            <Label className="text-xs font-medium text-muted-foreground">Auth preset</Label>
-            <Select value={selectedAuthId} onValueChange={handleAuthPresetChange}>
-              <SelectTrigger className="w-full">
-                <SelectValue>{selectedAuthOption?.label ?? 'Select auth preset'}</SelectValue>
-              </SelectTrigger>
-              <SelectContent className="w-72" alignItemWithTrigger={false}>
-                {authOptions.map((option) => (
-                  <SelectItem key={option.id} value={option.id}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
-
-        <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-muted-foreground">Authentication</Label>
-          <Select
-            value={form.authType}
-            onValueChange={(v) => set('authType', v as AddFormState['authType'])}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue>{AUTH_TYPE_LABELS[form.authType].label}</SelectValue>
-            </SelectTrigger>
-            <SelectContent className="w-72" alignItemWithTrigger={false}>
-              {MCP_AUTH_TYPES.map((type) => (
-                <SelectItem key={type} value={type} className="items-start py-2">
-                  <div className="flex flex-col gap-0.5">
-                    <span className="font-medium">{AUTH_TYPE_LABELS[type].label}</span>
-                    <span className="text-xs leading-snug text-muted-foreground">
-                      {AUTH_TYPE_LABELS[type].description}
-                    </span>
-                  </div>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
         </div>
 
         {form.authType === 'api_key' && (

--- a/apps/web/src/components/settings/mcp-servers/mcp-registry-list.tsx
+++ b/apps/web/src/components/settings/mcp-servers/mcp-registry-list.tsx
@@ -89,12 +89,9 @@ export function McpRegistryList({
           >
             <div className="flex min-w-0 items-start gap-3">
               <McpServerLogo registryId={server.id} name={server.name} className="mt-0.5 size-5" />
-              <div className="min-w-0 space-y-1">
+              <div className="min-w-0 space-y-0.5">
                 <div className="flex flex-wrap items-center gap-2">
                   <p className="truncate text-sm font-medium">{server.name}</p>
-                </div>
-                <p className="line-clamp-2 text-xs text-muted-foreground">{server.description}</p>
-                <div className="flex flex-wrap items-center gap-1.5">
                   {server.tags.slice(0, 4).map((tag) => (
                     <Badge
                       key={tag}
@@ -105,6 +102,7 @@ export function McpRegistryList({
                     </Badge>
                   ))}
                 </div>
+                <p className="line-clamp-2 text-xs text-muted-foreground">{server.description}</p>
               </div>
             </div>
 

--- a/apps/web/src/components/settings/mcp-servers/mcp-tools-preview.tsx
+++ b/apps/web/src/components/settings/mcp-servers/mcp-tools-preview.tsx
@@ -1,9 +1,10 @@
-import { WrenchIcon } from 'lucide-react';
+import { ChevronRightIcon, WrenchIcon } from 'lucide-react';
 
 import { useQuery } from '@tanstack/react-query';
 
 import type { McpServer } from '@stitch/shared/mcp/types';
 
+import ChatMarkdown from '@/components/chat/chat-markdown';
 import { SettingSubPage } from '@/components/settings/settings-ui';
 import { mcpToolsQueryOptions } from '@/lib/queries/mcp';
 
@@ -11,12 +12,7 @@ export function McpToolsPreview({ server, onBack }: { server: McpServer; onBack:
   const { data: tools, isLoading, isError, error } = useQuery(mcpToolsQueryOptions(server.id));
 
   return (
-    <SettingSubPage
-      title={server.name}
-      description="Available tools"
-      onBack={onBack}
-      backLabel="Back to MCP servers"
-    >
+    <SettingSubPage title={server.name} onBack={onBack} backLabel="Back to MCP servers">
       {isLoading && <p className="text-sm text-muted-foreground">Connecting to server...</p>}
 
       {isError && (
@@ -30,19 +26,24 @@ export function McpToolsPreview({ server, onBack }: { server: McpServer; onBack:
       )}
 
       {tools && tools.length > 0 && (
-        <ul className="space-y-2">
+        <ul className="overflow-hidden rounded-lg border border-border/60">
           {tools.map((tool) => (
-            <li
-              key={tool.name}
-              className="flex items-start gap-3 rounded-lg border border-border/60 px-3 py-2.5"
-            >
-              <WrenchIcon className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
-              <div className="min-w-0">
-                <p className="text-sm font-medium">{tool.name}</p>
+            <li key={tool.name} className="border-b border-border/50 last:border-b-0">
+              <details className="group">
+                <summary className="flex cursor-pointer list-none items-center gap-2.5 px-3 py-2.5 hover:bg-muted/20">
+                  <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
+                  <WrenchIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="text-sm font-medium">{tool.title ?? tool.name}</span>
+                  {tool.title && (
+                    <span className="text-xs text-muted-foreground/60">{tool.name}</span>
+                  )}
+                </summary>
                 {tool.description && (
-                  <p className="mt-0.5 text-xs text-muted-foreground">{tool.description}</p>
+                  <div className="px-9 pt-1 pb-3">
+                    <ChatMarkdown text={tool.description} className="text-xs [&_.prose]:text-xs" />
+                  </div>
                 )}
-              </div>
+              </details>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## 🚀 Change Summary

Polishes the MCP Settings UI across the marketplace, install, and configured server flows — tightening layout, reducing visual noise, and improving discoverability.

### ✨ New Features
- **Collapsible tool rows**: MCP tools preview now lists tools collapsed by default; clicking expands the description rendered as markdown

### 🛠 Improvements & Refactors
- **Install form**: 2-column grid layout (Name + Auth preset side-by-side, URL full-width); server description promoted to page subtitle with "View docs" link in the header; removed redundant bordered info card and HTTP badge
- **Add custom form**: Matches install form layout — 2-col grid, fixed dropdown alignment
- **Marketplace list**: Tags moved inline next to server name, eliminating the extra row that made each entry tall
- **Auth dropdown**: Removed verbose description text from items, slimmed to label-only options
- **Auth logic**: Redundant "Authentication" dropdown hidden when an "Auth preset" is already shown; both dropdowns fixed to align with their trigger instead of floating off to the right
