### PR TITLE
feat(website): posthog proxy + managed services waitlist

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -39,4 +39,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy apps/website/dist --project-name=stitch --branch=master
+          workingDirectory: apps/website
+          command: pages deploy dist --project-name=stitch --branch=master

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Build website
         run: bun run --cwd apps/website build
+        env:
+          VITE_POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/apps/website/functions/ingest/[[path]].ts
+++ b/apps/website/functions/ingest/[[path]].ts
@@ -1,0 +1,38 @@
+export const onRequest: PagesFunction = async (context) => {
+	const url = new URL(context.request.url);
+	const pathname = url.pathname.replace(/^\/ingest/, '');
+	const search = url.search;
+	const pathWithParams = pathname + search;
+
+	if (pathname.startsWith('/static/') || pathname.startsWith('/array/')) {
+		return retrieveAsset(pathWithParams);
+	}
+
+	return forwardRequest(context.request, pathWithParams);
+};
+
+const API_HOST = 'us.i.posthog.com';
+const ASSET_HOST = 'us-assets.i.posthog.com';
+
+async function retrieveAsset(pathname: string): Promise<Response> {
+	return fetch(`https://${ASSET_HOST}${pathname}`);
+}
+
+async function forwardRequest(request: Request, pathWithSearch: string): Promise<Response> {
+	const ip = request.headers.get('CF-Connecting-IP') || '';
+	const originHeaders = new Headers(request.headers);
+	originHeaders.delete('cookie');
+	originHeaders.set('X-Forwarded-For', ip);
+
+	const originRequest = new Request(`https://${API_HOST}${pathWithSearch}`, {
+		method: request.method,
+		headers: originHeaders,
+		body:
+			request.method !== 'GET' && request.method !== 'HEAD'
+				? await request.arrayBuffer()
+				: null,
+		redirect: request.redirect,
+	});
+
+	return await fetch(originRequest);
+}

--- a/apps/website/functions/tsconfig.json
+++ b/apps/website/functions/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["@cloudflare/workers-types"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"]
+}

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -29,6 +29,59 @@
     <script type="module" src="/src/main.ts"></script>
   </head>
   <body>
+    <!-- Announcement Banner -->
+    <div class="announcement-banner" id="announcement-banner">
+      <div class="container">
+        <button class="announcement-banner-btn" id="open-waitlist-dialog">
+          Managed services coming soon — get notified &rarr;
+        </button>
+      </div>
+    </div>
+
+    <!-- Waitlist Dialog -->
+    <dialog class="waitlist-dialog" id="waitlist-dialog">
+      <div class="dialog-content">
+        <div class="dialog-header">
+          <h2>Get notified about managed services</h2>
+          <button class="dialog-close" id="close-waitlist-dialog" aria-label="Close">
+            &times;
+          </button>
+        </div>
+        <p class="dialog-desc">
+          We're building managed services so you don't have to bring your own API keys or run
+          anything locally. Enter your email and select what interests you.
+        </p>
+        <form id="waitlist-form">
+          <div class="form-field">
+            <label for="waitlist-email">Email</label>
+            <input
+              type="email"
+              id="waitlist-email"
+              name="email"
+              required
+              placeholder="you@example.com"
+              autocomplete="email"
+            />
+          </div>
+          <fieldset class="form-field">
+            <legend>I'm interested in:</legend>
+            <label class="checkbox-label">
+              <input type="checkbox" name="interest-inference" value="inference" />
+              <span>Inference service — one key, access to multiple models</span>
+            </label>
+            <label class="checkbox-label">
+              <input type="checkbox" name="interest-remote" value="remote" />
+              <span>Full remote version — Stitch hosted in the cloud</span>
+            </label>
+          </fieldset>
+          <button type="submit" class="btn btn-primary dialog-submit">Notify me</button>
+        </form>
+        <p class="dialog-success" id="waitlist-success" hidden>
+          You're on the list. We'll be in touch.
+        </p>
+      </div>
+    </dialog>
+
     <!-- Nav -->
     <nav>
       <div class="container">

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -7,6 +7,9 @@
     "build": "vite build && bun run ../../scripts/build-website-registries.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit --project functions/tsconfig.json"
   },
