### PR TITLE
fix: improve new chat transition

### DIFF
--- a/apps/web/src/components/home/new-session-page.tsx
+++ b/apps/web/src/components/home/new-session-page.tsx
@@ -12,6 +12,7 @@ import type { Attachment } from '@/components/chat/chat-input-parts/types';
 import { useChatModel } from '@/hooks/session/use-chat-model';
 import { setNextSessionInputSeed } from '@/lib/chat-input-transition-seed';
 import { sessionKeys, useCreateSession, useSendMessage } from '@/lib/queries/chat';
+import { todoKeys } from '@/lib/queries/todos';
 import { useStreamStore } from '@/stores/stream-store';
 
 export function NewSessionPage() {
@@ -41,6 +42,7 @@ export function NewSessionPage() {
       pages: [{ messages: [], hasMore: false }],
       pageParams: [undefined],
     });
+    queryClient.setQueryData(todoKeys.list(session.id), []);
 
     startStream(session.id, assistantMessageId);
     void sendMessage.mutateAsync({

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -16,7 +16,8 @@ import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { err, isServiceError, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
-import { buildCompactedHistory, compact } from '@/llm/compaction.js';
+import { compact } from '@/llm/compaction.js';
+import { buildSessionLlmMessages } from '@/llm/session-history.js';
 import { cancelDecision, resolveDecision, type DoomLoopResponse } from '@/llm/stream/doom-loop.js';
 import { runStream } from '@/llm/stream/runner.js';
 import { generateTitle } from '@/llm/title-generator.js';
@@ -347,7 +348,7 @@ export async function sendMessage(
 
   await db.update(sessions).set({ updatedAt: Date.now() }).where(eq(sessions.id, input.sessionId));
 
-  const llmMessages = await buildCompactedHistory(input.sessionId, {
+  const llmMessages = await buildSessionLlmMessages(input.sessionId, {
     useBasePrompt: true,
     systemPrompt: null,
   });

--- a/packages/server/src/llm/compaction.ts
+++ b/packages/server/src/llm/compaction.ts
@@ -14,13 +14,11 @@ import { isServiceError } from '@/lib/service-result.js';
 import { addCacheControlToMessages, getProviderOptions } from '@/llm/cache-control.js';
 import { buildHistoryMessages } from '@/llm/history-messages.js';
 import { getPromptUserContext } from '@/llm/prompt/builder.js';
-import type { PromptConfig } from '@/llm/prompt/builder.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
 import { mapAIError, toStreamErrorDetails } from '@/llm/stream/ai-error-mapper.js';
 import { getSessionToolsetState } from '@/llm/stream/session-toolsets.js';
-import { retrieveMemoryContext } from '@/memory/retriever.js';
 import * as OllamaModels from '@/models/llm/ollama.js';
 import * as Models from '@/models/llm/registry.js';
 import { getSettings } from '@/settings/service.js';
@@ -467,65 +465,6 @@ export async function compact(input: {
   } finally {
     activeCompactions.delete(sessionId);
   }
-}
-
-/**
- * Build the LLM message history for a session, respecting compaction
- * boundaries. Returns messages starting from the most recent summary.
- */
-export async function buildCompactedHistory(
-  sessionId: PrefixedString<'ses'>,
-  promptConfig: Pick<PromptConfig, 'useBasePrompt' | 'systemPrompt'>,
-): Promise<ModelMessage[]> {
-  const db = getDb();
-
-  const [msgs, promptUserContext, sessionRow, todoContext] = await Promise.all([
-    db
-      .select()
-      .from(messages)
-      .where(eq(messages.sessionId, sessionId))
-      .orderBy(asc(messages.createdAt)),
-    getPromptUserContext(),
-    db.select({ type: sessions.type }).from(sessions).where(eq(sessions.id, sessionId)).limit(1),
-    getSessionTodosPromptBlock(sessionId),
-  ]);
-
-  // Automations can read all memories; chat only sees 'chat' memories
-  const memorySourceFilter = sessionRow[0]?.type === 'automation' ? undefined : ('chat' as const);
-
-  // Find the last compaction boundary (summary message)
-  let startIndex = 0;
-  for (let i = msgs.length - 1; i >= 0; i--) {
-    if (msgs[i].isSummary) {
-      startIndex = i;
-      break;
-    }
-  }
-
-  // Extract the latest user message text for memory retrieval
-  let memoryContext: string | null = null;
-  const latestUserMsg = [...msgs].reverse().find((m) => m.role === 'user');
-  if (latestUserMsg) {
-    const userText = latestUserMsg.parts
-      .filter((p): p is StoredPart & { type: 'text-delta' } => p.type === 'text-delta')
-      .map((p) => p.text)
-      .join('');
-
-    if (userText.length > 0) {
-      memoryContext = await retrieveMemoryContext(userText, memorySourceFilter).catch(() => null);
-    }
-  }
-
-  const historyMessages = buildHistoryMessages(msgs.slice(startIndex), {
-    useBasePrompt: promptConfig.useBasePrompt,
-    systemPrompt: promptConfig.systemPrompt,
-    userName: promptUserContext.userName,
-    userTimezone: promptUserContext.userTimezone,
-    memoryContext,
-    todoContext,
-  });
-
-  return historyMessages;
 }
 
 export function buildActiveToolsetInstructionsBlock(sessionId: PrefixedString<'ses'>): string {

--- a/packages/server/src/llm/session-history.ts
+++ b/packages/server/src/llm/session-history.ts
@@ -1,0 +1,67 @@
+import { asc, eq } from 'drizzle-orm';
+
+import type { StoredPart } from '@stitch/shared/chat/messages';
+import type { PrefixedString } from '@stitch/shared/id';
+
+import { getDb } from '@/db/client.js';
+import { messages, sessions } from '@/db/schema/sessions.js';
+import { buildHistoryMessages } from '@/llm/history-messages.js';
+import { getPromptUserContext } from '@/llm/prompt/builder.js';
+import type { PromptConfig } from '@/llm/prompt/builder.js';
+import { retrieveMemoryContext } from '@/memory/retriever.js';
+import { getSessionTodosPromptBlock } from '@/todos/service.js';
+import type { ModelMessage } from 'ai';
+
+/**
+ * Build the LLM message history for a session, starting from the latest summary boundary.
+ */
+export async function buildSessionLlmMessages(
+  sessionId: PrefixedString<'ses'>,
+  promptConfig: Pick<PromptConfig, 'useBasePrompt' | 'systemPrompt'>,
+): Promise<ModelMessage[]> {
+  const db = getDb();
+
+  const [msgs, promptUserContext, sessionRow, todoContext] = await Promise.all([
+    db
+      .select()
+      .from(messages)
+      .where(eq(messages.sessionId, sessionId))
+      .orderBy(asc(messages.createdAt)),
+    getPromptUserContext(),
+    db.select({ type: sessions.type }).from(sessions).where(eq(sessions.id, sessionId)).limit(1),
+    getSessionTodosPromptBlock(sessionId),
+  ]);
+
+  // Automations can read all memories; chat only sees 'chat' memories.
+  const memorySourceFilter = sessionRow[0]?.type === 'automation' ? undefined : ('chat' as const);
+
+  let startIndex = 0;
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    if (msgs[i].isSummary) {
+      startIndex = i;
+      break;
+    }
+  }
+
+  let memoryContext: string | null = null;
+  const latestUserMsg = [...msgs].reverse().find((m) => m.role === 'user');
+  if (latestUserMsg) {
+    const userText = latestUserMsg.parts
+      .filter((p): p is StoredPart & { type: 'text-delta' } => p.type === 'text-delta')
+      .map((p) => p.text)
+      .join('');
+
+    if (userText.length > 0) {
+      memoryContext = await retrieveMemoryContext(userText, memorySourceFilter).catch(() => null);
+    }
+  }
+
+  return buildHistoryMessages(msgs.slice(startIndex), {
+    useBasePrompt: promptConfig.useBasePrompt,
+    systemPrompt: promptConfig.systemPrompt,
+    userName: promptUserContext.userName,
+    userTimezone: promptUserContext.userTimezone,
+    memoryContext,
+    todoContext,
+  });
+}

--- a/packages/server/src/tools/core/inspect-image.ts
+++ b/packages/server/src/tools/core/inspect-image.ts
@@ -15,8 +15,8 @@ import * as AbortRegistry from '@/lib/abort-registry.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { isServiceError } from '@/lib/service-result.js';
-import { buildCompactedHistory } from '@/llm/compaction.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
+import { buildSessionLlmMessages } from '@/llm/session-history.js';
 import { runStream } from '@/llm/stream/runner.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 
@@ -173,7 +173,7 @@ export function createInspectImageTool(context: ToolContext, deps: InspectImageT
         duration: null,
       });
 
-      const llmMessages = await buildCompactedHistory(childSessionId, {
+      const llmMessages = await buildSessionLlmMessages(childSessionId, {
         useBasePrompt: true,
         systemPrompt: null,
       });

--- a/packages/server/src/tools/core/task.ts
+++ b/packages/server/src/tools/core/task.ts
@@ -13,8 +13,8 @@ import * as AbortRegistry from '@/lib/abort-registry.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { isServiceError } from '@/lib/service-result.js';
-import { buildCompactedHistory } from '@/llm/compaction.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
+import { buildSessionLlmMessages } from '@/llm/session-history.js';
 import { runStream } from '@/llm/stream/runner.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 import type { ToolsetManager } from '@/tools/toolsets/manager.js';
@@ -123,7 +123,7 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
       });
 
       // Build history (just the system prompt + user message)
-      const llmMessages = await buildCompactedHistory(childSessionId, {
+      const llmMessages = await buildSessionLlmMessages(childSessionId, {
         useBasePrompt: true,
         systemPrompt: null,
       });


### PR DESCRIPTION
## 🚀 Change Summary

Improves the initial chat-session transition by seeding known-empty todos data before navigation, and clarifies the LLM session-history code path by separating prompt/history assembly from actual compaction logic.

### 🛠 Improvements & Refactors
- **Session history builder**: Renamed and moved the per-turn LLM history preparation logic from `compaction.ts` to `session-history.ts`, making it clear this code prepares prompt messages rather than performing compaction.

### 🐛 Bug Fixes
- **New chat transition lag**: Seeds the empty todos cache for newly-created sessions so the session route does not suspend on an unnecessary todos query during the home-to-chat transition.
