### PR TITLE
fix(recordings): improve data loading

### DIFF
--- a/apps/web/src/components/recordings/meeting-recording-banner.tsx
+++ b/apps/web/src/components/recordings/meeting-recording-banner.tsx
@@ -9,7 +9,7 @@ import type { MeetingCallDetectedPayload } from '@stitch/shared/recordings/meeti
 import { PLATFORM_CONFIG } from './shared/formatting';
 
 import { Button } from '@/components/ui/button';
-import { recordingsQueryOptions, useStartRecording } from '@/lib/queries/recordings';
+import { activeRecordingQueryOptions, useStartRecording } from '@/lib/queries/recordings';
 
 const WARNING_LABELS: Record<string, string> = {
   input_backpressure: 'Audio input is falling behind — some audio may be dropped.',
@@ -42,10 +42,11 @@ export function MeetingRecordingBanner() {
   const [dismissedKeys, setDismissedKeys] = React.useState<Set<string>>(new Set());
 
   const startRecording = useStartRecording();
-  const { data } = useQuery(recordingsQueryOptions({ page: 1, pageSize: 10 }));
+  const { data } = useQuery(activeRecordingQueryOptions);
+  const activeRecordingId = data?.activeRecordingId ?? null;
 
-  const activeRecordingIdRef = React.useRef(data?.activeRecordingId ?? null);
-  activeRecordingIdRef.current = data?.activeRecordingId ?? null;
+  const activeRecordingIdRef = React.useRef(activeRecordingId);
+  activeRecordingIdRef.current = activeRecordingId;
 
   const dismissedKeysRef = React.useRef(dismissedKeys);
   dismissedKeysRef.current = dismissedKeys;
@@ -118,12 +119,12 @@ export function MeetingRecordingBanner() {
   }, []);
 
   React.useEffect(() => {
-    if (data?.activeRecordingId) {
+    if (activeRecordingId) {
       setDetection(null);
     }
-  }, [data?.activeRecordingId]);
+  }, [activeRecordingId]);
 
