### PR TITLE
Fix provider layout and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Think of it as an AI pair programmer for your entire operating system: it can re
 - **AI Chat** — Full conversational interface with an LLM that has tool-use capabilities across your local machine
 - **Tool System** — The AI can read/write files, run bash, search code/glob/grep, browse the web, ask you questions, and delegate subtasks to child sessions
 - **Automations** — Turn any chat into a recurring workflow (daily summaries, cleanup tasks, scheduled reports)
-- **Meeting Analysis** — Records audio from Zoom, Meet, Teams, Slack, or Discord, transcribes it, and generates summaries with action items
+- **Agenda Management** — Built-in planning for todos, priorities, due dates, and daily schedules that Stitch can update from chats or meetings
+- **Meeting Recordings** — Granola-style local meeting capture from Zoom, Meet, Teams, Slack, or Discord, with transcription, summaries, and action items
 - **Memory System** — Semantic memory using LanceDB vector storage so the AI remembers your preferences, workflows, and key facts across conversations
 - **Connectors** — Integrate with external services (Google: Gmail, Drive, Calendar) via a pluggable connector framework
 - **MCP Support** — Model Context Protocol integration for additional tool ecosystems

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
 
 Think of it as an AI pair programmer for your entire operating system: it can read and write files, run shell commands, search code, browse the web, manage your calendar and email, record and summarize meetings, and execute recurring automations — all through a natural language chat interface.
 
-## Status
-
-Stitch is in **alpha**. Things will break, behavior will change quickly, and APIs are not stable yet. We do our best to keep things usable and improve reliability each release.
-
 ## Features
 
 - **AI Chat** — Full conversational interface with an LLM that has tool-use capabilities across your local machine
@@ -50,17 +46,17 @@ stitch/
 
 ## Tech Stack
 
-| Layer | Technology |
-|-------|-----------|
-| Desktop Shell | Electron |
-| Frontend | React 19, TanStack Router, TanStack Query |
-| Backend | Hono (TypeScript), Bun runtime |
-| Database | SQLite via Drizzle ORM |
-| Vector Store | LanceDB |
-| AI SDK | Vercel AI SDK (OpenAI, Anthropic, Google, AWS Bedrock, OpenRouter) |
-| Audio Capture | Rust (cpal, WASAPI, CoreAudio) |
-| Monorepo | Bun workspaces, Turborepo |
-| Linting/Formatting | Oxlint, Oxfmt |
+| Layer              | Technology                                                         |
+| ------------------ | ------------------------------------------------------------------ |
+| Desktop Shell      | Electron                                                           |
+| Frontend           | React 19, TanStack Router, TanStack Query                          |
+| Backend            | Hono (TypeScript), Bun runtime                                     |
+| Database           | SQLite via Drizzle ORM                                             |
+| Vector Store       | LanceDB                                                            |
+| AI SDK             | Vercel AI SDK (OpenAI, Anthropic, Google, AWS Bedrock, OpenRouter) |
+| Audio Capture      | Rust (cpal, WASAPI, CoreAudio)                                     |
+| Monorepo           | Bun workspaces, Turborepo                                          |
+| Linting/Formatting | Oxlint, Oxfmt                                                      |
 
 ## Development
 
@@ -74,16 +70,16 @@ bun run audio-native:build  # Build native Rust audio binaries
 
 ## Packages
 
-| Package | Description |
-|---------|-------------|
-| `@stitch/desktop` | Electron desktop shell |
-| `@stitch/web` | React/TanStack web UI |
-| `@stitch/server` | Local backend service and AI orchestration |
-| `@stitch/shared` | Shared types and cross-package contracts |
-| `@stitch/scheduler` | Scheduling utilities and job-related logic |
-| `@stitch/audio-capture` | Native audio recording wrapper |
-| `@stitch-connectors/sdk` | Connector framework |
-| `@stitch-connectors/google` | Google connector implementation |
+| Package                     | Description                                |
+| --------------------------- | ------------------------------------------ |
+| `@stitch/desktop`           | Electron desktop shell                     |
+| `@stitch/web`               | React/TanStack web UI                      |
+| `@stitch/server`            | Local backend service and AI orchestration |
+| `@stitch/shared`            | Shared types and cross-package contracts   |
+| `@stitch/scheduler`         | Scheduling utilities and job-related logic |
+| `@stitch/audio-capture`     | Native audio recording wrapper             |
+| `@stitch-connectors/sdk`    | Connector framework                        |
+| `@stitch-connectors/google` | Google connector implementation            |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ stitch/
 │   ├── server/         # Hono-based local backend — LLM orchestration, tool execution, DB
 │   ├── shared/         # Zod schemas, TypeScript interfaces, constants
 │   ├── scheduler/      # Cron-like scheduling for automations
+│   ├── sandbox/        # Process-isolated TypeScript execution for Code Mode
 │   └── audio-capture/  # TypeScript wrapper around native Rust audio recording
 ├── native/             # Rust workspace (audio capture, meeting detection)
 │   └── crates/
@@ -77,6 +78,7 @@ bun run audio-native:build  # Build native Rust audio binaries
 | `@stitch/server`            | Local backend service and AI orchestration |
 | `@stitch/shared`            | Shared types and cross-package contracts   |
 | `@stitch/scheduler`         | Scheduling utilities and job-related logic |
+| `@stitch/sandbox`           | Process-isolated Code Mode runtime         |
 | `@stitch/audio-capture`     | Native audio recording wrapper             |
 | `@stitch-connectors/sdk`    | Connector framework                        |
 | `@stitch-connectors/google` | Google connector implementation            |

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -479,8 +479,8 @@
         <p class="section-label" style="margin-top: 48px; margin-bottom: 24px">
           Free LLM providers
         </p>
-        <div class="install-grid">
-          <div class="install-card">
+        <div class="install-grid provider-grid">
+          <div class="install-card provider-card-wide">
             <div class="install-header">
               <h3>Gemini AI Studio</h3>
             </div>
@@ -574,7 +574,7 @@
         <p class="section-label" style="margin-top: 48px; margin-bottom: 24px">
           Free Speech-to-Text provider
         </p>
-        <div class="install-grid" style="grid-template-columns: 1fr">
+        <div class="install-grid install-grid-single">
           <div class="install-card">
             <div class="install-header">
               <h3>ElevenLabs</h3>

--- a/apps/website/src/styles.css
+++ b/apps/website/src/styles.css
@@ -1006,6 +1006,25 @@ footer a:hover {
   border: 1px solid var(--color-border);
 }
 
+.provider-grid {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.provider-card-wide {
+  grid-column: 1 / -1;
+}
+
+.install-grid-single {
+  grid-template-columns: 1fr;
+  justify-content: center;
+  background: none;
+  border: 0;
+}
+
+.install-grid-single .install-card {
+  border: 1px solid var(--color-border);
+}
+
 .install-card {
   background: var(--color-bg);
   padding: 36px 32px;


### PR DESCRIPTION
## 🚀 Change Summary

Updates the website free-provider layout so the Gemini card spans the top row while OpenRouter and NVIDIA share the second row, and cleans up README project documentation.

### 🛠 Improvements & Refactors
- Adjusted the free API provider cards to avoid empty grey grid cells on wide screens.
- Kept the Speech-to-Text provider card full-width without inline grid styling.

### 📚 Documentation
- Removed the README status section.
- Added `@stitch/sandbox` to the architecture tree and packages table.
- Updated the feature overview with agenda management and meeting recordings.
