### PR TITLE
improvement: stream runner hot path, flush signals, retry cap, doom loop fix

### DIFF
--- a/packages/server/src/lib/retry.ts
+++ b/packages/server/src/lib/retry.ts
@@ -3,7 +3,12 @@ import { mapAIError, OVERLOADED_PATTERN } from '@/llm/stream/ai-error-mapper.js'
 const RETRY_INITIAL_DELAY = 2000;
 const RETRY_BACKOFF_FACTOR = 2;
 const RETRY_MAX_DELAY_NO_HEADERS = 30000;
+const RETRY_MAX_DELAY = 2_147_483_647;
 export const MAX_RETRIES = 5;
+
+function cap(ms: number): number {
+  return Math.min(ms, RETRY_MAX_DELAY);
+}
 
 type ErrorInfo = ReturnType<typeof mapAIError>;
 
@@ -27,7 +32,7 @@ export function delay(attempt: number, headers?: Record<string, string>): number
     if (retryAfterMs) {
       const parsedMs = Number.parseFloat(retryAfterMs);
       if (!Number.isNaN(parsedMs)) {
-        return parsedMs;
+        return cap(parsedMs);
       }
     }
 
@@ -35,15 +40,15 @@ export function delay(attempt: number, headers?: Record<string, string>): number
     if (retryAfter) {
       const parsedSeconds = Number.parseFloat(retryAfter);
       if (!Number.isNaN(parsedSeconds)) {
-        return Math.ceil(parsedSeconds * 1000);
+        return cap(Math.ceil(parsedSeconds * 1000));
       }
       const parsed = Date.parse(retryAfter) - Date.now();
       if (!Number.isNaN(parsed) && parsed > 0) {
-        return Math.ceil(parsed);
+        return cap(Math.ceil(parsed));
       }
     }
 
