### PR TITLE
fix: repair STT socket rotation/recovery state machine

### DIFF
--- a/apps/web/src/components/recordings/meeting-recording-banner.tsx
+++ b/apps/web/src/components/recordings/meeting-recording-banner.tsx
@@ -12,8 +12,13 @@ import type { SttModelSelection } from '@/components/model-selectors/stt-model-s
 import { SttModelSelectorPopover } from '@/components/model-selectors/stt-model-selector-popover';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup, ButtonGroupSeparator } from '@/components/ui/button-group';
+import { useRecordingEvents } from '@/hooks/sse/sse-context';
 import { sttProviderModelsQueryOptions } from '@/lib/queries/providers';
-import { activeRecordingQueryOptions, useStartRecording } from '@/lib/queries/recordings';
+import {
+  activeRecordingQueryOptions,
+  useStartRecording,
+  useStopRecording,
+} from '@/lib/queries/recordings';
 
 const WARNING_LABELS: Record<string, string> = {
   input_backpressure: 'Audio input is falling behind — some audio may be dropped.',
@@ -22,6 +27,10 @@ const WARNING_LABELS: Record<string, string> = {
 };
 
 export function RecordingEventListener() {
+  const { data } = useQuery(activeRecordingQueryOptions);
+  const activeRecordingId = data?.activeRecordingId ?? null;
+  const stopRecording = useStopRecording();
+
   React.useEffect(() => {
     const unsubscribeWarning = window.api?.recording?.onWarning((payload) => {
       const label = WARNING_LABELS[payload.code] ?? payload.message;
@@ -37,6 +46,15 @@ export function RecordingEventListener() {
       unsubscribeDeviceChanged?.();
     };
   }, []);
+
+  useRecordingEvents(activeRecordingId, {
+    'recording-unrecoverable': () => {
+      toast.error('Transcription disconnected and could not recover. Finalizing the recording.');
+      void stopRecording.mutateAsync().catch(() => {
+        toast.error('Failed to finalize the recording.');
+      });
+    },
+  });
 
   return null;
 }

--- a/apps/web/src/components/recordings/meeting-recording-banner.tsx
+++ b/apps/web/src/components/recordings/meeting-recording-banner.tsx
@@ -48,8 +48,8 @@ export function RecordingEventListener() {
   }, []);
 
   useRecordingEvents(activeRecordingId, {
-    'recording-unrecoverable': () => {
-      toast.error('Transcription disconnected and could not recover. Finalizing the recording.');
+    'recording-unrecoverable': ({ reason }) => {
+      toast.error(reason);
       void stopRecording.mutateAsync().catch(() => {
         toast.error('Failed to finalize the recording.');
       });

--- a/packages/server/src/adapters/sse.ts
+++ b/packages/server/src/adapters/sse.ts
@@ -234,6 +234,13 @@ export function registerSseAdapter(): void {
     broadcast('recording-stopped', { recordingId: event.recordingId });
   });
 
+  internalBus.onSync('recording.unrecoverable', (event) => {
+    broadcast('recording-unrecoverable', {
+      recordingId: event.recordingId,
+      reason: event.reason,
+    });
+  });
+
   internalBus.onSync('recording.analysis.updated', (event) => {
     broadcast('recording-analysis-updated', {
       recordingId: event.recordingId,

--- a/packages/server/src/lib/internal-bus-events.ts
+++ b/packages/server/src/lib/internal-bus-events.ts
@@ -251,6 +251,11 @@ export type RecordingStoppedEvent = {
   recordingId: PrefixedString<'rec'>;
 };
 
+export type RecordingUnrecoverableEvent = {
+  recordingId: PrefixedString<'rec'>;
+  reason: string;
+};
+
 export type RecordingAnalysisUpdatedEvent = {
   recordingId: PrefixedString<'rec'>;
   status: RecordingAnalysisStatus;
@@ -324,6 +329,7 @@ export type InternalEventMap = {
   // Recordings
   'recording.started': RecordingStartedEvent;
   'recording.stopped': RecordingStoppedEvent;
+  'recording.unrecoverable': RecordingUnrecoverableEvent;
   'recording.analysis.updated': RecordingAnalysisUpdatedEvent;
   'recording.transcript.entry': RecordingTranscriptEntryEvent;
 

--- a/packages/server/src/models/stt/schema.ts
+++ b/packages/server/src/models/stt/schema.ts
@@ -29,6 +29,7 @@ const ReconnectConfigSchema = z.object({
   enabled: z.boolean(),
   maxRetries: z.number().int().nonnegative(),
   backoffMs: z.number().int().nonnegative(),
+  maxBackoffMs: z.number().int().positive().optional(),
   rotateBeforeMs: z.number().int().positive().optional(),
 });
 

--- a/packages/server/src/routes/recordings.ts
+++ b/packages/server/src/routes/recordings.ts
@@ -25,6 +25,8 @@ import {
 const startRecordingSchema = z.object({
   title: z.string().trim().min(1).max(200).optional(),
   platform: z.enum(['manual', 'zoom', 'teams', 'slack', 'discord', 'google-meet']).optional(),
+  sttProviderId: z.string().min(1).optional(),
+  sttModelId: z.string().min(1).optional(),
 });
 
 const stopRecordingSchema = z.object({

--- a/packages/server/src/stt/adapter-iface.ts
+++ b/packages/server/src/stt/adapter-iface.ts
@@ -10,6 +10,7 @@ export type STTConnection = {
   onUsage(cb: (u: STTUsage) => void): void;
   onError(cb: (err: Error) => void): void;
   onClose(cb: () => void): void;
+  onUnrecoverable(cb: (reason: string) => void): void;
 };
 
 /**

--- a/packages/server/src/stt/adapters/assemblyai.ts
+++ b/packages/server/src/stt/adapters/assemblyai.ts
@@ -3,13 +3,17 @@ import type { TranscriptEvent, STTUsage } from '@stitch/shared/stt/types';
 import * as Log from '@/lib/log.js';
 import { getModelDescriptor } from '@/models/stt/service.js';
 import type { STTAdapter, STTConnection } from '@/stt/adapter-iface.js';
-import { createManagedConnection } from '@/stt/base-adapter.js';
+import { createManagedConnection, type STTErrorClassification } from '@/stt/base-adapter.js';
 import type { ModelDescriptor, STTConnectionConfig } from '@/stt/types.js';
 import { createWsTransport, type WsMessageResult } from '@/stt/ws-transport.js';
 
 const log = Log.create({ service: 'stt.assemblyai' });
 
 const ASSEMBLYAI_STREAMING_URL = 'wss://streaming.assemblyai.com/v3/ws';
+const CREDENTIALS_ERROR_REASON =
+  'Invalid transcription API credentials. Please check your settings.';
+const QUOTA_ERROR_REASON = 'Transcription quota exceeded. Please check your billing.';
+const STREAM_LIMIT_REASON = 'AssemblyAI transcription stream limit reached.';
 
 // https://www.assemblyai.com/docs/streaming/
 type AssemblyAIMessage =
@@ -101,21 +105,26 @@ function buildAssemblyAIUrl(config: STTConnectionConfig): string {
   return `${ASSEMBLYAI_STREAMING_URL}?${params.toString()}`;
 }
 
-function isFatalAssemblyAI(err: Error): boolean {
+function classifyAssemblyAIError(err: Error): STTErrorClassification {
   const msg = err.message.toLowerCase();
   const code = (err as Error & { code?: string }).code ?? '';
 
-  // WS close code 1008 = unauthorized (can come as string "1008" from JSON error_code)
-  if (code === '1008' || msg.includes('1008') || msg.includes('unauthorized')) return true;
-  if (msg.includes('401') || msg.includes('403')) return true;
-  // Session expired (3-hour cap)
-  if (code === '3008' || msg.includes('3008')) return true;
-  // Too many concurrent sessions
-  if (code === '3009' || msg.includes('3009')) return true;
-  // Invalid request
-  if (code === '3006' || msg.includes('invalid')) return true;
+  // 4001 = not authorized (WS close code as string)
+  if (code === '4001' || msg.includes('4001') || msg.includes('not authorized')) {
+    return { fatal: true, reason: CREDENTIALS_ERROR_REASON };
+  }
 
-  return false;
+  // 4002 = insufficient funds, 4003 = free tier user (paid-only feature)
+  if (code === '4002' || code === '4003' || msg.includes('4002') || msg.includes('4003')) {
+    return { fatal: true, reason: QUOTA_ERROR_REASON };
+  }
+
+  // 4102 = account has exceeded number of allowed streams
+  if (code === '4102' || msg.includes('4102')) {
+    return { fatal: true, reason: STREAM_LIMIT_REASON };
+  }
+
+  return { fatal: false };
 }
 
 function createAssemblyAITransport(config: STTConnectionConfig) {
@@ -152,7 +161,7 @@ export const assemblyaiAdapter: STTAdapter = {
       buffer: config.buffer,
       reconnect: config.reconnect,
       partialStrategy: config.partialStrategy,
-      isFatal: isFatalAssemblyAI,
+      classifyError: classifyAssemblyAIError,
       openConnection: () => createAssemblyAITransport(config),
     });
   },

--- a/packages/server/src/stt/adapters/elevenlabs.ts
+++ b/packages/server/src/stt/adapters/elevenlabs.ts
@@ -3,13 +3,18 @@ import type { TranscriptEvent, STTUsage } from '@stitch/shared/stt/types';
 import * as Log from '@/lib/log.js';
 import { getModelDescriptor } from '@/models/stt/service.js';
 import type { STTAdapter, STTConnection } from '@/stt/adapter-iface.js';
-import { createManagedConnection } from '@/stt/base-adapter.js';
+import { createManagedConnection, type STTErrorClassification } from '@/stt/base-adapter.js';
 import type { ModelDescriptor, STTConnectionConfig } from '@/stt/types.js';
 import { createWsTransport, type WsMessageResult } from '@/stt/ws-transport.js';
 
 const log = Log.create({ service: 'stt.elevenlabs' });
 
 const ELEVENLABS_STT_BASE_URL = 'wss://api.elevenlabs.io/v1/speech-to-text/realtime';
+const CREDENTIALS_ERROR_REASON =
+  'Invalid transcription API credentials. Please check your settings.';
+const QUOTA_ERROR_REASON = 'Transcription quota exceeded. Please check your billing.';
+const TERMS_ERROR_REASON = 'ElevenLabs transcription terms must be accepted before recording.';
+const SESSION_LIMIT_REASON = 'ElevenLabs transcription session reached its time limit.';
 
 type ElevenLabsMessage =
   | { message_type: 'partial_transcript'; text: string; language_code?: string }
@@ -83,7 +88,7 @@ function createElevenLabsMessageParser(sessionStartMs: number, includeTimestamps
       default: {
         if ('error' in msg && msg.error) {
           const err = new Error(`ElevenLabs STT: ${msg.error}`);
-          (err as Error & { code?: string }).code = msg.code;
+          (err as Error & { code?: string }).code = msg.code ?? msg.message_type;
           return { error: err };
         }
         log.debug({ messageType: msg.message_type }, 'unhandled ElevenLabs message type');
@@ -127,15 +132,32 @@ function buildKeytermsConfig(keyterms: string[]): string {
   });
 }
 
-function isFatalElevenLabs(err: Error): boolean {
+function classifyElevenLabsError(err: Error): STTErrorClassification {
   const msg = err.message.toLowerCase();
-  const code = (err as Error & { code?: string }).code;
+  const code = (err as Error & { code?: string }).code ?? '';
 
-  if (code === 'invalid_api_key' || code === 'quota_exceeded') return true;
-  if (msg.includes('401') || msg.includes('403') || msg.includes('quota')) return true;
-  if (msg.includes('invalid_model')) return true;
+  if (
+    code === 'auth_error' ||
+    code === 'invalid_api_key' ||
+    msg.includes('401') ||
+    msg.includes('403')
+  ) {
+    return { fatal: true, reason: CREDENTIALS_ERROR_REASON };
+  }
 
-  return false;
+  if (code === 'quota_exceeded' || msg.includes('quota')) {
+    return { fatal: true, reason: QUOTA_ERROR_REASON };
+  }
+
+  if (code === 'unaccepted_terms') {
+    return { fatal: true, reason: TERMS_ERROR_REASON };
+  }
+
+  if (code === 'session_time_limit_exceeded') {
+    return { fatal: true, reason: SESSION_LIMIT_REASON };
+  }
+
+  return { fatal: false };
 }
 
 function createElevenLabsTransport(config: STTConnectionConfig) {
@@ -180,7 +202,7 @@ export const elevenlabsAdapter: STTAdapter = {
       buffer: config.buffer,
       reconnect: config.reconnect,
       partialStrategy: config.partialStrategy,
-      isFatal: isFatalElevenLabs,
+      classifyError: classifyElevenLabsError,
       openConnection: () => createElevenLabsTransport(config),
     });
   },

--- a/packages/server/src/stt/adapters/openai.ts
+++ b/packages/server/src/stt/adapters/openai.ts
@@ -3,13 +3,18 @@ import type { TranscriptEvent, STTUsage } from '@stitch/shared/stt/types';
 import * as Log from '@/lib/log.js';
 import { getModelDescriptor } from '@/models/stt/service.js';
 import type { STTAdapter, STTConnection } from '@/stt/adapter-iface.js';
-import { createManagedConnection } from '@/stt/base-adapter.js';
+import { createManagedConnection, type STTErrorClassification } from '@/stt/base-adapter.js';
 import type { ModelDescriptor, STTConnectionConfig } from '@/stt/types.js';
 import { createWsTransport, type WsMessageResult } from '@/stt/ws-transport.js';
 
 const log = Log.create({ service: 'stt.openai' });
 
 const OPENAI_REALTIME_BASE_URL = 'wss://api.openai.com/v1/realtime';
+const CREDENTIALS_ERROR_REASON =
+  'Invalid transcription API credentials. Please check your settings.';
+const QUOTA_ERROR_REASON = 'Transcription quota exceeded. Please check your billing.';
+const MODEL_ERROR_REASON =
+  'Selected transcription model is unavailable. Please check your settings.';
 
 type OpenAIRealtimeMessage =
   | { type: 'session.created' }
@@ -112,15 +117,33 @@ function buildSessionConfig(config: STTConnectionConfig): string {
   });
 }
 
-function isFatalOpenAI(err: Error): boolean {
+function classifyOpenAIError(err: Error): STTErrorClassification {
   const msg = err.message.toLowerCase();
-  const code = (err as Error & { code?: string }).code;
+  const code = (err as Error & { code?: string }).code ?? '';
 
-  if (code === 'invalid_api_key' || code === 'insufficient_quota') return true;
-  if (msg.includes('401') || msg.includes('403') || msg.includes('quota')) return true;
-  if (msg.includes('invalid_model') || msg.includes('model_not_found')) return true;
+  if (
+    code === 'invalid_api_key' ||
+    code === 'auth_error' ||
+    msg.includes('401') ||
+    msg.includes('403')
+  ) {
+    return { fatal: true, reason: CREDENTIALS_ERROR_REASON };
+  }
 
-  return false;
+  if (
+    code === 'insufficient_quota' ||
+    msg.includes('exceeded your quota') ||
+    msg.includes('quota exceeded') ||
+    msg.includes('insufficient_quota')
+  ) {
+    return { fatal: true, reason: QUOTA_ERROR_REASON };
+  }
+
+  if (code === 'model_not_found' || msg.includes('model_not_found')) {
+    return { fatal: true, reason: MODEL_ERROR_REASON };
+  }
+
+  return { fatal: false };
 }
 
 function createOpenAITransport(config: STTConnectionConfig) {
@@ -158,7 +181,7 @@ export const openaiAdapter: STTAdapter = {
       buffer: config.buffer,
       reconnect: config.reconnect,
       partialStrategy: config.partialStrategy,
-      isFatal: isFatalOpenAI,
+      classifyError: classifyOpenAIError,
       openConnection: () => createOpenAITransport(config),
     });
   },

--- a/packages/server/src/stt/base-adapter.test.ts
+++ b/packages/server/src/stt/base-adapter.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { AudioChunk, STTUsage, TranscriptEvent } from '@stitch/shared/stt/types';
+
+import type { STTTransport } from '@/stt/adapter-iface.js';
+import { createManagedConnection } from '@/stt/base-adapter.js';
+import type { BufferConfig, ReconnectConfig } from '@/stt/types.js';
+
+function makeChunk(index: number): AudioChunk {
+  // 1600 samples @ 16kHz = 100ms. samplesB64 carries the index so received order is checkable.
+  return {
+    samplesB64: `chunk-${index}`,
+    sampleRateHz: 16_000,
+    numSamples: 1600,
+    encoding: 'pcm_s16le',
+  };
+}
+
+type FakeTransport = STTTransport & {
+  received: AudioChunk[];
+  closed: boolean;
+  emitTranscript: (e: TranscriptEvent) => void;
+  emitClose: () => void;
+  emitError: (err: Error) => void;
+};
+
+function createFakeTransport(): FakeTransport {
+  const transcriptListeners: ((e: TranscriptEvent) => void)[] = [];
+  const usageListeners: ((u: STTUsage) => void)[] = [];
+  const errorListeners: ((err: Error) => void)[] = [];
+  const closeListeners: (() => void)[] = [];
+  const received: AudioChunk[] = [];
+
+  const transport: FakeTransport = {
+    received,
+    closed: false,
+    sendAudio(chunk) {
+      if (transport.closed) return;
+      received.push(chunk);
+    },
+    commit() {},
+    async close() {
+      transport.closed = true;
+    },
+    onTranscript(cb) {
+      transcriptListeners.push(cb);
+    },
+    onUsage(cb) {
+      usageListeners.push(cb);
+    },
+    onError(cb) {
+      errorListeners.push(cb);
+    },
+    onClose(cb) {
+      closeListeners.push(cb);
+    },
+    emitTranscript(e) {
+      for (const cb of transcriptListeners) cb(e);
+    },
+    emitClose() {
+      transport.closed = true;
+      for (const cb of closeListeners) cb();
+    },
+    emitError(err) {
+      for (const cb of errorListeners) cb(err);
+    },
+  };
+
+  return transport;
+}
+
+const baseBuffer: BufferConfig = {
+  maxChunkBytes: 1, // flush every chunk immediately so order is deterministic
+  flushIntervalMs: 5,
+  maxBufferedMs: 10 * 60 * 1000, // large so nothing is dropped in tests
+  paceRealtime: false,
+};
+
+const baseReconnect: ReconnectConfig = {
+  enabled: true,
+  maxRetries: 3,
+  backoffMs: 1,
+  maxBackoffMs: 4,
+  rotateBeforeMs: 10,
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe('createManagedConnection recovery', () => {
+  test('recovers when the new transport drops mid-rotation (no permanent wedge)', async () => {
+    const transports: FakeTransport[] = [];
+    const conn = await createManagedConnection({
+      buffer: baseBuffer,
+      reconnect: baseReconnect,
+      partialStrategy: 'cumulative',
+      isFatal: () => false,
+      openConnection: async () => {
+        const t = createFakeTransport();
+        transports.push(t);
+        return t;
+      },
+    });
+
+    // Wait for the first proactive rotation to occur, then kill the new transport.
+    await sleep(30);
+    const live = transports[transports.length - 1];
+    live.emitClose();
+
+    // Allow reactive reconnect to open a fresh transport.
+    await sleep(50);
+
+    const finalTransport = transports[transports.length - 1];
+    expect(finalTransport.closed).toBe(false);
+
+    // Audio sent after recovery must reach the live transport.
+    conn.sendAudio(makeChunk(999));
+    await sleep(20);
+    expect(finalTransport.received.some((c) => c.samplesB64 === 'chunk-999')).toBe(true);
+
+    await conn.close();
+  });
+
+  test('re-arms rotation after a failed proactive rotation', async () => {
+    let openCount = 0;
+    const transports: FakeTransport[] = [];
+    const conn = await createManagedConnection({
+      buffer: baseBuffer,
+      reconnect: baseReconnect,
+      partialStrategy: 'cumulative',
+      isFatal: () => false,
+      openConnection: async () => {
+        openCount++;
+        // Fail the first rotation attempt (2nd open) once.
+        if (openCount === 2) {
+          throw new Error('transient open failure');
+        }
+        const t = createFakeTransport();
+        transports.push(t);
+        return t;
+      },
+    });
+
+    // First rotation fails; rotation must still re-arm and eventually succeed.
+    await sleep(60);
+    expect(openCount).toBeGreaterThanOrEqual(3);
+
+    await conn.close();
+  });
+
+  test('reconnects indefinitely past maxRetries until success (option A)', async () => {
+    let openCount = 0;
+    const transports: FakeTransport[] = [];
+    const conn = await createManagedConnection({
+      buffer: { ...baseBuffer },
+      reconnect: { ...baseReconnect, rotateBeforeMs: undefined, maxRetries: 2 },
+      partialStrategy: 'cumulative',
+      isFatal: () => false,
+      openConnection: async () => {
+        openCount++;
+        // Initial open succeeds; then fail more times than maxRetries before succeeding.
+        if (openCount > 1 && openCount <= 5) {
+          throw new Error('still down');
+        }
+        const t = createFakeTransport();
+        transports.push(t);
+        return t;
+      },
+    });
+
+    // Drop the initial transport to trigger reactive reconnect.
+    transports[0].emitClose();
+
+    // maxRetries is 2 but we fail 4 times — indefinite retry must keep going.
+    await sleep(120);
+    expect(openCount).toBeGreaterThan(5);
+    expect(transports[transports.length - 1].closed).toBe(false);
+
+    await conn.close();
+  });
+
+  test('does not lose audio across rotations (flush before rotate)', async () => {
+    const transports: FakeTransport[] = [];
+    const conn = await createManagedConnection({
+      buffer: { ...baseBuffer, maxChunkBytes: 1_000_000, flushIntervalMs: 1000 }, // force pending
+      reconnect: baseReconnect,
+      partialStrategy: 'cumulative',
+      isFatal: () => false,
+      openConnection: async () => {
+        const t = createFakeTransport();
+        transports.push(t);
+        return t;
+      },
+    });
+
+    // Queue chunks that sit in the pending buffer (not yet flushed by size/time).
+    const total = 5;
+    for (let i = 0; i < total; i++) {
+      conn.sendAudio(makeChunk(i));
+    }
+
+    // Trigger rotation while chunks are pending; flush-before-rotate must preserve them.
+    await sleep(40);
+    await conn.close();
+
+    const allReceived = new Set(
+      transports.flatMap((t) => t.received.map((c) => c.samplesB64)),
+    );
+    for (let i = 0; i < total; i++) {
+      expect(allReceived.has(`chunk-${i}`)).toBe(true);
+    }
+  });
+
+  test('emits unrecoverable once when reconnect hits a fatal open error', async () => {
+    let openCount = 0;
+    const transports: FakeTransport[] = [];
+    const conn = await createManagedConnection({
+      buffer: baseBuffer,
+      reconnect: { ...baseReconnect, rotateBeforeMs: undefined },
+      partialStrategy: 'cumulative',
+      isFatal: (err) => err.message.includes('FATAL'),
+      openConnection: async () => {
+        openCount++;
+        if (openCount === 1) {
+          const t = createFakeTransport();
+          transports.push(t);
+          return t;
+        }
+        throw new Error('FATAL auth rejected');
+      },
+    });
+
+    const reasons: string[] = [];
+    conn.onUnrecoverable((reason) => reasons.push(reason));
+
+    // Drop the only transport: reactive reconnect runs, its open throws a fatal error.
+    transports[0].emitClose();
+
+    await sleep(40);
+
+    expect(reasons.length).toBe(1);
+    expect(reasons[0]).toContain('FATAL');
+
+    await conn.close();
+  });
+});

--- a/packages/server/src/stt/base-adapter.test.ts
+++ b/packages/server/src/stt/base-adapter.test.ts
@@ -16,6 +16,15 @@ function makeChunk(index: number): AudioChunk {
   };
 }
 
+function makePcmChunk(index: number): AudioChunk {
+  return {
+    samplesB64: Buffer.from([index]).toString('base64'),
+    sampleRateHz: 16_000,
+    numSamples: 160,
+    encoding: 'pcm_s16le',
+  };
+}
+
 type FakeTransport = STTTransport & {
   received: AudioChunk[];
   closed: boolean;
@@ -89,6 +98,32 @@ function sleep(ms: number): Promise<void> {
 }
 
 describe('createManagedConnection recovery', () => {
+  test('coalesces pending chunks before sending to transport', async () => {
+    const transports: FakeTransport[] = [];
+    const conn = await createManagedConnection({
+      buffer: { ...baseBuffer, maxChunkBytes: 1_000_000, flushIntervalMs: 5 },
+      reconnect: { ...baseReconnect, rotateBeforeMs: undefined },
+      partialStrategy: 'cumulative',
+      classifyError: () => ({ fatal: false }),
+      openConnection: async () => {
+        const t = createFakeTransport();
+        transports.push(t);
+        return t;
+      },
+    });
+
+    conn.sendAudio(makePcmChunk(1));
+    conn.sendAudio(makePcmChunk(2));
+    conn.sendAudio(makePcmChunk(3));
+    await sleep(20);
+
+    expect(transports[0].received).toHaveLength(1);
+    expect(transports[0].received[0].numSamples).toBe(480);
+    expect([...Buffer.from(transports[0].received[0].samplesB64, 'base64')]).toEqual([1, 2, 3]);
+
+    await conn.close();
+  });
+
   test('recovers when the new transport drops mid-rotation (no permanent wedge)', async () => {
     const transports: FakeTransport[] = [];
     const conn = await createManagedConnection({
@@ -197,16 +232,18 @@ describe('createManagedConnection recovery', () => {
     // Queue chunks that sit in the pending buffer (not yet flushed by size/time).
     const total = 5;
     for (let i = 0; i < total; i++) {
-      conn.sendAudio(makeChunk(i));
+      conn.sendAudio(makePcmChunk(i));
     }
 
     // Trigger rotation while chunks are pending; flush-before-rotate must preserve them.
     await sleep(40);
     await conn.close();
 
-    const allReceived = new Set(transports.flatMap((t) => t.received.map((c) => c.samplesB64)));
+    const allReceived = transports.flatMap((t) =>
+      t.received.flatMap((c) => [...Buffer.from(c.samplesB64, 'base64')]),
+    );
     for (let i = 0; i < total; i++) {
-      expect(allReceived.has(`chunk-${i}`)).toBe(true);
+      expect(allReceived).toContain(i);
     }
   });
 

--- a/packages/server/src/stt/base-adapter.test.ts
+++ b/packages/server/src/stt/base-adapter.test.ts
@@ -95,7 +95,7 @@ describe('createManagedConnection recovery', () => {
       buffer: baseBuffer,
       reconnect: baseReconnect,
       partialStrategy: 'cumulative',
-      isFatal: () => false,
+      classifyError: () => ({ fatal: false }),
       openConnection: async () => {
         const t = createFakeTransport();
         transports.push(t);
@@ -129,7 +129,7 @@ describe('createManagedConnection recovery', () => {
       buffer: baseBuffer,
       reconnect: baseReconnect,
       partialStrategy: 'cumulative',
-      isFatal: () => false,
+      classifyError: () => ({ fatal: false }),
       openConnection: async () => {
         openCount++;
         // Fail the first rotation attempt (2nd open) once.
@@ -156,7 +156,7 @@ describe('createManagedConnection recovery', () => {
       buffer: { ...baseBuffer },
       reconnect: { ...baseReconnect, rotateBeforeMs: undefined, maxRetries: 2 },
       partialStrategy: 'cumulative',
-      isFatal: () => false,
+      classifyError: () => ({ fatal: false }),
       openConnection: async () => {
         openCount++;
         // Initial open succeeds; then fail more times than maxRetries before succeeding.
@@ -186,7 +186,7 @@ describe('createManagedConnection recovery', () => {
       buffer: { ...baseBuffer, maxChunkBytes: 1_000_000, flushIntervalMs: 1000 }, // force pending
       reconnect: baseReconnect,
       partialStrategy: 'cumulative',
-      isFatal: () => false,
+      classifyError: () => ({ fatal: false }),
       openConnection: async () => {
         const t = createFakeTransport();
         transports.push(t);
@@ -204,9 +204,7 @@ describe('createManagedConnection recovery', () => {
     await sleep(40);
     await conn.close();
 
-    const allReceived = new Set(
-      transports.flatMap((t) => t.received.map((c) => c.samplesB64)),
-    );
+    const allReceived = new Set(transports.flatMap((t) => t.received.map((c) => c.samplesB64)));
     for (let i = 0; i < total; i++) {
       expect(allReceived.has(`chunk-${i}`)).toBe(true);
     }
@@ -219,7 +217,10 @@ describe('createManagedConnection recovery', () => {
       buffer: baseBuffer,
       reconnect: { ...baseReconnect, rotateBeforeMs: undefined },
       partialStrategy: 'cumulative',
-      isFatal: (err) => err.message.includes('FATAL'),
+      classifyError: (err) =>
+        err.message.includes('FATAL')
+          ? { fatal: true, reason: 'adapter classified auth as fatal' }
+          : { fatal: false },
       openConnection: async () => {
         openCount++;
         if (openCount === 1) {
@@ -240,7 +241,7 @@ describe('createManagedConnection recovery', () => {
     await sleep(40);
 
     expect(reasons.length).toBe(1);
-    expect(reasons[0]).toContain('FATAL');
+    expect(reasons[0]).toBe('adapter classified auth as fatal');
 
     await conn.close();
   });

--- a/packages/server/src/stt/base-adapter.ts
+++ b/packages/server/src/stt/base-adapter.ts
@@ -5,6 +5,7 @@ import type { STTConnection, STTTransport } from '@/stt/adapter-iface.js';
 import type { BufferConfig, PartialStrategy, ReconnectConfig } from '@/stt/types.js';
 
 const log = Log.create({ service: 'stt.base-adapter' });
+const MAX_SEND_BATCH_MS = 900;
 
 export type STTErrorClassification = { fatal: false } | { fatal: true; reason: string };
 
@@ -27,6 +28,21 @@ function chunkByteSize(chunk: AudioChunk): number {
 
 function chunkDurationMs(chunk: AudioChunk): number {
   return (chunk.numSamples / chunk.sampleRateHz) * 1000;
+}
+
+function mergeChunks(chunks: AudioChunk[]): AudioChunk | null {
+  if (chunks.length === 0) return null;
+  if (chunks.length === 1) return chunks[0];
+
+  const [first] = chunks;
+  return {
+    samplesB64: Buffer.concat(
+      chunks.map((chunk) => Buffer.from(chunk.samplesB64, 'base64')),
+    ).toString('base64'),
+    sampleRateHz: first.sampleRateHz,
+    numSamples: chunks.reduce((total, chunk) => total + chunk.numSamples, 0),
+    encoding: first.encoding,
+  };
 }
 
 export async function createManagedConnection(
@@ -101,6 +117,39 @@ export async function createManagedConnection(
     totalBufferedMs = 0;
   }
 
+  function sendChunkBatch(target: STTTransport, chunks: AudioChunk[]): void {
+    let batch: AudioChunk[] = [];
+    let batchBytes = 0;
+    let batchMs = 0;
+
+    function flushBatch(): void {
+      const merged = mergeChunks(batch);
+      if (merged) target.sendAudio(merged);
+      batch = [];
+      batchBytes = 0;
+      batchMs = 0;
+    }
+
+    for (const chunk of chunks) {
+      const bytes = chunkByteSize(chunk);
+      const durationMs = chunkDurationMs(chunk);
+
+      if (
+        batch.length > 0 &&
+        (batchBytes + bytes > bufferConfig.maxChunkBytes ||
+          batchMs + durationMs > MAX_SEND_BATCH_MS)
+      ) {
+        flushBatch();
+      }
+
+      batch.push(chunk);
+      batchBytes += bytes;
+      batchMs += durationMs;
+    }
+
+    flushBatch();
+  }
+
   function wireTransport(conn: STTTransport): void {
     conn.onTranscript((e) => {
       const normalized = normalizeTranscript(e);
@@ -173,9 +222,7 @@ export async function createManagedConnection(
       wireTransport(newTransport);
 
       const replay = getReplayChunks();
-      for (const chunk of replay) {
-        newTransport.sendAudio(chunk);
-      }
+      sendChunkBatch(newTransport, replay);
 
       await oldTransport?.close();
       log.info({ rotationCount, replayedChunks: replay.length }, 'proactive rotation complete');
@@ -242,9 +289,7 @@ export async function createManagedConnection(
         wireTransport(newTransport);
 
         const replay = getReplayChunks();
-        for (const chunk of replay) {
-          newTransport.sendAudio(chunk);
-        }
+        sendChunkBatch(newTransport, replay);
 
         scheduleRotation();
         log.info({ attempt, replayedChunks: replay.length }, 'reactive reconnect succeeded');
@@ -269,9 +314,7 @@ export async function createManagedConnection(
   function flushPending(): void {
     if (pendingChunks.length === 0 || !transport || closed) return;
 
-    for (const chunk of pendingChunks) {
-      transport.sendAudio(chunk);
-    }
+    sendChunkBatch(transport, pendingChunks);
 
     pendingChunks = [];
     pendingBytes = 0;

--- a/packages/server/src/stt/base-adapter.ts
+++ b/packages/server/src/stt/base-adapter.ts
@@ -6,11 +6,13 @@ import type { BufferConfig, PartialStrategy, ReconnectConfig } from '@/stt/types
 
 const log = Log.create({ service: 'stt.base-adapter' });
 
+export type STTErrorClassification = { fatal: false } | { fatal: true; reason: string };
+
 type ManagedConnectionConfig = {
   buffer: BufferConfig;
   reconnect: ReconnectConfig;
   partialStrategy: PartialStrategy;
-  isFatal: (err: Error) => boolean;
+  classifyError: (err: Error) => STTErrorClassification;
   openConnection: () => Promise<STTTransport>;
 };
 
@@ -34,7 +36,7 @@ export async function createManagedConnection(
     buffer: bufferConfig,
     reconnect: reconnectConfig,
     partialStrategy,
-    isFatal,
+    classifyError,
     openConnection,
   } = config;
 
@@ -204,8 +206,10 @@ export async function createManagedConnection(
   }
 
   function handleError(err: Error): void {
-    if (isFatal(err)) {
-      emitUnrecoverable(`fatal adapter error: ${err.message}`);
+    const classification = classifyError(err);
+    if (classification.fatal) {
+      log.error({ error: err }, 'fatal adapter error');
+      emitUnrecoverable(classification.reason);
       for (const cb of errorListeners) cb(err);
       return;
     }
@@ -247,9 +251,12 @@ export async function createManagedConnection(
         reconnecting = false;
         return;
       } catch (err) {
-        if (isFatal(err instanceof Error ? err : new Error(String(err)))) {
+        const asError = err instanceof Error ? err : new Error(String(err));
+        const classification = classifyError(asError);
+        if (classification.fatal) {
           reconnecting = false;
-          emitUnrecoverable(`fatal error during reconnect: ${String(err)}`);
+          log.error({ error: err, attempt }, 'fatal error during reconnect');
+          emitUnrecoverable(classification.reason);
           return;
         }
         log.warn({ error: err, attempt }, 'reconnect attempt failed');

--- a/packages/server/src/stt/base-adapter.ts
+++ b/packages/server/src/stt/base-adapter.ts
@@ -27,9 +27,6 @@ function chunkDurationMs(chunk: AudioChunk): number {
   return (chunk.numSamples / chunk.sampleRateHz) * 1000;
 }
 
-/**
- * Creates a managed STTConnection with bounded buffer, pacing, and reconnect/rotation.
- */
 export async function createManagedConnection(
   config: ManagedConnectionConfig,
 ): Promise<STTConnection> {
@@ -41,10 +38,13 @@ export async function createManagedConnection(
     openConnection,
   } = config;
 
+  const maxBackoffMs = reconnectConfig.maxBackoffMs ?? 30_000;
+
   const transcriptListeners: ((e: TranscriptEvent) => void)[] = [];
   const usageListeners: ((u: STTUsage) => void)[] = [];
   const errorListeners: ((err: Error) => void)[] = [];
   const closeListeners: (() => void)[] = [];
+  const unrecoverableListeners: ((reason: string) => void)[] = [];
 
   // Bounded ring buffer for replay on reconnect
   const ringBuffer: BufferedChunk[] = [];
@@ -60,8 +60,23 @@ export async function createManagedConnection(
 
   let transport: STTTransport | null = null;
   let closed = false;
+  let rotating = false;
   let reconnecting = false;
+  let recoveryQueued = false;
   let rotationTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const sessionStartedAt = Date.now();
+  let rotationCount = 0;
+
+  function sessionAgeMs(): number {
+    return Date.now() - sessionStartedAt;
+  }
+
+  function emitUnrecoverable(reason: string): void {
+    log.error({ reason, rotationCount, sessionAgeMs: sessionAgeMs() }, 'connection unrecoverable');
+    for (const cb of unrecoverableListeners) cb(reason);
+    void close();
+  }
 
   function addToBuffer(chunk: AudioChunk): void {
     const duration = chunkDurationMs(chunk);
@@ -93,11 +108,11 @@ export async function createManagedConnection(
       for (const cb of usageListeners) cb(u);
     });
     conn.onError((err) => {
-      if (closed) return;
+      if (closed || conn !== transport) return;
       handleError(err);
     });
     conn.onClose(() => {
-      if (closed) return;
+      if (closed || conn !== transport) return;
       void handleDisconnect();
     });
   }
@@ -122,6 +137,7 @@ export async function createManagedConnection(
   function scheduleRotation(): void {
     if (!reconnectConfig.enabled || !reconnectConfig.rotateBeforeMs) return;
 
+    if (rotationTimer) clearTimeout(rotationTimer);
     rotationTimer = setTimeout(() => {
       if (closed) return;
       void proactiveRotate();
@@ -129,12 +145,24 @@ export async function createManagedConnection(
   }
 
   async function proactiveRotate(): Promise<void> {
-    if (closed || reconnecting) return;
-    reconnecting = true;
+    if (closed || rotating || reconnecting) return;
+    rotating = true;
+    rotationCount++;
 
-    log.info('proactive session rotation starting');
+    log.info(
+      {
+        rotationCount,
+        sessionAgeMs: sessionAgeMs(),
+        pendingChunks: pendingChunks.length,
+        pendingBytes,
+        bufferedChunks: ringBuffer.length,
+        totalBufferedMs: Math.round(totalBufferedMs),
+      },
+      'proactive session rotation starting',
+    );
 
     const oldTransport = transport;
+    flushPending();
     oldTransport?.commit();
 
     try {
@@ -148,19 +176,28 @@ export async function createManagedConnection(
       }
 
       await oldTransport?.close();
-      scheduleRotation();
-      log.info({ replayedChunks: replay.length }, 'proactive rotation complete');
+      log.info({ rotationCount, replayedChunks: replay.length }, 'proactive rotation complete');
     } catch (err) {
-      log.error({ error: err }, 'proactive rotation failed, continuing on existing connection');
+      log.error({ error: err, rotationCount }, 'proactive rotation failed, retaining connection');
     } finally {
-      reconnecting = false;
+      rotating = false;
+      scheduleRotation();
+      if (recoveryQueued && !closed) {
+        recoveryQueued = false;
+        void reactiveReconnect();
+      }
     }
   }
 
   async function handleDisconnect(): Promise<void> {
-    if (closed || reconnecting) return;
+    if (closed) return;
     if (!reconnectConfig.enabled) {
       for (const cb of closeListeners) cb();
+      return;
+    }
+    if (rotating || reconnecting) {
+      recoveryQueued = true;
+      log.warn({ rotating, reconnecting }, 'disconnect during recovery, deferring reconnect');
       return;
     }
     await reactiveReconnect();
@@ -168,23 +205,29 @@ export async function createManagedConnection(
 
   function handleError(err: Error): void {
     if (isFatal(err)) {
-      log.error({ error: err }, 'fatal adapter error, closing');
+      emitUnrecoverable(`fatal adapter error: ${err.message}`);
       for (const cb of errorListeners) cb(err);
-      void close();
       return;
     }
     log.warn({ error: err }, 'transient adapter error');
   }
 
   async function reactiveReconnect(): Promise<void> {
+    if (reconnecting) return;
     reconnecting = true;
     let attempt = 0;
+    const reconnectStartedAt = Date.now();
 
-    while (attempt < reconnectConfig.maxRetries && !closed) {
+    while (!closed) {
       attempt++;
-      const delay =
-        reconnectConfig.backoffMs * Math.pow(2, attempt - 1) * (0.5 + Math.random() * 0.5);
-      log.info({ attempt, delay: Math.round(delay) }, 'reactive reconnect attempt');
+      const delay = Math.min(
+        reconnectConfig.backoffMs * Math.pow(2, attempt - 1) * (0.5 + Math.random() * 0.5),
+        maxBackoffMs,
+      );
+      log.info(
+        { attempt, delay: Math.round(delay), elapsedMs: Date.now() - reconnectStartedAt },
+        'reactive reconnect attempt',
+      );
 
       await new Promise((r) => setTimeout(r, delay));
       if (closed) break;
@@ -204,16 +247,16 @@ export async function createManagedConnection(
         reconnecting = false;
         return;
       } catch (err) {
+        if (isFatal(err instanceof Error ? err : new Error(String(err)))) {
+          reconnecting = false;
+          emitUnrecoverable(`fatal error during reconnect: ${String(err)}`);
+          return;
+        }
         log.warn({ error: err, attempt }, 'reconnect attempt failed');
       }
     }
 
     reconnecting = false;
-    if (!closed) {
-      const error = new Error(`Reconnect failed after ${reconnectConfig.maxRetries} attempts`);
-      for (const cb of errorListeners) cb(error);
-      for (const cb of closeListeners) cb();
-    }
   }
 
   function flushPending(): void {
@@ -308,6 +351,9 @@ export async function createManagedConnection(
     },
     onClose(cb) {
       closeListeners.push(cb);
+    },
+    onUnrecoverable(cb) {
+      unrecoverableListeners.push(cb);
     },
   };
 }

--- a/packages/server/src/stt/route.ts
+++ b/packages/server/src/stt/route.ts
@@ -175,6 +175,18 @@ async function handleStart(
       });
     });
 
+    session.onUnrecoverable((reason) => {
+      log.error({ reason, sttSessionId: message.sttSessionId }, 'session unrecoverable');
+      send(ws, { type: 'unrecoverable', sttSessionId: message.sttSessionId, reason });
+
+      if (message.service === 'meeting-recording' && state.recordingId) {
+        internalBus.emit('recording.unrecoverable', {
+          recordingId: state.recordingId as PrefixedString<'rec'>,
+          reason,
+        });
+      }
+    });
+
     send(ws, {
       type: 'ready',
       sttSessionId: message.sttSessionId,

--- a/packages/server/src/stt/session.ts
+++ b/packages/server/src/stt/session.ts
@@ -58,6 +58,7 @@ export type STTSession = {
   stop(): Promise<STTSessionResult>;
   onTranscript(cb: (e: SourcedTranscriptEvent) => void): void;
   onError(cb: (err: Error) => void): void;
+  onUnrecoverable(cb: (reason: string) => void): void;
 };
 
 type STTSessionDeps = {
@@ -156,6 +157,7 @@ export async function createSTTSession(
   // Open connections eagerly
   const transcriptListeners: ((e: SourcedTranscriptEvent) => void)[] = [];
   const errorListeners: ((err: Error) => void)[] = [];
+  const unrecoverableListeners: ((reason: string) => void)[] = [];
 
   const connections = new Map<AudioSource, STTConnection>();
 
@@ -191,6 +193,10 @@ export async function createSTTSession(
 
     conn.onError((err) => {
       for (const cb of errorListeners) cb(err);
+    });
+
+    conn.onUnrecoverable((reason) => {
+      for (const cb of unrecoverableListeners) cb(reason);
     });
   }
 
@@ -293,6 +299,9 @@ export async function createSTTSession(
     },
     onError(cb) {
       errorListeners.push(cb);
+    },
+    onUnrecoverable(cb) {
+      unrecoverableListeners.push(cb);
     },
   };
 }

--- a/packages/server/src/stt/types.ts
+++ b/packages/server/src/stt/types.ts
@@ -9,6 +9,7 @@ export type ReconnectConfig = {
   enabled: boolean;
   maxRetries: number;
   backoffMs: number;
+  maxBackoffMs?: number;
   rotateBeforeMs?: number;
 };
 

--- a/packages/server/src/stt/ws-transport.ts
+++ b/packages/server/src/stt/ws-transport.ts
@@ -58,11 +58,23 @@ export function createWsTransport(
 
       const transport: STTTransport = {
         sendAudio(chunk) {
-          if (ws.readyState !== WebSocket.OPEN) return;
+          if (ws.readyState !== WebSocket.OPEN) {
+            log.warn(
+              { label: config.label, readyState: ws.readyState },
+              'dropping audio, socket not open',
+            );
+            return;
+          }
           ws.send(buildAudioMessage(chunk));
         },
         commit() {
-          if (ws.readyState !== WebSocket.OPEN) return;
+          if (ws.readyState !== WebSocket.OPEN) {
+            log.warn(
+              { label: config.label, readyState: ws.readyState },
+              'dropping commit, socket not open',
+            );
+            return;
+          }
           ws.send(buildCommitMessage());
         },
         async close() {

--- a/packages/server/src/stt/ws-transport.ts
+++ b/packages/server/src/stt/ws-transport.ts
@@ -119,12 +119,18 @@ export function createWsTransport(
     });
 
     ws.addEventListener('close', (event) => {
+      const err = new Error(`${config.label} WebSocket closed: ${event.code} ${event.reason}`);
+      (err as Error & { code?: string }).code = String(event.code);
+
       if (!opened) {
-        reject(
-          new Error(`${config.label} WebSocket failed to connect: ${event.code} ${event.reason}`),
-        );
+        reject(err);
         return;
       }
+
+      if (event.code !== 1000) {
+        for (const cb of errorListeners) cb(err);
+      }
+
       for (const cb of closeListeners) cb();
     });
 

--- a/packages/shared/src/recordings/events.ts
+++ b/packages/shared/src/recordings/events.ts
@@ -25,6 +25,11 @@ export type RecordingStoppedPayload = {
   recordingId: PrefixedString<'rec'>;
 };
 
+export type RecordingUnrecoverablePayload = {
+  recordingId: PrefixedString<'rec'>;
+  reason: string;
+};
+
 export type RecordingTranscriptEntryPayload = {
   recordingId: string;
   kind: 'partial' | 'final';
@@ -40,6 +45,7 @@ export const RECORDING_EVENT_NAMES = [
   'recording-transcript-entry',
   'recording-started',
   'recording-stopped',
+  'recording-unrecoverable',
 ] as const;
 
 export type RecordingEvents = {
@@ -47,4 +53,5 @@ export type RecordingEvents = {
   'recording-transcript-entry': RecordingTranscriptEntryPayload;
   'recording-started': RecordingStartedPayload;
   'recording-stopped': RecordingStoppedPayload;
+  'recording-unrecoverable': RecordingUnrecoverablePayload;
 };

--- a/packages/shared/src/settings/types.test.ts
+++ b/packages/shared/src/settings/types.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 
-import { isValidLeaderKeyHotkey } from './types';
+import { SETTINGS_SCHEMAS, isValidLeaderKeyHotkey } from './types';
+
+describe('SETTINGS_SCHEMAS', () => {
+  test('parses boolean setting strings', () => {
+    expect(SETTINGS_SCHEMAS['recordings.autoAnalyze'].parse('true')).toBe(true);
+    expect(SETTINGS_SCHEMAS['recordings.autoAnalyze'].parse('false')).toBe(false);
+  });
+});
 
 describe('isValidLeaderKeyHotkey', () => {
   test('accepts Mod+single letter', () => {

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -53,6 +53,8 @@ export const SETTINGS_KEYS = [
 
 export type SettingsKey = (typeof SETTINGS_KEYS)[number];
 
+const booleanSetting = z.enum(['true', 'false']).transform((value) => value === 'true');
+
 export const SETTINGS_SCHEMAS = {
   'model.default.providerId': z.string(),
   'model.default.modelId': z.string(),
@@ -60,8 +62,8 @@ export const SETTINGS_SCHEMAS = {
   'model.compaction.modelId': z.string(),
   'model.title.providerId': z.string(),
   'model.title.modelId': z.string(),
-  'compaction.auto': z.coerce.boolean(),
-  'compaction.prune': z.coerce.boolean(),
+  'compaction.auto': booleanSetting,
+  'compaction.prune': booleanSetting,
   'compaction.reserved': z.coerce.number().int().min(0),
   'toolsets.defaultScope': z.enum(['current_run', 'ttl_turns', 'until_deactivated']),
   'toolsets.ttlTurns': z.coerce.number().int().min(1),
@@ -71,12 +73,12 @@ export const SETTINGS_SCHEMAS = {
   'onboarding.version': z.string().regex(/^\d+$/),
   'profile.name': z.string().min(1).max(80),
   'profile.timezone': z.string().min(1).max(120),
-  'notifications.sound.enabled': z.coerce.boolean(),
+  'notifications.sound.enabled': booleanSetting,
   'browser.profileImported': z.string(),
   'browser.activeProfile': z.string(),
   'shortcuts.leaderKey': z.string().regex(/^Mod\+[A-Za-z0-9]$/),
-  'memory.enabled': z.coerce.boolean(),
-  'memory.autoExtract': z.coerce.boolean(),
+  'memory.enabled': booleanSetting,
+  'memory.autoExtract': booleanSetting,
   'memory.embedding.providerId': z.string(),
   'memory.embedding.modelId': z.string(),
   'memory.extraction.maxFactsPerTurn': z.coerce.number().int().min(1),
@@ -87,11 +89,11 @@ export const SETTINGS_SCHEMAS = {
   'memory.extraction.minTurnsBetweenWrites': z.coerce.number().int().min(0),
   'memory.retention.maxMemories': z.coerce.number().int().min(10),
   'memory.retention.staleDays': z.coerce.number().int().min(1),
-  'memory.retention.autoprune': z.coerce.boolean(),
+  'memory.retention.autoprune': booleanSetting,
   'memory.retrieval.maxResults': z.coerce.number().int().min(1),
   'memory.retrieval.minScore': z.coerce.number().min(0).max(1),
-  'memory.retrieval.recencyBoost': z.coerce.boolean(),
-  'recordings.autoAnalyze': z.coerce.boolean(),
+  'memory.retrieval.recencyBoost': booleanSetting,
+  'recordings.autoAnalyze': booleanSetting,
   'recordings.inputDeviceId': z.string(),
   'recordings.outputDeviceId': z.string(),
   'recordings.speakerGain': z.coerce.number().min(0.1).max(50),

--- a/packages/shared/src/stt/types.ts
+++ b/packages/shared/src/stt/types.ts
@@ -133,11 +133,18 @@ export type SttDoneMessage = {
   usage: STTUsage;
 };
 
+export type SttUnrecoverableMessage = {
+  type: 'unrecoverable';
+  sttSessionId: string;
+  reason: string;
+};
+
 export type SttOutboundMessage =
   | SttReadyMessage
   | SttTranscriptMessage
   | SttErrorMessage
-  | SttDoneMessage;
+  | SttDoneMessage
+  | SttUnrecoverableMessage;
 
 export type SttModelSummary = {
   id: string;


### PR DESCRIPTION
## 🚀 Change Summary

Repairs the STT socket rotation and recovery path so long-running recordings keep transcribing through provider session rotation, transient disconnects, and recoverable connection failures. The branch also improves how fatal provider errors are classified and surfaced to users, preserves per-recording STT model overrides, and coalesces buffered PCM audio before sending/replaying it so reconnects and rotations do not flood providers with tiny chunks.

### 🐛 Bug Fixes

- **Wedged state on mid-rotation disconnect**: split `rotating` and `reconnecting` into separate flags; disconnects arriving during rotation are deferred via `recoveryQueued` and run once rotation settles instead of being silently swallowed
- **Permanent rotation disable on failure**: moved `scheduleRotation()` into `finally` so a one-off `openConnection` failure always re-arms the proactive rotation timer
- **Audio loss on every rotation**: `flushPending()` now runs before `commit()` during proactive rotation so in-flight coalesced chunks reach the old socket before it closes
- **Fragmented audio flush/replay**: pending and replayed PCM chunks are merged into bounded send batches, preserving sample order while reducing tiny-frame traffic during normal flushes, reconnects, and rotations
- **Spurious recovery after intentional socket close**: `onClose`/`onError` handlers now ignore events from superseded sockets with `conn !== transport`
- **Recording STT override dropped by validation**: `/recordings/start` now accepts `sttProviderId` and `sttModelId`, preserving the model selected from the meeting recording banner
- **Disabled auto-analysis still running**: persisted boolean settings now parse explicit `true`/`false` strings so `recordings.autoAnalyze = false` no longer triggers recording analysis after completion

### ✨ New Features

- **Indefinite reconnect with capped backoff**: `reactiveReconnect` retries while the session is active, using configurable `maxBackoffMs` capped backoff so long recordings resume transcription after transient connectivity loss instead of silently stopping
- **User-facing unrecoverable transcription flow**: fatal STT failures emit `recording.unrecoverable` through the internal bus, outbound WebSocket message, SSE event, and web toast; the client then gracefully stops the recording so buffered audio is flushed
- **Provider-specific fatal error reasons**: OpenAI, ElevenLabs, and AssemblyAI now classify credentials, quota, model, terms, stream/session limit, and close-code failures into actionable messages shown to the user

### 🛠 Improvements & Refactors

- Log dropped `sendAudio` and `commit` calls in `ws-transport` when the socket is not open
- Treat abnormal WebSocket closes as errors and retain close codes for adapter classification
- Log rotation stats (`rotationCount`, `sessionAgeMs`, `pendingChunks`, `bufferedMs`) on each proactive rotation
- Added regression coverage for mid-rotation drop recovery, rotation re-arm after failed opens, indefinite reconnect, flush-before-rotate audio preservation, fatal unrecoverable emission, and PCM chunk coalescing
