### PR TITLE
Start recording/dictation immediately on STT model selection

### DIFF
--- a/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
@@ -122,7 +122,32 @@ export function ChatInputInner({
   const sttBaseOffsetRef = React.useRef(0);
   const valueRef = React.useRef(value);
   valueRef.current = value;
-  const [sttModelOverride, setSttModelOverride] = React.useState<SttModelSelection | null>(null);
+
+  const defaultSttModel: SttModelSelection | null =
+    settings['stt.default.providerId'] && settings['stt.default.modelId']
+      ? { providerId: settings['stt.default.providerId'], modelId: settings['stt.default.modelId'] }
+      : null;
+
+  function startStt(model?: SttModelSelection) {
+    if (stt.state !== 'idle') return;
+
+    const providerId = model?.providerId ?? settings['stt.default.providerId'];
+    const modelId = model?.modelId ?? settings['stt.default.modelId'];
+    if (!providerId || !modelId) {
+      toast.error('No STT model configured. Set one in Settings → General → STT Model.');
+      return;
+    }
+
+    const provider = sttProviders.find((p) => p.providerId === providerId);
+    const foundModel = provider?.models.find((m) => m.id === modelId);
+    if (!foundModel) {
+      toast.error('Configured STT model not found. Check Settings → General → STT Model.');
+      return;
+    }
+
+    sttBaseOffsetRef.current = value.length;
+    void stt.start(providerId, modelId, foundModel.sampleRateHz);
+  }
 
   async function handleMicClick() {
     if (stt.state === 'recording') {
@@ -133,24 +158,7 @@ export function ChatInputInner({
       return;
     }
 
-    if (stt.state !== 'idle') return;
-
-    const providerId = sttModelOverride?.providerId ?? settings['stt.default.providerId'];
-    const modelId = sttModelOverride?.modelId ?? settings['stt.default.modelId'];
-    if (!providerId || !modelId) {
-      toast.error('No STT model configured. Set one in Settings → General → STT Model.');
-      return;
-    }
-
-    const provider = sttProviders.find((p) => p.providerId === providerId);
-    const model = provider?.models.find((m) => m.id === modelId);
-    if (!model) {
-      toast.error('Configured STT model not found. Check Settings → General → STT Model.');
-      return;
-    }
-
-    sttBaseOffsetRef.current = value.length;
-    await stt.start(providerId, modelId, model.sampleRateHz);
+    startStt();
   }
 
   // Splice partial text into textarea value while recording
@@ -289,8 +297,8 @@ export function ChatInputInner({
                 <>
                   <ButtonGroupSeparator />
                   <SttModelSelectorPopover
-                    selectedValue={sttModelOverride}
-                    onSelect={setSttModelOverride}
+                    defaultValue={defaultSttModel}
+                    onSelect={(model) => startStt(model)}
                     sttProviders={sttProviders}
                     triggerRender={
                       <Button

--- a/apps/web/src/components/model-selectors/stt-model-selector-popover.tsx
+++ b/apps/web/src/components/model-selectors/stt-model-selector-popover.tsx
@@ -12,8 +12,8 @@ export type SttModelSelection = {
 };
 
 type SttModelSelectorPopoverProps = {
-  selectedValue: SttModelSelection | null;
-  onSelect: (value: SttModelSelection | null) => void;
+  defaultValue: SttModelSelection | null;
+  onSelect: (value: SttModelSelection) => void;
   sttProviders: SttProviderModels[];
   /**
    * Element to render as the popover trigger. When omitted a standalone
@@ -24,18 +24,12 @@ type SttModelSelectorPopoverProps = {
 };
 
 export function SttModelSelectorPopover({
-  selectedValue,
+  defaultValue,
   onSelect,
   sttProviders,
   triggerRender,
 }: SttModelSelectorPopoverProps) {
   const [search, setSearch] = React.useState('');
-
-  const selectedModel = React.useMemo(() => {
-    if (!selectedValue) return null;
-    const provider = sttProviders.find((p) => p.providerId === selectedValue.providerId);
-    return provider?.models.find((m) => m.id === selectedValue.modelId) ?? null;
-  }, [sttProviders, selectedValue]);
 
   const filtered = React.useMemo(() => {
     if (!search.trim()) return sttProviders;
@@ -52,22 +46,18 @@ export function SttModelSelectorPopover({
       .filter((p) => p.models.length > 0);
   }, [sttProviders, search]);
 
-  const label = selectedModel?.name ?? 'Default';
-
   return (
     <PopoverPrimitive.Root>
       <PopoverPrimitive.Trigger
         render={triggerRender}
-        title={`STT model: ${label}`}
+        title="Choose STT model"
         className={
           triggerRender
             ? undefined
             : cn(
                 'flex items-center justify-center rounded-md p-1 transition-colors',
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
-                selectedValue
-                  ? 'text-foreground bg-muted/50'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+                'text-muted-foreground hover:text-foreground hover:bg-muted/50',
               )
         }
       >
@@ -91,7 +81,7 @@ export function SttModelSelectorPopover({
               'w-72 max-h-80 flex flex-col origin-(--transform-origin) outline-none duration-100',
             )}
           >
-            <div className="px-3 py-2 border-b border-border/50">
+            <div className="border-b border-border/50 px-3 py-2">
               <p className="text-xs font-medium text-muted-foreground">STT Model</p>
             </div>
 
@@ -108,21 +98,6 @@ export function SttModelSelectorPopover({
 
             <div className="no-scrollbar max-h-60 overflow-y-auto overscroll-contain">
               <div className="p-1">
-                <PopoverPrimitive.Close
-                  onClick={() => onSelect(null)}
-                  className={cn(
-                    'w-full flex items-center justify-between rounded-md px-2 py-1.5 text-sm cursor-default',
-                    'transition-colors hover:bg-accent hover:text-accent-foreground',
-                    'focus-visible:outline-none focus-visible:bg-accent',
-                    !selectedValue && 'font-medium',
-                  )}
-                >
-                  <span className="text-muted-foreground">Default (from settings)</span>
-                  {!selectedValue && <CheckIcon className="size-3.5 shrink-0" />}
-                </PopoverPrimitive.Close>
-
-                {filtered.length > 0 && <div className="my-1 h-px bg-border/50" />}
-
                 {filtered.map((provider, index) => (
                   <div key={provider.providerId}>
                     {index > 0 && <div className="my-1 h-px bg-border/50" />}
@@ -130,9 +105,9 @@ export function SttModelSelectorPopover({
                       {provider.providerName}
                     </p>
                     {provider.models.map((model) => {
-                      const isSelected =
-                        selectedValue?.providerId === provider.providerId &&
-                        selectedValue?.modelId === model.id;
+                      const isDefault =
+                        defaultValue?.providerId === provider.providerId &&
+                        defaultValue?.modelId === model.id;
                       return (
                         <PopoverPrimitive.Close
                           key={model.id}
@@ -143,11 +118,11 @@ export function SttModelSelectorPopover({
                             'w-full flex items-center justify-between rounded-md px-2 py-1.5 text-sm cursor-default',
                             'transition-colors hover:bg-accent hover:text-accent-foreground',
                             'focus-visible:outline-none focus-visible:bg-accent',
-                            isSelected && 'font-medium',
+                            isDefault && 'font-medium',
                           )}
                         >
                           <span>{model.name}</span>
-                          {isSelected && <CheckIcon className="size-3.5 shrink-0" />}
+                          {isDefault && <CheckIcon className="size-3.5 shrink-0" />}
                         </PopoverPrimitive.Close>
                       );
                     })}

--- a/apps/web/src/components/recordings/list/recording-start-stop-bar.tsx
+++ b/apps/web/src/components/recordings/list/recording-start-stop-bar.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { ButtonGroup, ButtonGroupSeparator } from '@/components/ui/button-group';
 import { Input } from '@/components/ui/input';
 import { sttProviderModelsQueryOptions } from '@/lib/queries/providers';
+import { settingsQueryOptions } from '@/lib/queries/settings';
 
 interface RecordingStartStopBarProps {
   activeRecording: Recording | undefined;
@@ -19,9 +20,7 @@ interface RecordingStartStopBarProps {
   isStopping: boolean;
   title: string;
   onTitleChange: (title: string) => void;
-  sttModelOverride: SttModelSelection | null;
-  onSttModelOverrideChange: (value: SttModelSelection | null) => void;
-  onStart: () => void;
+  onStart: (sttModel?: SttModelSelection) => void;
   onStop: () => void;
 }
 
@@ -31,12 +30,19 @@ export function RecordingStartStopBar({
   isStopping,
   title,
   onTitleChange,
-  sttModelOverride,
-  onSttModelOverrideChange,
   onStart,
   onStop,
 }: RecordingStartStopBarProps) {
   const { data: sttProviders } = useSuspenseQuery(sttProviderModelsQueryOptions);
+  const { data: settings } = useSuspenseQuery(settingsQueryOptions);
+
+  const defaultSttModel: SttModelSelection | null =
+    settings['recordings.transcription.providerId'] && settings['recordings.transcription.modelId']
+      ? {
+          providerId: settings['recordings.transcription.providerId'],
+          modelId: settings['recordings.transcription.modelId'],
+        }
+      : null;
 
   return (
     <div className="rounded-xl border border-border/60 bg-card/70 p-4">
@@ -67,7 +73,7 @@ export function RecordingStartStopBar({
         ) : sttProviders.length > 0 ? (
           <ButtonGroup className="overflow-hidden rounded-lg border border-primary/20 bg-primary shadow-sm shadow-primary/10">
             <Button
-              onClick={onStart}
+              onClick={() => onStart()}
               disabled={isStarting}
               className="h-8 rounded-none px-2.5 text-primary-foreground hover:bg-primary/90"
             >
@@ -76,14 +82,14 @@ export function RecordingStartStopBar({
             </Button>
             <ButtonGroupSeparator className="bg-primary-foreground/20" />
             <SttModelSelectorPopover
-              selectedValue={sttModelOverride}
-              onSelect={onSttModelOverrideChange}
+              defaultValue={defaultSttModel}
+              onSelect={(value) => onStart(value)}
               sttProviders={sttProviders}
               triggerRender={
                 <Button
                   disabled={isStarting}
                   className="h-8 rounded-none px-1.5 text-primary-foreground hover:bg-primary/90"
-                  title="Choose transcription model"
+                  title="Choose transcription model and start"
                 >
                   <ChevronDownIcon className="size-3.5" />
                 </Button>
@@ -92,7 +98,7 @@ export function RecordingStartStopBar({
           </ButtonGroup>
         ) : (
           <Button
-            onClick={onStart}
+            onClick={() => onStart()}
             disabled={isStarting}
             className="h-8 rounded-lg px-2.5 shadow-sm"
           >

--- a/apps/web/src/components/recordings/meeting-recording-banner.tsx
+++ b/apps/web/src/components/recordings/meeting-recording-banner.tsx
@@ -19,6 +19,7 @@ import {
   useStartRecording,
   useStopRecording,
 } from '@/lib/queries/recordings';
+import { settingsQueryOptions } from '@/lib/queries/settings';
 
 const WARNING_LABELS: Record<string, string> = {
   input_backpressure: 'Audio input is falling behind — some audio may be dropped.',
@@ -62,12 +63,20 @@ export function RecordingEventListener() {
 export function MeetingRecordingBanner() {
   const [detection, setDetection] = React.useState<MeetingCallDetectedPayload | null>(null);
   const [dismissedKeys, setDismissedKeys] = React.useState<Set<string>>(new Set());
-  const [sttModelOverride, setSttModelOverride] = React.useState<SttModelSelection | null>(null);
 
   const startRecording = useStartRecording();
   const { data } = useQuery(activeRecordingQueryOptions);
   const { data: sttProviders } = useSuspenseQuery(sttProviderModelsQueryOptions);
+  const { data: settings } = useSuspenseQuery(settingsQueryOptions);
   const activeRecordingId = data?.activeRecordingId ?? null;
+
+  const defaultSttModel: SttModelSelection | null =
+    settings['recordings.transcription.providerId'] && settings['recordings.transcription.modelId']
+      ? {
+          providerId: settings['recordings.transcription.providerId'],
+          modelId: settings['recordings.transcription.modelId'],
+        }
+      : null;
 
   const activeRecordingIdRef = React.useRef(activeRecordingId);
   activeRecordingIdRef.current = activeRecordingId;
@@ -181,8 +190,6 @@ export function MeetingRecordingBanner() {
                   void startRecording
                     .mutateAsync({
                       platform: detection.platform,
-                      sttProviderId: sttModelOverride?.providerId,
-                      sttModelId: sttModelOverride?.modelId,
                     })
                     .then(
                       () => {
@@ -203,8 +210,26 @@ export function MeetingRecordingBanner() {
               </Button>
               <ButtonGroupSeparator className="bg-primary-foreground/20" />
               <SttModelSelectorPopover
-                selectedValue={sttModelOverride}
-                onSelect={setSttModelOverride}
+                defaultValue={defaultSttModel}
+                onSelect={(value) => {
+                  void startRecording
+                    .mutateAsync({
+                      platform: detection.platform,
+                      sttProviderId: value.providerId,
+                      sttModelId: value.modelId,
+                    })
+                    .then(
+                      () => {
+                        requestDismissMeeting(detection.key);
+                        toast.success('Recording started');
+                      },
+                      (error: unknown) => {
+                        toast.error(
+                          error instanceof Error ? error.message : 'Failed to start recording',
+                        );
+                      },
+                    );
+                }}
                 sttProviders={sttProviders}
                 triggerRender={
                   <Button
@@ -212,7 +237,7 @@ export function MeetingRecordingBanner() {
                     size="sm"
                     disabled={startRecording.isPending}
                     className="rounded-none px-1.5 text-primary-foreground hover:bg-primary/90"
-                    title="Choose transcription model"
+                    title="Choose transcription model and start"
                   >
                     <ChevronDownIcon className="size-3.5" />
                   </Button>
@@ -227,8 +252,6 @@ export function MeetingRecordingBanner() {
                 void startRecording
                   .mutateAsync({
                     platform: detection.platform,
-                    sttProviderId: sttModelOverride?.providerId,
-                    sttModelId: sttModelOverride?.modelId,
                   })
                   .then(
                     () => {

--- a/apps/web/src/components/recordings/recordings-page.tsx
+++ b/apps/web/src/components/recordings/recordings-page.tsx
@@ -38,7 +38,6 @@ export function RecordingsPage() {
   const [sorting, setSorting] = React.useState<SortingState>([{ id: 'startedAt', desc: true }]);
   const [title, setTitle] = React.useState('');
   const [recordingToDelete, setRecordingToDelete] = React.useState<Recording | null>(null);
-  const [sttModelOverride, setSttModelOverride] = React.useState<SttModelSelection | null>(null);
 
   const { data } = useSuspenseQuery({
     ...recordingsQueryOptions({ page, pageSize: PAGE_SIZE }),
@@ -101,14 +100,12 @@ export function RecordingsPage() {
           isStopping={stopRecording.isPending}
           title={title}
           onTitleChange={setTitle}
-          sttModelOverride={sttModelOverride}
-          onSttModelOverrideChange={setSttModelOverride}
-          onStart={() => {
+          onStart={(sttModel?: SttModelSelection) => {
             void startRecording
               .mutateAsync({
                 title: title.trim() || undefined,
-                sttProviderId: sttModelOverride?.providerId,
-                sttModelId: sttModelOverride?.modelId,
+                sttProviderId: sttModel?.providerId,
+                sttModelId: sttModel?.modelId,
               })
               .then(
                 () => {


### PR DESCRIPTION
## Change Summary

Selecting an STT model from the dropdown now immediately starts the action (recording or dictation) with that model, instead of requiring a separate button click.

### Improvements & Refactors
- **STT model dropdown triggers action on select**: Removes the intermediate sttModelOverride state from the recordings page, meeting recording banner, and chat input. Picking a model starts recording/dictation directly.
- **Default model indicated with checkmark**: The "Default (from settings)" option is removed from the popover; instead, the currently configured default model is checkmarked in the list.