-  if (data === undefined || !detection || data.activeRecordingId) {
+  if (data === undefined || !detection || activeRecordingId) {
     return null;
   }
 

--- a/apps/web/src/components/recordings/recording-analysis-page.tsx
+++ b/apps/web/src/components/recordings/recording-analysis-page.tsx
@@ -15,8 +15,7 @@ import { DeleteRecordingDialog } from './shared/delete-recording-dialog';
 import { Page, PageContent } from '@/components/ui/page';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import {
-  recordingAnalysisQueryOptions,
-  recordingsQueryOptions,
+  recordingDetailsQueryOptions,
   useCancelRecordingAnalysis,
   useDeleteRecording,
   useStartRecordingAnalysis,
@@ -24,8 +23,7 @@ import {
 } from '@/lib/queries/recordings';
 
 export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) {
-  const { data: analysisResponse } = useSuspenseQuery(recordingAnalysisQueryOptions(recordingId));
-  const { data: recordings } = useSuspenseQuery(recordingsQueryOptions({ page: 1, pageSize: 100 }));
+  const { data } = useSuspenseQuery(recordingDetailsQueryOptions(recordingId));
 
   const startAnalysis = useStartRecordingAnalysis();
   const cancelAnalysis = useCancelRecordingAnalysis();
@@ -34,9 +32,8 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
   const navigate = useNavigate();
   const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
 
-  const analysis = analysisResponse.analysis;
-  const recording = recordings.recordings.find((item) => item.id === recordingId);
-  const isActiveRecording = recording?.id === recordings.activeRecordingId;
+  const { analysis, recording } = data;
+  const isActiveRecording = recording.id === data.activeRecordingId;
   const analysisMarkdown = React.useMemo(
     () => buildAnalysisMarkdown(analysis, recording),
     [analysis, recording],

--- a/apps/web/src/components/recordings/recordings-sidebar.tsx
+++ b/apps/web/src/components/recordings/recordings-sidebar.tsx
@@ -1,6 +1,7 @@
-import { LibraryIcon, MicIcon } from 'lucide-react';
+import { LibraryIcon, Loader2Icon, MicIcon } from 'lucide-react';
+import * as React from 'react';
 
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { Link, useParams } from '@tanstack/react-router';
 
 import {
@@ -11,14 +12,31 @@ import {
 } from './shared/formatting';
 
 import { InternalSidebar } from '@/components/navigation/internal-sidebar';
-import { recordingsQueryOptions } from '@/lib/queries/recordings';
+import { recordingsInfiniteQueryOptions } from '@/lib/queries/recordings';
 
 export function RecordingsSidebarContent() {
   const params = useParams({ strict: false });
   const selectedRecordingId = typeof params.id === 'string' ? params.id : null;
+  const loadMoreRef = React.useRef<HTMLDivElement>(null);
 
-  const { data } = useQuery(recordingsQueryOptions({ page: 1, pageSize: 100 }));
-  const recordings = data?.recordings ?? [];
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
+    recordingsInfiniteQueryOptions(),
+  );
+  const recordings = data?.pages.flatMap((page) => page.recordings) ?? [];
+
+  React.useEffect(() => {
+    const node = loadMoreRef.current;
+    if (!node || !hasNextPage) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting && !isFetchingNextPage) {
+        void fetchNextPage();
+      }
+    });
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   return (
     <>
@@ -76,6 +94,13 @@ export function RecordingsSidebarContent() {
                 );
               })}
             </InternalSidebar.List>
+            {hasNextPage ? (
+              <div ref={loadMoreRef} className="flex h-9 items-center justify-center">
+                {isFetchingNextPage ? (
+                  <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+                ) : null}
+              </div>
+            ) : null}
           </InternalSidebar.Group>
         ) : (
           <InternalSidebar.EmptyState

--- a/apps/web/src/hooks/sse/server-event-sync.ts
+++ b/apps/web/src/hooks/sse/server-event-sync.ts
@@ -1,17 +1,18 @@
+import { useEffect, useRef } from 'react';
+
 import { useQueryClient } from '@tanstack/react-query';
 import type { InfiniteData, QueryClient } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
-import { useEffect, useRef } from 'react';
 
 import type { Session, SessionsPage } from '@stitch/shared/chat/messages';
 import type { PartDelta } from '@stitch/shared/chat/stream-events';
 
 import { useSSE } from '@/hooks/sse/sse-context';
 import { sessionKeys } from '@/lib/queries/chat';
-import { todoKeys } from '@/lib/queries/todos';
-import { questionKeys } from '@/lib/queries/questions';
 import { permissionResponseKeys } from '@/lib/queries/permissions';
+import { questionKeys } from '@/lib/queries/questions';
 import { settingsQueryOptions } from '@/lib/queries/settings';
+import { todoKeys } from '@/lib/queries/todos';
 import { playNotificationSound } from '@/lib/sounds';
 import { useStreamStore } from '@/stores/stream-store';
 
@@ -167,12 +168,16 @@ function useServerEventSync(): void {
     // Recording Events
     'recording-started': () => {
       void queryClient.invalidateQueries({ queryKey: ['recordings', 'list'] });
+      void queryClient.invalidateQueries({ queryKey: ['recordings', 'detail'] });
+      void queryClient.invalidateQueries({ queryKey: ['recordings', 'active'] });
     },
     'recording-stopped': () => {
       void queryClient.invalidateQueries({ queryKey: ['recordings', 'list'] });
+      void queryClient.invalidateQueries({ queryKey: ['recordings', 'detail'] });
+      void queryClient.invalidateQueries({ queryKey: ['recordings', 'active'] });
     },
     'recording-analysis-updated': ({ recordingId }) => {
-      void queryClient.invalidateQueries({ queryKey: ['recordings', 'analysis', recordingId] });
+      void queryClient.invalidateQueries({ queryKey: ['recordings', 'detail', recordingId] });
     },
 
     // Session Events
@@ -190,8 +195,9 @@ function useServerEventSync(): void {
           };
         },
       );
