### PR TITLE
fix: update STT registry limits and pricing

### DIFF
--- a/registries/stt/models/assemblyai.json
+++ b/registries/stt/models/assemblyai.json
@@ -31,11 +31,12 @@
       "reconnect": {
         "enabled": true,
         "maxRetries": 5,
-        "backoffMs": 500
+        "backoffMs": 500,
+        "rotateBeforeMs": 10740000
       },
       "pricing": {
         "type": "duration",
-        "perMinuteUsd": 0.011
+        "perMinuteUsd": 0.0075
       }
     }
   ]

--- a/registries/stt/models/elevenlabs.json
+++ b/registries/stt/models/elevenlabs.json
@@ -35,7 +35,7 @@
       },
       "pricing": {
         "type": "duration",
-        "perMinuteUsd": 0.007
+        "perMinuteUsd": 0.0065
       }
     }
   ]

--- a/registries/stt/models/openai.json
+++ b/registries/stt/models/openai.json
@@ -32,14 +32,11 @@
         "enabled": true,
         "maxRetries": 5,
         "backoffMs": 500,
-        "rotateBeforeMs": 1740000
+        "rotateBeforeMs": 3540000
       },
       "pricing": {
-        "type": "token",
-        "perMillionTokens": {
-          "audioInput": 40,
-          "textOutput": 10
-        }
+        "type": "duration",
+        "perMinuteUsd": 0.017
       }
     }
   ]


### PR DESCRIPTION
## Change Summary

Updates the STT model registry to match current provider documentation for realtime session limits and pricing.

### Improvements & Refactors
- Adjust OpenAI realtime rotation to occur before the documented 60-minute session limit and switch `gpt-realtime-whisper` pricing to duration-based billing.
- Add AssemblyAI proactive rotation before the documented 3-hour streaming session cap and update Universal-3 Pro Streaming base pricing.
- Update ElevenLabs Scribe v2 Realtime pricing to the documented hourly rate converted to per-minute registry units.
