### PR TITLE
feat: track app and registry stats

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -2,7 +2,7 @@ name: stats
 
 on:
   schedule:
-    - cron: "0 12 * * *" # Daily at 12:00 UTC
+    - cron: '0 12 * * *' # Daily at 12:00 UTC
   workflow_dispatch:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -23,3 +23,5 @@ jobs:
         run: bun scripts/stats.ts
         env:
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -32,7 +32,7 @@ import { createUpdater } from './updater.js';
 import { createWindow } from './window.js';
 
 const DEV_APP_NAME = 'stitch-dev';
-const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1_000;
+const UPDATE_CHECK_INTERVAL_MS = 10 * 60 * 1_000;
 
 function configureAppIdentityForEnvironment(): void {
   if (app.isPackaged) return;

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -130,6 +130,9 @@ export async function spawnServer(port: number, extraEnv: NodeJS.ProcessEnv = {}
     ...extraEnv,
     NODE_ENV: app.isPackaged ? 'production' : 'development',
     STITCH_APP_NAME: app.isPackaged ? 'stitch' : 'stitch-dev',
+    STITCH_APP_VERSION: app.getVersion(),
+    STITCH_CHANNEL: app.isPackaged ? 'production' : 'development',
+    STITCH_CLIENT: 'desktop',
   };
 
   if (app.isPackaged) {

--- a/apps/website/index.html
+++ b/apps/website/index.html
@@ -153,12 +153,14 @@
           <a
             class="btn btn-primary"
             href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-windows-setup.exe"
+            data-app-download-platform="windows"
           >
             Windows
           </a>
           <a
             class="btn btn-primary"
             href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-macos-arm64.dmg"
+            data-app-download-platform="macos"
           >
             macOS
           </a>
@@ -684,12 +686,14 @@
           <a
             class="btn btn-primary"
             href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-windows-setup.exe"
+            data-app-download-platform="windows"
           >
             Windows
           </a>
           <a
             class="btn btn-primary"
             href="https://github.com/UseStitch/stitch/releases/latest/download/Stitch-macos-arm64.dmg"
+            data-app-download-platform="macos"
           >
             macOS
           </a>

--- a/apps/website/src/main.ts
+++ b/apps/website/src/main.ts
@@ -22,6 +22,18 @@ document.addEventListener('click', (e: MouseEvent) => {
   });
 });
 
