### PR TITLE
fix: correct STT cost reporting

### DIFF
--- a/apps/web/src/components/recordings/analysis/analysis-header.tsx
+++ b/apps/web/src/components/recordings/analysis/analysis-header.tsx
@@ -13,11 +13,11 @@ import {
   PageIcon,
   PageTitle,
 } from '@/components/ui/page';
+import { formatUsdCost } from '@/lib/format-cost';
 
 function formatCost(costUsd: number | null | undefined): string | null {
   if (costUsd === null || costUsd === undefined) return null;
-  if (costUsd < 0.01) return `$${costUsd.toFixed(4)}`;
-  return `$${costUsd.toFixed(2)}`;
+  return formatUsdCost(costUsd);
 }
 
 interface AnalysisHeaderProps {

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Badge, type badgeVariants } from '@/components/ui/badge';
+import { formatUsdCost } from '@/lib/format-cost';
 import { cn } from '@/lib/utils';
 import type { VariantProps } from 'class-variance-authority';
 
@@ -46,8 +47,7 @@ function formatTableTime(value: number | string | Date, format: TableTimeFormat)
 
 function formatTableMoney(value: number | null): string {
   if (value === null) return '—';
-  if (value < 0.01) return `$${value.toFixed(4)}`;
-  return `$${value.toFixed(2)}`;
+  return formatUsdCost(value);
 }
 
 function TableContainer({ bordered = true, className, ...props }: TableContainerProps) {

--- a/apps/web/src/components/usage/usage-dashboard-cost-chart.tsx
+++ b/apps/web/src/components/usage/usage-dashboard-cost-chart.tsx
@@ -29,7 +29,6 @@ const SOURCE_COLOR_CONFIG: Record<string, { cssVar: string; fallback: string }> 
   automation: { cssVar: '--chart-2', fallback: '#10b981' },
   automation_generation: { cssVar: '--chart-5', fallback: '#8b5cf6' },
   title_generation: { cssVar: '--chart-3', fallback: '#3b82f6' },
-  transcription: { cssVar: '--chart-4', fallback: '#f59e0b' },
   memory_extraction: { cssVar: '--chart-4', fallback: '#ec4899' },
   recording_analysis: { cssVar: '--chart-5', fallback: '#14b8a6' },
 };

--- a/apps/web/src/components/usage/usage-dashboard-utils.test.ts
+++ b/apps/web/src/components/usage/usage-dashboard-utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+
+import { formatCost } from '@/components/usage/usage-dashboard-utils';
+
+describe('formatCost', () => {
+  test('keeps zero at cent precision', () => {
+    expect(formatCost(0)).toBe('$0.00');
+  });
+
+  test('shows non-zero sub-cent costs', () => {
+    expect(formatCost(0.00154245)).toBe('$0.0015');
+  });
+
+  test('trims trailing zeroes from sub-cent costs', () => {
+    expect(formatCost(0.001)).toBe('$0.001');
+  });
+
+  test('uses cent precision for cent-level costs', () => {
+    expect(formatCost(0.1740201167)).toBe('$0.17');
+  });
+});

--- a/apps/web/src/components/usage/usage-dashboard-utils.ts
+++ b/apps/web/src/components/usage/usage-dashboard-utils.ts
@@ -20,7 +20,6 @@ const SOURCE_LABELS: Record<string, string> = {
   automation_generation: 'Automation Generation',
   title_generation: 'Title Generation',
   memory_extraction: 'Memory',
-  transcription: 'Transcription',
   recording_analysis: 'Recording Analysis',
 };
 

--- a/apps/web/src/components/usage/usage-dashboard-utils.ts
+++ b/apps/web/src/components/usage/usage-dashboard-utils.ts
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import { USAGE_SOURCES, type UsageDateRange } from '@stitch/shared/usage/types';
 
