### PR TITLE
fix: browser tool fails to type into contenteditable rich text editors

### DIFF
--- a/apps/desktop/src/main/browser/command-handlers.ts
+++ b/apps/desktop/src/main/browser/command-handlers.ts
@@ -112,6 +112,7 @@ export async function executeBrowserCommand(
         command.submit,
         command.slowly,
       );
+      await waitForPageStability(ctx.browser);
       return `Typed into ${command.ref}`;
     case 'press':
       ctx.browser.sendInputEvent({ type: 'keyDown', keyCode: command.key });
@@ -170,11 +171,30 @@ export async function executeBrowserCommand(
         ctx.browser,
         buildSearchPageScript(command),
       );
-    case 'findElements':
-      return runScript<ElectronBrowserFindElementsResult>(
-        ctx.browser,
-        buildFindElementsScript(command),
-      );
+    case 'findElements': {
+      type RawFindResult = {
+        elements: Array<{
+          tag: string;
+          text?: string;
+          attributes?: Record<string, string>;
+          cssPath?: string;
+        }>;
+        total: number;
+      };
+      const raw = await runScript<RawFindResult>(ctx.browser, buildFindElementsScript(command));
+      const result: ElectronBrowserFindElementsResult = {
+        total: raw.total,
+        elements: raw.elements.map((el) => {
+          const ref = el.cssPath ? ctx.refResolver.findRefBySelector(el.cssPath) : undefined;
+          return {
+            tag: el.tag,
+            text: el.text,
+            attributes: { ...el.attributes, ...(ref ? { ref } : {}) },
+          };
+        }),
+      };
+      return result;
+    }
     case 'dialogState':
       return ctx.getDialogState();
     case 'handleDialog':

--- a/apps/desktop/src/main/browser/input-actions.ts
+++ b/apps/desktop/src/main/browser/input-actions.ts
@@ -3,6 +3,8 @@ import type { WebContents } from 'electron';
 
 const DEFAULT_SCROLL_PX = 650;
 const SELECT_CHANGE_DELAY_MS = 10;
