### PR TITLE
feat: hold-to-talk and toggle dictation UX for chat input

### DIFF
--- a/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
@@ -1,20 +1,14 @@
-import {
-  ArrowUpIcon,
-  ChevronDownIcon,
-  MicIcon,
-  MicOffIcon,
-  PaperclipIcon,
-  SquareIcon,
-} from 'lucide-react';
+import { ArrowUpIcon, ChevronDownIcon, MicIcon, PaperclipIcon, SquareIcon } from 'lucide-react';
 import * as React from 'react';
-import { toast } from 'sonner';
 
+import { useHotkey } from '@tanstack/react-hotkeys';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { AttachmentPreview } from './attachment-preview';
 import { ModelSelectorPopover } from './model-selector-popover';
+import { RecordingBar } from './recording-bar';
 import { ATTACHMENT_ACCEPT, useAttachments } from './use-attachments';
-import { useStt } from './use-stt';
+import { useDictation } from './use-dictation';
 
 import type { Attachment, ModelSpec } from './types';
 import {
@@ -31,6 +25,7 @@ import {
   visibleProviderModelsQueryOptions,
 } from '@/lib/queries/providers';
 import { settingsQueryOptions } from '@/lib/queries/settings';
+import { useShortcuts } from '@/lib/shortcuts';
 import { cn } from '@/lib/utils';
 
 type ChatInputInnerProps = {
@@ -67,6 +62,7 @@ export function ChatInputInner({
   const { data: providerModels } = useSuspenseQuery(visibleProviderModelsQueryOptions);
   const { data: settings } = useSuspenseQuery(settingsQueryOptions);
   const { data: sttProviders } = useSuspenseQuery(sttProviderModelsQueryOptions);
+  const shortcuts = useShortcuts();
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
@@ -102,7 +98,7 @@ export function ChatInputInner({
   function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
-      if ((value.trim() || attachments.length > 0) && !disabled) {
+      if ((value.trim() || attachments.length > 0) && !disabled && !dictation.isRecording) {
         submit();
       }
     }
@@ -117,64 +113,46 @@ export function ChatInputInner({
 
   const canSubmit = (value.trim().length > 0 || attachments.length > 0) && !disabled;
 
-  // STT
-  const stt = useStt();
-  const sttBaseOffsetRef = React.useRef(0);
-  const valueRef = React.useRef(value);
-  valueRef.current = value;
+  // Dictation
+  const dictation = useDictation({
+    value,
+    onChange,
+    sttProviders,
+    defaultProviderId: settings['stt.default.providerId'],
+    defaultModelId: settings['stt.default.modelId'],
+  });
+  const { isRecording, isStopping } = dictation;
 
   const defaultSttModel: SttModelSelection | null =
     settings['stt.default.providerId'] && settings['stt.default.modelId']
       ? { providerId: settings['stt.default.providerId'], modelId: settings['stt.default.modelId'] }
       : null;
 
-  function startStt(model?: SttModelSelection) {
-    if (stt.state !== 'idle') return;
+  const dictationHotkey = shortcuts.get('toggle-dictation');
+  const holdToTalk = settings['stt.holdToTalk'] === 'true';
+  const dictationEnabled = sttProviders.length > 0 && !!dictationHotkey?.hotkey && !disabled;
 
-    const providerId = model?.providerId ?? settings['stt.default.providerId'];
-    const modelId = model?.modelId ?? settings['stt.default.modelId'];
-    if (!providerId || !modelId) {
-      toast.error('No STT model configured. Set one in Settings → General → STT Model.');
-      return;
-    }
+  // Toggle mode: press once to start, again to finalize.
+  useHotkey(dictationHotkey?.hotkey ?? 'Mod+Space', () => dictation.toggle(), {
+    preventDefault: true,
+    enabled: dictationEnabled && !holdToTalk,
+  });
 
-    const provider = sttProviders.find((p) => p.providerId === providerId);
-    const foundModel = provider?.models.find((m) => m.id === modelId);
-    if (!foundModel) {
-      toast.error('Configured STT model not found. Check Settings → General → STT Model.');
-      return;
-    }
+  // Hold-to-talk mode: record while held, finalize on release.
+  useHotkey(dictationHotkey?.hotkey ?? 'Mod+Space', () => dictation.start(), {
+    preventDefault: true,
+    requireReset: true,
+    enabled: dictationEnabled && holdToTalk,
+  });
+  useHotkey(
+    dictationHotkey?.hotkey ?? 'Mod+Space',
+    () => {
+      void dictation.stopAndCommit();
+    },
+    { eventType: 'keyup', enabled: dictationEnabled && holdToTalk },
+  );
 
-    sttBaseOffsetRef.current = value.length;
-    void stt.start(providerId, modelId, foundModel.sampleRateHz);
-  }
-
-  async function handleMicClick() {
-    if (stt.state === 'recording') {
-      const transcript = await stt.stop();
-      const base = valueRef.current.slice(0, sttBaseOffsetRef.current);
-      const separator = base.trimEnd().length > 0 ? ' ' : '';
-      onChange(base.trimEnd() + separator + transcript);
-      return;
-    }
-
-    startStt();
-  }
-
-  // Splice partial text into textarea value while recording
-  React.useEffect(() => {
-    if (stt.state !== 'recording') return;
-    const base = value.slice(0, sttBaseOffsetRef.current);
-    const separator = base.trimEnd().length > 0 ? ' ' : '';
-    const transcript = [stt.committedText, stt.partialText].filter(Boolean).join(' ');
-    const next = base.trimEnd() + separator + transcript;
-    if (next !== value) onChange(next);
-    // Only re-run when STT text changes — value intentionally omitted to avoid loops
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [stt.committedText, stt.partialText, stt.state]);
-
-  const isRecording = stt.state === 'recording';
-  const isStopping = stt.state === 'stopping';
+  const canSend = canSubmit && !isRecording && !isStopping;
 
   return (
     <div
@@ -243,98 +221,79 @@ export function ChatInputInner({
       />
 
       <div className="flex items-center justify-between px-3 pt-1 pb-3">
-        <div className="flex items-center gap-1">
-          {providerModels.length > 0 && (
-            <ModelSelectorPopover
-              selectedValue={selectedModel}
-              onSelect={onModelChange}
-              providerModels={providerModels}
-            />
-          )}
+        {isRecording || isStopping ? (
+          <RecordingBar
+            audioLevel={dictation.audioLevel}
+            startedAt={dictation.startedAt}
+            isStopping={isStopping}
+            onCancel={dictation.cancel}
+            onStop={() => {
+              void dictation.stopAndCommit();
+            }}
+          />
+        ) : (
+          <div className="flex items-center gap-1">
+            {providerModels.length > 0 && (
+              <ModelSelectorPopover
+                selectedValue={selectedModel}
+                onSelect={onModelChange}
+                providerModels={providerModels}
+              />
+            )}
 
-          {canAttach && (
-            <button
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={disabled}
-              className={cn(
-                'flex items-center justify-center rounded-md p-1 transition-colors',
-                'text-muted-foreground hover:text-foreground hover:bg-muted/50',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
-                disabled && 'pointer-events-none',
-              )}
-              title="Attach files"
-            >
-              <PaperclipIcon className="size-3.5" />
-            </button>
-          )}
-
-          {sttProviders.length > 0 ? (
-            <ButtonGroup>
-              <Button
+            {canAttach && (
+              <button
                 type="button"
-                size="icon-xs"
-                variant="ghost"
-                onClick={() => {
-                  void handleMicClick();
-                }}
-                disabled={disabled || isStopping}
+                onClick={() => fileInputRef.current?.click()}
+                disabled={disabled}
                 className={cn(
-                  isRecording
-                    ? 'text-destructive hover:text-destructive/80 hover:bg-destructive/10 animate-pulse'
-                    : 'text-muted-foreground hover:text-foreground',
-                  (disabled || isStopping) && 'pointer-events-none opacity-50',
+                  'flex items-center justify-center rounded-md p-1 transition-colors',
+                  'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+                  disabled && 'pointer-events-none',
                 )}
-                title={isRecording ? 'Stop recording' : 'Speak to type'}
+                title="Attach files"
               >
-                {isRecording ? (
-                  <MicOffIcon className="size-3.5" />
-                ) : (
+                <PaperclipIcon className="size-3.5" />
+              </button>
+            )}
+
+            {sttProviders.length > 0 ? (
+              <ButtonGroup>
+                <Button
+                  type="button"
+                  size="icon-xs"
+                  variant="ghost"
+                  onClick={() => dictation.toggle()}
+                  disabled={disabled}
+                  className={cn(
+                    'text-muted-foreground hover:text-foreground',
+                    disabled && 'pointer-events-none opacity-50',
+                  )}
+                  title="Speak to type"
+                >
                   <MicIcon className="size-3.5" />
-                )}
-              </Button>
-              {!isRecording && (
-                <>
-                  <ButtonGroupSeparator />
-                  <SttModelSelectorPopover
-                    defaultValue={defaultSttModel}
-                    onSelect={(model) => startStt(model)}
-                    sttProviders={sttProviders}
-                    triggerRender={
-                      <Button
-                        type="button"
-                        size="icon-xs"
-                        variant="ghost"
-                        className="w-4 px-0 text-muted-foreground hover:text-foreground"
-                      >
-                        <ChevronDownIcon className="size-3" />
-                      </Button>
-                    }
-                  />
-                </>
-              )}
-            </ButtonGroup>
-          ) : (
-            <button
-              type="button"
-              onClick={() => {
-                void handleMicClick();
-              }}
-              disabled={disabled || isStopping}
-              className={cn(
-                'flex items-center justify-center rounded-md p-1 transition-colors',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
-                isRecording
-                  ? 'text-destructive hover:text-destructive/80 hover:bg-destructive/10 animate-pulse'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
-                (disabled || isStopping) && 'pointer-events-none opacity-50',
-              )}
-              title={isRecording ? 'Stop recording' : 'Speak to type'}
-            >
-              {isRecording ? <MicOffIcon className="size-3.5" /> : <MicIcon className="size-3.5" />}
-            </button>
-          )}
-        </div>
+                </Button>
+                <ButtonGroupSeparator />
+                <SttModelSelectorPopover
+                  defaultValue={defaultSttModel}
+                  onSelect={(model) => dictation.start(model)}
+                  sttProviders={sttProviders}
+                  triggerRender={
+                    <Button
+                      type="button"
+                      size="icon-xs"
+                      variant="ghost"
+                      className="w-4 px-0 text-muted-foreground hover:text-foreground"
+                    >
+                      <ChevronDownIcon className="size-3" />
+                    </Button>
+                  }
+                />
+              </ButtonGroup>
+            ) : null}
+          </div>
+        )}
 
         <div className="flex items-center gap-1">
           {isStreaming ? (
@@ -353,12 +312,12 @@ export function ChatInputInner({
             <Button
               type="button"
               size="icon-xs"
-              variant={canSubmit ? 'default' : 'outline'}
-              disabled={!canSubmit}
+              variant={canSend ? 'default' : 'outline'}
+              disabled={!canSend}
               onClick={() => {
-                if (canSubmit) submit();
+                if (canSend) submit();
               }}
-              className={cn('shrink-0 transition-all', canSubmit && 'shadow-sm')}
+              className={cn('shrink-0 transition-all', canSend && 'shadow-sm')}
               title="Send message"
             >
               <ArrowUpIcon className="size-3.5" />

--- a/apps/web/src/components/chat/chat-input-parts/mic-level-meter.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/mic-level-meter.tsx
@@ -1,0 +1,37 @@
+import { cn } from '@/lib/utils';
+
+type MicLevelMeterProps = {
+  /** Normalized audio level in the 0–1 range. */
+  level: number;
+  className?: string;
+};
+
+// Fixed per-bar weights so the meter reads as a centered, organic spread
+// rather than a flat block. Multiplied by the live level.
+const BAR_WEIGHTS = [0.45, 0.75, 1, 0.75, 0.45];
+
+/**
+ * Live microphone level meter. Bars scale with the incoming audio level.
+ * Falls back to a static "Listening" label when reduced motion is preferred.
+ */
+export function MicLevelMeter({ level, className }: MicLevelMeterProps) {
+  return (
+    <div className={cn('flex items-center', className)} aria-hidden="true">
+      <div className="flex h-4 items-center gap-0.5 motion-reduce:hidden">
+        {BAR_WEIGHTS.map((weight, i) => {
+          const height = Math.max(3, Math.min(16, level * weight * 16 + 3));
+          return (
+            <span
+              key={i}
+              className="w-0.5 rounded-full bg-destructive transition-[height] duration-75 ease-out"
+              style={{ height: `${height}px` }}
+            />
+          );
+        })}
+      </div>
+      <span className="hidden text-xs font-medium text-destructive motion-reduce:inline">
+        Listening
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/chat-input-parts/recording-bar.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/recording-bar.tsx
@@ -1,0 +1,89 @@
+import { CheckIcon, XIcon } from 'lucide-react';
+import * as React from 'react';
+
+import { MicLevelMeter } from './mic-level-meter';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type RecordingBarProps = {
+  audioLevel: number;
+  startedAt: number | null;
+  isStopping: boolean;
+  onCancel: () => void;
+  onStop: () => void;
+};
+
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function useElapsed(startedAt: number | null): number {
+  const [now, setNow] = React.useState(() => Date.now());
+
+  React.useEffect(() => {
+    if (startedAt === null) return;
+    setNow(Date.now());
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [startedAt]);
+
+  return startedAt === null ? 0 : Math.max(0, now - startedAt);
+}
+
+/**
+ * Replaces the chat input toolbar while dictation is active. Shows an
+ * unmistakable recording indicator, a live level meter, elapsed time, and
+ * explicit cancel (discard) and stop (finalize) controls.
+ */
+export function RecordingBar({
+  audioLevel,
+  startedAt,
+  isStopping,
+  onCancel,
+  onStop,
+}: RecordingBarProps) {
+  const elapsedMs = useElapsed(startedAt);
+
+  return (
+    <div className="flex w-full items-center gap-2" role="status" aria-live="polite">
+      <span
+        className={cn(
+          'size-2 shrink-0 rounded-full bg-destructive',
+          !isStopping && 'animate-pulse',
+        )}
+      />
+      <span className="text-xs font-medium text-destructive">
+        {isStopping ? 'Transcribing…' : 'Recording'}
+      </span>
+      <MicLevelMeter level={isStopping ? 0 : audioLevel} />
+      <span className="ml-auto text-xs font-medium text-muted-foreground tabular-nums">
+        {formatElapsed(elapsedMs)}
+      </span>
+      <Button
+        type="button"
+        size="icon-xs"
+        variant="ghost"
+        onClick={onCancel}
+        disabled={isStopping}
+        title="Discard recording"
+        className="text-muted-foreground hover:text-foreground"
+      >
+        <XIcon className="size-3.5" />
+      </Button>
+      <Button
+        type="button"
+        size="icon-xs"
+        variant="default"
+        onClick={onStop}
+        disabled={isStopping}
+        title="Stop and insert transcript"
+      >
+        <CheckIcon className="size-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/chat-input-parts/use-dictation.test.ts
+++ b/apps/web/src/components/chat/chat-input-parts/use-dictation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+
+import { spliceTranscript } from './use-dictation.js';
+
+describe('spliceTranscript', () => {
+  test('returns the transcript alone when the base is empty', () => {
+    expect(spliceTranscript('', 'hello world')).toBe('hello world');
+  });
+
+  test('joins base and transcript with a single space', () => {
+    expect(spliceTranscript('note:', 'hello world')).toBe('note: hello world');
+  });
+
+  test('trims trailing whitespace from the base before joining', () => {
+    expect(spliceTranscript('note:   ', 'hello')).toBe('note: hello');
+  });
+
+  test('omits the separator when there is no transcript yet', () => {
+    expect(spliceTranscript('existing text', '')).toBe('existing text');
+  });
+
+  test('returns an empty string when both inputs are empty', () => {
+    expect(spliceTranscript('', '')).toBe('');
+  });
+});

--- a/apps/web/src/components/chat/chat-input-parts/use-dictation.ts
+++ b/apps/web/src/components/chat/chat-input-parts/use-dictation.ts
@@ -1,0 +1,147 @@
+import * as React from 'react';
+import { toast } from 'sonner';
+
+import type { SttProviderModels } from '@stitch/shared/stt/types';
+
+import { useStt } from './use-stt';
+
+import type { SttModelSelection } from '@/components/model-selectors/stt-model-selector-popover';
+
+type UseDictationArgs = {
+  value: string;
+  onChange: (value: string) => void;
+  sttProviders: SttProviderModels[];
+  defaultProviderId: string | undefined;
+  defaultModelId: string | undefined;
+};
+
+type DictationState = 'idle' | 'recording' | 'stopping';
+
+type UseDictationReturn = {
+  state: DictationState;
+  audioLevel: number;
+  startedAt: number | null;
+  isRecording: boolean;
+  isStopping: boolean;
+  /** Toggle recording: starts when idle, finalizes the transcript when recording. */
+  toggle: (model?: SttModelSelection) => void;
+  /** Start recording (no-op if not idle). */
+  start: (model?: SttModelSelection) => void;
+  /** Finalize the transcript and splice it into the input. */
+  stopAndCommit: () => Promise<void>;
+  /** Discard the in-progress recording without committing. */
+  cancel: () => void;
+};
+
+/** Joins the preserved prefix with new transcript text using a single space when needed. */
+export function spliceTranscript(base: string, transcript: string): string {
+  const trimmed = base.trimEnd();
+  const separator = trimmed.length > 0 && transcript.length > 0 ? ' ' : '';
+  return trimmed + separator + transcript;
+}
+
+export function useDictation({
+  value,
+  onChange,
+  sttProviders,
+  defaultProviderId,
+  defaultModelId,
+}: UseDictationArgs): UseDictationReturn {
+  const stt = useStt();
+  const baseOffsetRef = React.useRef(0);
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+  // Set when stop is requested before recording has actually started (fast
+  // push-to-talk taps). Finalizes as soon as the session reaches 'recording'.
+  const pendingStopRef = React.useRef(false);
+
+  const resolveModel = React.useCallback(
+    (model?: SttModelSelection) => {
+      const providerId = model?.providerId ?? defaultProviderId;
+      const modelId = model?.modelId ?? defaultModelId;
+      if (!providerId || !modelId) {
+        toast.error('No STT model configured. Set one in Settings → General → STT Model.');
+        return null;
+      }
+      const provider = sttProviders.find((p) => p.providerId === providerId);
+      const found = provider?.models.find((m) => m.id === modelId);
+      if (!found) {
+        toast.error('Configured STT model not found. Check Settings → General → STT Model.');
+        return null;
+      }
+      return { providerId, modelId, sampleRateHz: found.sampleRateHz };
+    },
+    [sttProviders, defaultProviderId, defaultModelId],
+  );
+
+  const start = React.useCallback(
+    (model?: SttModelSelection) => {
+      if (stt.state !== 'idle') return;
+      const resolved = resolveModel(model);
+      if (!resolved) return;
+      pendingStopRef.current = false;
+      baseOffsetRef.current = valueRef.current.length;
+      void stt.start(resolved.providerId, resolved.modelId, resolved.sampleRateHz);
+    },
+    [stt, resolveModel],
+  );
+
+  const stopAndCommit = React.useCallback(async () => {
+    // Release requested before the session finished starting up — finalize
+    // once it reaches the recording state (see effect below).
+    if (stt.state === 'idle' || stt.state === 'stopping') {
+      pendingStopRef.current = true;
+      return;
+    }
+    const transcript = await stt.stop();
+    const base = valueRef.current.slice(0, baseOffsetRef.current);
+    onChange(spliceTranscript(base, transcript));
+  }, [stt, onChange]);
+
+  // Honor a stop requested during the startup window.
+  React.useEffect(() => {
+    if (stt.state === 'recording' && pendingStopRef.current) {
+      pendingStopRef.current = false;
+      void stopAndCommit();
+    }
+  }, [stt.state, stopAndCommit]);
+
+  const toggle = React.useCallback(
+    (model?: SttModelSelection) => {
+      if (stt.state === 'recording') {
+        void stopAndCommit();
+        return;
+      }
+      start(model);
+    },
+    [stt.state, start, stopAndCommit],
+  );
+
+  // Splice live partial + committed text into the input while recording.
+  React.useEffect(() => {
+    if (stt.state !== 'recording') return;
+    const base = value.slice(0, baseOffsetRef.current);
+    const transcript = [stt.committedText, stt.partialText].filter(Boolean).join(' ');
+    const next = spliceTranscript(base, transcript);
+    if (next !== value) onChange(next);
+    // Only re-run when STT text changes — value intentionally omitted to avoid loops.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stt.committedText, stt.partialText, stt.state]);
+
+  const cancel = React.useCallback(() => {
+    pendingStopRef.current = false;
+    stt.cancel();
+  }, [stt]);
+
+  return {
+    state: stt.state,
+    audioLevel: stt.audioLevel,
+    startedAt: stt.startedAt,
+    isRecording: stt.state === 'recording',
+    isStopping: stt.state === 'stopping',
+    toggle,
+    start,
+    stopAndCommit,
+    cancel,
+  };
+}

--- a/apps/web/src/components/chat/chat-input-parts/use-stt.test.ts
+++ b/apps/web/src/components/chat/chat-input-parts/use-stt.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+
+import { computeAudioLevel } from './use-stt.js';
+
+describe('computeAudioLevel', () => {
+  test('returns 0 for an empty frame', () => {
+    expect(computeAudioLevel(new Float32Array(0))).toBe(0);
+  });
+
+  test('returns 0 for silence', () => {
+    expect(computeAudioLevel(new Float32Array([0, 0, 0, 0]))).toBe(0);
+  });
+
+  test('scales RMS into the meter range and clamps at 1', () => {
+    // Full-scale signal: RMS = 1, scaled by 3 then clamped to 1.
+    expect(computeAudioLevel(new Float32Array([1, -1, 1, -1]))).toBe(1);
+  });
+
+  test('produces a proportional level for quiet speech', () => {
+    // RMS of 0.1 → 0.3 after the x3 scale.
+    const frame = new Float32Array([0.1, -0.1, 0.1, -0.1]);
+    expect(computeAudioLevel(frame)).toBeCloseTo(0.3, 5);
+  });
+});

--- a/apps/web/src/components/chat/chat-input-parts/use-stt.ts
+++ b/apps/web/src/components/chat/chat-input-parts/use-stt.ts
@@ -11,9 +11,24 @@ type UseSttReturn = {
   state: SttState;
   committedText: string;
   partialText: string;
+  audioLevel: number;
+  startedAt: number | null;
   start: (providerId: string, modelId: string, sampleRateHz: number) => Promise<void>;
   stop: () => Promise<string>;
+  cancel: () => void;
 };
+
+/** Root-mean-square amplitude of a PCM frame, normalized to a usable 0–1 meter range. */
+export function computeAudioLevel(f32: Float32Array): number {
+  if (f32.length === 0) return 0;
+  let sumSquares = 0;
+  for (let i = 0; i < f32.length; i++) {
+    sumSquares += f32[i] * f32[i];
+  }
+  const rms = Math.sqrt(sumSquares / f32.length);
+  // Speech RMS rarely exceeds ~0.3; scale so normal speaking fills the meter.
+  return Math.min(1, rms * 3);
+}
 
 function toWsUrl(serverUrl: string): string {
   const url = new URL('/stt/stream', serverUrl);
@@ -49,6 +64,8 @@ export function useStt(): UseSttReturn {
   const [state, setState] = React.useState<SttState>('idle');
   const [committedText, setCommittedText] = React.useState('');
   const [partialText, setPartialText] = React.useState('');
+  const [audioLevel, setAudioLevel] = React.useState(0);
+  const [startedAt, setStartedAt] = React.useState<number | null>(null);
 
   // Refs hold the live session state so callbacks don't capture stale closures.
   const wsRef = React.useRef<WebSocket | null>(null);
@@ -59,9 +76,18 @@ export function useStt(): UseSttReturn {
   const finalTextRef = React.useRef<string>('');
   const stopResolveRef = React.useRef<((text: string) => void) | null>(null);
   const stopRejectRef = React.useRef<((err: Error) => void) | null>(null);
+  const levelRef = React.useRef(0);
+  const levelRafRef = React.useRef<number | null>(null);
 
   // Cleanup all audio and WS resources.
   const cleanup = React.useCallback(() => {
+    if (levelRafRef.current !== null) {
+      cancelAnimationFrame(levelRafRef.current);
+      levelRafRef.current = null;
+    }
+    levelRef.current = 0;
+    setAudioLevel(0);
+    setStartedAt(null);
     workletRef.current?.disconnect();
     workletRef.current?.port.close();
     workletRef.current = null;
@@ -201,6 +227,13 @@ export function useStt(): UseSttReturn {
       workletNode.port.onmessage = (e: MessageEvent<ArrayBuffer>) => {
         if (wsRef.current?.readyState !== WebSocket.OPEN) return;
         const f32 = new Float32Array(e.data);
+        levelRef.current = computeAudioLevel(f32);
+        if (levelRafRef.current === null) {
+          levelRafRef.current = requestAnimationFrame(() => {
+            levelRafRef.current = null;
+            setAudioLevel(levelRef.current);
+          });
+        }
         const pcm = encodeF32ToPcmS16le(f32);
         send({
           type: 'chunk',
@@ -215,6 +248,7 @@ export function useStt(): UseSttReturn {
       source.connect(workletNode);
       workletNode.connect(audioCtx.destination);
 
+      setStartedAt(Date.now());
       setState('recording');
     },
     [state, send, cleanup],
@@ -233,6 +267,21 @@ export function useStt(): UseSttReturn {
     });
   }, [state, send]);
 
+  // Discard the in-progress recording without committing any transcript.
+  const cancel = React.useCallback(() => {
+    if (state === 'idle') return;
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      send({ type: 'stop', sttSessionId: sessionIdRef.current });
+    }
+    stopResolveRef.current = null;
+    stopRejectRef.current = null;
+    finalTextRef.current = '';
+    setState('idle');
+    setCommittedText('');
+    setPartialText('');
+    cleanup();
+  }, [state, send, cleanup]);
+
   // Clean up on unmount
   React.useEffect(() => {
     return () => {
@@ -240,5 +289,5 @@ export function useStt(): UseSttReturn {
     };
   }, [cleanup]);
 
-  return { state, committedText, partialText, start, stop };
+  return { state, committedText, partialText, audioLevel, startedAt, start, stop, cancel };
 }

--- a/apps/web/src/components/settings/general.tsx
+++ b/apps/web/src/components/settings/general.tsx
@@ -149,6 +149,9 @@ export function GeneralSettings() {
       <SettingSection title="Models">
         <ModelsContent />
       </SettingSection>
+      <SettingSection title="Dictation">
+        <DictationContent />
+      </SettingSection>
       <SettingSection title="App Updates">
         <AppUpdatesContent />
       </SettingSection>
@@ -250,6 +253,19 @@ function NotificationsContent() {
       label="Sound alerts"
       description="Play an attention sound when the AI needs your input"
       checked={settings['notifications.sound.enabled'] !== 'false'}
+    />
+  );
+}
+
+function DictationContent() {
+  const { data: settings } = useSuspenseQuery(settingsQueryOptions);
+
+  return (
+    <SwitchSettingRow
+      settingKey="stt.holdToTalk"
+      label="Hold to talk"
+      description="Record only while the dictation shortcut is held, finalizing on release. When off, the shortcut toggles recording on and off."
+      checked={settings['stt.holdToTalk'] === 'true'}
     />
   );
 }

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -49,6 +49,7 @@ export const SETTINGS_KEYS = [
   'recordings.analysis.defaultTemplateId',
   'stt.default.providerId',
   'stt.default.modelId',
+  'stt.holdToTalk',
 ] as const;
 
 export type SettingsKey = (typeof SETTINGS_KEYS)[number];
@@ -104,6 +105,7 @@ export const SETTINGS_SCHEMAS = {
   'recordings.analysis.defaultTemplateId': z.string(),
   'stt.default.providerId': z.string(),
   'stt.default.modelId': z.string(),
+  'stt.holdToTalk': booleanSetting,
 } as const;
 
 export function isValidLeaderKeyHotkey(value: string): boolean {
@@ -365,5 +367,11 @@ export const SETTINGS_DEFAULTS: SettingDefault[] = [
     value: '',
     description:
       'Model ID for the default STT model used for live speech-to-text in the chat input.',
+  },
+  {
+    key: 'stt.holdToTalk',
+    value: 'false',
+    description:
+      'When enabled, the dictation shortcut records only while held and finalizes on release (push-to-talk). When disabled, the shortcut toggles recording on and off.',
   },
 ];

--- a/packages/shared/src/shortcuts/types.ts
+++ b/packages/shared/src/shortcuts/types.ts
@@ -11,6 +11,7 @@ export const SHORTCUT_ACTION_IDS = [
   'rename-session',
   'compact-session',
   'stop-stream',
+  'toggle-dictation',
 ] as const;
 
 export type ShortcutActionId = (typeof SHORTCUT_ACTION_IDS)[number];
@@ -110,6 +111,13 @@ export const SHORTCUT_DEFAULTS: ShortcutDefault[] = [
     hotkey: 'Escape',
     isSequence: true,
     label: 'Stop stream (double press)',
+    category: 'Chat',
+  },
+  {
+    actionId: 'toggle-dictation',
+    hotkey: 'Mod+Space',
+    isSequence: false,
+    label: 'Toggle dictation',
     category: 'Chat',
   },
 ];


### PR DESCRIPTION
## 🚀 Change Summary

Overhauls the chat input's dictation experience: replaces the bare mic button with a full recording lifecycle (animated bar, live audio level meter, cancel vs. commit, send gating) and adds two new user-configurable controls — a `Mod+Space` keyboard shortcut and a hold-to-talk toggle in Settings.

### ✨ New Features

- **Toggle & hold-to-talk dictation**: `Mod+Space` starts/stops recording in toggle mode (default). Enabling "Hold to talk" in Settings → General → Dictation switches to push-to-talk — hold to record, release to finalize. Modes are mutually exclusive.
- **Recording bar**: replaces the toolbar's left cluster while active — pulsing dot, "Recording / Transcribing…" label, live audio level meter, elapsed timer, and explicit **Cancel** (discard) and **Stop** (commit) buttons. Accessible via `aria-live`.
- **Mic level meter**: 5-bar animated RMS meter driven by the audio worklet. Respects `prefers-reduced-motion` (shows static "Listening" text instead).
- **Send gating**: the Send button and Enter key are disabled while recording or transcribing, preventing partial sends.
- **`Mod+Space` shortcut in Settings**: appears in Settings → Shortcuts → Chat and is rebindable like any other shortcut.

### 🛠 Improvements & Refactors

- Extracted `use-dictation` hook from `chat-input-inner` to own the toggle/hold/cancel/commit logic and text-splice state, including a pending-stop guard for fast push-to-talk taps (release before WebSocket opens).
- Added `audioLevel` (throttled RMS), `cancel()`, and `startedAt` to `use-stt`.
- Added `stt.holdToTalk` setting (default `false`) and `toggle-dictation` shortcut action to shared packages.