-    return RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1);
+    return cap(RETRY_INITIAL_DELAY * Math.pow(RETRY_BACKOFF_FACTOR, attempt - 1));
   }
 
   return Math.min(

--- a/packages/server/src/llm/stream/doom-loop.ts
+++ b/packages/server/src/llm/stream/doom-loop.ts
@@ -134,8 +134,10 @@ export async function checkAndHandleDoomLoop(opts: {
       content: DOOM_LOOP_MESSAGE,
     });
 
+    // Use empty tools for the summary step
     const summaryResult = await executeStepWithRetry({
       ...stepOptions,
+      tools: {},
       conversation,
       onAttemptFailure: onDoomLoopAttemptFailure,
     });

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -233,7 +233,7 @@ class StreamRunner {
   }
 
   private logStart(): void {
-    const userPromptPreview = this.getLastUserPromptPreview();
+    const userPromptPreview = this.getLastUserText(200);
 
     log.info(
       {
@@ -250,7 +250,7 @@ class StreamRunner {
     );
   }
 
-  private getLastUserPromptPreview(): string | null {
+  private getLastUserText(maxLength?: number): string | null {
     for (let i = this.state.conversation.length - 1; i >= 0; i--) {
       const message = this.state.conversation[i];
       if (message?.role !== 'user') {
@@ -259,17 +259,24 @@ class StreamRunner {
 
       const { content } = message;
       if (typeof content === 'string') {
-        return content.slice(0, 200);
+        return maxLength ? content.slice(0, maxLength) : content;
       }
 
       if (Array.isArray(content)) {
         const textPart = content.find(
           (part) => typeof part === 'object' && part !== null && part.type === 'text',
         );
-        if (textPart && typeof textPart.text === 'string') {
-          return textPart.text.slice(0, 200);
+        if (
+          textPart &&
+          typeof textPart === 'object' &&
+          'text' in textPart &&
+          typeof textPart.text === 'string'
+        ) {
+          return maxLength ? textPart.text.slice(0, maxLength) : textPart.text;
         }
       }
+
+      return null;
     }
 
     return null;
@@ -1073,28 +1080,6 @@ class StreamRunner {
         'async memory processing failed',
       );
     });
-  }
-
-  private getLastUserText(): string | null {
-    for (let i = this.state.conversation.length - 1; i >= 0; i--) {
-      const msg = this.state.conversation[i];
-      if (msg?.role !== 'user') continue;
-
-      const { content } = msg;
-      if (typeof content === 'string') return content;
-
-      if (Array.isArray(content)) {
-        const textPart = content.find(
-          (part) => typeof part === 'object' && part !== null && part.type === 'text',
-        );
-        if (textPart && typeof textPart === 'object' && 'text' in textPart) {
-          return textPart.text;
-        }
-      }
-
-      return null;
-    }
-    return null;
   }
 
   private getAssistantText(): string | null {

--- a/packages/server/src/llm/stream/step-executor.ts
+++ b/packages/server/src/llm/stream/step-executor.ts
@@ -188,7 +188,7 @@ async function executeStep(opts: StepOptions): Promise<StepResult> {
         };
       }
 
-      await accumulator.handlePart(part);
+      accumulator.handlePart(part);
 
       if (abortSignal.aborted) {
         throw new StreamAbortedError();

--- a/packages/server/src/llm/stream/stream-accumulator.test.ts
+++ b/packages/server/src/llm/stream/stream-accumulator.test.ts
@@ -12,6 +12,7 @@ import {
   StreamPartError,
 } from '@/llm/stream/errors.js';
 import { StreamAccumulator } from '@/llm/stream/stream-accumulator.js';
+import type { TextStreamPart, ToolSet } from 'ai';
 
 type EmittedEvent = [SseEventName, SseEventPayloadMap[SseEventName]];
 let emittedEvents: EmittedEvent[] = [];
@@ -41,6 +42,11 @@ function createAccumulator(
   );
 }
 
+/** Minimal valid part factory helpers — only include fields our code actually reads */
+function part<T extends TextStreamPart<ToolSet>>(p: T): T {
+  return p;
+}
+
 describe('StreamAccumulator', () => {
   beforeEach(() => {
     emittedEvents = [];
@@ -52,14 +58,14 @@ describe('StreamAccumulator', () => {
   // ─── Text accumulation ──────────────────────────────────────────────
 
   describe('text accumulation', () => {
-    test('accumulates text-start → text-delta → text-end into a stored part', async () => {
+    test('accumulates text-start → text-delta → text-end into a stored part', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      await acc.handlePart({ type: 'text-start' });
-      await acc.handlePart({ type: 'text-delta', text: 'Hello' });
-      await acc.handlePart({ type: 'text-delta', text: ', world!' });
-      await acc.handlePart({ type: 'text-end' });
+      acc.handlePart(part({ type: 'text-start', id: 'id1' }));
+      acc.handlePart(part({ type: 'text-delta', id: 'id1', text: 'Hello' }));
+      acc.handlePart(part({ type: 'text-delta', id: 'id1', text: ', world!' }));
+      acc.handlePart(part({ type: 'text-end', id: 'id1' }));
 
       expect(parts).toHaveLength(1);
       expect(parts[0]).toMatchObject({
@@ -68,12 +74,12 @@ describe('StreamAccumulator', () => {
       });
     });
 
-    test('flush() emits buffered text when no text-end arrives', async () => {
+    test('flush() emits buffered text when no text-end arrives', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      await acc.handlePart({ type: 'text-start' });
-      await acc.handlePart({ type: 'text-delta', text: 'Incomplete' });
+      acc.handlePart(part({ type: 'text-start', id: 'id1' }));
+      acc.handlePart(part({ type: 'text-delta', id: 'id1', text: 'Incomplete' }));
       acc.flush();
 
       expect(parts).toHaveLength(1);
@@ -83,20 +89,20 @@ describe('StreamAccumulator', () => {
       });
     });
 
-    test('flush() does nothing when text buffer is empty', async () => {
+    test('flush() does nothing when text buffer is empty', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      await acc.handlePart({ type: 'text-start' });
+      acc.handlePart(part({ type: 'text-start', id: 'id1' }));
       acc.flush();
 
       expect(parts).toHaveLength(0);
     });
 
-    test('text-delta without text-start increments protocol violation count', async () => {
+    test('text-delta without text-start increments protocol violation count', () => {
       const acc = createAccumulator();
 
-      await acc.handlePart({ type: 'text-delta', text: 'orphan delta' });
+      acc.handlePart(part({ type: 'text-delta', id: 'id1', text: 'orphan delta' }));
 
       expect(acc.getProtocolViolationCount()).toBe(1);
     });
@@ -105,14 +111,14 @@ describe('StreamAccumulator', () => {
   // ─── Reasoning accumulation ─────────────────────────────────────────
 
   describe('reasoning accumulation', () => {
-    test('accumulates reasoning into a stored reasoning-delta part', async () => {
+    test('accumulates reasoning into a stored reasoning-delta part', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      await acc.handlePart({ type: 'reasoning-start' });
-      await acc.handlePart({ type: 'reasoning-delta', text: 'Thinking step 1' });
-      await acc.handlePart({ type: 'reasoning-delta', text: '. Thinking step 2' });
-      await acc.handlePart({ type: 'reasoning-end' });
+      acc.handlePart(part({ type: 'reasoning-start', id: 'id1' }));
+      acc.handlePart(part({ type: 'reasoning-delta', id: 'id1', text: 'Thinking step 1' }));
+      acc.handlePart(part({ type: 'reasoning-delta', id: 'id1', text: '. Thinking step 2' }));
+      acc.handlePart(part({ type: 'reasoning-end', id: 'id1' }));
 
       expect(parts).toHaveLength(1);
       expect(parts[0]).toMatchObject({
@@ -121,20 +127,20 @@ describe('StreamAccumulator', () => {
       });
     });
 
-    test('reasoning-delta without reasoning-start increments protocol violation', async () => {
+    test('reasoning-delta without reasoning-start increments protocol violation', () => {
       const acc = createAccumulator();
 
-      await acc.handlePart({ type: 'reasoning-delta', text: 'orphan' });
+      acc.handlePart(part({ type: 'reasoning-delta', id: 'id1', text: 'orphan' }));
 
       expect(acc.getProtocolViolationCount()).toBe(1);
     });
 
-    test('flush() emits buffered reasoning when no reasoning-end arrives', async () => {
+    test('flush() emits buffered reasoning when no reasoning-end arrives', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      await acc.handlePart({ type: 'reasoning-start' });
-      await acc.handlePart({ type: 'reasoning-delta', text: 'Partial reasoning' });
+      acc.handlePart(part({ type: 'reasoning-start', id: 'id1' }));
+      acc.handlePart(part({ type: 'reasoning-delta', id: 'id1', text: 'Partial reasoning' }));
       acc.flush();
 
       expect(parts).toHaveLength(1);
@@ -148,17 +154,19 @@ describe('StreamAccumulator', () => {
   // ─── Tool call handling ─────────────────────────────────────────────
 
   describe('tool calls', () => {
-    test('records tool-call in both accumulatedParts and toolCalls', async () => {
+    test('records tool-call in both accumulatedParts and toolCalls', () => {
       const parts: StoredPart[] = [];
       const toolCalls: ToolCallRecord[] = [];
       const acc = createAccumulator(parts, toolCalls);
 
-      await acc.handlePart({
-        type: 'tool-call',
-        toolCallId: 'call_1',
-        toolName: 'bash',
-        input: { command: 'pwd' },
-      });
+      acc.handlePart(
+        part({
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'bash',
+          input: { command: 'pwd' },
+        }),
+      );
 
       expect(toolCalls).toEqual([expect.objectContaining({ toolName: 'bash' })]);
       expect(parts).toHaveLength(1);
@@ -169,17 +177,19 @@ describe('StreamAccumulator', () => {
       });
     });
 
-    test('records tool-result in accumulatedParts', async () => {
+    test('records tool-result in accumulatedParts', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      await acc.handlePart({
-        type: 'tool-result',
-        toolCallId: 'call_1',
-        toolName: 'bash',
-        input: { command: 'pwd' },
-        output: { result: '/home/user' },
-      });
+      acc.handlePart(
+        part({
+          type: 'tool-result',
+          toolCallId: 'call_1',
+          toolName: 'bash',
+          input: { command: 'pwd' },
+          output: { result: '/home/user' },
+        }),
+      );
 
       expect(parts).toHaveLength(1);
       expect(parts[0]).toMatchObject({
@@ -191,22 +201,26 @@ describe('StreamAccumulator', () => {
       });
     });
 
-    test('broadcasts stream-tool-state for tool-call and tool-result lifecycle', async () => {
+    test('broadcasts stream-tool-state for tool-call and tool-result lifecycle', () => {
       const acc = createAccumulator();
 
-      await acc.handlePart({
-        type: 'tool-call',
-        toolCallId: 'call_1',
-        toolName: 'read',
-        input: { filePath: 'README.md' },
-      });
-      await acc.handlePart({
-        type: 'tool-result',
-        toolCallId: 'call_1',
-        toolName: 'read',
-        input: { filePath: 'README.md' },
-        output: { content: '# Hello' },
-      });
+      acc.handlePart(
+        part({
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'read',
+          input: { filePath: 'README.md' },
+        }),
+      );
+      acc.handlePart(
+        part({
+          type: 'tool-result',
+          toolCallId: 'call_1',
+          toolName: 'read',
+          input: { filePath: 'README.md' },
+          output: { content: '# Hello' },
+        }),
+      );
 
       const toolStateCalls = getEmittedCalls('stream-tool-state');
 
@@ -215,16 +229,18 @@ describe('StreamAccumulator', () => {
       expect(toolStateCalls[1]).toMatchObject({ status: 'completed' });
     });
 
-    test('broadcasts error status when a tool-result contains an error payload', async () => {
+    test('broadcasts error status when a tool-result contains an error payload', () => {
       const acc = createAccumulator();
 
-      await acc.handlePart({
-        type: 'tool-result',
-        toolCallId: 'call_1',
-        toolName: 'browser',
-        input: { action: 'snapshot' },
-        output: { error: 'Navigation failed' },
-      });
+      acc.handlePart(
+        part({
+          type: 'tool-result',
+          toolCallId: 'call_1',
+          toolName: 'browser',
+          input: { action: 'snapshot' },
+          output: { error: 'Navigation failed' },
+        }),
+      );
 
       const toolStateCalls = getEmittedCalls('stream-tool-state');
       expect(toolStateCalls).toHaveLength(1);
@@ -235,14 +251,16 @@ describe('StreamAccumulator', () => {
       });
     });
 
-    test('broadcasts stream-tool-state pending for tool-input-start', async () => {
+    test('broadcasts stream-tool-state pending for tool-input-start', () => {
       const acc = createAccumulator();
 
-      await acc.handlePart({
-        type: 'tool-input-start',
-        id: 'call_1',
-        toolName: 'bash',
-      });
+      acc.handlePart(
+        part({
+          type: 'tool-input-start',
+          id: 'call_1',
+          toolName: 'bash',
+        }),
+      );
 
       const toolStateCalls = getEmittedCalls('stream-tool-state');
       expect(toolStateCalls).toHaveLength(1);
@@ -253,16 +271,19 @@ describe('StreamAccumulator', () => {
   // ─── Tool error handling ────────────────────────────────────────────
 
   describe('tool errors', () => {
-    test('converts tool-error to tool-result with error output', async () => {
+    test('converts tool-error to tool-result with error output', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      await acc.handlePart({
-        type: 'tool-error',
-        toolCallId: 'call_1',
-        toolName: 'webfetch',
-        error: 'connection refused',
-      });
+      acc.handlePart(
+        part({
+          type: 'tool-error',
+          toolCallId: 'call_1',
+          toolName: 'webfetch',
+          input: {},
+          error: 'connection refused',
+        }),
+      );
 
       expect(parts).toHaveLength(1);
       expect(parts[0]).toMatchObject({
@@ -273,42 +294,51 @@ describe('StreamAccumulator', () => {
       });
     });
 
-    test('captures PermissionRejectedError from tool-error', async () => {
+    test('captures PermissionRejectedError from tool-error', () => {
       const acc = createAccumulator();
       const permError = new PermissionRejectedError('webfetch');
 
-      await acc.handlePart({
-        type: 'tool-error',
-        toolCallId: 'call_1',
-        toolName: 'webfetch',
-        error: permError,
-      });
+      acc.handlePart(
+        part({
+          type: 'tool-error',
+          toolCallId: 'call_1',
+          toolName: 'webfetch',
+          input: {},
+          error: permError,
+        }),
+      );
 
       expect(acc.getPermissionRejected()).toBeInstanceOf(PermissionRejectedError);
     });
 
-    test('does not set permissionRejected for non-permission errors', async () => {
+    test('does not set permissionRejected for non-permission errors', () => {
       const acc = createAccumulator();
 
-      await acc.handlePart({
-        type: 'tool-error',
-        toolCallId: 'call_1',
-        toolName: 'bash',
-        error: new Error('command failed'),
-      });
+      acc.handlePart(
+        part({
+          type: 'tool-error',
+          toolCallId: 'call_1',
+          toolName: 'bash',
+          input: {},
+          error: new Error('command failed'),
+        }),
+      );
 
       expect(acc.getPermissionRejected()).toBeNull();
     });
 
-    test('broadcasts error status for tool errors', async () => {
+    test('broadcasts error status for tool errors', () => {
       const acc = createAccumulator();
 
-      await acc.handlePart({
-        type: 'tool-error',
-        toolCallId: 'call_1',
-        toolName: 'bash',
-        error: 'something went wrong',
-      });
+      acc.handlePart(
+        part({
+          type: 'tool-error',
+          toolCallId: 'call_1',
+          toolName: 'bash',
+          input: {},
+          error: 'something went wrong',
+        }),
+      );
 
       const toolStateCalls = getEmittedCalls('stream-tool-state');
       expect(toolStateCalls).toHaveLength(1);
@@ -322,36 +352,42 @@ describe('StreamAccumulator', () => {
   // ─── Error parts ────────────────────────────────────────────────────
 
   describe('error parts', () => {
-    test('throws StreamPartError for error parts with Error cause', async () => {
+    test('throws StreamPartError for error parts with Error cause', () => {
       const acc = createAccumulator();
 
-      expect(
-        acc.handlePart({
-          type: 'error',
-          error: new Error('stream broke'),
-        }),
-      ).rejects.toBeInstanceOf(StreamPartError);
+      expect(() =>
+        acc.handlePart(
+          part({
+            type: 'error',
+            error: new Error('stream broke'),
+          }),
+        ),
+      ).toThrow(StreamPartError);
     });
 
-    test('throws StreamPartError for non-Error error parts', async () => {
+    test('throws StreamPartError for non-Error error parts', () => {
       const acc = createAccumulator();
 
-      expect(
-        acc.handlePart({
-          type: 'error',
-          error: 'string error message',
-        }),
-      ).rejects.toBeInstanceOf(StreamPartError);
+      expect(() =>
+        acc.handlePart(
+          part({
+            type: 'error',
+            error: 'string error message',
+          }),
+        ),
+      ).toThrow(StreamPartError);
     });
 
-    test('broadcasts stream-error for error parts', async () => {
+    test('broadcasts stream-error for error parts', () => {
       const acc = createAccumulator();
 
       try {
-        await acc.handlePart({
-          type: 'error',
-          error: new Error('provider error'),
-        });
+        acc.handlePart(
+          part({
+            type: 'error',
+            error: new Error('provider error'),
+          }),
+        );
       } catch {
         // expected to throw
       }
@@ -368,26 +404,29 @@ describe('StreamAccumulator', () => {
   // ─── Abort handling ─────────────────────────────────────────────────
 
   describe('abort handling', () => {
-    test('throws StreamAbortedError on abort part', async () => {
+    test('throws StreamAbortedError on abort part', () => {
       const acc = createAccumulator();
 
-      expect(acc.handlePart({ type: 'abort' })).rejects.toBeInstanceOf(StreamAbortedError);
+      expect(() => acc.handlePart(part({ type: 'abort' }))).toThrow(StreamAbortedError);
     });
   });
 
   // ─── Source and file parts ──────────────────────────────────────────
 
   describe('source and file parts', () => {
-    test('stores source parts', async () => {
+    test('stores source parts', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      await acc.handlePart({
-        type: 'source',
-        sourceType: 'url',
-        url: 'https://example.com',
-        title: 'Example',
-      });
+      acc.handlePart(
+        part({
+          type: 'source',
+          sourceType: 'url',
+          id: 'src_1',
+          url: 'https://example.com',
+          title: 'Example',
+        }),
+      );
 
       expect(parts).toHaveLength(1);
       expect(parts[0]).toMatchObject({
@@ -396,20 +435,20 @@ describe('StreamAccumulator', () => {
       });
     });
 
-    test('stores file parts', async () => {
+    test('stores file parts', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      await acc.handlePart({
-        type: 'file',
-        data: 'base64data',
-        mediaType: 'image/png',
-      });
+      acc.handlePart(
+        part({
+          type: 'file',
+          file: { uint8Array: new Uint8Array(), mediaType: 'image/png', base64: '' } as any,
+        }),
+      );
 
       expect(parts).toHaveLength(1);
       expect(parts[0]).toMatchObject({
         type: 'file',
-        mediaType: 'image/png',
       });
     });
   });
@@ -417,25 +456,46 @@ describe('StreamAccumulator', () => {
   // ─── Ignored/passthrough parts ──────────────────────────────────────
 
   describe('passthrough parts', () => {
-    test('silently ignores start-step and finish-step parts', async () => {
+    test('silently ignores start-step and finish-step parts', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      await acc.handlePart({ type: 'start-step' });
-      await acc.handlePart({ type: 'finish-step' });
-      await acc.handlePart({ type: 'start' });
-      await acc.handlePart({ type: 'raw', rawValue: {} });
+      acc.handlePart(
+        part({
+          type: 'start-step',
+          request: {} as any,
+          warnings: [],
+        }),
+      );
+      acc.handlePart(
+        part({
+          type: 'finish-step',
+          response: {} as any,
+          usage: {
+            inputTokens: 0,
+            outputTokens: 0,
+            totalTokens: 0,
+            inputTokenDetails: {},
+            outputTokenDetails: {},
+          } as any,
+          finishReason: 'stop',
+          rawFinishReason: 'stop',
+          providerMetadata: undefined,
+        }),
+      );
+      acc.handlePart(part({ type: 'start' }));
+      acc.handlePart(part({ type: 'raw', rawValue: {} }));
 
       expect(parts).toHaveLength(0);
       expect(acc.getProtocolViolationCount()).toBe(0);
     });
 
-    test('tool-input-delta and tool-input-end do not create stored parts', async () => {
+    test('tool-input-delta and tool-input-end do not create stored parts', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      await acc.handlePart({ type: 'tool-input-delta', id: 'call_1', delta: '{}' });
-      await acc.handlePart({ type: 'tool-input-end', id: 'call_1' });
+      acc.handlePart(part({ type: 'tool-input-delta', id: 'call_1', delta: '{}' }));
+      acc.handlePart(part({ type: 'tool-input-end', id: 'call_1' }));
 
       expect(parts).toHaveLength(0);
     });
@@ -444,56 +504,86 @@ describe('StreamAccumulator', () => {
   // ─── SSE broadcasting ──────────────────────────────────────────────
 
   describe('SSE broadcasting', () => {
-    test('broadcasts stream-part-update on text-start and text-end', async () => {
+    test('broadcasts stream-part-update on text-start and text-end', () => {
       const acc = createAccumulator();
 
-      await acc.handlePart({ type: 'text-start' });
-      await acc.handlePart({ type: 'text-delta', text: 'Hi' });
-      await acc.handlePart({ type: 'text-end' });
+      acc.handlePart(part({ type: 'text-start', id: 'id1' }));
+      acc.handlePart(part({ type: 'text-delta', id: 'id1', text: 'Hi' }));
+      acc.handlePart(part({ type: 'text-end', id: 'id1' }));
 
       const updateCalls = getEmittedCalls('stream-part-update');
       expect(updateCalls).toHaveLength(2);
     });
 
-    test('broadcasts stream-part-delta for each text-delta', async () => {
+    test('broadcasts stream-part-delta for each text-delta', () => {
       const acc = createAccumulator();
 
-      await acc.handlePart({ type: 'text-start' });
-      await acc.handlePart({ type: 'text-delta', text: 'A' });
-      await acc.handlePart({ type: 'text-delta', text: 'B' });
+      acc.handlePart(part({ type: 'text-start', id: 'id1' }));
+      acc.handlePart(part({ type: 'text-delta', id: 'id1', text: 'A' }));
+      acc.handlePart(part({ type: 'text-delta', id: 'id1', text: 'B' }));
 
       const deltaCalls = getEmittedCalls('stream-part-delta');
       expect(deltaCalls).toHaveLength(2);
+    });
+
+    test('flush() broadcasts text-end signal for buffered text parts', () => {
+      const acc = createAccumulator();
+
+      acc.handlePart(part({ type: 'text-start', id: 'id1' }));
+      acc.handlePart(part({ type: 'text-delta', id: 'id1', text: 'Partial' }));
+      acc.flush();
+
+      const updateCalls = getEmittedCalls('stream-part-update');
+      // text-start + text-end (from flush)
+      expect(updateCalls).toHaveLength(2);
+      expect(updateCalls[1]).toMatchObject({ part: { type: 'text-end' } });
+    });
+
+    test('flush() broadcasts reasoning-end signal for buffered reasoning parts', () => {
+      const acc = createAccumulator();
+
+      acc.handlePart(part({ type: 'reasoning-start', id: 'id1' }));
+      acc.handlePart(part({ type: 'reasoning-delta', id: 'id1', text: 'Thinking' }));
+      acc.flush();
+
+      const updateCalls = getEmittedCalls('stream-part-update');
+      // reasoning-start + reasoning-end (from flush)
+      expect(updateCalls).toHaveLength(2);
+      expect(updateCalls[1]).toMatchObject({ part: { type: 'reasoning-end' } });
     });
   });
 
   // ─── Mixed content ─────────────────────────────────────────────────
 
   describe('mixed content', () => {
-    test('handles interleaved reasoning + text + tool calls', async () => {
+    test('handles interleaved reasoning + text + tool calls', () => {
       const parts: StoredPart[] = [];
       const toolCalls: ToolCallRecord[] = [];
       const acc = createAccumulator(parts, toolCalls);
 
-      await acc.handlePart({ type: 'reasoning-start' });
-      await acc.handlePart({ type: 'reasoning-delta', text: 'Analyzing...' });
-      await acc.handlePart({ type: 'reasoning-end' });
-      await acc.handlePart({ type: 'text-start' });
-      await acc.handlePart({ type: 'text-delta', text: 'Let me check.' });
-      await acc.handlePart({ type: 'text-end' });
-      await acc.handlePart({
-        type: 'tool-call',
-        toolCallId: 'call_1',
-        toolName: 'bash',
-        input: { command: 'ls' },
-      });
-      await acc.handlePart({
-        type: 'tool-result',
-        toolCallId: 'call_1',
-        toolName: 'bash',
-        input: { command: 'ls' },
-        output: { files: ['a.ts', 'b.ts'] },
-      });
+      acc.handlePart(part({ type: 'reasoning-start', id: 'id1' }));
+      acc.handlePart(part({ type: 'reasoning-delta', id: 'id1', text: 'Analyzing...' }));
+      acc.handlePart(part({ type: 'reasoning-end', id: 'id1' }));
+      acc.handlePart(part({ type: 'text-start', id: 'id2' }));
+      acc.handlePart(part({ type: 'text-delta', id: 'id2', text: 'Let me check.' }));
+      acc.handlePart(part({ type: 'text-end', id: 'id2' }));
+      acc.handlePart(
+        part({
+          type: 'tool-call',
+          toolCallId: 'call_1',
+          toolName: 'bash',
+          input: { command: 'ls' },
+        }),
+      );
+      acc.handlePart(
+        part({
+          type: 'tool-result',
+          toolCallId: 'call_1',
+          toolName: 'bash',
+          input: { command: 'ls' },
+          output: { files: ['a.ts', 'b.ts'] },
+        }),
+      );
 
       expect(parts).toHaveLength(4);
       expect(parts[0]).toMatchObject({ type: 'reasoning-delta', text: 'Analyzing...' });

--- a/packages/server/src/llm/stream/stream-accumulator.ts
+++ b/packages/server/src/llm/stream/stream-accumulator.ts
@@ -15,6 +15,7 @@ import {
   isPermissionRejectedError,
 } from '@/llm/stream/errors.js';
 import { stableStringify } from '@/utils/stable-stringify.js';
+import type { TextStreamPart, ToolSet } from 'ai';
 
 const log = Log.create({ service: 'stream-accumulator' });
 
@@ -89,20 +90,20 @@ export class StreamAccumulator {
     });
   }
 
-  private async handleTextualStart(
+  private handleTextualStart(
     field: 'currentTextPart' | 'currentReasoningPart',
     part: unknown,
-  ): Promise<void> {
+  ): void {
     const partId = createPartId();
     this[field] = { id: partId, text: '', startedAt: Date.now() };
     this.broadcastPartUpdate(partId, part);
   }
 
-  private async handleTextualDelta(
+  private handleTextualDelta(
     field: 'currentTextPart' | 'currentReasoningPart',
     violationName: string,
     part: { text: string },
-  ): Promise<void> {
+  ): void {
     const current = this[field];
     if (current) {
       current.text += part.text;
@@ -123,11 +124,11 @@ export class StreamAccumulator {
     }
   }
 
-  private async handleTextualEnd(
+  private handleTextualEnd(
     field: 'currentTextPart' | 'currentReasoningPart',
     storedType: 'text-delta' | 'reasoning-delta',
     part: unknown,
-  ): Promise<void> {
+  ): void {
     const current = this[field];
     if (current) {
       const now = Date.now();
@@ -145,7 +146,7 @@ export class StreamAccumulator {
 
   // ─── Main dispatcher ──────────────────────────────────────────────────────
 
-  async handlePart(part: any): Promise<void> {
+  handlePart(part: TextStreamPart<ToolSet>): void {
     log.debug(
       {
         event: 'stream.part.received',
@@ -160,23 +161,23 @@ export class StreamAccumulator {
 
     switch (part.type) {
       case 'text-start':
-        await this.handleTextualStart('currentTextPart', part);
+        this.handleTextualStart('currentTextPart', part);
         break;
 
       case 'text-delta':
-        await this.handleTextualDelta('currentTextPart', 'text_delta_without_text_start', part);
+        this.handleTextualDelta('currentTextPart', 'text_delta_without_text_start', part);
         break;
 
       case 'text-end':
-        await this.handleTextualEnd('currentTextPart', 'text-delta', part);
+        this.handleTextualEnd('currentTextPart', 'text-delta', part);
         break;
 
       case 'reasoning-start':
-        await this.handleTextualStart('currentReasoningPart', part);
+        this.handleTextualStart('currentReasoningPart', part);
         break;
 
       case 'reasoning-delta':
-        await this.handleTextualDelta(
+        this.handleTextualDelta(
           'currentReasoningPart',
           'reasoning_delta_without_reasoning_start',
           part,
@@ -184,7 +185,7 @@ export class StreamAccumulator {
         break;
 
       case 'reasoning-end':
-        await this.handleTextualEnd('currentReasoningPart', 'reasoning-delta', part);
+        this.handleTextualEnd('currentReasoningPart', 'reasoning-delta', part);
         break;
 
       case 'source': {
@@ -346,8 +347,7 @@ export class StreamAccumulator {
             error: errorText,
             errorName,
             errorStack,
-            rawPartKeys:
-              part && typeof part === 'object' ? Object.keys(part as Record<string, unknown>) : [],
+            rawPartKeys: Object.keys(part as Record<string, unknown>),
           },
           'stream part error',
         );
@@ -370,6 +370,11 @@ export class StreamAccumulator {
         // Step lifecycle events are not broadcast or persisted — they add noise without UI value
         break;
 
+      case 'tool-output-denied':
+      case 'tool-approval-request':
+        // Not handled — approval flow is managed outside the accumulator
+        break;
+
       case 'start':
       case 'raw':
         break;
@@ -389,6 +394,11 @@ export class StreamAccumulator {
         startedAt: this.currentTextPart.startedAt,
         endedAt: now,
       });
+      // Signal to the client that the text part is finalized so it can exit streaming state
+      this.broadcastPartUpdate(this.currentTextPart.id, {
+        type: 'text-end',
+        id: this.currentTextPart.id,
+      });
       this.currentTextPart = null;
     }
     if (this.currentReasoningPart && this.currentReasoningPart.text) {
@@ -398,6 +408,11 @@ export class StreamAccumulator {
         id: this.currentReasoningPart.id,
         startedAt: this.currentReasoningPart.startedAt,
         endedAt: now,
+      });
+      // Signal to the client that the reasoning part is finalized so it can exit streaming state
+      this.broadcastPartUpdate(this.currentReasoningPart.id, {
+        type: 'reasoning-end',
+        id: this.currentReasoningPart.id,
       });
       this.currentReasoningPart = null;
     }


### PR DESCRIPTION
## 🚀 Change Summary

A set of targeted improvements to the core LLM stream runner, informed by a comparison with the SST/OpenCode stream architecture. These changes address a latent `setTimeout` overflow bug, fix incomplete UI state after stream aborts, eliminate unnecessary microtask overhead on the hot path, and plug a gap where doom loop recovery could re-trigger the same stuck behaviour.

### 🛠 Improvements & Refactors

- **Synchronous accumulator hot path**: Removed `async` from `handlePart`, `handleTextualStart`, `handleTextualDelta`, and `handleTextualEnd` in `StreamAccumulator` — none of these methods awaited anything, meaning every text-delta token (thousands per response) was creating an unnecessary microtask
- **Typed `handlePart` parameter**: Replaced `part: any` with `TextStreamPart<ToolSet>` from the AI SDK, giving full type coverage over the stream dispatch switch. Also added handling for the `tool-output-denied` and `tool-approval-request` cases the SDK now emits
- **Consolidate user-text helpers in runner**: Removed the duplicate `getLastUserPromptPreview()` and unified it into `getLastUserText(maxLength?: number)`

### 🐛 Bug Fixes

- **`flush()` now emits end signals**: When `flush()` is called on abort or error, it now broadcasts `stream-part-update` with `text-end`/`reasoning-end` for any buffered parts. Without this, aborted streams left parts stuck in `'streaming'` state indefinitely — syntax highlighting and math rendering in the UI never triggered
- **Cap retry delays to max safe `setTimeout` value**: Added `RETRY_MAX_DELAY = 2_147_483_647` (max 32-bit signed int) and wrapped all header-based retry delay paths with a `cap()` helper. A provider returning a multi-day `Retry-After` header previously caused `setTimeout` overflow, which wraps to ~1ms and produces an uncontrolled rapid-retry storm (identical to SST/OpenCode issue #6430)
- **Strip tools from doom loop summary step**: The LLM call triggered after doom loop detection now passes `tools: {}`. Previously it inherited the full toolset, which could cause the model to re-trigger the exact stuck behaviour the summary was meant to escape