+const CONTENTEDITABLE_CHAR_DELAY_MS = 5;
+const FOCUS_SETTLE_MS = 50;
 
 export async function clickRef(
   browser: WebContents,
@@ -75,19 +77,89 @@ export async function typeIntoRef(
   submit?: boolean,
   slowly?: boolean,
 ): Promise<void> {
-  await refResolver.focusRef(ref);
+  const isContentEditable = await refResolver.runOnRef<boolean>(
+    ref,
+    (element) =>
+      `return ${element}.isContentEditable || ${element}.getAttribute('contenteditable') !== null`,
+  );
+
+  if (isContentEditable) {
+    await typeIntoContentEditable(browser, refResolver, ref, text, clear, submit, slowly);
+  } else {
+    await refResolver.focusRef(ref);
+    await new Promise((resolve) => setTimeout(resolve, FOCUS_SETTLE_MS));
+    if (clear) {
+      sendShortcut(browser, 'A');
+      sendKey(browser, 'Backspace');
+    }
+    if (slowly) {
+      for (const char of text) {
+        await browser.insertText(char);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+    } else {
+      await browser.insertText(text);
+    }
+    if (submit) {
+      sendKey(browser, 'Enter');
+    }
+  }
+}
+
+async function typeIntoContentEditable(
+  browser: WebContents,
+  refResolver: RefResolver,
+  ref: string,
+  text: string,
+  clear?: boolean,
+  submit?: boolean,
+  slowly?: boolean,
+): Promise<void> {
+  // Click the element to activate the rich text editor framework
+  const target = await refResolver.resolveRef(ref);
+  browser.sendInputEvent({ type: 'mouseMove', x: target.x, y: target.y });
+  browser.sendInputEvent({
+    type: 'mouseDown',
+    x: target.x,
+    y: target.y,
+    button: 'left',
+    clickCount: 1,
+  });
+  browser.sendInputEvent({
+    type: 'mouseUp',
+    x: target.x,
+    y: target.y,
+    button: 'left',
+    clickCount: 1,
+  });
+  await new Promise((resolve) => setTimeout(resolve, FOCUS_SETTLE_MS));
+
   if (clear) {
     sendShortcut(browser, 'A');
+    await new Promise((resolve) => setTimeout(resolve, FOCUS_SETTLE_MS));
     sendKey(browser, 'Backspace');
+    await new Promise((resolve) => setTimeout(resolve, FOCUS_SETTLE_MS));
   }
-  if (slowly) {
-    for (const char of text) {
-      await browser.insertText(char);
-      await new Promise((resolve) => setTimeout(resolve, 20));
+
+  // Type character-by-character using key events for contenteditable compatibility
+  const delay = slowly ? 20 : CONTENTEDITABLE_CHAR_DELAY_MS;
+  for (const char of text) {
+    if (char === '\n') {
+      sendKey(browser, 'Enter');
+    } else {
+      browser.sendInputEvent({ type: 'keyDown', keyCode: char });
+      browser.sendInputEvent({ type: 'char', keyCode: char });
+      browser.sendInputEvent({ type: 'keyUp', keyCode: char });
     }
-  } else {
-    await browser.insertText(text);
+    await new Promise((resolve) => setTimeout(resolve, delay));
   }
+
+  // Dispatch input event to trigger framework reactivity
+  await refResolver.runOnRef(
+    ref,
+    (element) => `${element}.dispatchEvent(new Event('input', { bubbles: true })); return true;`,
+  );
+
   if (submit) {
     sendKey(browser, 'Enter');
   }

--- a/apps/desktop/src/main/browser/ref-resolver.ts
+++ b/apps/desktop/src/main/browser/ref-resolver.ts
@@ -12,6 +12,13 @@ export class RefResolver {
     this.refs = new Map(Object.entries(refs));
   }
 
+  findRefBySelector(selector: string): string | undefined {
+    for (const [ref, entry] of this.refs) {
+      if (entry.selector === selector) return ref;
+    }
+    return undefined;
+  }
+
   async runOnRef<T = unknown>(ref: string, buildScript: (element: string) => string): Promise<T> {
     const result = await (
       await this.getBrowser()

--- a/apps/desktop/src/main/browser/scripts/dom-helpers.injected.ts
+++ b/apps/desktop/src/main/browser/scripts/dom-helpers.injected.ts
@@ -25,6 +25,7 @@ function role(el) {
   if (/^h[1-6]$/.test(tag)) return 'heading';
   if (tag === 'img') return 'img';
   if (tag === 'svg') return 'img';
+  if (el.isContentEditable && el.getAttribute('contenteditable') !== null) return 'textbox';
   return 'generic';
 }
 

--- a/apps/desktop/src/main/browser/scripts/find-elements.injected.ts
+++ b/apps/desktop/src/main/browser/scripts/find-elements.injected.ts
@@ -3,5 +3,31 @@ import type { ElectronBrowserCommand } from '@stitch/shared/browser/electron';
 export function buildFindElementsScript(
   command: Extract<ElectronBrowserCommand, { action: 'findElements' }>,
 ): string {
-  return `(() => { const nodes = Array.from(document.querySelectorAll(${JSON.stringify(command.selector)})); const attrs = ${JSON.stringify(command.attributes ?? [])}; const includeText = ${command.includeText !== false}; const elements = nodes.slice(0, ${command.maxResults ?? 20}).map((el) => ({ tag: el.tagName.toLowerCase(), text: includeText ? (el.innerText || el.textContent || '').trim().slice(0, 200) : undefined, attributes: Object.fromEntries(attrs.map((name) => [name, el.getAttribute(name) || '']).filter(([, value]) => value)) })); return { elements, total: nodes.length }; })()`;
+  return `(() => {
+  function cssPath(el) {
+    if (el.id) return '#' + CSS.escape(el.id);
+    const parts = [];
+    let node = el;
+    while (node && node.nodeType === 1 && node !== document.body) {
+      const tag = node.tagName.toLowerCase();
+      const parent = node.parentElement;
+      if (!parent) break;
+      const siblings = Array.from(parent.children).filter((child) => child.tagName === node.tagName);
+      const index = siblings.indexOf(node) + 1;
+      parts.unshift(tag + ':nth-of-type(' + index + ')');
+      node = parent;
+    }
+    return parts.length ? parts.join(' > ') : 'body';
+  }
+  const nodes = Array.from(document.querySelectorAll(${JSON.stringify(command.selector)}));
+  const attrs = ${JSON.stringify(command.attributes ?? [])};
+  const includeText = ${command.includeText !== false};
+  const elements = nodes.slice(0, ${command.maxResults ?? 20}).map((el) => ({
+    tag: el.tagName.toLowerCase(),
+    text: includeText ? (el.innerText || el.textContent || '').trim().slice(0, 200) : undefined,
+    attributes: Object.fromEntries(attrs.map((name) => [name, el.getAttribute(name) || '']).filter(([, value]) => value)),
+    cssPath: cssPath(el),
+  }));
+  return { elements, total: nodes.length };
+})()`;
 }

--- a/apps/desktop/src/main/browser/scripts/snapshot.injected.ts
+++ b/apps/desktop/src/main/browser/scripts/snapshot.injected.ts
@@ -44,6 +44,7 @@ export function buildSnapshotScript(previousSnapshotIdentities: string[]): strin
   function normalizedValue(el) {
     const tag = el.tagName.toLowerCase();
     if (tag === 'input' || tag === 'textarea' || tag === 'select') return el.value || '';
+    if (el.isContentEditable && el.getAttribute('contenteditable') !== null) return (el.innerText || el.textContent || '').trim().slice(0, maxTextLength);
     return el.getAttribute('aria-valuetext') || el.getAttribute('aria-valuenow') || '';
   }
 
@@ -75,7 +76,7 @@ export function buildSnapshotScript(previousSnapshotIdentities: string[]): strin
   function interactable(el) {
     const tag = el.tagName.toLowerCase();
     const r = role(el);
-    return ['a', 'button', 'input', 'textarea', 'select', 'summary', 'option'].includes(tag) || ['button', 'link', 'tab', 'menuitem', 'checkbox', 'radio', 'combobox', 'textbox', 'switch'].includes(r) || el.hasAttribute('onclick') || el.hasAttribute('tabindex') || getComputedStyle(el).cursor === 'pointer';
+    return ['a', 'button', 'input', 'textarea', 'select', 'summary', 'option'].includes(tag) || ['button', 'link', 'tab', 'menuitem', 'checkbox', 'radio', 'combobox', 'textbox', 'switch'].includes(r) || el.hasAttribute('onclick') || el.hasAttribute('tabindex') || (el.isContentEditable && el.getAttribute('contenteditable') !== null) || getComputedStyle(el).cursor === 'pointer';
   }
 
   function inViewport(rect) {


### PR DESCRIPTION
## 🚀 Change Summary

Fixes the browser tool's inability to type into rich text editors (contenteditable divs) such as Reddit's comment box, Notion, and similar frameworks. The agent was correctly identifying and clicking these elements, but text typed via `insertText` was silently swallowed by the editor framework, leaving the field empty. This blocked any automated browser task that required submitting text through a modern web editor.

### 🐛 Bug Fixes

- **contenteditable typing**: `typeIntoRef` now detects contenteditable elements and activates them with real mouse click events before typing character-by-character via `keyDown`/`char`/`keyUp` input events. This matches how real user input reaches the browser and how `browser-use` handles the same problem. `WebContents.insertText` continues to be used for standard `<input>`/`<textarea>` elements where it works fine.
- **Missing page stability wait after type**: `type` action now calls `waitForPageStability` after completing, consistent with `click` and `press`. Previously the agent would take a snapshot before the page had settled.
- **contenteditable not assigned a snapshot ref**: Elements with `contenteditable` attribute but no explicit `role="textbox"` were not considered interactable by the snapshot walker, so they received no ref and couldn't be targeted. The `role()` helper and `interactable()` check in the snapshot script now explicitly handle `contenteditable`.
- **Snapshot doesn't show typed content**: `normalizedValue()` in the snapshot script now extracts `innerText`/`textContent` from contenteditable elements, so typed content is visible in subsequent snapshots for verification.
- **`find_elements` returns no ref**: The `find_elements` action found elements by CSS selector but had no way to return their snapshot ref. It now computes a CSS path per element and cross-references it against the current `RefResolver` map, returning the `ref` in the attributes when a match is found.