-      queryClient.setQueryData<Session>(sessionKeys.detail(sessionId), (prev: Session | undefined) =>
-        prev ? { ...prev, title } : prev,
+      queryClient.setQueryData<Session>(
+        sessionKeys.detail(sessionId),
+        (prev: Session | undefined) => (prev ? { ...prev, title } : prev),
       );
     },
     'session-todos-updated': ({ sessionId }) => {

--- a/apps/web/src/lib/queries/recordings.ts
+++ b/apps/web/src/lib/queries/recordings.ts
@@ -1,8 +1,15 @@
-import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  infiniteQueryOptions,
+  keepPreviousData,
+  queryOptions,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import type {
+  ActiveRecordingResponse,
   ListRecordingsResponse,
-  RecordingAnalysisResponse,
+  RecordingDetailsResponse,
   StartRecordingInput,
   StartRecordingAnalysisResponse,
   StartRecordingResponse,
@@ -15,9 +22,13 @@ const recordingsKeys = {
   all: ['recordings'] as const,
   lists: () => [...recordingsKeys.all, 'list'] as const,
   list: (page: number, pageSize: number) => [...recordingsKeys.lists(), page, pageSize] as const,
-  analysis: (recordingId: string) => [...recordingsKeys.all, 'analysis', recordingId] as const,
+  infiniteList: (pageSize: number) => [...recordingsKeys.lists(), 'infinite', pageSize] as const,
+  detail: (recordingId: string) => [...recordingsKeys.all, 'detail', recordingId] as const,
+  active: () => [...recordingsKeys.all, 'active'] as const,
   devices: () => [...recordingsKeys.all, 'devices'] as const,
 };
+
+const RECORDINGS_PAGE_SIZE = 12;
 
 export function recordingsQueryOptions(input: { page: number; pageSize: number }) {
   return queryOptions({
@@ -29,8 +40,32 @@ export function recordingsQueryOptions(input: { page: number; pageSize: number }
       });
       return serverRequest<ListRecordingsResponse>(`/recordings?${params.toString()}`);
     },
+    placeholderData: keepPreviousData,
   });
 }
+
+export const recordingsInfiniteQueryOptions = () =>
+  infiniteQueryOptions({
+    queryKey: recordingsKeys.infiniteList(RECORDINGS_PAGE_SIZE),
+    queryFn: ({ pageParam }) => {
+      const params = new URLSearchParams({
+        page: String(pageParam),
+        pageSize: String(RECORDINGS_PAGE_SIZE),
+      });
+      return serverRequest<ListRecordingsResponse>(`/recordings?${params.toString()}`);
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.page >= lastPage.totalPages) return undefined;
+      return lastPage.page + 1;
+    },
+    placeholderData: keepPreviousData,
+  });
+
+export const activeRecordingQueryOptions = queryOptions({
+  queryKey: recordingsKeys.active(),
+  queryFn: () => serverRequest<ActiveRecordingResponse>('/recordings/active'),
+});
 
 type AudioDeviceList = {
   microphoneDevices: string[];
@@ -157,6 +192,7 @@ export function useStartRecording() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: recordingsKeys.lists() });
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.active() });
     },
   });
 }
@@ -178,6 +214,7 @@ export function useStopRecording() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: recordingsKeys.lists() });
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.active() });
     },
   });
 }
@@ -194,10 +231,10 @@ export function useDeleteRecording() {
   });
 }
 
-export function recordingAnalysisQueryOptions(recordingId: string) {
+export function recordingDetailsQueryOptions(recordingId: string) {
   return queryOptions({
-    queryKey: recordingsKeys.analysis(recordingId),
-    queryFn: () => serverRequest<RecordingAnalysisResponse>(`/recordings/${recordingId}/analysis`),
+    queryKey: recordingsKeys.detail(recordingId),
+    queryFn: () => serverRequest<RecordingDetailsResponse>(`/recordings/${recordingId}`),
   });
 }
 
@@ -218,7 +255,7 @@ export function useStartRecordingAnalysis() {
     },
     onSuccess: (_, variables) => {
       void queryClient.invalidateQueries({
-        queryKey: recordingsKeys.analysis(variables.recordingId),
+        queryKey: recordingsKeys.detail(variables.recordingId),
       });
     },
   });
@@ -233,7 +270,7 @@ export function useCancelRecordingAnalysis() {
         method: 'POST',
       }),
     onSuccess: (_, recordingId) => {
-      void queryClient.invalidateQueries({ queryKey: recordingsKeys.analysis(recordingId) });
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.detail(recordingId) });
     },
   });
 }

--- a/apps/web/src/routes/recordings/$id.tsx
+++ b/apps/web/src/routes/recordings/$id.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
 
 import { RecordingAnalysisPage } from '@/components/recordings/recording-analysis-page';
-import { recordingAnalysisQueryOptions } from '@/lib/queries/recordings';
+import { recordingDetailsQueryOptions } from '@/lib/queries/recordings';
 
 export const Route = createFileRoute('/recordings/$id')({
   loader: ({ context, params }) =>
-    context.queryClient.ensureQueryData(recordingAnalysisQueryOptions(params.id)),
+    context.queryClient.ensureQueryData(recordingDetailsQueryOptions(params.id)),
   component: RouteComponent,
 });
 

