### PR TITLE
Add reusable textarea completions

### DIFF
--- a/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
@@ -19,6 +19,7 @@ import type { SttModelSelection } from '@/components/model-selectors/stt-model-s
 import { SttModelSelectorPopover } from '@/components/model-selectors/stt-model-selector-popover';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup, ButtonGroupSeparator } from '@/components/ui/button-group';
+import { Popover, PopoverContent } from '@/components/ui/popover';
 import { supportsAnyAttachment } from '@/lib/model-capabilities';
 import {
   sttProviderModelsQueryOptions,
@@ -44,6 +45,131 @@ type ChatInputInnerProps = {
   onPendingAttachmentsConsumed?: () => void;
 };
 
+type CompletionPrefix = '/' | '@';
+
+type CompletionState = {
+  prefix: CompletionPrefix;
+  anchorIndex: number;
+  filter: string;
+};
+
+type CompletionOption = {
+  value: string;
+  label: string;
+  description: string;
+};
+
+const SLASH_COMPLETIONS: CompletionOption[] = [
+  { value: 'summarize', label: 'Summarize', description: 'Summarize the current context' },
+  { value: 'rewrite', label: 'Rewrite', description: 'Rewrite selected text or your draft' },
+  { value: 'plan', label: 'Plan', description: 'Create a step-by-step plan' },
+  { value: 'debug', label: 'Debug', description: 'Help diagnose an issue' },
+];
+
+const MENTION_COMPLETIONS: CompletionOption[] = [
+  { value: 'workspace', label: 'Workspace', description: 'Reference the current workspace' },
+  { value: 'agenda', label: 'Agenda', description: 'Reference agenda items' },
+  { value: 'notes', label: 'Notes', description: 'Reference notes and summaries' },
+  { value: 'files', label: 'Files', description: 'Reference attached or local files' },
+];
+
+function getCompletionState(textarea: HTMLTextAreaElement): CompletionState | null {
+  const { selectionStart, selectionEnd, value } = textarea;
+  if (selectionStart !== selectionEnd || document.activeElement !== textarea) return null;
+
+  const textBeforeCaret = value.slice(0, selectionStart);
+  const slashIndex = textBeforeCaret.lastIndexOf('/');
+  const mentionIndex = textBeforeCaret.lastIndexOf('@');
+  const anchorIndex = Math.max(slashIndex, mentionIndex);
+  if (anchorIndex < 0) return null;
+
+  const prefix = value[anchorIndex] as CompletionPrefix;
+  const previousCharacter = anchorIndex > 0 ? value[anchorIndex - 1] : '';
+  if (previousCharacter && !/\s/.test(previousCharacter)) return null;
+
+  const filter = value.slice(anchorIndex + 1, selectionStart);
+  if (/\s/.test(filter)) return null;
+
+  return { prefix, anchorIndex, filter };
+}
+
+function filterCompletionOptions(state: CompletionState | null): CompletionOption[] {
+  if (!state) return [];
+
+  const options = state.prefix === '/' ? SLASH_COMPLETIONS : MENTION_COMPLETIONS;
+  const filter = state.filter.toLocaleLowerCase();
+  if (!filter) return options;
+
+  return options.filter((option) => {
+    return (
+      option.value.toLocaleLowerCase().startsWith(filter) ||
+      option.label.toLocaleLowerCase().startsWith(filter)
+    );
+  });
+}
+
+function getTextareaCharacterRect(textarea: HTMLTextAreaElement, index: number): DOMRect {
+  const computedStyle = window.getComputedStyle(textarea);
+  const mirror = document.createElement('div');
+  const textareaRect = textarea.getBoundingClientRect();
+  const properties = [
+    'boxSizing',
+    'width',
+    'height',
+    'borderTopWidth',
+    'borderRightWidth',
+    'borderBottomWidth',
+    'borderLeftWidth',
+    'paddingTop',
+    'paddingRight',
+    'paddingBottom',
+    'paddingLeft',
+    'fontFamily',
+    'fontSize',
+    'fontWeight',
+    'fontStyle',
+    'letterSpacing',
+    'lineHeight',
+    'textTransform',
+    'textIndent',
+    'textAlign',
+    'whiteSpace',
+    'wordBreak',
+    'overflowWrap',
+    'tabSize',
+  ] as const;
+
+  mirror.style.position = 'fixed';
+  mirror.style.top = `${textareaRect.top}px`;
+  mirror.style.left = `${textareaRect.left}px`;
+  mirror.style.visibility = 'hidden';
+  mirror.style.pointerEvents = 'none';
+  mirror.style.overflow = 'hidden';
+  mirror.style.whiteSpace = 'pre-wrap';
+  mirror.style.overflowWrap = 'break-word';
+
+  for (const property of properties) {
+    mirror.style[property] = computedStyle[property];
+  }
+
+  const before = textarea.value.slice(0, index);
+  const marker = document.createElement('span');
+  marker.textContent = textarea.value[index] || ' ';
+  mirror.textContent = before;
+  mirror.append(marker);
+  document.body.append(mirror);
+
+  const markerRect = marker.getBoundingClientRect();
+  mirror.remove();
+
+  return new DOMRect(
+    markerRect.left - textarea.scrollLeft,
+    markerRect.top - textarea.scrollTop,
+    1,
+    markerRect.height || Number.parseFloat(computedStyle.lineHeight) || 16,
+  );
+}
+
 export function ChatInputInner({
   value,
   onChange,
@@ -65,6 +191,9 @@ export function ChatInputInner({
   const shortcuts = useShortcuts();
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const completionListId = React.useId();
+  const [completionState, setCompletionState] = React.useState<CompletionState | null>(null);
+  const [activeCompletionIndex, setActiveCompletionIndex] = React.useState(0);
 
   const {
     attachments,
@@ -90,18 +219,84 @@ export function ChatInputInner({
     [allOptions, selectedModel],
   );
   const canAttach = supportsAnyAttachment(selectedModelOption?.modelSummary ?? null);
+  const completionOptions = filterCompletionOptions(completionState);
+  const isCompletionOpen = completionState !== null && completionOptions.length > 0 && !disabled;
+
+  const completionAnchor = React.useMemo(() => {
+    return {
+      getBoundingClientRect: () => {
+        const textarea = textareaRef.current;
+        if (!textarea || !completionState) return new DOMRect();
+
+        return getTextareaCharacterRect(textarea, completionState.anchorIndex);
+      },
+    };
+  }, [completionState]);
+
+  const updateCompletionState = React.useCallback(() => {
+    const textarea = textareaRef.current;
+    const nextState = textarea ? getCompletionState(textarea) : null;
+    setCompletionState(nextState);
+    setActiveCompletionIndex(0);
+  }, []);
 
   const submit = React.useCallback(() => {
     onSubmit(value, consumeForSubmit());
   }, [consumeForSubmit, onSubmit, value]);
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (isCompletionOpen) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setActiveCompletionIndex((index) => (index + 1) % completionOptions.length);
+        return;
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveCompletionIndex((index) =>
+          index === 0 ? completionOptions.length - 1 : index - 1,
+        );
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setCompletionState(null);
+        return;
+      }
+
+      if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
+        event.preventDefault();
+        applyCompletion(completionOptions[activeCompletionIndex]);
+        return;
+      }
+    }
+
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       if ((value.trim() || attachments.length > 0) && !disabled && !dictation.isRecording) {
         submit();
       }
     }
+  }
+
+  function applyCompletion(option: CompletionOption) {
+    const textarea = textareaRef.current;
+    if (!textarea || !completionState) return;
+
+    const replacement = `${completionState.prefix}${option.value} `;
+    const prefix = value.slice(0, completionState.anchorIndex) + replacement;
+    const suffix = value.slice(textarea.selectionEnd);
+    const nextValue = prefix + suffix;
+
+    onChange(nextValue);
+    setCompletionState(null);
+
+    requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.setSelectionRange(prefix.length, prefix.length);
+    });
   }
 
   React.useEffect(() => {
@@ -203,11 +398,23 @@ export function ChatInputInner({
       <textarea
         ref={textareaRef}
         value={value}
-        onChange={(event) => onChange(event.target.value)}
+        aria-activedescendant={
+          isCompletionOpen ? `${completionListId}-${activeCompletionIndex}` : undefined
+        }
+        aria-autocomplete="list"
+        aria-controls={isCompletionOpen ? completionListId : undefined}
+        aria-expanded={isCompletionOpen}
+        onChange={(event) => {
+          onChange(event.target.value);
+          requestAnimationFrame(updateCompletionState);
+        }}
         onKeyDown={handleKeyDown}
         onPaste={(event) => {
           void handlePaste(event);
         }}
+        onSelect={updateCompletionState}
+        onBlur={() => setCompletionState(null)}
+        onFocus={updateCompletionState}
         placeholder={placeholder}
         disabled={disabled}
         rows={1}
@@ -219,6 +426,51 @@ export function ChatInputInner({
           disabled && 'cursor-not-allowed',
         )}
       />
+
+      <Popover open={isCompletionOpen} modal={false}>
+        <PopoverContent
+          anchor={completionAnchor}
+          align="start"
+          collisionPadding={8}
+          finalFocus={false}
+          initialFocus={false}
+          side="bottom"
+          sideOffset={6}
+          className="w-72 gap-1 p-1"
+        >
+          <div
+            id={completionListId}
+            role="listbox"
+            className="thin-scrollbar max-h-64 overflow-y-auto"
+          >
+            <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+              {completionState?.prefix === '/' ? 'Commands' : 'References'}
+            </div>
+            {completionOptions.map((option, index) => (
+              <button
+                id={`${completionListId}-${index}`}
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={index === activeCompletionIndex}
+                className={cn(
+                  'flex w-full cursor-default flex-col rounded-md px-2 py-1.5 text-left text-sm outline-none transition-colors',
+                  index === activeCompletionIndex && 'bg-muted text-foreground',
+                )}
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setActiveCompletionIndex(index)}
+                onClick={() => applyCompletion(option)}
+              >
+                <span className="font-medium">
+                  {completionState?.prefix}
+                  {option.value}
+                </span>
+                <span className="text-xs text-muted-foreground">{option.description}</span>
+              </button>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
 
       <div className="flex items-center justify-between px-3 pt-1 pb-3">
         {isRecording || isStopping ? (

--- a/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
@@ -19,7 +19,10 @@ import type { SttModelSelection } from '@/components/model-selectors/stt-model-s
 import { SttModelSelectorPopover } from '@/components/model-selectors/stt-model-selector-popover';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup, ButtonGroupSeparator } from '@/components/ui/button-group';
-import { Popover, PopoverContent } from '@/components/ui/popover';
+import {
+  TextareaCompletions,
+  type TextareaCompletionGroup,
+} from '@/components/ui/textarea-completions';
 import { supportsAnyAttachment } from '@/lib/model-capabilities';
 import {
   sttProviderModelsQueryOptions,
@@ -45,130 +48,7 @@ type ChatInputInnerProps = {
   onPendingAttachmentsConsumed?: () => void;
 };
 
-type CompletionPrefix = '/' | '@';
-
-type CompletionState = {
-  prefix: CompletionPrefix;
-  anchorIndex: number;
-  filter: string;
-};
-
-type CompletionOption = {
-  value: string;
-  label: string;
-  description: string;
-};
-
-const SLASH_COMPLETIONS: CompletionOption[] = [
-  { value: 'summarize', label: 'Summarize', description: 'Summarize the current context' },
-  { value: 'rewrite', label: 'Rewrite', description: 'Rewrite selected text or your draft' },
-  { value: 'plan', label: 'Plan', description: 'Create a step-by-step plan' },
-  { value: 'debug', label: 'Debug', description: 'Help diagnose an issue' },
-];
-
-const MENTION_COMPLETIONS: CompletionOption[] = [
-  { value: 'workspace', label: 'Workspace', description: 'Reference the current workspace' },
-  { value: 'agenda', label: 'Agenda', description: 'Reference agenda items' },
-  { value: 'notes', label: 'Notes', description: 'Reference notes and summaries' },
-  { value: 'files', label: 'Files', description: 'Reference attached or local files' },
-];
-
-function getCompletionState(textarea: HTMLTextAreaElement): CompletionState | null {
-  const { selectionStart, selectionEnd, value } = textarea;
-  if (selectionStart !== selectionEnd || document.activeElement !== textarea) return null;
-
-  const textBeforeCaret = value.slice(0, selectionStart);
-  const slashIndex = textBeforeCaret.lastIndexOf('/');
-  const mentionIndex = textBeforeCaret.lastIndexOf('@');
-  const anchorIndex = Math.max(slashIndex, mentionIndex);
-  if (anchorIndex < 0) return null;
-
-  const prefix = value[anchorIndex] as CompletionPrefix;
-  const previousCharacter = anchorIndex > 0 ? value[anchorIndex - 1] : '';
-  if (previousCharacter && !/\s/.test(previousCharacter)) return null;
-
-  const filter = value.slice(anchorIndex + 1, selectionStart);
-  if (/\s/.test(filter)) return null;
-
-  return { prefix, anchorIndex, filter };
-}
-
-function filterCompletionOptions(state: CompletionState | null): CompletionOption[] {
-  if (!state) return [];
-
-  const options = state.prefix === '/' ? SLASH_COMPLETIONS : MENTION_COMPLETIONS;
-  const filter = state.filter.toLocaleLowerCase();
-  if (!filter) return options;
-
-  return options.filter((option) => {
-    return (
-      option.value.toLocaleLowerCase().startsWith(filter) ||
-      option.label.toLocaleLowerCase().startsWith(filter)
-    );
-  });
-}
-
-function getTextareaCharacterRect(textarea: HTMLTextAreaElement, index: number): DOMRect {
-  const computedStyle = window.getComputedStyle(textarea);
-  const mirror = document.createElement('div');
-  const textareaRect = textarea.getBoundingClientRect();
-  const properties = [
-    'boxSizing',
-    'width',
-    'height',
-    'borderTopWidth',
-    'borderRightWidth',
-    'borderBottomWidth',
-    'borderLeftWidth',
-    'paddingTop',
-    'paddingRight',
-    'paddingBottom',
-    'paddingLeft',
-    'fontFamily',
-    'fontSize',
-    'fontWeight',
-    'fontStyle',
-    'letterSpacing',
-    'lineHeight',
-    'textTransform',
-    'textIndent',
-    'textAlign',
-    'whiteSpace',
-    'wordBreak',
-    'overflowWrap',
-    'tabSize',
-  ] as const;
-
-  mirror.style.position = 'fixed';
-  mirror.style.top = `${textareaRect.top}px`;
-  mirror.style.left = `${textareaRect.left}px`;
-  mirror.style.visibility = 'hidden';
-  mirror.style.pointerEvents = 'none';
-  mirror.style.overflow = 'hidden';
-  mirror.style.whiteSpace = 'pre-wrap';
-  mirror.style.overflowWrap = 'break-word';
-
-  for (const property of properties) {
-    mirror.style[property] = computedStyle[property];
-  }
-
-  const before = textarea.value.slice(0, index);
-  const marker = document.createElement('span');
-  marker.textContent = textarea.value[index] || ' ';
-  mirror.textContent = before;
-  mirror.append(marker);
-  document.body.append(mirror);
-
-  const markerRect = marker.getBoundingClientRect();
-  mirror.remove();
-
-  return new DOMRect(
-    markerRect.left - textarea.scrollLeft,
-    markerRect.top - textarea.scrollTop,
-    1,
-    markerRect.height || Number.parseFloat(computedStyle.lineHeight) || 16,
-  );
-}
+const CHAT_COMPLETION_GROUPS: TextareaCompletionGroup[] = [];
 
 export function ChatInputInner({
   value,
@@ -191,9 +71,6 @@ export function ChatInputInner({
   const shortcuts = useShortcuts();
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
-  const completionListId = React.useId();
-  const [completionState, setCompletionState] = React.useState<CompletionState | null>(null);
-  const [activeCompletionIndex, setActiveCompletionIndex] = React.useState(0);
 
   const {
     attachments,
@@ -219,84 +96,18 @@ export function ChatInputInner({
     [allOptions, selectedModel],
   );
   const canAttach = supportsAnyAttachment(selectedModelOption?.modelSummary ?? null);
-  const completionOptions = filterCompletionOptions(completionState);
-  const isCompletionOpen = completionState !== null && completionOptions.length > 0 && !disabled;
-
-  const completionAnchor = React.useMemo(() => {
-    return {
-      getBoundingClientRect: () => {
-        const textarea = textareaRef.current;
-        if (!textarea || !completionState) return new DOMRect();
-
-        return getTextareaCharacterRect(textarea, completionState.anchorIndex);
-      },
-    };
-  }, [completionState]);
-
-  const updateCompletionState = React.useCallback(() => {
-    const textarea = textareaRef.current;
-    const nextState = textarea ? getCompletionState(textarea) : null;
-    setCompletionState(nextState);
-    setActiveCompletionIndex(0);
-  }, []);
 
   const submit = React.useCallback(() => {
     onSubmit(value, consumeForSubmit());
   }, [consumeForSubmit, onSubmit, value]);
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (isCompletionOpen) {
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        setActiveCompletionIndex((index) => (index + 1) % completionOptions.length);
-        return;
-      }
-
-      if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        setActiveCompletionIndex((index) =>
-          index === 0 ? completionOptions.length - 1 : index - 1,
-        );
-        return;
-      }
-
-      if (event.key === 'Escape') {
-        event.preventDefault();
-        setCompletionState(null);
-        return;
-      }
-
-      if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
-        event.preventDefault();
-        applyCompletion(completionOptions[activeCompletionIndex]);
-        return;
-      }
-    }
-
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
       if ((value.trim() || attachments.length > 0) && !disabled && !dictation.isRecording) {
         submit();
       }
     }
-  }
-
-  function applyCompletion(option: CompletionOption) {
-    const textarea = textareaRef.current;
-    if (!textarea || !completionState) return;
-
-    const replacement = `${completionState.prefix}${option.value} `;
-    const prefix = value.slice(0, completionState.anchorIndex) + replacement;
-    const suffix = value.slice(textarea.selectionEnd);
-    const nextValue = prefix + suffix;
-
-    onChange(nextValue);
-    setCompletionState(null);
-
-    requestAnimationFrame(() => {
-      textarea.focus();
-      textarea.setSelectionRange(prefix.length, prefix.length);
-    });
   }
 
   React.useEffect(() => {
@@ -395,82 +206,35 @@ export function ChatInputInner({
         }}
       />
 
-      <textarea
-        ref={textareaRef}
+      <TextareaCompletions
+        textareaRef={textareaRef}
         value={value}
-        aria-activedescendant={
-          isCompletionOpen ? `${completionListId}-${activeCompletionIndex}` : undefined
-        }
-        aria-autocomplete="list"
-        aria-controls={isCompletionOpen ? completionListId : undefined}
-        aria-expanded={isCompletionOpen}
-        onChange={(event) => {
-          onChange(event.target.value);
-          requestAnimationFrame(updateCompletionState);
-        }}
-        onKeyDown={handleKeyDown}
-        onPaste={(event) => {
-          void handlePaste(event);
-        }}
-        onSelect={updateCompletionState}
-        onBlur={() => setCompletionState(null)}
-        onFocus={updateCompletionState}
-        placeholder={placeholder}
+        onChange={onChange}
+        groups={CHAT_COMPLETION_GROUPS}
         disabled={disabled}
-        rows={1}
-        className={cn(
-          'w-full resize-none bg-transparent px-4 pt-4 pb-2 text-sm leading-relaxed outline-none',
-          'placeholder:text-muted-foreground/60',
-          'max-h-48 overflow-y-auto thin-scrollbar',
-          'field-sizing-content',
-          disabled && 'cursor-not-allowed',
+        onKeyDown={handleKeyDown}
+      >
+        {({ textareaProps }) => (
+          <textarea
+            ref={textareaRef}
+            value={value}
+            {...textareaProps}
+            onPaste={(event) => {
+              void handlePaste(event);
+            }}
+            placeholder={placeholder}
+            disabled={disabled}
+            rows={1}
+            className={cn(
+              'w-full resize-none bg-transparent px-4 pt-4 pb-2 text-sm leading-relaxed outline-none',
+              'placeholder:text-muted-foreground/60',
+              'max-h-48 overflow-y-auto thin-scrollbar',
+              'field-sizing-content',
+              disabled && 'cursor-not-allowed',
+            )}
+          />
         )}
-      />
-
-      <Popover open={isCompletionOpen} modal={false}>
-        <PopoverContent
-          anchor={completionAnchor}
-          align="start"
-          collisionPadding={8}
-          finalFocus={false}
-          initialFocus={false}
-          side="bottom"
-          sideOffset={6}
-          className="w-72 gap-1 p-1"
-        >
-          <div
-            id={completionListId}
-            role="listbox"
-            className="thin-scrollbar max-h-64 overflow-y-auto"
-          >
-            <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
-              {completionState?.prefix === '/' ? 'Commands' : 'References'}
-            </div>
-            {completionOptions.map((option, index) => (
-              <button
-                id={`${completionListId}-${index}`}
-                key={option.value}
-                type="button"
-                role="option"
-                aria-selected={index === activeCompletionIndex}
-                className={cn(
-                  'flex w-full cursor-default flex-col rounded-md px-2 py-1.5 text-left text-sm outline-none transition-colors',
-                  index === activeCompletionIndex && 'bg-muted text-foreground',
-                )}
-                onMouseDown={(event) => event.preventDefault()}
-                onMouseEnter={() => setActiveCompletionIndex(index)}
-                onClick={() => applyCompletion(option)}
-              >
-                <span className="font-medium">
-                  {completionState?.prefix}
-                  {option.value}
-                </span>
-                <span className="text-xs text-muted-foreground">{option.description}</span>
-              </button>
-            ))}
-          </div>
-        </PopoverContent>
-      </Popover>
+      </TextareaCompletions>
 
       <div className="flex items-center justify-between px-3 pt-1 pb-3">
         {isRecording || isStopping ? (

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -15,16 +15,31 @@ function PopoverContent({
   className,
   align = 'center',
   alignOffset = 0,
+  anchor,
+  collisionBoundary,
+  collisionPadding,
   side = 'bottom',
   sideOffset = 4,
   ...props
 }: PopoverPrimitive.Popup.Props &
-  Pick<PopoverPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset'>) {
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    | 'align'
+    | 'alignOffset'
+    | 'anchor'
+    | 'collisionBoundary'
+    | 'collisionPadding'
+    | 'side'
+    | 'sideOffset'
+  >) {
   return (
     <PopoverPrimitive.Portal>
       <PopoverPrimitive.Positioner
         align={align}
         alignOffset={alignOffset}
+        anchor={anchor}
+        collisionBoundary={collisionBoundary}
+        collisionPadding={collisionPadding}
         side={side}
         sideOffset={sideOffset}
         className="isolate z-50"

--- a/apps/web/src/components/ui/textarea-completions.tsx
+++ b/apps/web/src/components/ui/textarea-completions.tsx
@@ -1,0 +1,299 @@
+import * as React from 'react';
+
+import { Popover, PopoverContent } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+export type TextareaCompletionOption = {
+  value: string;
+  label: string;
+  description?: string;
+};
+
+export type TextareaCompletionGroup = {
+  prefix: string;
+  label: string;
+  options: TextareaCompletionOption[];
+};
+
+type CompletionState = {
+  group: TextareaCompletionGroup;
+  anchorIndex: number;
+  filter: string;
+};
+
+type TextareaCompletionChildProps = {
+  textareaProps: Pick<
+    React.ComponentProps<'textarea'>,
+    | 'aria-activedescendant'
+    | 'aria-autocomplete'
+    | 'aria-controls'
+    | 'aria-expanded'
+    | 'onBlur'
+    | 'onChange'
+    | 'onFocus'
+    | 'onKeyDown'
+    | 'onSelect'
+  >;
+  isOpen: boolean;
+};
+
+type TextareaCompletionsProps = {
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  value: string;
+  onChange: (value: string) => void;
+  groups: TextareaCompletionGroup[];
+  disabled?: boolean;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  children: (props: TextareaCompletionChildProps) => React.ReactNode;
+};
+
+function getCompletionState(
+  textarea: HTMLTextAreaElement,
+  groups: TextareaCompletionGroup[],
+): CompletionState | null {
+  const { selectionStart, selectionEnd, value } = textarea;
+  if (selectionStart !== selectionEnd || document.activeElement !== textarea) return null;
+
+  const textBeforeCaret = value.slice(0, selectionStart);
+  let matchingGroup: TextareaCompletionGroup | null = null;
+  let anchorIndex = -1;
+
+  for (const group of groups) {
+    const index = textBeforeCaret.lastIndexOf(group.prefix);
+    if (index > anchorIndex) {
+      matchingGroup = group;
+      anchorIndex = index;
+    }
+  }
+
+  if (!matchingGroup || anchorIndex < 0) return null;
+
+  const previousCharacter = anchorIndex > 0 ? value[anchorIndex - 1] : '';
+  if (previousCharacter && !/\s/.test(previousCharacter)) return null;
+
+  const filter = value.slice(anchorIndex + matchingGroup.prefix.length, selectionStart);
+  if (/\s/.test(filter)) return null;
+
+  return { group: matchingGroup, anchorIndex, filter };
+}
+
+function filterCompletionOptions(state: CompletionState | null): TextareaCompletionOption[] {
+  if (!state) return [];
+
+  const filter = state.filter.toLocaleLowerCase();
+  if (!filter) return state.group.options;
+
+  return state.group.options.filter((option) => {
+    return (
+      option.value.toLocaleLowerCase().startsWith(filter) ||
+      option.label.toLocaleLowerCase().startsWith(filter)
+    );
+  });
+}
+
+function getTextareaCharacterRect(textarea: HTMLTextAreaElement, index: number): DOMRect {
+  const computedStyle = window.getComputedStyle(textarea);
+  const mirror = document.createElement('div');
+  const textareaRect = textarea.getBoundingClientRect();
+  const properties = [
+    'boxSizing',
+    'width',
+    'height',
+    'borderTopWidth',
+    'borderRightWidth',
+    'borderBottomWidth',
+    'borderLeftWidth',
+    'paddingTop',
+    'paddingRight',
+    'paddingBottom',
+    'paddingLeft',
+    'fontFamily',
+    'fontSize',
+    'fontWeight',
+    'fontStyle',
+    'letterSpacing',
+    'lineHeight',
+    'textTransform',
+    'textIndent',
+    'textAlign',
+    'whiteSpace',
+    'wordBreak',
+    'overflowWrap',
+    'tabSize',
+  ] as const;
+
+  mirror.style.position = 'fixed';
+  mirror.style.top = `${textareaRect.top}px`;
+  mirror.style.left = `${textareaRect.left}px`;
+  mirror.style.visibility = 'hidden';
+  mirror.style.pointerEvents = 'none';
+  mirror.style.overflow = 'hidden';
+  mirror.style.whiteSpace = 'pre-wrap';
+  mirror.style.overflowWrap = 'break-word';
+
+  for (const property of properties) {
+    mirror.style[property] = computedStyle[property];
+  }
+
+  const before = textarea.value.slice(0, index);
+  const marker = document.createElement('span');
+  marker.textContent = textarea.value[index] || ' ';
+  mirror.textContent = before;
+  mirror.append(marker);
+  document.body.append(mirror);
+
+  const markerRect = marker.getBoundingClientRect();
+  mirror.remove();
+
+  return new DOMRect(
+    markerRect.left - textarea.scrollLeft,
+    markerRect.top - textarea.scrollTop,
+    1,
+    markerRect.height || Number.parseFloat(computedStyle.lineHeight) || 16,
+  );
+}
+
+export function TextareaCompletions({
+  textareaRef,
+  value,
+  onChange,
+  groups,
+  disabled,
+  onKeyDown,
+  children,
+}: TextareaCompletionsProps) {
+  const listId = React.useId();
+  const [completionState, setCompletionState] = React.useState<CompletionState | null>(null);
+  const [activeIndex, setActiveIndex] = React.useState(0);
+
+  const completionOptions = filterCompletionOptions(completionState);
+  const isOpen = completionState !== null && completionOptions.length > 0 && !disabled;
+
+  const completionAnchor = React.useMemo(() => {
+    return {
+      getBoundingClientRect: () => {
+        const textarea = textareaRef.current;
+        if (!textarea || !completionState) return new DOMRect();
+
+        return getTextareaCharacterRect(textarea, completionState.anchorIndex);
+      },
+    };
+  }, [completionState, textareaRef]);
+
+  const updateCompletionState = React.useCallback(() => {
+    const textarea = textareaRef.current;
+    const nextState = textarea ? getCompletionState(textarea, groups) : null;
+    setCompletionState(nextState);
+    setActiveIndex(0);
+  }, [groups, textareaRef]);
+
+  function applyCompletion(option: TextareaCompletionOption) {
+    const textarea = textareaRef.current;
+    if (!textarea || !completionState) return;
+
+    const replacement = `${completionState.group.prefix}${option.value} `;
+    const prefix = value.slice(0, completionState.anchorIndex) + replacement;
+    const suffix = value.slice(textarea.selectionEnd);
+
+    onChange(prefix + suffix);
+    setCompletionState(null);
+
+    requestAnimationFrame(() => {
+      textarea.focus();
+      textarea.setSelectionRange(prefix.length, prefix.length);
+    });
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (isOpen) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setActiveIndex((index) => (index + 1) % completionOptions.length);
+        return;
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveIndex((index) => (index === 0 ? completionOptions.length - 1 : index - 1));
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setCompletionState(null);
+        return;
+      }
+
+      if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
+        event.preventDefault();
+        applyCompletion(completionOptions[activeIndex]);
+        return;
+      }
+    }
+
+    onKeyDown?.(event);
+  }
+
+  const textareaProps: TextareaCompletionChildProps['textareaProps'] = {
+    'aria-activedescendant': isOpen ? `${listId}-${activeIndex}` : undefined,
+    'aria-autocomplete': 'list',
+    'aria-controls': isOpen ? listId : undefined,
+    'aria-expanded': isOpen,
+    onChange: (event) => {
+      onChange(event.target.value);
+      requestAnimationFrame(updateCompletionState);
+    },
+    onKeyDown: handleKeyDown,
+    onSelect: updateCompletionState,
+    onBlur: () => setCompletionState(null),
+    onFocus: updateCompletionState,
+  };
+
+  return (
+    <>
+      {children({ textareaProps, isOpen })}
+      <Popover open={isOpen} modal={false}>
+        <PopoverContent
+          anchor={completionAnchor}
+          align="start"
+          collisionPadding={8}
+          finalFocus={false}
+          initialFocus={false}
+          side="bottom"
+          sideOffset={6}
+          className="w-72 gap-1 p-1"
+        >
+          <div id={listId} role="listbox" className="thin-scrollbar max-h-64 overflow-y-auto">
+            <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+              {completionState?.group.label}
+            </div>
+            {completionOptions.map((option, index) => (
+              <button
+                id={`${listId}-${index}`}
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={index === activeIndex}
+                className={cn(
+                  'flex w-full cursor-default flex-col rounded-md px-2 py-1.5 text-left text-sm outline-none transition-colors',
+                  index === activeIndex && 'bg-muted text-foreground',
+                )}
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setActiveIndex(index)}
+                onClick={() => applyCompletion(option)}
+              >
+                <span className="font-medium">
+                  {completionState?.group.prefix}
+                  {option.value}
+                </span>
+                {option.description ? (
+                  <span className="text-xs text-muted-foreground">{option.description}</span>
+                ) : null}
+              </button>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </>
+  );
+}


### PR DESCRIPTION
## 🚀 Change Summary

Adds a reusable textarea completions foundation for chat-style inputs, with caret-anchored popover positioning and keyboard handling. The chat input is wired to the component with empty completion groups for now, so no completion popover is shown until real options are provided.

### ✨ New Features
- **Textarea Completions Component**: Reusable UI component for trigger-based textarea completions with filtering, keyboard navigation, insertion, ARIA attributes, and caret-positioned popover rendering.

### 🛠 Improvements & Refactors
- **Chat Input Integration**: Moves completion behavior out of the chat input and into the shared UI component.
- **Popover Positioning**: Extends the popover wrapper to support virtual anchors for caret-based positioning.
