### PR TITLE
fix(ci): set packageManager to bun in wrangler action

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -42,4 +42,5 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/website
+          packageManager: bun
           command: pages deploy dist --project-name=stitch --branch=master


### PR DESCRIPTION
The \workingDirectory: apps/website\ setting causes wrangler-action to look for a lockfile in the subdirectory instead of the repo root. Since there's no \un.lock\ there, it falls back to npm which fails on \workspace:*\ protocol. Explicitly setting \packageManager: bun\ fixes this.