+document.addEventListener('click', (e: MouseEvent) => {
+  if (!(e.target instanceof Element)) return;
+
+  const downloadLink = e.target.closest<HTMLAnchorElement>('a[data-app-download-platform]');
+
+  if (!downloadLink || !posthogKey) return;
+
+  posthog.capture('app_download', {
+    platform: downloadLink.dataset.appDownloadPlatform,
+  });
+});
+
 // Theme toggle
 (() => {
   const stored = localStorage.getItem('theme');

--- a/packages/server/src/lib/registry-cache.test.ts
+++ b/packages/server/src/lib/registry-cache.test.ts
@@ -50,6 +50,47 @@ describe('createRegistryCache', () => {
     expect(written).toEqual(PAYLOAD);
   });
 
+  test('sends configured user agent when fetching from network', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    const cache = createRegistryCache({
+      cacheFilePath,
+      url: 'https://example.com',
+      parse,
+      userAgent: 'stitch',
+    });
+
+    const captured = { userAgent: null as string | null };
+    const fetchImpl: FetchLike = async (_input, init) => {
+      captured.userAgent = new Headers(init?.headers).get('User-Agent');
+      return new Response(JSON.stringify(PAYLOAD), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+
+    await cache.get(fetchImpl);
+
+    expect(captured.userAgent).toBe('stitch');
+  });
+
+  test('does not send user agent unless configured', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    const cache = createRegistryCache({ cacheFilePath, url: 'https://example.com', parse });
+
+    const captured = { userAgent: 'unexpected' as string | null };
+    const fetchImpl: FetchLike = async (_input, init) => {
+      captured.userAgent = new Headers(init?.headers).get('User-Agent');
+      return new Response(JSON.stringify(PAYLOAD), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+
+    await cache.get(fetchImpl);
+
+    expect(captured.userAgent).toBeNull();
+  });
+
   test('returns in-memory cache on second get without fetching', async () => {
     const cacheFilePath = await createTempCacheFilePath();
     const cache = createRegistryCache({ cacheFilePath, url: 'https://example.com', parse });

--- a/packages/server/src/lib/registry-cache.ts
+++ b/packages/server/src/lib/registry-cache.ts
@@ -5,6 +5,9 @@ import * as Log from '@/lib/log.js';
 
 const log = Log.create({ service: 'registry-cache' });
 const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_VERSION = '0.0.0';
+
+type BunGlobal = typeof globalThis & { Bun?: { version?: string } };
 
 export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
@@ -19,9 +22,29 @@ type RegistryCacheOptions<T> = {
   fallback?: T;
   /** Fetch timeout in milliseconds. Defaults to 10 000. */
   timeoutMs?: number;
+  /** Optional User-Agent header for registries we own. */
+  userAgent?: string | (() => string);
   /** Inject a custom fetch implementation (useful for tests). */
   fetchImpl?: FetchLike;
 };
+
+function userAgentToken(value: string | undefined, fallback: string): string {
+  return (value?.trim() || fallback).replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+function runtimeToken(): string {
+  const bunVersion = (globalThis as BunGlobal).Bun?.version;
+  if (bunVersion) return `Bun/${userAgentToken(bunVersion, 'unknown')}`;
+  return `Node/${userAgentToken(process.versions.node, 'unknown')}`;
+}
+
+export function getStitchRegistryUserAgent(): string {
+  const version = userAgentToken(process.env['STITCH_APP_VERSION'], DEFAULT_VERSION);
+  const channel = userAgentToken(process.env['STITCH_CHANNEL'] ?? process.env.NODE_ENV, 'unknown');
+  const client = userAgentToken(process.env['STITCH_CLIENT'], 'server');
+
+  return `Stitch/${version} (${channel}; ${client}; ${process.platform}; ${process.arch}) ${runtimeToken()} RegistryClient/1`;
+}
 
 /**
  * Generic registry cache.
@@ -35,7 +58,14 @@ type RegistryCacheOptions<T> = {
  * Deliberately knows nothing about LLM models or embeddings.
  */
 export function createRegistryCache<T>(options: RegistryCacheOptions<T>) {
-  const { cacheFilePath, url, parse, fallback, fetchImpl: defaultFetch = fetch } = options;
+  const {
+    cacheFilePath,
+    url,
+    parse,
+    fallback,
+    userAgent,
+    fetchImpl: defaultFetch = fetch,
+  } = options;
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   let memory: T | null = null;
@@ -58,7 +88,11 @@ export function createRegistryCache<T>(options: RegistryCacheOptions<T>) {
   }
 
   async function fetchFromNetwork(fetchImpl: FetchLike): Promise<T> {
-    const response = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
+    const resolvedUserAgent = typeof userAgent === 'function' ? userAgent() : userAgent;
+    const response = await fetchImpl(url, {
+      headers: resolvedUserAgent ? { 'User-Agent': resolvedUserAgent } : undefined,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     return parse(await response.json());
   }

--- a/packages/server/src/mcp/registry-service.test.ts
+++ b/packages/server/src/mcp/registry-service.test.ts
@@ -1,7 +1,7 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import {
   clearMcpRegistryCacheForTests,
@@ -88,6 +88,28 @@ describe('mcp registry service', () => {
     const cachedText = await fs.readFile(cacheFilePath, 'utf8');
     const cachedPayload = JSON.parse(cachedText) as { servers: { id: string }[] };
     expect(cachedPayload.servers).toHaveLength(2);
+  });
+
+  test('sends Stitch user agent when fetching registry payload', async () => {
+    const cacheFilePath = await createTempCacheFilePath();
+    const captured = { userAgent: null as string | null };
+    const fetchImpl: FetchLike = async (_input, init) => {
+      captured.userAgent = new Headers(init?.headers).get('User-Agent');
+      return new Response(JSON.stringify(REGISTRY_PAYLOAD), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+
+    const result = await refreshMcpRegistryCache({
+      cacheFilePath,
+      fetchImpl,
+      force: true,
+    });
+
+    expect('error' in result).toBe(false);
+    expect(captured.userAgent?.startsWith('Stitch/')).toBe(true);
+    expect(captured.userAgent).toContain('RegistryClient/1');
   });
 
   test('uses disk cache when present', async () => {

--- a/packages/server/src/mcp/registry-service.ts
+++ b/packages/server/src/mcp/registry-service.ts
@@ -6,6 +6,7 @@ import type { McpRegistryPayload, McpRegistryServer } from '@stitch/shared/mcp/t
 
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
+import { getStitchRegistryUserAgent } from '@/lib/registry-cache.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { isServiceError } from '@/lib/service-result.js';
@@ -97,6 +98,7 @@ function normalizeServers(payload: McpRegistryPayload): McpRegistryServer[] {
 
 async function fetchRegistryPayload(fetchImpl: FetchLike): Promise<McpRegistryPayload> {
   const response = await fetchImpl(getRegistryUrl(), {
+    headers: { 'User-Agent': getStitchRegistryUserAgent() },
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
   if (!response.ok) {

--- a/packages/server/src/models/embedding/registry.ts
+++ b/packages/server/src/models/embedding/registry.ts
@@ -1,5 +1,5 @@
 import { PATHS } from '@/lib/paths.js';
-import { createRegistryCache } from '@/lib/registry-cache.js';
+import { createRegistryCache, getStitchRegistryUserAgent } from '@/lib/registry-cache.js';
 import {
   EmbeddingRegistryPayloadSchema,
   type EmbeddingModel,
@@ -67,6 +67,7 @@ const embeddingRegistryCache = createRegistryCache<EmbeddingRegistryPayload>({
       })),
     };
   },
+  userAgent: getStitchRegistryUserAgent,
 });
 
 export async function getEmbeddingModelsFromRegistry(

--- a/packages/server/src/models/stt/registry.ts
+++ b/packages/server/src/models/stt/registry.ts
@@ -1,5 +1,5 @@
 import { PATHS } from '@/lib/paths.js';
-import { createRegistryCache } from '@/lib/registry-cache.js';
+import { createRegistryCache, getStitchRegistryUserAgent } from '@/lib/registry-cache.js';
 import {
   SttRegistryPayloadSchema,
   type SttProvider,
@@ -27,6 +27,7 @@ const sttRegistryCache = createRegistryCache<SttRegistryPayload>({
       })),
     };
   },
+  userAgent: getStitchRegistryUserAgent,
 });
 
 export async function getSttProvidersFromRegistry(fetchImpl = fetch): Promise<SttProvider[]> {

--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -1,60 +1,87 @@
 #!/usr/bin/env bun
 
 interface Asset {
-  name: string
-  download_count: number
+  name: string;
+  download_count: number;
 }
 
 interface Release {
-  tag_name: string
-  assets: Asset[]
+  tag_name: string;
+  assets: Asset[];
 }
 
+interface CloudflareGraphQLResponse<T> {
+  data?: T;
+  errors?: { message: string }[];
+}
+
+interface RegistryStatsGroup {
+  dimensions: {
+    clientRequestPath: string;
+    userAgent: string;
+  };
+  sum: {
+    requests: number;
+    bytes: number;
+  };
+}
+
+interface RegistryStats {
+  since: string;
+  until: string;
+  total: number;
+  bytes: number;
+  per_path: { path: string; requests: number; bytes: number }[];
+  per_user_agent: { user_agent: string; requests: number; bytes: number }[];
+}
+
+const REGISTRY_PATHS = ['/mcp-registry.json', '/embedding-models.json', '/stt-models.json'];
+
 async function fetchReleases(): Promise<Release[]> {
-  const releases: Release[] = []
-  let page = 1
-  const per = 100
+  const releases: Release[] = [];
+  let page = 1;
+  const per = 100;
 
   while (true) {
-    const url = `https://api.github.com/repos/UseStitch/stitch/releases?page=${page}&per_page=${per}`
-    const response = await fetch(url)
+    const url = `https://api.github.com/repos/UseStitch/stitch/releases?page=${page}&per_page=${per}`;
+    const response = await fetch(url);
 
     if (!response.ok) {
-      throw new Error(`GitHub API error: ${response.status} ${response.statusText}`)
+      throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
     }
 
-    const batch: Release[] = await response.json()
-    if (batch.length === 0) break
+    const batch: Release[] = await response.json();
+    if (batch.length === 0) break;
 
-    releases.push(...batch)
-    console.log(`Fetched page ${page} with ${batch.length} releases`)
+    releases.push(...batch);
+    console.log(`Fetched page ${page} with ${batch.length} releases`);
 
-    if (batch.length < per) break
-    page++
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    if (batch.length < per) break;
+    page++;
+    await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 
-  return releases
+  return releases;
 }
 
 function sumDownloads(releases: Release[]): number {
   return releases.reduce((total, release) => {
-    return total + release.assets.reduce((sum, asset) => sum + asset.download_count, 0)
-  }, 0)
+    return total + release.assets.reduce((sum, asset) => sum + asset.download_count, 0);
+  }, 0);
 }
 
 async function reportToPostHog(total: number, releases: Release[]) {
-  const key = process.env['POSTHOG_KEY']
+  const key = process.env['POSTHOG_KEY'];
 
   if (!key) {
-    console.warn('POSTHOG_KEY not set, skipping PostHog report')
-    return
+    console.warn('POSTHOG_KEY not set, skipping PostHog report');
+    return;
   }
 
   const perRelease = releases.map((release) => ({
     tag: release.tag_name,
     downloads: release.assets.reduce((sum, asset) => sum + asset.download_count, 0),
-  }))
+  }));
 
   const response = await fetch('https://us.i.posthog.com/i/v0/e/', {
     method: 'POST',
@@ -69,23 +96,167 @@ async function reportToPostHog(total: number, releases: Release[]) {
         per_release: perRelease,
       },
     }),
-  }).catch(() => null)
+  }).catch(() => null);
 
   if (response && !response.ok) {
-    console.warn(`PostHog API error: ${response.status}`)
+    console.warn(`PostHog API error: ${response.status}`);
   }
 }
 
-console.log('Fetching GitHub releases for UseStitch/stitch...\n')
+function aggregateRegistryStats(
+  groups: RegistryStatsGroup[],
+  since: string,
+  until: string,
+): RegistryStats {
+  const perPath = new Map<string, { requests: number; bytes: number }>();
+  const perUserAgent = new Map<string, { requests: number; bytes: number }>();
 
-const releases = await fetchReleases()
-console.log(`\nFetched ${releases.length} releases total\n`)
+  for (const group of groups) {
+    const requests = group.sum.requests;
+    const bytes = group.sum.bytes;
+    const path = group.dimensions.clientRequestPath || 'unknown';
+    const userAgent = group.dimensions.userAgent || 'unknown';
 
-const total = sumDownloads(releases)
-console.log(`Total GitHub downloads: ${total.toLocaleString()}`)
+    const pathStats = perPath.get(path) ?? { requests: 0, bytes: 0 };
+    pathStats.requests += requests;
+    pathStats.bytes += bytes;
+    perPath.set(path, pathStats);
 
-await reportToPostHog(total, releases)
+    const userAgentStats = perUserAgent.get(userAgent) ?? { requests: 0, bytes: 0 };
+    userAgentStats.requests += requests;
+    userAgentStats.bytes += bytes;
+    perUserAgent.set(userAgent, userAgentStats);
+  }
 
-console.log('='.repeat(60))
-console.log(`TOTAL DOWNLOADS: ${total.toLocaleString()}`)
-console.log('='.repeat(60))
+  return {
+    since,
+    until,
+    total: groups.reduce((sum, group) => sum + group.sum.requests, 0),
+    bytes: groups.reduce((sum, group) => sum + group.sum.bytes, 0),
+    per_path: [...perPath.entries()].map(([path, stats]) => ({ path, ...stats })),
+    per_user_agent: [...perUserAgent.entries()]
+      .map(([user_agent, stats]) => ({ user_agent, ...stats }))
+      .toSorted((a, b) => b.requests - a.requests),
+  };
+}
+
+async function fetchCloudflareRegistryStats(): Promise<RegistryStats | null> {
+  const token = process.env['CLOUDFLARE_API_TOKEN'];
+  const zoneTag = process.env['CLOUDFLARE_ZONE_ID'];
+  const host = process.env['CLOUDFLARE_REGISTRY_HOST'] || 'usestitch.ai';
+
+  if (!token || !zoneTag) {
+    console.warn('CLOUDFLARE_API_TOKEN or CLOUDFLARE_ZONE_ID not set, skipping registry stats');
+    return null;
+  }
+
+  const until = new Date();
+  const since = new Date(until.getTime() - 24 * 60 * 60 * 1000);
+  const query = `
+    query RegistryStats($zoneTag: string!, $host: string!, $paths: [string!], $since: Time!, $until: Time!) {
+      viewer {
+        zones(filter: { zoneTag: $zoneTag }) {
+          httpRequestsAdaptiveGroups(
+            limit: 10000
+            filter: {
+              datetime_geq: $since
+              datetime_lt: $until
+              clientRequestHTTPHost: $host
+              clientRequestPath_in: $paths
+            }
+          ) {
+            dimensions {
+              clientRequestPath
+              userAgent
+            }
+            sum {
+              requests
+              bytes
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const response = await fetch('https://api.cloudflare.com/client/v4/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query,
+      variables: {
+        zoneTag,
+        host,
+        paths: REGISTRY_PATHS,
+        since: since.toISOString(),
+        until: until.toISOString(),
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Cloudflare API error: ${response.status} ${response.statusText}`);
+  }
+
+  const payload: CloudflareGraphQLResponse<{
+    viewer: { zones: { httpRequestsAdaptiveGroups: RegistryStatsGroup[] }[] };
+  }> = await response.json();
+
+  if (payload.errors?.length) {
+    throw new Error(
+      `Cloudflare GraphQL error: ${payload.errors.map((error) => error.message).join(', ')}`,
+    );
+  }
+
+  const groups = payload.data?.viewer.zones[0]?.httpRequestsAdaptiveGroups ?? [];
+  return aggregateRegistryStats(groups, since.toISOString(), until.toISOString());
+}
+
+async function reportRegistryStatsToPostHog(stats: RegistryStats | null) {
+  if (!stats) return;
+
+  const key = process.env['POSTHOG_KEY'];
+  if (!key) return;
+
+  const response = await fetch('https://us.i.posthog.com/i/v0/e/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      api_key: key,
+      distinct_id: 'registry',
+      event: 'registry_fetch',
+      properties: {
+        source: 'cloudflare',
+        ...stats,
+      },
+    }),
+  }).catch(() => null);
+
+  if (response && !response.ok) {
+    console.warn(`PostHog registry stats API error: ${response.status}`);
+  }
+}
+
+console.log('Fetching GitHub releases for UseStitch/stitch...\n');
+
+const releases = await fetchReleases();
+console.log(`\nFetched ${releases.length} releases total\n`);
+
+const total = sumDownloads(releases);
+console.log(`Total GitHub downloads: ${total.toLocaleString()}`);
+
+await reportToPostHog(total, releases);
+
+const registryStats = await fetchCloudflareRegistryStats();
+if (registryStats) {
+  console.log(`Registry requests in last 24h: ${registryStats.total.toLocaleString()}`);
+  await reportRegistryStatsToPostHog(registryStats);
+}
+
+console.log('='.repeat(60));
+console.log(`TOTAL DOWNLOADS: ${total.toLocaleString()}`);
+if (registryStats) console.log(`TOTAL REGISTRY REQUESTS: ${registryStats.total.toLocaleString()}`);
+console.log('='.repeat(60));


### PR DESCRIPTION
## 🚀 Change Summary

Adds lightweight stats collection for app downloads and registry fetches while improving update checks and registry request attribution.

### ✨ New Features
- **Download Tracking**: Tracks website app download clicks and reports aggregate GitHub release download counts to PostHog.
- **Registry Fetch Metrics**: Reports aggregated Cloudflare request stats for Stitch registry endpoints, grouped by path and User-Agent.

### 🛠 Improvements & Refactors
- **Registry User-Agent**: Adds a structured Stitch User-Agent to Stitch-owned registry fetches without changing the models.dev fetch path.
- **Updater Frequency**: Updates the desktop app update check interval to run every 10 minutes.