+import { formatUsdCost } from '@/lib/format-cost';
+
 export const ALL_FILTER = 'all';
 
 export const RANGE_LABELS: Record<UsageDateRange, string> = {
@@ -27,7 +29,7 @@ export function getSourceLabel(source: string): string {
 }
 
 export function formatCost(costUsd: number): string {
-  return `$${costUsd.toFixed(2)}`;
+  return formatUsdCost(costUsd);
 }
 
 export function formatTokens(value: number): string {

--- a/apps/web/src/lib/format-cost.ts
+++ b/apps/web/src/lib/format-cost.ts
@@ -1,0 +1,11 @@
+export function formatUsdCost(costUsd: number): string {
+  if (costUsd === 0) {
+    return '$0.00';
+  }
+
+  if (Math.abs(costUsd) < 0.01) {
+    return `$${costUsd.toFixed(4).replace(/0+$/, '')}`;
+  }
+
+  return `$${costUsd.toFixed(2)}`;
+}

--- a/packages/server/src/stt/adapters/openai.test.ts
+++ b/packages/server/src/stt/adapters/openai.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createOpenAIMessageParser } from '@/stt/adapters/openai.js';
+
+describe('createOpenAIMessageParser', () => {
+  test('parses token usage from completed transcription events', () => {
+    const parseMessage = createOpenAIMessageParser(Date.now() - 1000);
+
+    const result = parseMessage(
+      JSON.stringify({
+        type: 'conversation.item.input_audio_transcription.completed',
+        transcript: 'Hi, can you hear me?',
+        usage: {
+          type: 'tokens',
+          total_tokens: 26,
+          input_tokens: 17,
+          input_token_details: {
+            text_tokens: 0,
+            audio_tokens: 17,
+          },
+          output_tokens: 9,
+        },
+      }),
+    );
+
+    expect(result?.usage?.audioInputTokens).toBe(17);
+    expect(result?.usage?.textOutputTokens).toBe(9);
+    expect(result?.usage?.durationMs).toBeGreaterThan(0);
+  });
+
+  test('falls back to input tokens when audio token details are absent', () => {
+    const parseMessage = createOpenAIMessageParser(Date.now() - 1000);
+
+    const result = parseMessage(
+      JSON.stringify({
+        type: 'conversation.item.input_audio_transcription.completed',
+        transcript: 'Fallback usage',
+        usage: {
+          type: 'tokens',
+          total_tokens: 12,
+          input_tokens: 8,
+          output_tokens: 4,
+        },
+      }),
+    );
+
+    expect(result?.usage?.audioInputTokens).toBe(8);
+    expect(result?.usage?.textOutputTokens).toBe(4);
+  });
+
+  test('parses duration usage from completed transcription events', () => {
+    const parseMessage = createOpenAIMessageParser(Date.now() - 1000);
+
+    const result = parseMessage(
+      JSON.stringify({
+        type: 'conversation.item.input_audio_transcription.completed',
+        transcript: 'Duration usage',
+        usage: {
+          type: 'duration',
+          seconds: 1.25,
+        },
+      }),
+    );
+
+    expect(result?.usage).toEqual({ durationMs: 1250 });
+  });
+});

--- a/packages/server/src/stt/adapters/openai.ts
+++ b/packages/server/src/stt/adapters/openai.ts
@@ -27,10 +27,38 @@ type OpenAIRealtimeMessage =
       transcript: string;
       item_id?: string;
       content_index?: number;
+      usage?:
+        | {
+            type: 'tokens';
+            input_tokens: number;
+            output_tokens: number;
+            input_token_details?: { audio_tokens?: number; text_tokens?: number };
+          }
+        | { type: 'duration'; seconds: number };
     }
   | { type: 'error'; error: { type: string; message: string; code?: string } };
 