--- a/apps/web/src/routes/recordings/index.tsx
+++ b/apps/web/src/routes/recordings/index.tsx
@@ -1,10 +1,13 @@
 import { createFileRoute } from '@tanstack/react-router';
 
 import { RecordingsPage } from '@/components/recordings/recordings-page';
-import { recordingsQueryOptions } from '@/lib/queries/recordings';
+import { recordingsInfiniteQueryOptions, recordingsQueryOptions } from '@/lib/queries/recordings';
 
 export const Route = createFileRoute('/recordings/')({
   loader: ({ context }) =>
-    context.queryClient.ensureQueryData(recordingsQueryOptions({ page: 1, pageSize: 12 })),
+    Promise.all([
+      context.queryClient.ensureQueryData(recordingsQueryOptions({ page: 1, pageSize: 12 })),
+      context.queryClient.ensureInfiniteQueryData(recordingsInfiniteQueryOptions()),
+    ]),
   component: RecordingsPage,
 });

--- a/packages/server/src/recordings/analysis-service.ts
+++ b/packages/server/src/recordings/analysis-service.ts
@@ -131,12 +131,9 @@ function normalizeTopicSections(
   }));
 }
 
-function toResponse(
-  row: typeof recordingAnalyses.$inferSelect,
-  fallbackRecordingId: PrefixedString<'rec'>,
-): RecordingAnalysis {
+export function toRecordingAnalysis(row: typeof recordingAnalyses.$inferSelect): RecordingAnalysis {
   return {
-    recordingId: row.recordingId ?? fallbackRecordingId,
+    recordingId: row.recordingId,
     status: row.status,
     transcript: row.transcript ?? [],
     topicSections: row.topicSections ?? [],
@@ -186,7 +183,7 @@ export async function getRecordingAnalysis(
     .from(recordingAnalyses)
     .where(eq(recordingAnalyses.recordingId, recordingId));
 
-  return ok({ analysis: analysis ? toResponse(analysis, recordingId) : null });
+  return ok({ analysis: analysis ? toRecordingAnalysis(analysis) : null });
 }
 
 export async function startRecordingAnalysis(
@@ -210,7 +207,7 @@ export async function startRecordingAnalysis(
     .where(eq(recordingAnalyses.recordingId, recordingId));
 
   if (existing && existing.status !== 'failed' && existing.status !== 'pending' && !input?.force) {
-    return ok({ analysis: toResponse(existing, recordingId) });
+    return ok({ analysis: toRecordingAnalysis(existing) });
   }
 
   const transcript: RecordingTranscriptEntry[] = existing?.transcript ?? [];
@@ -304,7 +301,7 @@ export async function startRecordingAnalysis(
     return err('Failed to create recording analysis', 400);
   }
 
-  return ok({ analysis: toResponse(created, recordingId) });
+  return ok({ analysis: toRecordingAnalysis(created) });
 }
 
 export async function cancelRecordingAnalysis(

--- a/packages/server/src/recordings/service.ts
+++ b/packages/server/src/recordings/service.ts
@@ -4,8 +4,10 @@ import path from 'node:path';
 
 import { createRecordingAnalysisId, createRecordingId } from '@stitch/shared/id';
 import type {
+  ActiveRecordingResponse,
   ListRecordingsResponse,
   Recording,
+  RecordingDetailsResponse,
   StartRecordingInput,
   StartRecordingResponse,
   StopRecordingInput,
@@ -22,12 +24,11 @@ import { PATHS } from '@/lib/paths.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { getModelDescriptor } from '@/models/stt/service.js';
-import { startRecordingAnalysis } from '@/recordings/analysis-service.js';
+import { startRecordingAnalysis, toRecordingAnalysis } from '@/recordings/analysis-service.js';
 import { finalFlushAndCleanup } from '@/recordings/transcript-store.js';
 import { getSettings } from '@/settings/service.js';
 
 type RecordingRow = typeof recordings.$inferSelect;
-
 type ActiveRecording = {
   id: Recording['id'];
   filePath: string;
@@ -171,6 +172,36 @@ export async function listRecordings(input: {
     total,
     totalPages,
   };
+}
+
+export async function getRecordingDetails(
+  recordingId: Recording['id'],
+): Promise<ServiceResult<RecordingDetailsResponse>> {
+  const db = getDb();
+  const [row] = await db
+    .select({
+      recording: recordings,
+      analysis: recordingAnalyses,
+      analysisTitle: recordingAnalyses.title,
+      analysisCostUsd: recordingAnalyses.costUsd,
+    })
+    .from(recordings)
+    .leftJoin(recordingAnalyses, eq(recordingAnalyses.recordingId, recordings.id))
+    .where(eq(recordings.id, recordingId));
+
+  if (!row) {
+    return err('Recording not found', 404);
+  }
+
+  return ok({
+    recording: toRecording(row.recording, row.analysisTitle || null, row.analysisCostUsd ?? null),
+    analysis: row.analysis ? toRecordingAnalysis(row.analysis) : null,
+    activeRecordingId: activeRecording?.id ?? null,
+  });
+}
+
+export function getActiveRecording(): ActiveRecordingResponse {
+  return { activeRecordingId: activeRecording?.id ?? null };
 }
 
 export async function startRecording(

--- a/packages/server/src/routes/recordings.ts
+++ b/packages/server/src/routes/recordings.ts
@@ -10,14 +10,12 @@ import type { StartRecordingInput, StopRecordingInput } from '@stitch/shared/rec
 import { unwrapResult } from '@/lib/route-helpers.js';
 import { paginationQuerySchema } from '@/lib/route-schemas.js';
 import { isServiceError } from '@/lib/service-result.js';
-import {
-  cancelRecordingAnalysis,
-  getRecordingAnalysis,
-  startRecordingAnalysis,
-} from '@/recordings/analysis-service.js';
+import { cancelRecordingAnalysis, startRecordingAnalysis } from '@/recordings/analysis-service.js';
 import {
   deleteRecording,
+  getActiveRecording,
   getRecordingAudioFile,
+  getRecordingDetails,
   listRecordings,
   startRecording,
   stopRecording,
@@ -69,6 +67,14 @@ recordingsRouter.delete('/:id', zValidator('param', recordingIdParamSchema), asy
   const { id } = c.req.valid('param');
   const result = await deleteRecording(id);
   return unwrapResult(c, result, 204);
+});
+
+recordingsRouter.get('/active', (c) => c.json(getActiveRecording()));
+
+recordingsRouter.get('/:id', zValidator('param', recordingIdParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  const result = await getRecordingDetails(id);
+  return unwrapResult(c, result);
 });
 
 recordingsRouter.get('/:id/audio', zValidator('param', recordingIdParamSchema), async (c) => {
@@ -140,12 +146,6 @@ recordingsRouter.post(
     return unwrapResult(c, result, 202);
   },
 );
-
-recordingsRouter.get('/:id/analysis', zValidator('param', recordingIdParamSchema), async (c) => {
-  const { id } = c.req.valid('param');
-  const result = await getRecordingAnalysis(id);
-  return unwrapResult(c, result);
-});
 
 recordingsRouter.post(
   '/:id/analysis/cancel',

--- a/packages/shared/src/recordings/types.ts
+++ b/packages/shared/src/recordings/types.ts
@@ -124,6 +124,16 @@ export type RecordingAnalysisResponse = {
   analysis: RecordingAnalysis | null;
 };
 
+export type RecordingDetailsResponse = {
+  recording: Recording;
+  analysis: RecordingAnalysis | null;
+  activeRecordingId: PrefixedString<'rec'> | null;
+};
+
+export type ActiveRecordingResponse = {
+  activeRecordingId: PrefixedString<'rec'> | null;
+};
+
 export type StartRecordingAnalysisResponse = {
   analysis: RecordingAnalysis;
 };


### PR DESCRIPTION
## Change Summary

Improves recordings data loading by separating each surface into the query shape it actually needs: the sidebar uses infinite loading, the main table uses normal paginated data, the details page loads a single combined recording payload, and the meeting banner checks only active recording state.

### Improvements

- Added automatic infinite loading to the recordings sidebar.
- Kept the recordings table on paginated data and preloaded both table and sidebar queries for the recordings route.
- Added a combined recording details endpoint for the analysis page so it no longer loads the recordings list.
- Added a narrow active-recording endpoint for the meeting banner so it no longer loads list data.
- Updated recordings query invalidation for list, detail, and active-recording cache entries.
