### PR TITLE
improvement: split system prompt into cache-optimized layers

### DIFF
--- a/packages/server/src/llm/cache-control.test.ts
+++ b/packages/server/src/llm/cache-control.test.ts
@@ -2,10 +2,11 @@ import { describe, test, expect } from 'bun:test';
 
 import {
   addCacheControlToMessages,
+  addCacheControlToTools,
   getCacheConfig,
   getProviderOptions,
 } from '@/llm/cache-control.js';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage, Tool } from 'ai';
 
 describe('getCacheConfig', () => {
   test('returns anthropic config for anthropic provider', () => {
@@ -14,6 +15,7 @@ describe('getCacheConfig', () => {
       namespace: 'anthropic',
       key: 'cacheControl',
       value: { type: 'ephemeral' },
+      breakpointCap: 4,
     });
   });
 
@@ -23,6 +25,7 @@ describe('getCacheConfig', () => {
       namespace: 'bedrock',
       key: 'cachePoint',
       value: { type: 'default' },
+      breakpointCap: 4,
     });
   });
 
@@ -32,6 +35,7 @@ describe('getCacheConfig', () => {
       namespace: 'openrouter',
       key: 'cacheControl',
       value: { type: 'ephemeral' },
+      breakpointCap: 4,
     });
   });
 
@@ -41,6 +45,7 @@ describe('getCacheConfig', () => {
       namespace: 'anthropic',
       key: 'cacheControl',
       value: { type: 'ephemeral' },
+      breakpointCap: 4,
     });
   });
 
@@ -50,6 +55,7 @@ describe('getCacheConfig', () => {
       namespace: 'anthropic',
       key: 'cacheControl',
       value: { type: 'ephemeral' },
+      breakpointCap: 4,
     });
   });
 
@@ -84,39 +90,14 @@ describe('addCacheControlToMessages', () => {
     expect(result).toEqual(messages);
   });
 