-function createOpenAIMessageParser(sessionStartMs: number) {
+function parseUsage(
+  usage: Extract<
+    OpenAIRealtimeMessage,
+    { type: 'conversation.item.input_audio_transcription.completed' }
+  >['usage'],
+  durationMs: number,
+): STTUsage {
+  if (!usage) return { durationMs };
+
+  if (usage.type === 'tokens') {
+    return {
+      durationMs,
+      audioInputTokens: usage.input_token_details?.audio_tokens ?? usage.input_tokens,
+      textOutputTokens: usage.output_tokens,
+    };
+  }
+
+  return { durationMs: Math.round(usage.seconds * 1000) };
+}
+
+export function createOpenAIMessageParser(sessionStartMs: number) {
   // Monotonic offset tracker: OpenAI doesn't provide word timestamps,
   // so we use elapsed time since session start as the offset.
   // We track the last offset to ensure monotonicity even if messages arrive out of order.
@@ -50,7 +78,7 @@ function createOpenAIMessageParser(sessionStartMs: number) {
         const offsetMs = Math.max(Date.now() - sessionStartMs, lastOffsetMs + 1);
         lastOffsetMs = offsetMs;
         const transcript: TranscriptEvent = { kind: 'final', text: msg.transcript, offsetMs };
-        const usage: STTUsage = { durationMs: Date.now() - sessionStartMs };
+        const usage = parseUsage(msg.usage, Date.now() - sessionStartMs);
         return { transcript, usage };
       }
       case 'error': {

--- a/packages/server/src/usage/service.test.ts
+++ b/packages/server/src/usage/service.test.ts
@@ -132,6 +132,27 @@ describe('getUsageDashboard', () => {
     expect(result.data.totals.costUsd).toBeCloseTo(0.03);
   });
 
+  test('excludes transcription from LLM usage totals', async () => {
+    const now = Date.now();
+    const from = now - 10_000;
+
+    await insertEvent({
+      source: 'transcription_recording',
+      providerId: 'openai',
+      modelId: 'gpt-realtime-whisper',
+      costUsd: 0.25,
+      startedAt: from + 1_000,
+    });
+
+    const result = await getUsageDashboard({ from, to: now });
+
+    expect(isServiceError(result)).toBe(false);
+    if (isServiceError(result)) return;
+
+    expect(result.data.totals.costUsd).toBe(0);
+    expect(result.data.sources).not.toContain('transcription');
+  });
+
   test('excludes events outside the time range', async () => {
     const now = Date.now();
     const from = now - 10_000;

--- a/packages/server/src/usage/service.ts
+++ b/packages/server/src/usage/service.ts
@@ -288,7 +288,7 @@ async function resolveWindow(input: GetUsageDashboardInput): Promise<TimeWindow>
 function normalizeEventSource(
   source: string,
   sessionType: 'chat' | 'automation' | null,
-): UsageSource {
+): UsageSource | null {
   if (source === 'title_generation') {
     return 'title_generation';
   }
@@ -302,7 +302,7 @@ function normalizeEventSource(
   }
 
   if (source.startsWith('transcription')) {
-    return 'transcription';
+    return null;
   }
 
   if (sessionType === 'automation') {
@@ -370,7 +370,6 @@ export async function getUsageDashboard(
 
   const usedProviderIds = new Set<string>();
   const usedModelKeys = new Set<string>();
-  const recordingAnalysisCostByRecordingId = new Map<string, number>();
 
   const addUsageRow = (args: {
     createdAt: number;
@@ -398,63 +397,14 @@ export async function getUsageDashboard(
     usedProviderIds.add(row.providerId);
     usedModelKeys.add(`${row.providerId}::${row.modelId}`);
 
-    if (row.source === 'recording_analysis') {
-      const recordingId = row.metadata?.recordingId;
-      if (typeof recordingId === 'string') {
-        recordingAnalysisCostByRecordingId.set(
-          recordingId,
-          (recordingAnalysisCostByRecordingId.get(recordingId) ?? 0) + (row.costUsd ?? 0),
-        );
-      }
-    }
+    const source = normalizeEventSource(row.source, row.sessionType ?? null);
+    if (!source) continue;
 
     addUsageRow({
       createdAt: row.createdAt,
-      source: normalizeEventSource(row.source, row.sessionType ?? null),
+      source,
       usage: row.usage,
       costUsd: row.costUsd,
-    });
-  }
-
-  const transcriptionConditions = [
-    gte(recordingAnalyses.startedAt, window.from),
-    lt(recordingAnalyses.startedAt, window.to),
-    isNotNull(recordingAnalyses.transcriptionProviderId),
-    isNotNull(recordingAnalyses.transcriptionModelId),
-  ];
-  if (input.providerId) {
-    transcriptionConditions.push(eq(recordingAnalyses.transcriptionProviderId, input.providerId));
-  }
-  if (input.modelId) {
-    transcriptionConditions.push(eq(recordingAnalyses.transcriptionModelId, input.modelId));
-  }
-
-  const transcriptionRows = await db
-    .select({
-      recordingId: recordingAnalyses.recordingId,
-      createdAt: recordingAnalyses.startedAt,
-      providerId: recordingAnalyses.transcriptionProviderId,
-      modelId: recordingAnalyses.transcriptionModelId,
-      costUsd: recordingAnalyses.costUsd,
-    })
-    .from(recordingAnalyses)
-    .where(and(...transcriptionConditions));
-
-  for (const row of transcriptionRows) {
-    if (!row.createdAt || !row.providerId || !row.modelId) continue;
-
-    usedProviderIds.add(row.providerId);
-    usedModelKeys.add(`${row.providerId}::${row.modelId}`);
-
-    const analysisCost = recordingAnalysisCostByRecordingId.get(row.recordingId) ?? 0;
-    const transcriptionCost = Math.max(0, row.costUsd - analysisCost);
-    if (transcriptionCost === 0) continue;
-
-    addUsageRow({
-      createdAt: row.createdAt,
-      source: 'transcription',
-      usage: null,
-      costUsd: transcriptionCost,
     });
   }
 

--- a/packages/shared/src/usage/types.ts
+++ b/packages/shared/src/usage/types.ts
@@ -4,7 +4,6 @@ export const USAGE_SOURCES = [
   'automation_generation',
   'title_generation',
   'memory_extraction',
-  'transcription',
   'recording_analysis',
 ] as const;
 


### PR DESCRIPTION
## 🚀 Change Summary

Fixes STT cost reporting and usage display so small non-zero transcription costs are visible, OpenAI realtime transcription usage is billed from returned token counts, and transcription no longer appears as an LLM usage metric.

### 🛠 Improvements & Refactors
- **Cost Formatting**: Share USD cost formatting across usage charts, recording tables, and analysis headers so sub-cent costs display without rounding to `$0.00`.
- **Usage Dashboard**: Remove transcription from the LLM usage source list and aggregation while preserving the dedicated STT usage dashboard.

### 🐛 Bug Fixes
- **OpenAI STT Costs**: Parse token and duration usage from OpenAI realtime transcription completion events so registry token pricing produces non-zero costs.
