### PR TITLE
fix(server): roll log files daily and stop truncating on init

### DIFF
--- a/packages/server/src/lib/log.test.ts
+++ b/packages/server/src/lib/log.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, setSystemTime } from 'bun:test';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -10,6 +10,14 @@ async function fileExists(filepath: string): Promise<boolean> {
     .access(filepath)
     .then(() => true)
     .catch(() => false);
+}
+
+// Mirrors the production formatDate in log.ts (local date components)
+function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
 async function clearLogDir() {
@@ -146,5 +154,78 @@ describe('Log.create', () => {
     expect(output).toContain('formatted message');
 
     await clearLogDir();
+  });
+});
+
+describe('Log rotation', () => {
+  beforeEach(async () => {
+    await fs.mkdir(PATHS.logDir, { recursive: true });
+    await clearLogDir();
+  });
+
+  afterEach(async () => {
+    setSystemTime();
+    await clearLogDir();
+  });
+
+  test('init does not truncate an existing same-day file', async () => {
+    const today = formatDate(new Date());
+    const logFile = path.join(PATHS.logDir, `app.${today}.1.log`);
+    await fs.writeFile(logFile, 'existing line\n', 'utf-8');
+
+    const log = Log.create({ service: 'test-no-truncate' });
+    await Log.init({});
+    log.info('new line after init');
+
+    const output = await waitForLogOutput('new line after init');
+    expect(output).toContain('existing line');
+    expect(output).toContain('new line after init');
+  });
+
+  test('rolls to a new file when the date changes', async () => {
+    const day1 = new Date('2030-03-01T12:00:00.000Z');
+    const day2 = new Date('2030-03-02T12:00:00.000Z');
+
+    setSystemTime(day1);
+    const log = Log.create({ service: 'test-roll' });
+    await Log.init({});
+    log.info('day one message');
+    await waitForLogOutput('day one message');
+
+    setSystemTime(day2);
+    log.info('day two message');
+    await waitForLogOutput('day two message');
+
+    const day1File = path.join(PATHS.logDir, `app.${formatDate(day1)}.1.log`);
+    const day2File = path.join(PATHS.logDir, `app.${formatDate(day2)}.1.log`);
+
+    expect(await fileExists(day1File)).toBe(true);
+    expect(await fileExists(day2File)).toBe(true);
+
+    const day1Content = await fs.readFile(day1File, 'utf-8');
+    const day2Content = await fs.readFile(day2File, 'utf-8');
+
+    expect(day1Content).toContain('day one message');
+    expect(day1Content).not.toContain('day two message');
+    expect(day2Content).toContain('day two message');
+    expect(day2Content).not.toContain('day one message');
+  });
+
+  test('same-day restart appends instead of truncating', async () => {
+    const today = formatDate(new Date());
+    const logFile = path.join(PATHS.logDir, `app.${today}.1.log`);
+
+    const log = Log.create({ service: 'test-restart' });
+    await Log.init({});
+    log.info('message A');
+    await waitForLogOutput('message A');
+
+    await Log.init({});
+    log.info('message B');
+    await waitForLogOutput('message B');
+
+    const content = await fs.readFile(logFile, 'utf-8');
+    expect(content).toContain('message A');
+    expect(content).toContain('message B');
   });
 });

--- a/packages/server/src/lib/log.ts
+++ b/packages/server/src/lib/log.ts
@@ -69,24 +69,34 @@ function formatValue(value: unknown): string {
 }
 
 let stream: WriteStream | undefined;
-let write = (_msg: string) => {};
+let currentDate: string | undefined;
+let prefix = 'app';
+let initialized = false;
 let last = Date.now();
 const loggers = new Map<string, Logger>();
 
+function openStream(date: string): void {
+  const logFile = path.join(PATHS.logDir, `${prefix}.${date}.1.log`);
+  stream?.end();
+  stream = createWriteStream(logFile, { flags: 'a' });
+  currentDate = date;
+}
+
+function write(msg: string): void {
+  if (!initialized) return;
+  const today = formatDate(new Date());
+  if (today !== currentDate) openStream(today);
+  stream?.write(msg);
+}
+
 export async function init(options: Options): Promise<void> {
   level = options.level ?? 'INFO';
+  prefix = options.dev ? 'dev' : 'app';
 
   await fs.mkdir(PATHS.logDir, { recursive: true });
 
-  const prefix = options.dev ? 'dev' : 'app';
-  const logFile = path.join(PATHS.logDir, `${prefix}.${formatDate(new Date())}.1.log`);
-
-  await fs.truncate(logFile).catch(() => {});
-  stream?.end();
-  stream = createWriteStream(logFile, { flags: 'a' });
-  write = (msg: string) => {
-    stream?.write(msg);
-  };
+  openStream(formatDate(new Date()));
+  initialized = true;
 }
 
 // Log filename format: <prefix>.<date>.<count>.log


### PR DESCRIPTION
## 🚀 Change Summary

Fixes packaged/deployed builds where logs never advanced past the launch day and were usually empty. The server logger now rolls to a new file when the calendar day changes and no longer wipes the current-day file on startup.

### 🐛 Bug Fixes
- **Frozen log date**: `init()` computed the log filename once at process start and held that write stream for the whole process. Since the desktop app runs the server as a long-lived sidecar, all logs after midnight kept flowing into the launch-day file. The target file is now resolved per write based on the current date, rolling the stream when the day changes.
- **Empty logs after restart**: `init()` truncated the current-day file on every server start. The stream now opens with append (no truncate), so same-day restarts preserve prior logs.

### 🛠 Improvements & Refactors
- `write` is now a stable module-level function rather than a reassigned closure, so all loggers reference the live implementation. The per-write cost is in-memory only (clock read + string compare); the filesystem is only touched once per day at the roll boundary.

### 📚 Tests
- Added rotation tests using Bun's `setSystemTime`: init does not truncate an existing same-day file, writes roll to a new file when the date changes, and same-day restarts append instead of truncating.