+  "dependencies": {
+    "posthog-js": "^1.386.8"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260615.1",
     "typescript": "catalog:",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -4,9 +4,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && bun run ../../scripts/build-website-registries.mjs"
+    "build": "vite build && bun run ../../scripts/build-website-registries.mjs",
+    "typecheck": "tsc --noEmit && tsc --noEmit --project functions/tsconfig.json"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260615.1",
     "typescript": "catalog:",
     "vite": "^8.0.16"
   }

--- a/apps/website/src/main.ts
+++ b/apps/website/src/main.ts
@@ -1,22 +1,22 @@
 import './styles.css';
 
 // Close open dropdowns on outside click
-document.addEventListener('click', function (e) {
-  document.querySelectorAll('.btn-group[open]').forEach(function (d) {
-    if (!d.contains(e.target)) d.removeAttribute('open');
+document.addEventListener('click', (e: MouseEvent) => {
+  document.querySelectorAll('.btn-group[open]').forEach((d) => {
+    if (!d.contains(e.target as Node)) d.removeAttribute('open');
   });
 });
 
 // Theme toggle
-(function () {
-  var stored = localStorage.getItem('theme');
+(() => {
+  const stored = localStorage.getItem('theme');
   if (stored) {
     document.documentElement.setAttribute('data-theme', stored);
   }
 
-  document.getElementById('theme-toggle').addEventListener('click', function () {
-    var current = document.documentElement.getAttribute('data-theme');
-    var isLight;
+  document.getElementById('theme-toggle')!.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme');
+    let isLight: boolean;
 
     if (current) {
       isLight = current === 'light';
@@ -24,7 +24,7 @@ document.addEventListener('click', function (e) {
       isLight = window.matchMedia('(prefers-color-scheme: light)').matches;
     }
 
-    var next = isLight ? 'dark' : 'light';
+    const next = isLight ? 'dark' : 'light';
     document.documentElement.setAttribute('data-theme', next);
     localStorage.setItem('theme', next);
   });

--- a/apps/website/src/main.ts
+++ b/apps/website/src/main.ts
@@ -1,4 +1,19 @@
+import posthog from 'posthog-js';
+
 import './styles.css';
+
+// PostHog init
+const posthogKey = import.meta.env.VITE_POSTHOG_KEY;
+if (posthogKey) {
+  posthog.init(posthogKey, {
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com',
+    autocapture: false,
+    capture_pageview: false,
+    capture_pageleave: false,
+    disable_session_recording: true,
+  });
+}
 
 // Close open dropdowns on outside click
 document.addEventListener('click', (e: MouseEvent) => {
@@ -27,5 +42,46 @@ document.addEventListener('click', (e: MouseEvent) => {
     const next = isLight ? 'dark' : 'light';
     document.documentElement.setAttribute('data-theme', next);
     localStorage.setItem('theme', next);
+  });
+})();
+
+// Waitlist dialog
+(() => {
+  const dialog = document.getElementById('waitlist-dialog') as HTMLDialogElement;
+  const openBtn = document.getElementById('open-waitlist-dialog')!;
+  const closeBtn = document.getElementById('close-waitlist-dialog')!;
+  const form = document.getElementById('waitlist-form') as HTMLFormElement;
+  const successMsg = document.getElementById('waitlist-success')!;
+
+  openBtn.addEventListener('click', () => {
+    dialog.showModal();
+  });
+
+  closeBtn.addEventListener('click', () => {
+    dialog.close();
+  });
+
+  dialog.addEventListener('click', (e: MouseEvent) => {
+    if (e.target === dialog) dialog.close();
+  });
+
+  form.addEventListener('submit', (e: SubmitEvent) => {
+    e.preventDefault();
+
+    const email = (document.getElementById('waitlist-email') as HTMLInputElement).value;
+    const inference = (form.elements.namedItem('interest-inference') as HTMLInputElement).checked;
+    const remote = (form.elements.namedItem('interest-remote') as HTMLInputElement).checked;
+
+    if (posthogKey) {
+      posthog.identify(email);
+      posthog.capture('waitlist_signup', {
+        email,
+        interest_inference: inference,
+        interest_remote: remote,
+      });
+    }
+
+    form.hidden = true;
+    successMsg.hidden = false;
   });
 })();

--- a/apps/website/src/styles.css
+++ b/apps/website/src/styles.css
@@ -821,6 +821,164 @@ section + section {
   margin-bottom: 0;
 }
 
+/* ── Announcement Banner ── */
+.announcement-banner {
+  background: var(--color-bg-subtle);
+  border-bottom: 1px solid var(--color-border);
+  padding: 10px 0;
+  text-align: center;
+}
+
+.announcement-banner-btn {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0;
+  transition: color 0.15s;
+}
+
+.announcement-banner-btn:hover {
+  color: var(--color-text);
+}
+
+/* ── Waitlist Dialog ── */
+.waitlist-dialog {
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-text);
+  padding: 0;
+  max-width: 480px;
+  width: calc(100% - 48px);
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  margin: 0;
+}
+
+.waitlist-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+}
+
+.dialog-content {
+  padding: 36px 32px;
+}
+
+.dialog-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.dialog-header h2 {
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+}
+
+.dialog-close {
+  background: none;
+  border: none;
+  color: var(--color-text-faint);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+
+.dialog-close:hover {
+  color: var(--color-text);
+}
+
+.dialog-desc {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  line-height: 1.6;
+  margin-bottom: 24px;
+}
+
+#waitlist-form .form-field {
+  margin-bottom: 20px;
+}
+
+#waitlist-form label:not(.checkbox-label) {
+  display: block;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  margin-bottom: 6px;
+}
+
+#waitlist-form input[type='email'] {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-bg-subtle);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  font-family: inherit;
+  transition: border-color 0.15s;
+}
+
+#waitlist-form input[type='email']::placeholder {
+  color: var(--color-text-ghost);
+}
+
+#waitlist-form input[type='email']:focus {
+  outline: none;
+  border-color: var(--color-text-faint);
+}
+
+#waitlist-form fieldset {
+  border: none;
+  padding: 0;
+}
+
+#waitlist-form fieldset legend {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  margin-bottom: 10px;
+}
+
+.checkbox-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  padding: 6px 0;
+}
+
+.checkbox-label input[type='checkbox'] {
+  margin-top: 2px;
+  flex-shrink: 0;
+  accent-color: var(--color-text);
+}
+
+.dialog-submit {
+  width: 100%;
+  margin-top: 4px;
+  cursor: pointer;
+}
+
+.dialog-success {
+  font-size: 0.85rem;
+  color: var(--color-success);
+  text-align: center;
+  margin-top: 16px;
+}
+
 /* ── Footer ── */
 footer {
   text-align: center;

--- a/apps/website/src/vite-env.d.ts
+++ b/apps/website/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/apps/website/src/vite-env.d.ts
+++ b/apps/website/src/vite-env.d.ts
@@ -1,1 +1,11 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_POSTHOG_KEY: string | undefined;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 declare module '*.css';

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM"],
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -27,4 +27,13 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
   },
+  server: {
+    proxy: {
+      '/ingest': {
+        target: 'https://us.i.posthog.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/ingest/, ''),
+      },
+    },
+  },
 });