-  test('marks first system message and last 2 non-system messages', () => {
+  test('marks first system, second system, and latest user message', () => {
     const messages: ModelMessage[] = [
-      { role: 'system', content: 'You are a helpful assistant.' },
+      { role: 'system', content: 'Static base prompt' },
+      { role: 'system', content: 'Semi-static env and catalogs' },
+      { role: 'system', content: 'Dynamic memory and todos' },
       { role: 'user', content: 'First message' },
       { role: 'assistant', content: 'Response' },
       { role: 'user', content: 'Second message' },
-    ];
-
-    const result = addCacheControlToMessages(messages, 'anthropic', 'claude-sonnet-4-5');
-
-    // System message (index 0) is marked
-    expect(result[0].providerOptions).toEqual({
-      anthropic: { cacheControl: { type: 'ephemeral' } },
-    });
-    // Index 1 is not in the last 2 non-system messages
-    expect(result[1].providerOptions).toBeUndefined();
-    // Index 2 is second-to-last non-system message — marked
-    expect(result[2].providerOptions).toEqual({
-      anthropic: { cacheControl: { type: 'ephemeral' } },
-    });
-    // Index 3 is last non-system message — marked
-    expect(result[3].providerOptions).toEqual({
-      anthropic: { cacheControl: { type: 'ephemeral' } },
-    });
-  });
-
-  test('marks both system messages when two are present', () => {
-    const messages: ModelMessage[] = [
-      { role: 'system', content: 'Base system prompt' },
-      { role: 'system', content: 'Agent system prompt' },
-      { role: 'user', content: 'Hello' },
-      { role: 'assistant', content: 'Hi' },
-      { role: 'user', content: 'Help me' },
     ];
 
     const result = addCacheControlToMessages(messages, 'anthropic', 'claude-sonnet-4-5');
@@ -127,18 +108,35 @@ describe('addCacheControlToMessages', () => {
     expect(result[1].providerOptions).toEqual({
       anthropic: { cacheControl: { type: 'ephemeral' } },
     });
-    // Index 2 is not in the last 2 non-system messages
     expect(result[2].providerOptions).toBeUndefined();
-    // Last 2 non-system messages
-    expect(result[3].providerOptions).toEqual({
-      anthropic: { cacheControl: { type: 'ephemeral' } },
-    });
-    expect(result[4].providerOptions).toEqual({
+    expect(result[3].providerOptions).toBeUndefined();
+    expect(result[4].providerOptions).toBeUndefined();
+    expect(result[5].providerOptions).toEqual({
       anthropic: { cacheControl: { type: 'ephemeral' } },
     });
   });
 
-  test('adds bedrock cachePoint to system and last 2 messages', () => {
+  test('marks only first system and latest user when one system message', () => {
+    const messages: ModelMessage[] = [
+      { role: 'system', content: 'System prompt' },
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi' },
+      { role: 'user', content: 'Help me' },
+    ];
+
+    const result = addCacheControlToMessages(messages, 'anthropic', 'claude-sonnet-4-5');
+
+    expect(result[0].providerOptions).toEqual({
+      anthropic: { cacheControl: { type: 'ephemeral' } },
+    });
+    expect(result[1].providerOptions).toBeUndefined();
+    expect(result[2].providerOptions).toBeUndefined();
+    expect(result[3].providerOptions).toEqual({
+      anthropic: { cacheControl: { type: 'ephemeral' } },
+    });
+  });
+
+  test('adds bedrock cachePoint to system and latest user', () => {
     const messages: ModelMessage[] = [
       { role: 'system', content: 'You are a helpful assistant.' },
       { role: 'user', content: 'Hello' },
@@ -157,12 +155,10 @@ describe('addCacheControlToMessages', () => {
     expect(result[1].providerOptions).toEqual({
       bedrock: { cachePoint: { type: 'default' } },
     });
-    expect(result[2].providerOptions).toEqual({
-      bedrock: { cachePoint: { type: 'default' } },
-    });
+    expect(result[2].providerOptions).toBeUndefined();
   });
 
-  test('adds openrouter cacheControl to system and last 2 messages', () => {
+  test('adds openrouter cacheControl to system and latest user', () => {
     const messages: ModelMessage[] = [
       { role: 'system', content: 'System prompt' },
       { role: 'user', content: 'Hello' },
@@ -175,11 +171,8 @@ describe('addCacheControlToMessages', () => {
     expect(result[0].providerOptions).toEqual({
       openrouter: { cacheControl: { type: 'ephemeral' } },
     });
-    // Index 1 is not in the last 2 non-system
     expect(result[1].providerOptions).toBeUndefined();
-    expect(result[2].providerOptions).toEqual({
-      openrouter: { cacheControl: { type: 'ephemeral' } },
-    });
+    expect(result[2].providerOptions).toBeUndefined();
     expect(result[3].providerOptions).toEqual({
       openrouter: { cacheControl: { type: 'ephemeral' } },
     });
@@ -190,13 +183,13 @@ describe('addCacheControlToMessages', () => {
 
     const result = addCacheControlToMessages(messages, 'anthropic', 'claude-sonnet-4-5');
 
-    // System message gets marked (no non-system messages to mark)
+    // System message gets marked (no user messages to mark)
     expect(result[0].providerOptions).toEqual({
       anthropic: { cacheControl: { type: 'ephemeral' } },
     });
   });
 
-  test('deduplicates when system and tail overlap in short conversation', () => {
+  test('marks both system and user in minimal conversation', () => {
     const messages: ModelMessage[] = [
       { role: 'system', content: 'System prompt' },
       { role: 'user', content: 'Hello' },
@@ -204,7 +197,6 @@ describe('addCacheControlToMessages', () => {
 
     const result = addCacheControlToMessages(messages, 'anthropic', 'claude-sonnet-4-5');
 
-    // Both messages are marked, each only once
     expect(result[0].providerOptions).toEqual({
       anthropic: { cacheControl: { type: 'ephemeral' } },
     });
@@ -249,7 +241,7 @@ describe('addCacheControlToMessages', () => {
     expect(messages[1].providerOptions).toBeUndefined();
   });
 
-  test('marks only tail messages when no system messages exist', () => {
+  test('marks latest user message when no system messages exist', () => {
     const messages: ModelMessage[] = [
       { role: 'user', content: 'Hello' },
       { role: 'assistant', content: 'Hi' },
@@ -258,17 +250,14 @@ describe('addCacheControlToMessages', () => {
 
     const result = addCacheControlToMessages(messages, 'anthropic', 'claude-sonnet-4-5');
 
-    // No system messages; last 2 non-system messages are marked
     expect(result[0].providerOptions).toBeUndefined();
-    expect(result[1].providerOptions).toEqual({
-      anthropic: { cacheControl: { type: 'ephemeral' } },
-    });
+    expect(result[1].providerOptions).toBeUndefined();
     expect(result[2].providerOptions).toEqual({
       anthropic: { cacheControl: { type: 'ephemeral' } },
     });
   });
 
-  test('limits to at most 2 system messages even when more exist', () => {
+  test('respects budget cap of 3 message breakpoints with many system messages', () => {
     const messages: ModelMessage[] = [
       { role: 'system', content: 'System 1' },
       { role: 'system', content: 'System 2' },
@@ -284,9 +273,7 @@ describe('addCacheControlToMessages', () => {
     expect(result[1].providerOptions).toEqual({
       anthropic: { cacheControl: { type: 'ephemeral' } },
     });
-    // Third system message is NOT marked
     expect(result[2].providerOptions).toBeUndefined();
-    // Last non-system message is marked
     expect(result[3].providerOptions).toEqual({
       anthropic: { cacheControl: { type: 'ephemeral' } },
     });
@@ -310,9 +297,7 @@ describe('addCacheControlToMessages', () => {
       anthropic: { cacheControl: { type: 'ephemeral' } },
     });
     expect(result[1].providerOptions).toBeUndefined();
-    expect(result[2].providerOptions).toEqual({
-      anthropic: { cacheControl: { type: 'ephemeral' } },
-    });
+    expect(result[2].providerOptions).toBeUndefined();
     expect(result[3].providerOptions).toEqual({
       anthropic: { cacheControl: { type: 'ephemeral' } },
     });
@@ -328,6 +313,54 @@ describe('addCacheControlToMessages', () => {
 
     expect(result[0].providerOptions).toBeUndefined();
     expect(result[1].providerOptions).toBeUndefined();
+  });
+});
+
+describe('addCacheControlToTools', () => {
+  test('returns tools unchanged for implicit caching providers', () => {
+    const tools = { bash: { description: 'Run a command' } } as unknown as Record<string, Tool>;
+    const result = addCacheControlToTools(tools, 'openai', 'gpt-4o');
+    expect(result).toBe(tools);
+  });
+
+  test('returns empty tools unchanged', () => {
+    const tools: Record<string, Tool> = {};
+    const result = addCacheControlToTools(tools, 'anthropic', 'claude-sonnet-4-5');
+    expect(result).toBe(tools);
+  });
+
+  test('marks the last tool with anthropic cache control', () => {
+    const tools = {
+      bash: { description: 'Run a command' },
+      read: { description: 'Read a file' },
+      write: { description: 'Write a file' },
+    } as unknown as Record<string, Tool>;
+
+    const result = addCacheControlToTools(tools, 'anthropic', 'claude-sonnet-4-5');
+
+    expect((result.bash as { providerOptions?: unknown }).providerOptions).toBeUndefined();
+    expect((result.read as { providerOptions?: unknown }).providerOptions).toBeUndefined();
+    expect((result.write as { providerOptions?: unknown }).providerOptions).toEqual({
+      anthropic: { cacheControl: { type: 'ephemeral' } },
+    });
+  });
+
+  test('marks the last tool with bedrock cache point', () => {
+    const tools = {
+      bash: { description: 'Run a command' },
+      read: { description: 'Read a file' },
+    } as unknown as Record<string, Tool>;
+
+    const result = addCacheControlToTools(
+      tools,
+      'amazon-bedrock',
+      'anthropic.claude-3-7-sonnet-20250219-v1:0',
+    );
+
+    expect((result.bash as { providerOptions?: unknown }).providerOptions).toBeUndefined();
+    expect((result.read as { providerOptions?: unknown }).providerOptions).toEqual({
+      bedrock: { cachePoint: { type: 'default' } },
+    });
   });
 });
 

--- a/packages/server/src/llm/cache-control.ts
+++ b/packages/server/src/llm/cache-control.ts
@@ -1,29 +1,33 @@
 import type { ProviderId } from '@stitch/shared/providers/types';
 
-import type { ModelMessage, JSONValue } from 'ai';
+import type { ModelMessage, JSONValue, Tool } from 'ai';
 
 type ProviderCacheConfig = {
   namespace: string;
   key: string;
   value: JSONValue;
+  breakpointCap: number;
 };
 
 const ANTHROPIC_CACHE: ProviderCacheConfig = {
   namespace: 'anthropic',
   key: 'cacheControl',
   value: { type: 'ephemeral' },
+  breakpointCap: 4,
 };
 
 const BEDROCK_CACHE: ProviderCacheConfig = {
   namespace: 'bedrock',
   key: 'cachePoint',
   value: { type: 'default' },
+  breakpointCap: 4,
 };
 
 const OPENROUTER_CACHE: ProviderCacheConfig = {
   namespace: 'openrouter',
   key: 'cacheControl',
   value: { type: 'ephemeral' },
+  breakpointCap: 4,
 };
 
 export function getCacheConfig(
@@ -80,12 +84,9 @@ function withCacheMarker(message: ModelMessage, config: ProviderCacheConfig): Mo
 /**
  * Adds provider-specific prompt caching markers to messages.
  *
- * For providers with explicit caching (Anthropic, Bedrock, OpenRouter),
- * this marks the first two system messages and the last two non-system
- * messages with cache control directives. System prompts are large and
- * static, making them ideal for caching. The last two messages are marked
- * to give the provider more flexibility to cache the longest matching
- * conversation prefix (per Anthropic's recommended pattern).
+ * Marks the first two system messages and the latest user message with
+ * cache control directives, reserving one breakpoint for tools (applied
+ * separately via `addCacheControlToTools`).
  *
  * For providers with implicit caching (OpenAI, Google, Vercel),
  * messages are returned unchanged.
@@ -100,24 +101,49 @@ export function addCacheControlToMessages(
   const config = getCacheConfig(providerId, modelId);
   if (!config) return messages;
 
-  // Collect up to 2 system messages and up to 2 trailing non-system messages
-  const systemIndices: number[] = [];
-  for (let i = 0; i < messages.length && systemIndices.length < 2; i++) {
-    if (messages[i].role === 'system') {
-      systemIndices.push(i);
+  // Budget: reserve 1 slot for tools, use remaining for messages
+  let remaining = config.breakpointCap - 1;
+
+  const toMark = new Set<number>();
+
+  // First system message
+  if (remaining > 0) {
+    for (let i = 0; i < messages.length; i++) {
+      if (messages[i].role === 'system') {
+        toMark.add(i);
+        remaining--;
+        break;
+      }
     }
   }
 
-  const tailIndices: number[] = [];
-  for (let i = messages.length - 1; i >= 0 && tailIndices.length < 2; i--) {
-    if (messages[i].role !== 'system') {
-      tailIndices.push(i);
+  // Second system message
+  if (remaining > 0) {
+    let systemCount = 0;
+    for (let i = 0; i < messages.length; i++) {
+      if (messages[i].role === 'system') {
+        systemCount++;
+        if (systemCount === 2) {
+          toMark.add(i);
+          remaining--;
+          break;
+        }
+      }
     }
   }
 
-  // Deduplicate indices (a system message could overlap with a tail message
-  // in very short conversations)
-  const toMark = new Set([...systemIndices, ...tailIndices]);
+  // Latest user message
+  if (remaining > 0) {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === 'user') {
+        toMark.add(i);
+        remaining--;
+        break;
+      }
+    }
+  }
+
+  if (toMark.size === 0) return messages;
 
   const result = [...messages];
   for (const index of toMark) {
@@ -125,6 +151,37 @@ export function addCacheControlToMessages(
   }
 
   return result;
+}
+
+/**
+ * Marks the last tool definition with a cache control breakpoint.
+ * For providers with implicit caching, tools are returned unchanged.
+ */
+export function addCacheControlToTools(
+  tools: Record<string, Tool>,
+  providerId: ProviderId,
+  modelId: string,
+): Record<string, Tool> {
+  const config = getCacheConfig(providerId, modelId);
+  if (!config) return tools;
+
+  const entries = Object.entries(tools);
+  if (entries.length === 0) return tools;
+
+  const [lastKey, lastTool] = entries[entries.length - 1];
+
+  const markedTool = {
+    ...lastTool,
+    providerOptions: {
+      ...(lastTool as { providerOptions?: Record<string, Record<string, JSONValue>> })
+        .providerOptions,
+      [config.namespace]: {
+        [config.key]: config.value,
+      },
+    },
+  } as Tool;
+
+  return { ...tools, [lastKey]: markedTool };
 }
 
 /**

--- a/packages/server/src/llm/compaction.test.ts
+++ b/packages/server/src/llm/compaction.test.ts
@@ -189,13 +189,18 @@ describe('buildHistoryMessages', () => {
       },
     );
 
-    expect(result).toHaveLength(3);
+    // 2 system messages (static + semi-static) + assistant + tool
+    const systemMessages = result.filter((m) => m.role === 'system');
+    expect(systemMessages.length).toBeGreaterThanOrEqual(2);
     expect(result[0]).toMatchObject({ role: 'system' });
-    expect(result[1]).toMatchObject({
+
+    const nonSystem = result.filter((m) => m.role !== 'system');
+    expect(nonSystem).toHaveLength(2);
+    expect(nonSystem[0]).toMatchObject({
       role: 'assistant',
       content: [{ type: 'tool-call', toolCallId: 'tc_1' }],
     });
-    expect(result[2]).toMatchObject({
+    expect(nonSystem[1]).toMatchObject({
       role: 'tool',
       content: [{ type: 'tool-result', toolCallId: 'tc_1' }],
     });
@@ -221,7 +226,9 @@ describe('buildHistoryMessages', () => {
       },
     );
 
-    expect(result).toHaveLength(1);
+    // Unmatched tool-call is dropped
+    const nonSystem = result.filter((m) => m.role !== 'system');
+    expect(nonSystem).toHaveLength(0);
     expect(result[0]).toMatchObject({ role: 'system' });
   });
 
@@ -245,9 +252,9 @@ describe('buildHistoryMessages', () => {
       },
     );
 
-    expect(result).toHaveLength(2);
-    expect(result[0]).toMatchObject({ role: 'system' });
-    expect(result[1]).toMatchObject({
+    const nonSystem = result.filter((m) => m.role !== 'system');
+    expect(nonSystem).toHaveLength(1);
+    expect(nonSystem[0]).toMatchObject({
       role: 'assistant',
       content: [{ type: 'text', text: 'hello' }],
     });
@@ -276,7 +283,9 @@ describe('buildHistoryMessages', () => {
       },
     );
 
-    expect(result[2]).toMatchObject({
+    const toolMessages = result.filter((m) => m.role === 'tool');
+    expect(toolMessages).toHaveLength(1);
+    expect(toolMessages[0]).toMatchObject({
       role: 'tool',
       content: [
         {
@@ -308,11 +317,14 @@ describe('buildHistoryMessages', () => {
       },
     );
 
-    expect(result[0]).toMatchObject({ role: 'system' });
-    expect(typeof result[0]?.content).toBe('string');
-    expect(result[0]?.content).toContain('<env>');
-    expect(result[0]?.content).toContain('Preferred shell:');
-    expect(result[0]?.content).toContain('You are Stitch, a local machine assistant');
+    const systemMessages = result.filter((m) => m.role === 'system');
+    expect(systemMessages.length).toBeGreaterThanOrEqual(2);
+
+    // Static layer contains identity
+    expect(systemMessages[0].content).toContain('You are Stitch, a local machine assistant');
+    // Semi-static layer contains env
+    expect(systemMessages[1].content).toContain('<env>');
+    expect(systemMessages[1].content).toContain('Preferred shell:');
   });
 
   test('uses custom system prompt when base prompt is disabled', () => {
@@ -335,10 +347,11 @@ describe('buildHistoryMessages', () => {
       },
     );
 
-    expect(result[0]).toMatchObject({ role: 'system' });
-    expect(typeof result[0]?.content).toBe('string');
-    expect(result[0]?.content).toContain('<env>');
-    expect(result[0]?.content).toContain('Custom system prompt for testing');
+    const systemMessages = result.filter((m) => m.role === 'system');
+    expect(systemMessages.length).toBeGreaterThanOrEqual(2);
+    // Semi-static layer contains env and custom prompt
+    expect(systemMessages[1].content).toContain('<env>');
+    expect(systemMessages[1].content).toContain('Custom system prompt for testing');
   });
 
   test('appends custom system prompt when base prompt is enabled', () => {
@@ -361,10 +374,11 @@ describe('buildHistoryMessages', () => {
       },
     );
 
-    expect(result[0]).toMatchObject({ role: 'system' });
-    expect(typeof result[0]?.content).toBe('string');
-    expect(result[0]?.content).toContain('<env>');
-    expect(result[0]?.content).toContain('Extra user instruction');
+    const systemMessages = result.filter((m) => m.role === 'system');
+    expect(systemMessages.length).toBeGreaterThanOrEqual(2);
+    // Semi-static layer contains env and user instruction
+    expect(systemMessages[1].content).toContain('<env>');
+    expect(systemMessages[1].content).toContain('Extra user instruction');
   });
 
   test('includes user profile name in system prompt when provided', () => {
@@ -387,9 +401,9 @@ describe('buildHistoryMessages', () => {
       },
     );
 
-    expect(result[0]).toMatchObject({ role: 'system' });
-    expect(typeof result[0]?.content).toBe('string');
-    expect(result[0]?.content).toContain('helps Jane with day-to-day tasks');
+    // Static layer contains identity with user name
+    const systemMessages = result.filter((m) => m.role === 'system');
+    expect(systemMessages[0].content).toContain('helps Jane with day-to-day tasks');
   });
 
   test('includes user timezone in system prompt environment when provided', () => {
@@ -412,9 +426,9 @@ describe('buildHistoryMessages', () => {
       },
     );
 
-    expect(result[0]).toMatchObject({ role: 'system' });
-    expect(typeof result[0]?.content).toBe('string');
-    expect(result[0]?.content).toContain('User timezone: America/New_York');
+    // Semi-static layer contains env with timezone
+    const systemMessages = result.filter((m) => m.role === 'system');
+    expect(systemMessages[1].content).toContain('User timezone: America/New_York');
   });
 
   test('throws when called with empty history', () => {

--- a/packages/server/src/llm/compaction.ts
+++ b/packages/server/src/llm/compaction.ts
@@ -526,10 +526,16 @@ export async function buildCompactedHistory(
   });
 
   const instructionsBlock = buildActiveToolsetInstructionsBlock(sessionId);
-  if (instructionsBlock && historyMessages.length > 0 && historyMessages[0]?.role === 'system') {
-    const sysMsg = historyMessages[0];
-    const existing = typeof sysMsg.content === 'string' ? sysMsg.content : '';
-    historyMessages[0] = { role: 'system', content: `${existing}${instructionsBlock}` };
+  if (instructionsBlock && historyMessages.length > 0) {
+    // Append to the last system message (dynamic layer)
+    for (let i = historyMessages.length - 1; i >= 0; i--) {
+      const msg = historyMessages[i];
+      if (msg.role === 'system') {
+        const existing = typeof msg.content === 'string' ? msg.content : '';
+        historyMessages[i] = { role: 'system', content: `${existing}${instructionsBlock}` };
+        break;
+      }
+    }
   }
 
   return historyMessages;

--- a/packages/server/src/llm/history-messages.ts
+++ b/packages/server/src/llm/history-messages.ts
@@ -1,7 +1,7 @@
 import type { Message, StoredPart } from '@stitch/shared/chat/messages';
 
 import * as Log from '@/lib/log.js';
-import { buildSystemPrompt } from '@/llm/prompt/builder.js';
+import { buildSystemPromptLayers } from '@/llm/prompt/builder.js';
 import type { PromptConfig } from '@/llm/prompt/builder.js';
 import { estimate } from '@/utils/token.js';
 import type { ModelMessage } from 'ai';
@@ -262,10 +262,15 @@ export function buildHistoryMessages(
   }
 
   if (llmMessages[0]?.role !== 'system') {
-    llmMessages.unshift({
-      role: 'system',
-      content: buildSystemPrompt(promptConfig),
-    });
+    const layers = buildSystemPromptLayers(promptConfig);
+    const systemMessages: ModelMessage[] = [
+      { role: 'system', content: layers.static },
+      { role: 'system', content: layers.semiStatic },
+    ];
+    if (layers.dynamic) {
+      systemMessages.push({ role: 'system', content: layers.dynamic });
+    }
+    llmMessages.unshift(...systemMessages);
   }
 
   return llmMessages;

--- a/packages/server/src/llm/prompt/builder.ts
+++ b/packages/server/src/llm/prompt/builder.ts
@@ -15,6 +15,16 @@ export type PromptConfig = {
   todoContext: string | null;
 };
 
+/**
+ * System prompt split into layers for optimal prompt caching.
+ * Static content stays cached regardless of memory/todo changes.
+ */
+type SystemPromptLayers = {
+  static: string;
+  semiStatic: string;
+  dynamic: string;
+};
+
 export async function getPromptUserContext(): Promise<{
   userName: string;
   userTimezone: string;
@@ -26,14 +36,10 @@ export async function getPromptUserContext(): Promise<{
   };
 }
 
-const identity = (userName: string) => {
-  const identityLine = userName
+const identity = (userName: string) =>
+  userName
     ? `You are Stitch, a local machine assistant that helps ${userName} with day-to-day tasks on their computer.`
     : 'You are Stitch, a local machine assistant that helps users with day-to-day tasks on their computer.';
-  return `
-  ${identityLine}
-  `;
-};
 
 const BASE_SYSTEM_PROMPT = readFileSync(
   resolveRuntimeAssetPath(
@@ -109,30 +115,35 @@ function buildEnforcementGuidance(): string {
 - Act, don't ask: act immediately when the request has an obvious safe default. Ask at most one focused question only when truly blocked.`;
 }
 
-export function buildSystemPrompt(input: PromptConfig): string {
+export function buildSystemPromptLayers(input: PromptConfig): SystemPromptLayers {
   const userPrompt = input.systemPrompt?.trim() ?? '';
 
-  let promptBody = userPrompt;
+  let staticContent: string;
   if (input.useBasePrompt) {
-    promptBody = BASE_SYSTEM_PROMPT;
-    if (userPrompt.length > 0) {
-      promptBody = `${promptBody}\n\n${userPrompt}`;
-    }
+    staticContent = `${identity(input.userName)}\n\n${BASE_SYSTEM_PROMPT}\n\n${buildEnforcementGuidance()}\n\n${buildLiquidUiPromptSection()}`;
+  } else {
+    staticContent = `${identity(input.userName)}\n\n${buildEnforcementGuidance()}\n\n${buildLiquidUiPromptSection()}`;
   }
 
-  let result = `${identity(input.userName)}\n\n${buildPromptEnvironment({ userTimezone: input.userTimezone })}\n\n${promptBody}`;
+  const envBlock = buildPromptEnvironment({ userTimezone: input.userTimezone });
+  const semiStaticParts = [envBlock];
+  if (userPrompt.length > 0) {
+    semiStaticParts.push(userPrompt);
+  }
+  const semiStaticContent = semiStaticParts.join('\n\n');
 
-  result = `${result}\n\n${buildEnforcementGuidance()}`;
-
-  result = `${result}\n\n${buildLiquidUiPromptSection()}`;
-
+  const dynamicParts: string[] = [];
   if (input.memoryContext) {
-    result = `${result}\n\n<memory>\n${input.memoryContext}\n</memory>`;
+    dynamicParts.push(`<memory>\n${input.memoryContext}\n</memory>`);
   }
-
   if (input.todoContext) {
-    result = `${result}\n\n${input.todoContext}`;
+    dynamicParts.push(input.todoContext);
   }
+  const dynamicContent = dynamicParts.join('\n\n');
 
-  return result;
+  return {
+    static: staticContent,
+    semiStatic: semiStaticContent,
+    dynamic: dynamicContent,
+  };
 }

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -1152,10 +1152,13 @@ export async function runStream(opts: {
   }).assemble();
 
   const messages = opts.llmMessages;
-  if (messages.length > 0 && messages[0]?.role === 'system') {
-    const sysMsg = messages[0];
-    const existingContent = typeof sysMsg.content === 'string' ? sysMsg.content : '';
-    messages[0] = {
+  if (messages.length > 0 && promptAdditions.length > 0) {
+    // Append to the semi-static system message (index 1) to avoid busting static cache
+    const semiStaticIndex = messages.findIndex((msg, i) => i > 0 && msg.role === 'system');
+    const targetIndex = semiStaticIndex !== -1 ? semiStaticIndex : 0;
+    const existingContent =
+      typeof messages[targetIndex].content === 'string' ? messages[targetIndex].content : '';
+    messages[targetIndex] = {
       role: 'system',
       content: `${existingContent}\n\n${promptAdditions.join('\n\n')}`,
     };

--- a/packages/server/src/llm/stream/step-executor.ts
+++ b/packages/server/src/llm/stream/step-executor.ts
@@ -10,7 +10,11 @@ import type { ToolCallRecord } from './doom-loop.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { MAX_RETRIES, sleep, delay, extractErrorInfo, isRetryable } from '@/lib/retry.js';
-import { addCacheControlToMessages, getProviderOptions } from '@/llm/cache-control.js';
+import {
+  addCacheControlToMessages,
+  addCacheControlToTools,
+  getProviderOptions,
+} from '@/llm/cache-control.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import {
   ContextOverflowError,
@@ -76,12 +80,13 @@ async function executeStep(opts: StepOptions): Promise<StepResult> {
     opts.providerId as ProviderId,
     model.modelId,
   );
+  const cachedTools = addCacheControlToTools(tools, opts.providerId as ProviderId, model.modelId);
   const providerOptions = getProviderOptions(opts.providerId as ProviderId, opts.sessionId);
 
   const result = streamText({
     model,
     messages: cachedMessages,
-    tools,
+    tools: cachedTools,
     providerOptions,
     experimental_repairToolCall: async (failed) => {
       const toolName = String(failed.toolCall.toolName ?? '');


### PR DESCRIPTION
## Change Summary

Splits the single system prompt message into static/semi-static/dynamic layers so Anthropic/Bedrock cache breakpoints align with content volatility, maximizing cache hit rates during multi-step tool-use loops.

### New Features
- **Tool-level cache breakpoints**: `addCacheControlToTools` marks the last tool definition with a cache control marker, using the 4th breakpoint slot
- **Layered system prompt**: `buildSystemPromptLayers()` returns structured layers instead of a single concatenated string

### Improvements & Refactors
- System prompt split into 3 messages: static (identity + base prompt + enforcement + liquid UI), semi-static (env + user prompt + catalogs), dynamic (memory + todos + toolset instructions)
- Cache breakpoint strategy changed from "first 2 system + last 2 non-system" to "first 2 system + latest user message + last tool def" for better prefix stability
- `runner.ts` appends prompt additions to semi-static message (index 1) instead of index 0
- `compaction.ts` appends toolset instructions to last system message (dynamic layer) instead of first
