### PR TITLE
fix: preserve immediate STT adapter failures

### DIFF
--- a/packages/server/src/stt/adapters/elevenlabs.ts
+++ b/packages/server/src/stt/adapters/elevenlabs.ts
@@ -139,6 +139,7 @@ function classifyElevenLabsError(err: Error): STTErrorClassification {
   if (
     code === 'auth_error' ||
     code === 'invalid_api_key' ||
+    msg.includes('must be authenticated') ||
     msg.includes('401') ||
     msg.includes('403')
   ) {

--- a/packages/server/src/stt/base-adapter.test.ts
+++ b/packages/server/src/stt/base-adapter.test.ts
@@ -282,4 +282,23 @@ describe('createManagedConnection recovery', () => {
 
     await conn.close();
   });
+
+  test('replays unrecoverable reason to listeners registered after a fatal error', async () => {
+    const transport = createFakeTransport();
+    const conn = await createManagedConnection({
+      buffer: baseBuffer,
+      reconnect: { ...baseReconnect, rotateBeforeMs: undefined },
+      partialStrategy: 'cumulative',
+      classifyError: () => ({ fatal: true, reason: 'adapter classified auth as fatal' }),
+      openConnection: async () => transport,
+    });
+
+    transport.emitError(new Error('auth rejected'));
+
+    const reasons: string[] = [];
+    conn.onUnrecoverable((reason) => reasons.push(reason));
+
+    expect(reasons).toEqual(['adapter classified auth as fatal']);
+    expect(transport.closed).toBe(true);
+  });
 });

--- a/packages/server/src/stt/base-adapter.ts
+++ b/packages/server/src/stt/base-adapter.ts
@@ -82,6 +82,7 @@ export async function createManagedConnection(
   let reconnecting = false;
   let recoveryQueued = false;
   let rotationTimer: ReturnType<typeof setTimeout> | null = null;
+  let unrecoverableReason: string | null = null;
 
   const sessionStartedAt = Date.now();
   let rotationCount = 0;
@@ -91,6 +92,8 @@ export async function createManagedConnection(
   }
 
   function emitUnrecoverable(reason: string): void {
+    if (unrecoverableReason) return;
+    unrecoverableReason = reason;
     log.error({ reason, rotationCount, sessionAgeMs: sessionAgeMs() }, 'connection unrecoverable');
     for (const cb of unrecoverableListeners) cb(reason);
     void close();
@@ -403,6 +406,10 @@ export async function createManagedConnection(
       closeListeners.push(cb);
     },
     onUnrecoverable(cb) {
+      if (unrecoverableReason) {
+        cb(unrecoverableReason);
+        return;
+      }
       unrecoverableListeners.push(cb);
     },
   };

--- a/packages/server/src/stt/ws-transport.ts
+++ b/packages/server/src/stt/ws-transport.ts
@@ -37,6 +37,7 @@ export function createWsTransport(
     const usageListeners: ((u: STTUsage) => void)[] = [];
     const errorListeners: ((err: Error) => void)[] = [];
     const closeListeners: (() => void)[] = [];
+    const pendingErrors: Error[] = [];
 
     // The WebSocket constructor in Node does not have a typed overload for headers.
     // This cast is isolated here so adapters don't repeat it.
@@ -45,6 +46,16 @@ export function createWsTransport(
     } as unknown as string[]);
 
     let opened = false;
+    let closed = false;
+
+    function emitOrQueueError(err: Error): void {
+      if (errorListeners.length === 0) {
+        pendingErrors.push(err);
+        return;
+      }
+
+      for (const cb of errorListeners) cb(err);
+    }
 
     ws.addEventListener('open', () => {
       opened = true;
@@ -90,9 +101,13 @@ export function createWsTransport(
         },
         onError(cb) {
           errorListeners.push(cb);
+          while (pendingErrors.length > 0) {
+            cb(pendingErrors.shift()!);
+          }
         },
         onClose(cb) {
           closeListeners.push(cb);
+          if (closed) cb();
         },
       };
 
@@ -111,7 +126,7 @@ export function createWsTransport(
           for (const cb of usageListeners) cb(result.usage);
         }
         if (result.error) {
-          for (const cb of errorListeners) cb(result.error);
+          emitOrQueueError(result.error);
         }
       } catch (err) {
         log.warn({ error: err, label: config.label }, 'failed to parse WebSocket message');
@@ -119,6 +134,7 @@ export function createWsTransport(
     });
 
     ws.addEventListener('close', (event) => {
+      closed = true;
       const err = new Error(`${config.label} WebSocket closed: ${event.code} ${event.reason}`);
       (err as Error & { code?: string }).code = String(event.code);
 
@@ -128,7 +144,7 @@ export function createWsTransport(
       }
 
       if (event.code !== 1000) {
-        for (const cb of errorListeners) cb(err);
+        emitOrQueueError(err);
       }
 
       for (const cb of closeListeners) cb();
@@ -141,7 +157,7 @@ export function createWsTransport(
         reject(err);
         return;
       }
-      for (const cb of errorListeners) cb(err);
+      emitOrQueueError(err);
     });
   });
 }


### PR DESCRIPTION
## 🚀 Change Summary

Fixes a race where immediate STT adapter failures could be emitted before session listeners were attached, causing meeting recordings to continue even after a fatal transcription error.

### 🐛 Bug Fixes
- Preserve and replay early STT transport errors so adapters do not lose provider failures during startup.
- Preserve and replay unrecoverable adapter reasons for listeners registered after a fast fatal error.
- Explicitly classify ElevenLabs `must be authenticated` responses as invalid transcription credentials.