--- a/bun.lock
+++ b/bun.lock
@@ -84,6 +84,7 @@
     "apps/website": {
       "name": "@stitch/website",
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260615.1",
         "typescript": "catalog:",
         "vite": "^8.0.16",
       },
@@ -365,6 +366,8 @@
     "@base-ui/react": ["@base-ui/react@1.3.0", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@base-ui/utils": "0.2.6", "@floating-ui/react-dom": "^2.1.8", "@floating-ui/utils": "^0.2.11", "tabbable": "^6.4.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-FwpKqZbPz14AITp1CVgf4AjhKPe1OeeVKSBMdgD10zbFlj3QSWelmtCMLi2+/PFZZcIm3l87G7rwtCZJwHyXWA=="],
 
     "@base-ui/utils": ["@base-ui/utils@0.2.6", "", { "dependencies": { "@babel/runtime": "^7.28.6", "@floating-ui/utils": "^0.2.11", "reselect": "^5.1.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "@types/react": "^17 || ^18 || ^19", "react": "^17 || ^18 || ^19", "react-dom": "^17 || ^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-yQ+qeuqohwhsNpoYDqqXaLllYAkPCP4vYdDrVo8FQXaAPfHWm1pG/Vm+jmGTA5JFS0BAIjookyapuJFY8F9PIw=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260615.1", "", {}, "sha512-fGOiTwoLj/8bU8mj3VAfa1EULx4ceZhDwnjvY+afDBlSXI9pvY7PE9t62rGEhJjbAOGd7i5WUDun0eZCWBDrzg=="],
 
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -83,6 +83,9 @@
     },
     "apps/website": {
       "name": "@stitch/website",
+      "dependencies": {
+        "posthog-js": "^1.386.8",
+      },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260615.1",
         "typescript": "catalog:",
@@ -727,6 +730,10 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
+    "@posthog/core": ["@posthog/core@1.32.5", "", { "dependencies": { "@posthog/types": "^1.386.4" } }, "sha512-Vmr6LZms7QEP1ljfTRRBVtLkeEHMrTmLECt0FXPLwUIgPwxOgvBdAYwRMWyP13WuN/XQweo1tJ9J1DxHNAF3qg=="],
+
+    "@posthog/types": ["@posthog/types@1.386.4", "", {}, "sha512-UgE9+5+wkZg7yc2MpW5G32/6zYW8fAbXJkG8WGnrb4X8OKWzNa9cWeNCd82vKok+TSoRpM4qiYQFtBSpJS1dsw=="],
+
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
     "@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
@@ -1059,6 +1066,8 @@
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -1273,6 +1282,8 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
     "core-util-is": ["core-util-is@1.0.2", "", {}, "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="],
 
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
@@ -1342,6 +1353,8 @@
     "dmg-builder": ["dmg-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "fs-extra": "^10.1.0", "iconv-lite": "^0.6.2", "js-yaml": "^4.1.0" }, "optionalDependencies": { "dmg-license": "^1.0.11" } }, "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg=="],
 
     "dmg-license": ["dmg-license@1.0.11", "", { "dependencies": { "@types/plist": "^3.0.1", "@types/verror": "^1.10.3", "ajv": "^6.10.0", "crc": "^3.8.0", "iconv-corefoundation": "^1.1.7", "plist": "^3.0.4", "smart-buffer": "^4.0.2", "verror": "^1.10.0" }, "os": "darwin", "bin": { "dmg-license": "bin/dmg-license.js" } }, "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q=="],
+
+    "dompurify": ["dompurify@3.4.10", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w=="],
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
@@ -1460,6 +1473,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "fflate": ["fflate@0.4.8", "", {}, "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
@@ -2025,9 +2040,13 @@
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
+    "posthog-js": ["posthog-js@1.386.8", "", { "dependencies": { "@posthog/core": "^1.32.4", "@posthog/types": "^1.386.4", "core-js": "^3.38.1", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.28.2", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.1.0" } }, "sha512-L4cJD1sleUULE7K4mZQI5wpS24NHGtNmFw1rPHruc579unVzHuooHiVDEHp/qyNnhNxtNE6alBTiVORbYnRTSw=="],
+
     "postject": ["postject@1.0.0-alpha.6", "", { "dependencies": { "commander": "^9.4.0" }, "bin": { "postject": "dist/cli.js" } }, "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A=="],
 
     "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
+
+    "preact": ["preact@10.29.2", "", {}, "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
@@ -2056,6 +2075,8 @@
     "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
 
     "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "query-selector-shadow-dom": ["query-selector-shadow-dom@1.0.1", "", {}, "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
@@ -2402,6 +2423,8 @@
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "web-vitals": ["web-vitals@5.3.0", "", {}, "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -12,6 +12,11 @@ const config: KnipConfig = {
       project: ['src/**/*.{ts,tsx}'],
       ignore: ['src/components/ui/**'],
     },
+    'apps/website': {
+      entry: ['src/main.ts', 'functions/**/*.ts'],
+      project: ['src/**/*.ts', 'functions/**/*.ts'],
+      ignore: ['functions/**/*.ts'],
+    },
     'apps/desktop': {
       entry: ['src/main/index.ts', 'src/preload/index.ts'],
       project: ['src/**/*.{ts,tsx}'],


### PR DESCRIPTION
## Change Summary

Adds a PostHog event proxy and a managed services waitlist to the marketing website.

### New Features
- **PostHog proxy via Cloudflare Pages Function**: Proxies analytics requests through `/ingest` to avoid ad-blockers, deployed automatically with the site
- **Managed services waitlist banner + dialog**: A banner at the top of the site opens a modal where users can enter their email and indicate interest in an inference service (one key, multiple models) or a full remote version of Stitch
- **PostHog waitlist_signup event**: Fires on form submission with email as distinct ID and interest selections as properties; all auto-tracking disabled

### Improvements & Refactors
- Deploy workflow now runs wrangler from `apps/website` so Pages Functions are included in the deploy
- Vite dev server proxies `/ingest` to PostHog for local testing
- `VITE_POSTHOG_KEY` injected at build time via the `POSTHOG_KEY` GitHub secret
