### PR TITLE
refactor(server): simplify service result handling

### DIFF
--- a/packages/server/src/automations/scheduler.ts
+++ b/packages/server/src/automations/scheduler.ts
@@ -3,7 +3,6 @@ import type { Automation, AutomationSchedule } from '@stitch/shared/automations/
 
 import { listAutomations, runAutomation } from './service.js';
 
-import { isServiceError } from '@/lib/service-result.js';
 import { registerSchedulerJob, unregisterSchedulerJob } from '@/scheduler/runtime.js';
 import { getSettings } from '@/settings/service.js';
 
@@ -47,8 +46,8 @@ async function registerAutomationJob(automation: Automation, timezone: string): 
     schedule: toSchedulerSchedule(automation.schedule, timezone),
     callback: async () => {
       const result = await runAutomation(automation.id);
-      if (isServiceError(result)) {
-        throw new Error(result.error);
+      if (result.error) {
+        throw new Error(result.error.message);
       }
     },
     maxConcurrency: 1,
@@ -79,7 +78,7 @@ export async function syncAllAutomationSchedules(): Promise<void> {
 
   while (true) {
     const result = await listAutomations({ page, pageSize });
-    if (isServiceError(result)) throw new Error(result.error);
+    if (result.error) throw new Error(result.error.message);
 
     automationList.push(...result.data.automations);
 

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -20,7 +20,7 @@ import { automations } from '@/db/schema/automations.js';
 import { sessions } from '@/db/schema/sessions.js';
 import * as Log from '@/lib/log.js';
 import { paginatedQuery } from '@/lib/paginated-query.js';
-import { err, isServiceError, ok } from '@/lib/service-result.js';
+import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { validateProviderModel } from '@/llm/resolve-model.js';
 
@@ -117,12 +117,12 @@ async function createAutomation(
   }
 
   const scheduleResult = validateAutomationSchedule(scheduleInput);
-  if ('error' in scheduleResult) {
+  if (scheduleResult.error) {
     return scheduleResult;
   }
 
   const validation = await validateProviderModel(providerId, modelId);
-  if ('error' in validation) {
+  if (validation.error) {
     return validation;
   }
 
@@ -148,7 +148,7 @@ export async function createAutomationAndSync(
   syncSchedule: SyncAutomationSchedule,
 ): Promise<ServiceResult<AutomationRow>> {
   const result = await createAutomation(input);
-  if (isServiceError(result)) return result;
+  if (result.error) return result;
 
   try {
     await syncSchedule(result.data);
@@ -190,12 +190,12 @@ async function updateAutomation(
   }
 
   const scheduleResult = validateAutomationSchedule(scheduleInput);
-  if ('error' in scheduleResult) {
+  if (scheduleResult.error) {
     return scheduleResult;
   }
 
   const validation = await validateProviderModel(providerId, modelId);
-  if ('error' in validation) {
+  if (validation.error) {
     return validation;
   }
 
@@ -225,10 +225,10 @@ export async function updateAutomationAndSync(
   syncSchedule: SyncAutomationSchedule,
 ): Promise<ServiceResult<AutomationRow>> {
   const beforeResult = await getAutomation(automationId);
-  if (isServiceError(beforeResult)) return beforeResult;
+  if (beforeResult.error) return beforeResult;
 
   const result = await updateAutomation(automationId, input);
-  if (isServiceError(result)) return result;
+  if (result.error) return result;
 
   try {
     await syncSchedule(result.data);
@@ -322,7 +322,7 @@ export async function runAutomation(
   }
 
   const validation = await validateProviderModel(automation.providerId, automation.modelId);
-  if ('error' in validation) {
+  if (validation.error) {
     return validation;
   }
 
@@ -332,7 +332,7 @@ export async function runAutomation(
     type: 'automation',
     automationId: automation.id,
   });
-  if (isServiceError(sessionResult)) return sessionResult;
+  if (sessionResult.error) return sessionResult;
   const session = sessionResult.data;
 
   const assistantMessageId = createMessageId();
@@ -343,7 +343,7 @@ export async function runAutomation(
     modelId: automation.modelId,
     assistantMessageId,
   });
-  if (isServiceError(sendResult)) return sendResult;
+  if (sendResult.error) return sendResult;
 
   const [updatedAutomation] = await db.transaction(async (tx) => {
     const [updated] = await tx

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -14,7 +14,7 @@ import { messages, sessions } from '@/db/schema/sessions.js';
 import * as AbortRegistry from '@/lib/abort-registry.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
-import { err, isServiceError, ok } from '@/lib/service-result.js';
+import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { compact } from '@/llm/compaction.js';
 import { buildSessionLlmMessages } from '@/llm/session-history.js';
@@ -625,9 +625,7 @@ export async function getSessionStats(
     listProvidersWithCapabilities(),
     Models.get(),
   ]);
-  const providers: ProviderWithCapabilities[] = isServiceError(providersResult)
-    ? []
-    : providersResult.data;
+  const providers: ProviderWithCapabilities[] = providersResult.error ? [] : providersResult.data;
 
   let providerLabel = '-';
   let modelLabel = '-';

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -112,10 +112,13 @@ export async function listSessions(
   return ok({ sessions: page, hasMore });
 }
 
-export async function getSessionById(sessionId: PrefixedString<'ses'>) {
+export async function getSessionById(
+  sessionId: PrefixedString<'ses'>,
+): Promise<ServiceResult<typeof sessions.$inferSelect>> {
   const db = getDb();
   const [session] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
-  return session;
+  if (!session) return err('Session not found', 404);
+  return ok(session);
 }
 
 export async function listSessionMessages(
@@ -156,24 +159,31 @@ export async function deleteSession(
   return ok(result[0]);
 }
 
-export async function renameSession(sessionId: PrefixedString<'ses'>, title: string) {
+export async function renameSession(
+  sessionId: PrefixedString<'ses'>,
+  title: string,
+): Promise<ServiceResult<typeof sessions.$inferSelect>> {
   const db = getDb();
   const [updated] = await db
     .update(sessions)
     .set({ title, updatedAt: Date.now() })
     .where(eq(sessions.id, sessionId))
     .returning();
-  return updated;
+  if (!updated) return err('Session not found', 404);
+  return ok(updated);
 }
 
-export async function markSessionRead(sessionId: PrefixedString<'ses'>) {
+export async function markSessionRead(
+  sessionId: PrefixedString<'ses'>,
+): Promise<ServiceResult<typeof sessions.$inferSelect>> {
   const db = getDb();
   const [updated] = await db
     .update(sessions)
     .set({ isUnread: false, updatedAt: Date.now() })
     .where(eq(sessions.id, sessionId))
     .returning();
-  return updated ?? null;
+  if (!updated) return err('Session not found', 404);
+  return ok(updated);
 }
 
 async function maybeGenerateTitle(input: {
@@ -394,7 +404,9 @@ export function resolveDoomLoop(
   return ok({ ok: true });
 }
 
-export async function abortSessionRun(sessionId: PrefixedString<'ses'>) {
+export async function abortSessionRun(
+  sessionId: PrefixedString<'ses'>,
+): Promise<ServiceResult<null>> {
   log.info({ event: 'stream.abort.requested', sessionId }, 'stream abort requested');
   AbortRegistry.abort(sessionId);
   cancelDecision(sessionId);
@@ -414,6 +426,8 @@ export async function abortSessionRun(sessionId: PrefixedString<'ses'>) {
       await Promise.all([abortQuestions(child.id), abortPermissionResponses(child.id)]);
     }),
   ]);
+
+  return ok(null);
 }
 
 function getSplitTitle(baseTitle: string, n: number): string {

--- a/packages/server/src/connectors/service.test.ts
+++ b/packages/server/src/connectors/service.test.ts
@@ -13,7 +13,6 @@ import {
 import { getDb } from '@/db/client.js';
 import { connectorInstances } from '@/db/schema/connectors.js';
 import { setupTestDb } from '@/db/test-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
 
 setupTestDb();
 
@@ -96,10 +95,10 @@ describe('connector service', () => {
 
     const result = await upgradeConnectorInstance(instanceId, {});
 
-    expect(isServiceError(result)).toBe(true);
-    if (isServiceError(result)) {
-      expect(result.status).toBe(400);
-      expect(result.error).toContain('API key is required');
+    expect(result.error).not.toBeNull();
+    if (result.error) {
+      expect(result.error.status).toBe(400);
+      expect(result.error.message).toContain('API key is required');
     }
 
     // Row should be unchanged
@@ -150,8 +149,8 @@ describe('connector service', () => {
       { startOAuthFlow: fakeStartOAuthFlow },
     );
 
-    expect(isServiceError(result)).toBe(false);
-    if (!isServiceError(result)) {
+    expect(result.error).toBeNull();
+    if (!result.error) {
       expect(result.data).toEqual({
         type: 'reauthorize',
         authUrl: 'https://example.com/authorize',
@@ -207,12 +206,12 @@ describe('connector service', () => {
       apiKey: 'secret',
     });
 
-    expect(isServiceError(oauthResult)).toBe(true);
-    expect(isServiceError(apiKeyResult)).toBe(true);
-    if (isServiceError(oauthResult))
-      expect(oauthResult.error).toBe('Connector is currently disabled');
-    if (isServiceError(apiKeyResult))
-      expect(apiKeyResult.error).toBe('Connector is currently disabled');
+    expect(oauthResult.error).not.toBeNull();
+    expect(apiKeyResult.error).not.toBeNull();
+    if (oauthResult.error)
+      expect(oauthResult.error.message).toBe('Connector is currently disabled');
+    if (apiKeyResult.error)
+      expect(apiKeyResult.error.message).toBe('Connector is currently disabled');
 
     // Nothing written to DB
     const rows = await getDb().select().from(connectorInstances);
@@ -256,8 +255,8 @@ describe('connector service', () => {
 
     const result = await authorizeOAuthInstance(instanceId, { startOAuthFlow: fakeStartOAuthFlow });
 
-    expect(isServiceError(result)).toBe(false);
-    if (isServiceError(result)) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     let threw = false;
     try {
@@ -310,8 +309,8 @@ describe('connector service', () => {
 
     const result = await authorizeOAuthInstance(instanceId, { startOAuthFlow: fakeStartOAuthFlow });
 
-    expect(isServiceError(result)).toBe(false);
-    if (isServiceError(result)) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     await result.data.waitForTokens();
 
@@ -363,8 +362,8 @@ describe('connector service', () => {
 
     const result = await authorizeOAuthInstance(instanceId, { startOAuthFlow: fakeStartOAuthFlow });
 
-    expect(isServiceError(result)).toBe(false);
-    if (isServiceError(result)) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     await result.data.waitForTokens();
 

--- a/packages/server/src/connectors/service.ts
+++ b/packages/server/src/connectors/service.ts
@@ -24,7 +24,7 @@ import { getConnectorModule, refreshConnectorToolsetsFor } from '@/connectors/ru
 import { getDb } from '@/db/client.js';
 import { connectorInstances } from '@/db/schema/connectors.js';
 import * as Log from '@/lib/log.js';
-import { err, ok, isServiceError } from '@/lib/service-result.js';
+import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 
 const log = Log.create({ service: 'connectors' });
@@ -411,7 +411,7 @@ export async function upgradeConnectorInstance(
       .where(eq(connectorInstances.id, typedInstanceId));
 
     const auth = await authorizeOAuthInstance(instanceId, deps);
-    if (isServiceError(auth)) {
+    if (auth.error) {
       return auth;
     }
 

--- a/packages/server/src/lib/route-helpers.ts
+++ b/packages/server/src/lib/route-helpers.ts
@@ -1,5 +1,3 @@
-import { err, ok } from './service-result.js';
-
 import type { ServiceResult } from './service-result.js';
 import type { Context } from 'hono';
 
@@ -18,9 +16,4 @@ export function unwrapResult<T>(
 
   if (successStatus === 204) return c.body(null, 204);
   return c.json(result.data, successStatus);
-}
-
-export function requireFound<T>(value: T | null | undefined, label: string): ServiceResult<T> {
-  if (value === null || value === undefined) return err(`${label} not found`, 404);
-  return ok(value);
 }

--- a/packages/server/src/lib/route-helpers.ts
+++ b/packages/server/src/lib/route-helpers.ts
@@ -1,4 +1,4 @@
-import { isServiceError } from './service-result.js';
+import { err, ok } from './service-result.js';
 
 import type { ServiceResult } from './service-result.js';
 import type { Context } from 'hono';
@@ -10,10 +10,10 @@ export function unwrapResult<T>(
   result: ServiceResult<T>,
   successStatus: SuccessStatus = 200,
 ): Response {
-  if (isServiceError(result)) {
-    const body: Record<string, unknown> = { error: result.error };
-    if (result.details !== undefined) body.details = result.details;
-    return c.json(body, result.status);
+  if (result.error) {
+    const body: Record<string, unknown> = { error: result.error.message };
+    if (result.error.details !== undefined) body.details = result.error.details;
+    return c.json(body, result.error.status);
   }
 
   if (successStatus === 204) return c.body(null, 204);
@@ -21,6 +21,6 @@ export function unwrapResult<T>(
 }
 
 export function requireFound<T>(value: T | null | undefined, label: string): ServiceResult<T> {
-  if (value === null || value === undefined) return { error: `${label} not found`, status: 404 };
-  return { data: value };
+  if (value === null || value === undefined) return err(`${label} not found`, 404);
+  return ok(value);
 }

--- a/packages/server/src/lib/service-result.ts
+++ b/packages/server/src/lib/service-result.ts
@@ -1,27 +1,29 @@
 export type ServiceError = {
-  error: string;
+  message: string;
   status: 400 | 401 | 403 | 404 | 409 | 422 | 500;
   details?: unknown;
 };
 
 export type ServiceSuccess<T> = {
   data: T;
+  error: null;
 };
 
-export type ServiceResult<T> = ServiceSuccess<T> | ServiceError;
+export type ServiceFailure = {
+  data: null;
+  error: ServiceError;
+};
+
+export type ServiceResult<T> = ServiceSuccess<T> | ServiceFailure;
 
 export function ok<T>(data: T): ServiceSuccess<T> {
-  return { data };
+  return { data, error: null };
 }
 
 export function err(
-  error: string,
+  message: string,
   status: 400 | 401 | 403 | 404 | 409 | 422 | 500,
   details?: unknown,
-): ServiceError {
-  return { error, status, details };
-}
-
-export function isServiceError<T>(result: ServiceResult<T>): result is ServiceError {
-  return 'error' in result;
+): ServiceFailure {
+  return { data: null, error: { message, status, details } };
 }

--- a/packages/server/src/lib/simple-icons.ts
+++ b/packages/server/src/lib/simple-icons.ts
@@ -3,18 +3,20 @@ import path from 'node:path';
 import { readCachedText, writeCachedText } from '@/lib/icon-cache.js';
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
+import { err, ok } from '@/lib/service-result.js';
+import type { ServiceResult } from '@/lib/service-result.js';
 
 const log = Log.create({ service: 'simple-icons' });
 const SIMPLE_ICONS_CDN = 'https://cdn.simpleicons.org';
 
-export async function getSimpleIcon(slug: string): Promise<string | undefined> {
-  if (!slug.trim()) return undefined;
+export async function getSimpleIcon(slug: string): Promise<ServiceResult<string>> {
+  if (!slug.trim()) return err('Icon not found', 404);
 
   const cacheDir = PATHS.dirPaths.simpleIcons;
   const filePath = path.join(cacheDir, `${slug}.svg`);
 
   const cached = await readCachedText(filePath);
-  if (cached) return cached;
+  if (cached) return ok(cached);
 
   const result = await fetch(`${SIMPLE_ICONS_CDN}/${slug}`, {
     signal: AbortSignal.timeout(10_000),
@@ -22,9 +24,9 @@ export async function getSimpleIcon(slug: string): Promise<string | undefined> {
     log.warn({ error, slug }, 'failed to fetch simple icon');
   });
 
-  if (!result || !result.ok) return undefined;
+  if (!result || !result.ok) return err('Icon not found', 404);
 
   const svg = await result.text();
   await writeCachedText(filePath, svg);
-  return svg;
+  return ok(svg);
 }

--- a/packages/server/src/llm/compaction.ts
+++ b/packages/server/src/llm/compaction.ts
@@ -10,7 +10,6 @@ import { getDb } from '@/db/client.js';
 import { messages, sessions } from '@/db/schema/sessions.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
-import { isServiceError } from '@/lib/service-result.js';
 import { addCacheControlToMessages, getProviderOptions } from '@/llm/cache-control.js';
 import { buildHistoryMessages } from '@/llm/history-messages.js';
 import { getPromptUserContext } from '@/llm/prompt/builder.js';
@@ -504,7 +503,7 @@ export function buildActiveToolsetInstructionsBlock(sessionId: PrefixedString<'s
 export async function getModelLimits(providerId: string, modelId: string): Promise<ModelLimits> {
   if (providerId === 'ollama_local') {
     const result = await OllamaModels.getOllamaModel(modelId);
-    if (!isServiceError(result)) {
+    if (!result.error) {
       return { context: result.data.contextWindow, output: result.data.outputLimit };
     }
     return { context: 200_000, output: 8_192 };

--- a/packages/server/src/llm/provider/service.ts
+++ b/packages/server/src/llm/provider/service.ts
@@ -4,7 +4,7 @@ import type { EmbeddingProviderModels } from '@stitch/shared/embedding/types';
 
 import { getDb } from '@/db/client.js';
 import { providerConfig, ollamaModels } from '@/db/schema/providers.js';
-import { err, isServiceError, ok } from '@/lib/service-result.js';
+import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import type { ResolvedEmbeddingModel } from '@/models/embedding/schema.js';
 import * as EmbeddingModels from '@/models/embedding/service.js';
@@ -102,7 +102,7 @@ export async function getProvider(providerId: string): Promise<ServiceResult<Pro
   }
 
   const providerResult = await resolveProvider(providerId);
-  if (isServiceError(providerResult)) {
+  if (providerResult.error) {
     return providerResult;
   }
 
@@ -148,7 +148,7 @@ export async function listProviderModels(
   }
 
   const providerResult = await resolveProvider(providerId);
-  if (isServiceError(providerResult)) {
+  if (providerResult.error) {
     return providerResult;
   }
 

--- a/packages/server/src/llm/resolve-cheap-model.ts
+++ b/packages/server/src/llm/resolve-cheap-model.ts
@@ -37,7 +37,7 @@ export async function resolveCheapModel(input: {
     priorityModelIds: CHEAP_MODEL_PRIORITY,
   });
 
-  if ('error' in result) {
+  if (result.error) {
     return null;
   }
 

--- a/packages/server/src/llm/resolve-model.ts
+++ b/packages/server/src/llm/resolve-model.ts
@@ -129,6 +129,6 @@ export async function validateProviderModel(
     fallbackProviderId: providerId,
     fallbackModelId: modelId,
   });
-  if ('error' in result) return result;
+  if (result.error) return result;
   return ok(null);
 }

--- a/packages/server/src/mcp/registry-logos.ts
+++ b/packages/server/src/mcp/registry-logos.ts
@@ -10,7 +10,6 @@ import { isSvgResponse, readCachedText, writeCachedText } from '@/lib/icon-cache
 import type { FetchLike } from '@/lib/icon-cache.js';
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
-import { isServiceError } from '@/lib/service-result.js';
 import { findMcpRegistryServerForInstall, listMcpRegistryServers } from '@/mcp/registry-service.js';
 
 const log = Log.create({ service: 'mcp-registry-logos' });
@@ -70,7 +69,7 @@ export async function getMcpRegistryLogo(
   if (cached) return cached;
 
   const result = await listMcpRegistryServers({ cacheFilePath: options.registryCacheFilePath });
-  if (isServiceError(result)) return undefined;
+  if (result.error) return undefined;
 
   const server = result.data.find((entry) => entry.id === registryId);
   if (!server) return undefined;

--- a/packages/server/src/mcp/registry-service.test.ts
+++ b/packages/server/src/mcp/registry-service.test.ts
@@ -77,11 +77,11 @@ describe('mcp registry service', () => {
       fetchImpl,
       force: true,
     });
-    expect('error' in refreshResult).toBe(false);
+    expect(refreshResult.error).toBeNull();
 
     const listResult = await listMcpRegistryServers({ cacheFilePath });
-    expect('error' in listResult).toBe(false);
-    if ('error' in listResult) return;
+    expect(listResult.error).toBeNull();
+    if (listResult.error) return;
 
     expect(listResult.data.map((server) => server.name)).toEqual(['Alpha Server', 'Zulu Server']);
 
@@ -107,7 +107,7 @@ describe('mcp registry service', () => {
       force: true,
     });
 
-    expect('error' in result).toBe(false);
+    expect(result.error).toBeNull();
     expect(captured.userAgent?.startsWith('Stitch/')).toBe(true);
     expect(captured.userAgent).toContain('RegistryClient/1');
   });
@@ -121,8 +121,8 @@ describe('mcp registry service', () => {
     };
 
     const result = await listMcpRegistryServers({ cacheFilePath, fetchImpl });
-    expect('error' in result).toBe(false);
-    if ('error' in result) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     expect(result.data).toHaveLength(2);
   });
@@ -140,9 +140,9 @@ describe('mcp registry service', () => {
       force: true,
     });
 
-    expect('error' in result).toBe(true);
-    if ('error' in result) {
-      expect(result.status).toBe(500);
+    expect(result.error).not.toBeNull();
+    if (result.error) {
+      expect(result.error.status).toBe(500);
     }
   });
 });

--- a/packages/server/src/mcp/registry-service.ts
+++ b/packages/server/src/mcp/registry-service.ts
@@ -9,7 +9,6 @@ import { PATHS } from '@/lib/paths.js';
 import { getStitchRegistryUserAgent } from '@/lib/registry-cache.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
-import { isServiceError } from '@/lib/service-result.js';
 
 const log = Log.create({ service: 'mcp-registry' });
 const DEFAULT_MCP_REGISTRY_URL = 'https://usestitch.ai/mcp-registry.json';
@@ -169,7 +168,7 @@ export async function listMcpRegistryServers(
     fetchImpl: options.fetchImpl,
     force: true,
   });
-  if (isServiceError(refreshed)) {
+  if (refreshed.error) {
     return refreshed;
   }
 
@@ -181,7 +180,7 @@ export async function findMcpRegistryServerForInstall(input: {
   url: string;
 }): Promise<McpRegistryServer | null> {
   const result = await listMcpRegistryServers();
-  if (isServiceError(result)) return null;
+  if (result.error) return null;
 
   const normalizedUrl = input.url.trim().toLowerCase();
   const normalizedName = input.name.trim().toLowerCase();

--- a/packages/server/src/mcp/tool-executor.test.ts
+++ b/packages/server/src/mcp/tool-executor.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 
+import { ok } from '@/lib/service-result.js';
 import type { McpServerWithTools } from '@/mcp/service.js';
 import { getMcpServerPresentation, refreshMcpToolsets } from '@/mcp/tool-executor.js';
 import {
@@ -33,9 +34,8 @@ describe('refreshMcpToolsets', () => {
       { refreshTools: true },
       {
         getMcpServersWithCachedTools: async () => [TEST_SERVER],
-        fetchMcpTools: async () => ({
-          data: [{ name: 'lookup', description: 'Lookup data', inputSchema: {} }],
-        }),
+        fetchMcpTools: async () =>
+          ok([{ name: 'lookup', description: 'Lookup data', inputSchema: {} }]),
         fetchServerInfo: async () => null,
         fetchServerPrompts: async () => [],
         findRegistryServer: async () => null,
@@ -64,9 +64,8 @@ describe('refreshMcpToolsets', () => {
       { refreshTools: true },
       {
         getMcpServersWithCachedTools: async () => [TEST_SERVER],
-        fetchMcpTools: async () => ({
-          data: [{ name: 'lookup', description: 'Lookup data', inputSchema: {} }],
-        }),
+        fetchMcpTools: async () =>
+          ok([{ name: 'lookup', description: 'Lookup data', inputSchema: {} }]),
         fetchServerInfo: async () => null,
         fetchServerPrompts: async () => [],
         findRegistryServer: async () => null,
@@ -86,9 +85,8 @@ describe('refreshMcpToolsets', () => {
       { refreshTools: true },
       {
         getMcpServersWithCachedTools: async () => [TEST_SERVER],
-        fetchMcpTools: async () => ({
-          data: [{ name: 'lookup', description: 'Lookup data', inputSchema: {} }],
-        }),
+        fetchMcpTools: async () =>
+          ok([{ name: 'lookup', description: 'Lookup data', inputSchema: {} }]),
         fetchServerInfo: async () => null,
         fetchServerPrompts: async () => [],
         findRegistryServer: async () => ({
@@ -124,9 +122,8 @@ describe('refreshMcpToolsets', () => {
       { refreshTools: true },
       {
         getMcpServersWithCachedTools: async () => [TEST_SERVER],
-        fetchMcpTools: async () => ({
-          data: [{ name: 'lookup', description: 'Lookup data', inputSchema: {} }],
-        }),
+        fetchMcpTools: async () =>
+          ok([{ name: 'lookup', description: 'Lookup data', inputSchema: {} }]),
         fetchServerInfo: async () => ({
           name: 'mcp-typescript server on vercel',
           title: 'mcp-typescript server on vercel',
@@ -162,9 +159,8 @@ describe('refreshMcpToolsets', () => {
       { refreshTools: true },
       {
         getMcpServersWithCachedTools: async () => [TEST_SERVER],
-        fetchMcpTools: async () => ({
-          data: [{ name: 'lookup', description: 'Lookup data', inputSchema: {} }],
-        }),
+        fetchMcpTools: async () =>
+          ok([{ name: 'lookup', description: 'Lookup data', inputSchema: {} }]),
         fetchServerInfo: async () => null,
         fetchServerPrompts: async () => [],
         findRegistryServer: async () => null,
@@ -189,9 +185,8 @@ describe('refreshMcpToolsets', () => {
 
   test('removing a stale server also drops its presentation', async () => {
     const deps = {
-      fetchMcpTools: async () => ({
-        data: [{ name: 'lookup', description: 'Lookup data', inputSchema: {} }],
-      }),
+      fetchMcpTools: async () =>
+        ok([{ name: 'lookup', description: 'Lookup data', inputSchema: {} }]),
       fetchServerInfo: async () => null,
       fetchServerPrompts: async () => [],
       findRegistryServer: async () => null,

--- a/packages/server/src/mcp/tool-executor.ts
+++ b/packages/server/src/mcp/tool-executor.ts
@@ -3,7 +3,6 @@ import type { McpIcon, McpRegistryServer } from '@stitch/shared/mcp/types';
 
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
-import { isServiceError } from '@/lib/service-result.js';
 import { buildAuthHeaders } from '@/mcp/auth.js';
 import { getMcpClient, listMcpAiTools } from '@/mcp/client.js';
 import { buildServerPresentation } from '@/mcp/presentation.js';
@@ -276,7 +275,7 @@ async function refreshMcpToolsetsInternal(
       const tools = refreshTools
         ? await deps
             .fetchMcpTools(server.id)
-            .then((result) => (isServiceError(result) ? (server.tools ?? []) : result.data))
+            .then((result) => (result.error ? (server.tools ?? []) : result.data))
             .catch(() => server.tools ?? [])
         : (server.tools ?? []);
       return {

--- a/packages/server/src/memory/maintenance.ts
+++ b/packages/server/src/memory/maintenance.ts
@@ -1,4 +1,6 @@
 import * as Log from '@/lib/log.js';
+import { ok } from '@/lib/service-result.js';
+import type { ServiceResult } from '@/lib/service-result.js';
 import { getMemoryConfig, isMemoryActive } from '@/memory/config.js';
 import { deduplicateMemories, getMemoryStats, pruneStaleMemories } from '@/memory/service.js';
 import type { MemoryStats } from '@/memory/service.js';
@@ -11,12 +13,12 @@ type MaintenanceResult = {
   stats: MemoryStats | null;
 };
 
-export async function runMemoryMaintenance(): Promise<MaintenanceResult> {
+export async function runMemoryMaintenance(): Promise<ServiceResult<MaintenanceResult>> {
   const config = await getMemoryConfig();
 
   if (!isMemoryActive(config)) {
     log.info('memory maintenance skipped — memory not active');
-    return { pruned: 0, deduplicated: 0, stats: null };
+    return ok({ pruned: 0, deduplicated: 0, stats: null });
   }
 
   log.info('starting memory maintenance');
@@ -54,5 +56,5 @@ export async function runMemoryMaintenance(): Promise<MaintenanceResult> {
     );
   }
 
-  return { pruned, deduplicated, stats };
+  return ok({ pruned, deduplicated, stats });
 }

--- a/packages/server/src/memory/maintenance.ts
+++ b/packages/server/src/memory/maintenance.ts
@@ -1,5 +1,4 @@
 import * as Log from '@/lib/log.js';
-import { isServiceError } from '@/lib/service-result.js';
 import { getMemoryConfig, isMemoryActive } from '@/memory/config.js';
 import { deduplicateMemories, getMemoryStats, pruneStaleMemories } from '@/memory/service.js';
 import type { MemoryStats } from '@/memory/service.js';
@@ -28,8 +27,8 @@ export async function runMemoryMaintenance(): Promise<MaintenanceResult> {
     const beforeResult = await getMemoryStats();
     await pruneStaleMemories({ maxMemories: config.maxMemories, staleDays: config.staleDays });
     const afterResult = await getMemoryStats();
-    const beforeTotal = isServiceError(beforeResult) ? 0 : beforeResult.data.total;
-    const afterTotal = isServiceError(afterResult) ? 0 : afterResult.data.total;
+    const beforeTotal = beforeResult.error ? 0 : beforeResult.data.total;
+    const afterTotal = afterResult.error ? 0 : afterResult.data.total;
     pruned = Math.max(0, beforeTotal - afterTotal);
     log.info({ pruned }, 'memory maintenance: pruning complete');
   }
@@ -40,7 +39,7 @@ export async function runMemoryMaintenance(): Promise<MaintenanceResult> {
 
   // Phase 3: Emit stats
   const statsResult = await getMemoryStats();
-  const stats = isServiceError(statsResult) ? null : statsResult.data;
+  const stats = statsResult.error ? null : statsResult.data;
   if (stats) {
     log.info(
       {

--- a/packages/server/src/memory/processor.ts
+++ b/packages/server/src/memory/processor.ts
@@ -7,7 +7,6 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { getDb } from '@/db/client.js';
 import { sessions } from '@/db/schema/sessions.js';
 import * as Log from '@/lib/log.js';
-import { isServiceError } from '@/lib/service-result.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
 import { getMemoryConfig, isMemoryActive } from '@/memory/config.js';
@@ -262,7 +261,7 @@ export async function processMemories(input: {
           query: fact.content,
           page: 1,
           pageSize: 5,
-        }).then((result) => (isServiceError(result) ? [] : result.data.memories)),
+        }).then((result) => (result.error ? [] : result.data.memories)),
       ),
     );
 

--- a/packages/server/src/memory/retriever.ts
+++ b/packages/server/src/memory/retriever.ts
@@ -1,5 +1,4 @@
 import * as Log from '@/lib/log.js';
-import { isServiceError } from '@/lib/service-result.js';
 import { getMemoryConfig, isMemoryActive } from '@/memory/config.js';
 import { searchSemanticMemories, touchSemanticMemories } from '@/memory/service.js';
 import type { MemoryCategory } from '@/memory/types.js';
@@ -70,7 +69,7 @@ export async function retrieveMemoryContext(
     sourceFilter,
   });
 
-  if (isServiceError(semanticResult)) return null;
+  if (semanticResult.error) return null;
   const semantic = semanticResult.data;
 
   // Apply category and score filters before reranking.

--- a/packages/server/src/permission/service.test.ts
+++ b/packages/server/src/permission/service.test.ts
@@ -93,7 +93,10 @@ describe('permission service interactions', () => {
 
     const permissionResponseId = requestedData.permissionResponse.id;
 
-    expect(allowPermissionResponse(permissionResponseId)).resolves.toEqual({ data: null });
+    expect(allowPermissionResponse(permissionResponseId)).resolves.toEqual({
+      data: null,
+      error: null,
+    });
     expect(promise).resolves.toEqual({ decision: 'allow' });
 
     const resolvedEvent = emittedEvents.find(([name]) => name === 'permission.resolved');
@@ -278,7 +281,7 @@ describe('permission service interactions', () => {
 
     expect(
       alternativePermissionResponse(permissionResponseId, 'Use read instead'),
-    ).resolves.toEqual({ data: null });
+    ).resolves.toEqual({ data: null, error: null });
     expect(promise).resolves.toEqual({
       decision: 'alternative',
       entry: 'Use read instead',

--- a/packages/server/src/permission/service.ts
+++ b/packages/server/src/permission/service.ts
@@ -238,8 +238,8 @@ export async function alternativePermissionResponse(
 
 export async function getPendingPermissionResponses(
   sessionId: PrefixedString<'ses'>,
-): Promise<PermissionResponse[]> {
-  return [...permissionResponseStore.values()].filter((r) => r.sessionId === sessionId);
+): Promise<ServiceResult<PermissionResponse[]>> {
+  return ok([...permissionResponseStore.values()].filter((r) => r.sessionId === sessionId));
 }
 
 export async function abortPermissionResponses(sessionId: PrefixedString<'ses'>): Promise<void> {

--- a/packages/server/src/question/service.test.ts
+++ b/packages/server/src/question/service.test.ts
@@ -135,7 +135,7 @@ describe('question service interactions', () => {
   test('replyQuestion accepts custom answers by default', async () => {
     const { createQuestion, replyQuestion } = await import('@/question/service.js');
 
-    const question = await createQuestion({
+    const questionResult = await createQuestion({
       sessionId,
       messageId,
       toolCallId: 'call_custom',
@@ -148,6 +148,9 @@ describe('question service interactions', () => {
         },
       ],
     });
+    expect(questionResult.error).toBeNull();
+    if (questionResult.error) return;
+    const question = questionResult.data;
 
     const result = await replyQuestion(question.id, [['Something else']]);
     expect(result).toEqual({ data: null, error: null });
@@ -161,7 +164,7 @@ describe('question service interactions', () => {
   test('replyQuestion rejects invalid answers without resolving the question', async () => {
     const { createQuestion, replyQuestion } = await import('@/question/service.js');
 
-    const question = await createQuestion({
+    const questionResult = await createQuestion({
       sessionId,
       messageId,
       toolCallId: 'call_invalid',
@@ -175,6 +178,9 @@ describe('question service interactions', () => {
         },
       ],
     });
+    expect(questionResult.error).toBeNull();
+    if (questionResult.error) return;
+    const question = questionResult.data;
 
     expect(replyQuestion(question.id, [[]])).resolves.toEqual({
       data: null,

--- a/packages/server/src/question/service.test.ts
+++ b/packages/server/src/question/service.test.ts
@@ -80,7 +80,7 @@ describe('question service interactions', () => {
     const questionId = askedData.question.id;
 
     const replyResult = await replyQuestion(questionId, [['A']]);
-    expect(replyResult).toEqual({ data: null });
+    expect(replyResult).toEqual({ data: null, error: null });
 
     expect(promise).resolves.toEqual([['A']]);
 
@@ -116,7 +116,7 @@ describe('question service interactions', () => {
     const questionId = askedData.question.id;
 
     const rejectResult = await rejectQuestion(questionId);
-    expect(rejectResult).toEqual({ data: null });
+    expect(rejectResult).toEqual({ data: null, error: null });
 
     expect(promise).rejects.toThrow('Question rejected by user');
 
@@ -150,7 +150,7 @@ describe('question service interactions', () => {
     });
 
     const result = await replyQuestion(question.id, [['Something else']]);
-    expect(result).toEqual({ data: null });
+    expect(result).toEqual({ data: null, error: null });
 
     const db = getDb();
     const [row] = await db.select().from(questions).where(eq(questions.id, question.id));
@@ -177,19 +177,16 @@ describe('question service interactions', () => {
     });
 
     expect(replyQuestion(question.id, [[]])).resolves.toEqual({
-      error: 'Question 1 requires an answer',
-      status: 400,
-      details: undefined,
+      data: null,
+      error: { message: 'Question 1 requires an answer', status: 400, details: undefined },
     });
     expect(replyQuestion(question.id, [['Something else']])).resolves.toEqual({
-      error: 'Question 1 received an invalid answer',
-      status: 400,
-      details: undefined,
+      data: null,
+      error: { message: 'Question 1 received an invalid answer', status: 400, details: undefined },
     });
     expect(replyQuestion(question.id, [['A', 'Something else']])).resolves.toEqual({
-      error: 'Question 1 only accepts one answer',
-      status: 400,
-      details: undefined,
+      data: null,
+      error: { message: 'Question 1 only accepts one answer', status: 400, details: undefined },
     });
 
     const db = getDb();

--- a/packages/server/src/question/service.ts
+++ b/packages/server/src/question/service.ts
@@ -151,7 +151,7 @@ export async function replyQuestion(
   }
 
   const validation = validateQuestionAnswers(existingQuestion, answers);
-  if ('error' in validation) return validation;
+  if (validation.error) return validation;
 
   const [question] = await db
     .update(questions)

--- a/packages/server/src/question/service.ts
+++ b/packages/server/src/question/service.ts
@@ -61,7 +61,7 @@ export async function createQuestion(opts: {
   questions: QuestionInfo[];
   toolCallId: string;
   messageId: PrefixedString<'msg'>;
-}): Promise<QuestionRequest> {
+}): Promise<ServiceResult<QuestionRequest>> {
   const db = getDb();
   const id = createQuestionId();
   const now = Date.now();
@@ -79,7 +79,7 @@ export async function createQuestion(opts: {
     })
     .returning();
 
-  return toQuestionRequest(row);
+  return ok(toQuestionRequest(row));
 }
 
 export async function askQuestion(opts: {
@@ -231,14 +231,14 @@ export async function rejectQuestion(
 
 export async function getPendingQuestions(
   sessionId: PrefixedString<'ses'>,
-): Promise<QuestionRequest[]> {
+): Promise<ServiceResult<QuestionRequest[]>> {
   const db = getDb();
   const rows = await db
     .select()
     .from(questions)
     .where(and(eq(questions.sessionId, sessionId), eq(questions.status, 'pending')));
 
-  return rows.map(toQuestionRequest);
+  return ok(rows.map(toQuestionRequest));
 }
 
 /**

--- a/packages/server/src/recordings/analysis-service.ts
+++ b/packages/server/src/recordings/analysis-service.ts
@@ -15,7 +15,7 @@ import { recordingAnalyses, recordings } from '@/db/schema/recordings.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { resolveRuntimeAssetPath } from '@/lib/runtime-assets.js';
-import { err, isServiceError, ok } from '@/lib/service-result.js';
+import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
@@ -147,7 +147,7 @@ export async function startRecordingAnalysis(
   }
 
   const templateResult = await getMeetingNoteTemplate(input.templateId);
-  if (isServiceError(templateResult)) {
+  if (templateResult.error) {
     return templateResult;
   }
 
@@ -161,7 +161,7 @@ export async function startRecordingAnalysis(
     modelIdKey: 'recordings.analysis.modelId',
   });
 
-  if (isServiceError(analysisModel)) {
+  if (analysisModel.error) {
     return analysisModel;
   }
 

--- a/packages/server/src/recordings/meeting-note-templates.test.ts
+++ b/packages/server/src/recordings/meeting-note-templates.test.ts
@@ -16,8 +16,10 @@ describe('meeting note templates', () => {
   test('seeds prebuilt templates', async () => {
     const result = await listMeetingNoteTemplates();
 
-    expect(result.templates).toHaveLength(PREBUILT_MEETING_NOTE_TEMPLATES.length);
-    expect(result.templates.map((template) => template.id).sort()).toEqual(
+    expect(result.error).toBeNull();
+    if (result.error) return;
+    expect(result.data.templates).toHaveLength(PREBUILT_MEETING_NOTE_TEMPLATES.length);
+    expect(result.data.templates.map((template) => template.id).sort()).toEqual(
       PREBUILT_MEETING_NOTE_TEMPLATES.map((template) => template.id).sort(),
     );
   });
@@ -34,7 +36,9 @@ describe('meeting note templates', () => {
     seedMeetingNoteTemplates();
 
     const result = await listMeetingNoteTemplates();
-    const edited = result.templates.find((item) => item.id === template.id);
+    expect(result.error).toBeNull();
+    if (result.error) return;
+    const edited = result.data.templates.find((item) => item.id === template.id);
 
     expect(edited?.name).toBe('Edited Template');
     expect(edited?.content).toBe('# Edited');
@@ -64,7 +68,9 @@ describe('meeting note templates', () => {
     expect(deleted.error).toBeNull();
 
     const result = await listMeetingNoteTemplates();
-    expect(result.templates.some((template) => template.id === created.data.template.id)).toBe(
+    expect(result.error).toBeNull();
+    if (result.error) return;
+    expect(result.data.templates.some((template) => template.id === created.data.template.id)).toBe(
       false,
     );
   });

--- a/packages/server/src/recordings/meeting-note-templates.test.ts
+++ b/packages/server/src/recordings/meeting-note-templates.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
 import { setupTestDb } from '@/db/test-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
 import {
   createMeetingNoteTemplate,
   deleteMeetingNoteTemplate,
@@ -30,7 +29,7 @@ describe('meeting note templates', () => {
       content: '# Edited',
     });
 
-    expect(isServiceError(updated)).toBe(false);
+    expect(updated.error).toBeNull();
 
     seedMeetingNoteTemplates();
 
@@ -47,22 +46,22 @@ describe('meeting note templates', () => {
       content: '# Custom',
     });
 
-    expect(isServiceError(created)).toBe(false);
-    if (isServiceError(created)) return;
+    expect(created.error).toBeNull();
+    if (created.error) return;
 
     const updated = await updateMeetingNoteTemplate(created.data.template.id, {
       name: 'Updated Template',
       content: '# Updated',
     });
 
-    expect(isServiceError(updated)).toBe(false);
-    if (isServiceError(updated)) return;
+    expect(updated.error).toBeNull();
+    if (updated.error) return;
     expect(updated.data.template.name).toBe('Updated Template');
     expect(updated.data.template.content).toBe('# Updated');
 
     const deleted = await deleteMeetingNoteTemplate(created.data.template.id);
 
-    expect(isServiceError(deleted)).toBe(false);
+    expect(deleted.error).toBeNull();
 
     const result = await listMeetingNoteTemplates();
     expect(result.templates.some((template) => template.id === created.data.template.id)).toBe(

--- a/packages/server/src/recordings/meeting-note-templates.ts
+++ b/packages/server/src/recordings/meeting-note-templates.ts
@@ -69,14 +69,16 @@ export function seedMeetingNoteTemplates(db = getDb()): void {
   }
 }
 
-export async function listMeetingNoteTemplates(): Promise<ListMeetingNoteTemplatesResponse> {
+export async function listMeetingNoteTemplates(): Promise<
+  ServiceResult<ListMeetingNoteTemplatesResponse>
+> {
   const db = getDb();
   const rows = await db
     .select()
     .from(meetingNoteTemplates)
     .orderBy(desc(meetingNoteTemplates.updatedAt));
 
-  return { templates: rows.map(toMeetingNoteTemplate) };
+  return ok({ templates: rows.map(toMeetingNoteTemplate) });
 }
 
 export async function getMeetingNoteTemplate(

--- a/packages/server/src/recordings/service.ts
+++ b/packages/server/src/recordings/service.ts
@@ -364,8 +364,11 @@ export async function stopRecording(
       void startRecordingAnalysis(current.id, {
         templateId: defaultTemplateId as PrefixedString<'mnt'>,
       }).then((result) => {
-        if ('error' in result) {
-          log.warn({ recordingId: current.id, error: result.error }, 'auto analysis skipped');
+        if (result.error) {
+          log.warn(
+            { recordingId: current.id, error: result.error.message },
+            'auto analysis skipped',
+          );
         }
       });
     }

--- a/packages/server/src/recordings/service.ts
+++ b/packages/server/src/recordings/service.ts
@@ -151,7 +151,7 @@ function toRecording(
 export async function listRecordings(input: {
   page: number;
   pageSize: number;
-}): Promise<ListRecordingsResponse> {
+}): Promise<ServiceResult<ListRecordingsResponse>> {
   const db = getDb();
   const offset = (input.page - 1) * input.pageSize;
   const [rows, countRows] = await Promise.all([
@@ -171,7 +171,7 @@ export async function listRecordings(input: {
   const total = Number(countRows[0]?.total ?? 0);
   const totalPages = computeTotalPages(total, input.pageSize);
 
-  return {
+  return ok({
     recordings: rows.map((row) =>
       toRecording(row.recording, row.analysisTitle || null, row.analysisCostUsd ?? null),
     ),
@@ -180,7 +180,7 @@ export async function listRecordings(input: {
     pageSize: input.pageSize,
     total,
     totalPages,
-  };
+  });
 }
 
 export async function getRecordingDetails(
@@ -209,8 +209,8 @@ export async function getRecordingDetails(
   });
 }
 
-export function getActiveRecording(): ActiveRecordingResponse {
-  return { activeRecordingId: activeRecording?.id ?? null };
+export function getActiveRecording(): ServiceResult<ActiveRecordingResponse> {
+  return ok({ activeRecordingId: activeRecording?.id ?? null });
 }
 
 export async function startRecording(

--- a/packages/server/src/routes/agenda.ts
+++ b/packages/server/src/routes/agenda.ts
@@ -20,7 +20,6 @@ import {
 } from '@/agenda/service.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
 import { paginationQuerySchema } from '@/lib/route-schemas.js';
-import { isServiceError } from '@/lib/service-result.js';
 
 const createListSchema = z.object({
   name: z.string().trim().min(1).max(200),
@@ -67,7 +66,7 @@ export const agendaRouter = new Hono();
 agendaRouter.get('/lists', (c) => {
   const includeArchived = c.req.query('includeArchived') === 'true';
   const result = getAgendaLists({ includeArchived });
-  if (isServiceError(result)) return unwrapResult(c, result);
+  if (result.error) return unwrapResult(c, result);
   return c.json({ lists: result.data });
 });
 

--- a/packages/server/src/routes/automations.ts
+++ b/packages/server/src/routes/automations.ts
@@ -20,7 +20,6 @@ import {
 import * as Log from '@/lib/log.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
 import { paginationQuerySchema, routeSchemas } from '@/lib/route-schemas.js';
-import { isServiceError } from '@/lib/service-result.js';
 
 const log = Log.create({ service: 'automations' });
 
@@ -80,7 +79,7 @@ automationsRouter.patch(
 automationsRouter.delete('/:id', zValidator('param', automationIdParamSchema), async (c) => {
   const { id } = c.req.valid('param');
   const result = await deleteAutomation(id);
-  if (isServiceError(result)) return unwrapResult(c, result);
+  if (result.error) return unwrapResult(c, result);
 
   await unregisterAutomationSchedule(id).catch((error: unknown) => {
     log.error({ error }, 'failed to unregister automation schedule');

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -18,7 +18,7 @@ import {
   sendMessage,
   splitSession,
 } from '@/chat/service.js';
-import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
+import { unwrapResult } from '@/lib/route-helpers.js';
 import { routeSchemas } from '@/lib/route-schemas.js';
 import { listSessionTodos } from '@/todos/service.js';
 
@@ -87,7 +87,7 @@ chatRouter.get('/sessions', zValidator('query', listSessionsQuerySchema), async 
 
 chatRouter.get('/sessions/:id', zValidator('param', sessionIdParamSchema), async (c) => {
   const { id } = c.req.valid('param');
-  const result = requireFound(await getSessionById(id), 'Session');
+  const result = await getSessionById(id);
   return unwrapResult(c, result);
 });
 
@@ -128,16 +128,14 @@ chatRouter.patch(
   async (c) => {
     const { id } = c.req.valid('param');
     const { title } = c.req.valid('json');
-    const updated = await renameSession(id, title);
-    const result = requireFound(updated, 'Session');
+    const result = await renameSession(id, title);
     return unwrapResult(c, result);
   },
 );
 
 chatRouter.patch('/sessions/:id/read', zValidator('param', sessionIdParamSchema), async (c) => {
   const { id } = c.req.valid('param');
-  const updated = await markSessionRead(id);
-  const result = requireFound(updated, 'Session');
+  const result = await markSessionRead(id);
   return unwrapResult(c, result, 204);
 });
 
@@ -174,8 +172,8 @@ chatRouter.post(
 
 chatRouter.post('/sessions/:id/abort', zValidator('param', sessionIdParamSchema), async (c) => {
   const { id } = c.req.valid('param');
-  await abortSessionRun(id);
-  return c.json({ ok: true });
+  const result = await abortSessionRun(id);
+  return unwrapResult(c, result, 204);
 });
 
 chatRouter.post('/sessions/:id/split/:msgId', zValidator('param', splitParamSchema), async (c) => {

--- a/packages/server/src/routes/connectors.ts
+++ b/packages/server/src/routes/connectors.ts
@@ -16,7 +16,6 @@ import {
 } from '@/connectors/service.js';
 import * as Log from '@/lib/log.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
 
 export const connectorsRouter = new Hono();
 const log = Log.create({ service: 'connectors-route' });
@@ -72,7 +71,7 @@ connectorsRouter.post('/instances/api-key', zValidator('json', createApiKeySchem
 connectorsRouter.post('/instances/:id/authorize', async (c) => {
   const id = c.req.param('id');
   const result = await authorizeOAuthInstance(id);
-  if (isServiceError(result)) return unwrapResult(c, result);
+  if (result.error) return unwrapResult(c, result);
 
   const { waitForTokens } = result.data;
   void waitForTokens().catch((error) => {
@@ -114,7 +113,7 @@ connectorsRouter.delete('/instances/:id', async (c) => {
 connectorsRouter.post('/instances/:id/test', async (c) => {
   const id = c.req.param('id');
   const result = await testConnectorInstance(id);
-  if (isServiceError(result)) return unwrapResult(c, result);
+  if (result.error) return unwrapResult(c, result);
   return c.json({ success: true });
 });
 

--- a/packages/server/src/routes/icons.ts
+++ b/packages/server/src/routes/icons.ts
@@ -1,15 +1,14 @@
 import { Hono } from 'hono';
 
 import { ICON_CACHE_CONTROL, SVG_CONTENT_TYPE } from '@/lib/icon-cache.js';
-import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
+import { unwrapResult } from '@/lib/route-helpers.js';
 import { getSimpleIcon } from '@/lib/simple-icons.js';
 
 export const iconsRouter = new Hono();
 
 iconsRouter.get('/simple-icons/:slug', async (c) => {
   const slug = c.req.param('slug');
-  const svg = await getSimpleIcon(slug);
-  const result = requireFound(svg, 'Icon');
+  const result = await getSimpleIcon(slug);
   if (result.error) return unwrapResult(c, result);
 
   c.header('Content-Type', SVG_CONTENT_TYPE);

--- a/packages/server/src/routes/icons.ts
+++ b/packages/server/src/routes/icons.ts
@@ -2,7 +2,6 @@ import { Hono } from 'hono';
 
 import { ICON_CACHE_CONTROL, SVG_CONTENT_TYPE } from '@/lib/icon-cache.js';
 import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
 import { getSimpleIcon } from '@/lib/simple-icons.js';
 
 export const iconsRouter = new Hono();
@@ -11,7 +10,7 @@ iconsRouter.get('/simple-icons/:slug', async (c) => {
   const slug = c.req.param('slug');
   const svg = await getSimpleIcon(slug);
   const result = requireFound(svg, 'Icon');
-  if (isServiceError(result)) return unwrapResult(c, result);
+  if (result.error) return unwrapResult(c, result);
 
   c.header('Content-Type', SVG_CONTENT_TYPE);
   c.header('Cache-Control', ICON_CACHE_CONTROL);

--- a/packages/server/src/routes/llm-provider.ts
+++ b/packages/server/src/routes/llm-provider.ts
@@ -7,7 +7,6 @@ import { PROVIDER_IDS } from '@stitch/shared/providers/types';
 import { ICON_CACHE_CONTROL, SVG_CONTENT_TYPE } from '@/lib/icon-cache.js';
 import * as Log from '@/lib/log.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
 import {
   getProvider,
   getProviderLogo,
@@ -38,7 +37,7 @@ providerRouter.get(
   async (c) => {
     const { providerId } = c.req.valid('param');
     const result = await getProvider(providerId);
-    if (isServiceError(result)) log.warn({ providerId }, 'blocked access to provider');
+    if (result.error) log.warn({ providerId }, 'blocked access to provider');
     return unwrapResult(c, result);
   },
 );
@@ -49,7 +48,7 @@ providerRouter.get(
   async (c) => {
     const { providerId } = c.req.valid('param');
     const result = await listProviderModels(providerId);
-    if (isServiceError(result)) log.warn({ providerId }, 'blocked access to provider models');
+    if (result.error) log.warn({ providerId }, 'blocked access to provider models');
     return unwrapResult(c, result);
   },
 );
@@ -60,7 +59,7 @@ providerRouter.get(
   async (c) => {
     const { providerId } = c.req.valid('param');
     const result = await getProviderLogo(providerId);
-    if (isServiceError(result)) {
+    if (result.error) {
       log.warn({ providerId }, 'provider logo request failed');
       return unwrapResult(c, result);
     }
@@ -77,7 +76,7 @@ providerRouter.get(
   async (c) => {
     const { providerId } = c.req.valid('param');
     const result = await getProviderCredentials(providerId);
-    if (isServiceError(result)) log.warn({ providerId }, 'provider config request failed');
+    if (result.error) log.warn({ providerId }, 'provider config request failed');
     return unwrapResult(c, result);
   },
 );
@@ -90,7 +89,7 @@ providerRouter.put(
     const { providerId } = c.req.valid('param');
     const body = c.req.valid('json');
     const result = await upsertProviderCredentials(providerId, body);
-    if (isServiceError(result)) log.warn({ providerId }, 'provider config update failed');
+    if (result.error) log.warn({ providerId }, 'provider config update failed');
     return unwrapResult(c, result, 204);
   },
 );
@@ -101,7 +100,7 @@ providerRouter.delete(
   async (c) => {
     const { providerId } = c.req.valid('param');
     const result = await deleteProviderCredentials(providerId);
-    if (isServiceError(result)) log.warn({ providerId }, 'provider config delete failed');
+    if (result.error) log.warn({ providerId }, 'provider config delete failed');
     return unwrapResult(c, result, 204);
   },
 );

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -6,7 +6,6 @@ import { MCP_TRANSPORT_TYPES } from '@stitch/shared/mcp/types';
 
 import { ICON_CACHE_CONTROL, SVG_CONTENT_TYPE } from '@/lib/icon-cache.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
 import { getMcpInstalledServerRegistryLogo, getMcpRegistryLogo } from '@/mcp/registry-logos.js';
 import { listMcpRegistryServers, reloadMcpRegistryCacheFromDisk } from '@/mcp/registry-service.js';
 import { createMcpServer, deleteMcpServer, fetchMcpTools, listMcpServers } from '@/mcp/service.js';
@@ -46,7 +45,7 @@ mcpRouter.post('/', zValidator('json', createMcpServerSchema), async (c) => {
     url: body.url,
     authConfig: body.authConfig,
   });
-  if (isServiceError(result)) return unwrapResult(c, result);
+  if (result.error) return unwrapResult(c, result);
   await refreshMcpToolsets({ serverIds: [result.data.id], refreshTools: true });
   return unwrapResult(c, result, 201);
 });
@@ -76,7 +75,7 @@ mcpRouter.get('/registry/:registryId/logo', async (c) => {
 mcpRouter.get('/:id/tools', async (c) => {
   const id = c.req.param('id');
   const result = await fetchMcpTools(id);
-  if (isServiceError(result)) return unwrapResult(c, result);
+  if (result.error) return unwrapResult(c, result);
   await refreshMcpToolsets({ serverIds: [id], refreshTools: false });
   return unwrapResult(c, result);
 });
@@ -107,7 +106,7 @@ mcpRouter.post('/:id/refresh', async (c) => {
 mcpRouter.delete('/:id', async (c) => {
   const id = c.req.param('id');
   const result = await deleteMcpServer(id);
-  if (isServiceError(result)) return unwrapResult(c, result);
+  if (result.error) return unwrapResult(c, result);
   evictMcpClient(id);
   await refreshMcpToolsets({ refreshTools: false });
   return unwrapResult(c, result, 204);

--- a/packages/server/src/routes/memory.ts
+++ b/packages/server/src/routes/memory.ts
@@ -155,7 +155,7 @@ memoryRouter.post('/maintenance', async (c) => {
   if (inactiveResponse) return inactiveResponse;
 
   const result = await runMemoryMaintenance();
-  return c.json(result);
+  return unwrapResult(c, result);
 });
 
 memoryRouter.post('/reset', async (c) => {

--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 
 import { getSessionById } from '@/chat/service.js';
 import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
 import {
   allowPermissionResponse,
   alternativePermissionResponse,
@@ -39,7 +38,7 @@ permissionsRouter.get(
     const { id: sessionId } = c.req.valid('param');
 
     const sessionResult = requireFound(await getSessionById(sessionId), 'Session');
-    if (isServiceError(sessionResult)) return unwrapResult(c, sessionResult);
+    if (sessionResult.error) return unwrapResult(c, sessionResult);
 
     const rows = await getPendingPermissionResponses(sessionId);
     return c.json(rows);

--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 
 import { getSessionById } from '@/chat/service.js';
-import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
+import { unwrapResult } from '@/lib/route-helpers.js';
 import {
   allowPermissionResponse,
   alternativePermissionResponse,
@@ -37,11 +37,11 @@ permissionsRouter.get(
   async (c) => {
     const { id: sessionId } = c.req.valid('param');
 
-    const sessionResult = requireFound(await getSessionById(sessionId), 'Session');
+    const sessionResult = await getSessionById(sessionId);
     if (sessionResult.error) return unwrapResult(c, sessionResult);
 
-    const rows = await getPendingPermissionResponses(sessionId);
-    return c.json(rows);
+    const result = await getPendingPermissionResponses(sessionId);
+    return unwrapResult(c, result);
   },
 );
 

--- a/packages/server/src/routes/questions.ts
+++ b/packages/server/src/routes/questions.ts
@@ -3,7 +3,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 
 import { getSessionById } from '@/chat/service.js';
-import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
+import { unwrapResult } from '@/lib/route-helpers.js';
 import {
   createQuestion,
   getPendingQuestions,
@@ -51,11 +51,11 @@ questionsRouter.get(
   async (c) => {
     const { id: sessionId } = c.req.valid('param');
 
-    const sessionResult = requireFound(await getSessionById(sessionId), 'Session');
+    const sessionResult = await getSessionById(sessionId);
     if (sessionResult.error) return unwrapResult(c, sessionResult);
 
-    const rows = await getPendingQuestions(sessionId);
-    return c.json(rows);
+    const result = await getPendingQuestions(sessionId);
+    return unwrapResult(c, result);
   },
 );
 
@@ -66,19 +66,19 @@ questionsRouter.post(
   async (c) => {
     const { id: sessionId } = c.req.valid('param');
 
-    const sessionResult = requireFound(await getSessionById(sessionId), 'Session');
+    const sessionResult = await getSessionById(sessionId);
     if (sessionResult.error) return unwrapResult(c, sessionResult);
 
     const body = c.req.valid('json');
 
-    const row = await createQuestion({
+    const result = await createQuestion({
       sessionId,
       questions: body.questions,
       toolCallId: body.toolCallId,
       messageId: body.messageId,
     });
 
-    return c.json(row, 201);
+    return unwrapResult(c, result, 201);
   },
 );
 

--- a/packages/server/src/routes/questions.ts
+++ b/packages/server/src/routes/questions.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 
 import { getSessionById } from '@/chat/service.js';
 import { requireFound, unwrapResult } from '@/lib/route-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
 import {
   createQuestion,
   getPendingQuestions,
@@ -53,7 +52,7 @@ questionsRouter.get(
     const { id: sessionId } = c.req.valid('param');
 
     const sessionResult = requireFound(await getSessionById(sessionId), 'Session');
-    if (isServiceError(sessionResult)) return unwrapResult(c, sessionResult);
+    if (sessionResult.error) return unwrapResult(c, sessionResult);
 
     const rows = await getPendingQuestions(sessionId);
     return c.json(rows);
@@ -68,7 +67,7 @@ questionsRouter.post(
     const { id: sessionId } = c.req.valid('param');
 
     const sessionResult = requireFound(await getSessionById(sessionId), 'Session');
-    if (isServiceError(sessionResult)) return unwrapResult(c, sessionResult);
+    if (sessionResult.error) return unwrapResult(c, sessionResult);
 
     const body = c.req.valid('json');
 

--- a/packages/server/src/routes/recordings.ts
+++ b/packages/server/src/routes/recordings.ts
@@ -62,7 +62,7 @@ recordingsRouter.get(
   async (c) => {
     const { page, pageSize } = c.req.valid('query');
     const result = await listRecordings({ page, pageSize });
-    return c.json(result);
+    return unwrapResult(c, result);
   },
 );
 
@@ -80,7 +80,7 @@ recordingsRouter.post('/stop', zValidator('json', stopRecordingSchema), async (c
 
 recordingsRouter.get('/templates', async (c) => {
   const result = await listMeetingNoteTemplates();
-  return c.json(result);
+  return unwrapResult(c, result);
 });
 
 recordingsRouter.post('/templates', zValidator('json', meetingNoteTemplateSchema), async (c) => {
@@ -117,7 +117,7 @@ recordingsRouter.delete('/:id', zValidator('param', recordingIdParamSchema), asy
   return unwrapResult(c, result, 204);
 });
 
-recordingsRouter.get('/active', (c) => c.json(getActiveRecording()));
+recordingsRouter.get('/active', (c) => unwrapResult(c, getActiveRecording()));
 
 recordingsRouter.get('/:id', zValidator('param', recordingIdParamSchema), async (c) => {
   const { id } = c.req.valid('param');

--- a/packages/server/src/settings/service.ts
+++ b/packages/server/src/settings/service.ts
@@ -6,7 +6,7 @@ import type { SettingsKey } from '@stitch/shared/settings/types';
 import { syncAllAutomationSchedules } from '@/automations/scheduler.js';
 import { getDb } from '@/db/client.js';
 import { userSettings } from '@/db/schema/settings.js';
-import { err, isServiceError, ok } from '@/lib/service-result.js';
+import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { listEnabledProviderEmbeddingModels } from '@/llm/provider/service.js';
 import { getMemoryConfig, hasConfiguredEmbeddingModel } from '@/memory/config.js';
@@ -69,7 +69,7 @@ async function checkMemoryEnablePrerequisites(): Promise<ServiceResult<null>> {
   }
 
   const providerModelsResult = await listEnabledProviderEmbeddingModels();
-  const providerModels = isServiceError(providerModelsResult) ? [] : providerModelsResult.data;
+  const providerModels = providerModelsResult.error ? [] : providerModelsResult.data;
   const hasConfiguredModel = providerModels.some(
     (provider) =>
       provider.providerId === memoryConfig.embeddingProviderId &&
@@ -117,7 +117,7 @@ export async function saveSetting(key: string, value: string): Promise<ServiceRe
 
   if (key === 'memory.enabled' && value === 'true') {
     const prereqResult = await checkMemoryEnablePrerequisites();
-    if (isServiceError(prereqResult)) return prereqResult;
+    if (prereqResult.error) return prereqResult;
   }
 
   const db = getDb();

--- a/packages/server/src/skills/service.ts
+++ b/packages/server/src/skills/service.ts
@@ -343,7 +343,7 @@ export async function importSkillFromDirectory(
 
 export async function buildSkillsSystemPrompt(): Promise<string> {
   const result = await listSkills();
-  if ('error' in result || result.data.length === 0) return '';
+  if (result.error || result.data.length === 0) return '';
 
   const lines = result.data.map((skill) => `- ${skill.name}: ${skill.description}`);
   return `Available skills provide task-specific instructions. Use the \`skill\` tool to load a skill when the user's request matches its description.\n\n${lines.join('\n')}`;

--- a/packages/server/src/todos/service.ts
+++ b/packages/server/src/todos/service.ts
@@ -7,7 +7,7 @@ import type { SessionTodo, TodoInput } from '@stitch/shared/todos/types';
 import { getDb } from '@/db/client.js';
 import { sessionTodos, sessions } from '@/db/schema/sessions.js';
 import { internalBus } from '@/lib/internal-bus.js';
-import { err, isServiceError, ok, type ServiceResult } from '@/lib/service-result.js';
+import { err, ok, type ServiceResult } from '@/lib/service-result.js';
 
 export async function listSessionTodos(
   sessionId: PrefixedString<'ses'>,
@@ -64,7 +64,7 @@ export async function getSessionTodosPromptBlock(
   sessionId: PrefixedString<'ses'>,
 ): Promise<string | null> {
   const result = await listSessionTodos(sessionId);
-  if (isServiceError(result) || result.data.length === 0) return null;
+  if (result.error || result.data.length === 0) return null;
 
   const lines = result.data.map((todo) => `- [${todo.status}] (${todo.priority}) ${todo.content}`);
 

--- a/packages/server/src/tools/core/catalog.ts
+++ b/packages/server/src/tools/core/catalog.ts
@@ -1,5 +1,4 @@
 import { isDbInitialized } from '@/db/client.js';
-import { isServiceError } from '@/lib/service-result.js';
 import { listEnabledProviderEmbeddingModels } from '@/llm/provider/service.js';
 import { getMemoryConfig, hasConfiguredEmbeddingModel } from '@/memory/config.js';
 import { definition as bash } from '@/tools/core/bash.js';
@@ -67,7 +66,7 @@ export const CORE_TOOL_CATALOG: CatalogEntry[] = [
       const memoryConfig = await getMemoryConfig();
       if (!hasConfiguredEmbeddingModel(memoryConfig)) return false;
       const result = await listEnabledProviderEmbeddingModels();
-      const providers = isServiceError(result) ? [] : result.data;
+      const providers = result.error ? [] : result.data;
       return providers.some(
         (provider) =>
           provider.providerId === memoryConfig.embeddingProviderId &&

--- a/packages/server/src/tools/core/inspect-image.ts
+++ b/packages/server/src/tools/core/inspect-image.ts
@@ -14,7 +14,6 @@ import { messages } from '@/db/schema/sessions.js';
 import * as AbortRegistry from '@/lib/abort-registry.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
-import { isServiceError } from '@/lib/service-result.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { buildSessionLlmMessages } from '@/llm/session-history.js';
 import { runStream } from '@/llm/stream/runner.js';
@@ -104,11 +103,11 @@ export function createInspectImageTool(context: ToolContext, deps: InspectImageT
         title: sessionTitle,
         parentSessionId: deps.parentSessionId,
       });
-      if (isServiceError(sessionResult)) {
+      if (sessionResult.error) {
         return {
           childSessionId: null,
           childSessionName: null,
-          summary: `Failed to create inspection session: ${sessionResult.error}`,
+          summary: `Failed to create inspection session: ${sessionResult.error.message}`,
         };
       }
       const childSession = sessionResult.data;

--- a/packages/server/src/tools/core/memory.ts
+++ b/packages/server/src/tools/core/memory.ts
@@ -1,7 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 
-import { isServiceError } from '@/lib/service-result.js';
 import { getMemoryConfig } from '@/memory/config.js';
 import {
   addSemanticMemory,
@@ -79,7 +78,7 @@ function createMemoryTool(context: ToolContext) {
             pageSize: 10,
             sourceFilter: 'chat',
           });
-          if (isServiceError(searchResult)) {
+          if (searchResult.error) {
             return { output: 'Failed to search memories.' };
           }
           const result = searchResult.data;
@@ -110,7 +109,7 @@ function createMemoryTool(context: ToolContext) {
             pageSize: 1000,
             sourceFilter: 'chat',
           });
-          if (isServiceError(listResult)) {
+          if (listResult.error) {
             return { output: 'Failed to list memories.' };
           }
           const all = listResult.data;

--- a/packages/server/src/tools/core/skill.ts
+++ b/packages/server/src/tools/core/skill.ts
@@ -19,7 +19,7 @@ export const definition: ToolDefinition = {
     inputSchema: skillInputSchema,
     execute: async ({ name }) => {
       const result = await getSkillByName(name);
-      if ('error' in result) return { error: result.error };
+      if (result.error) return { error: result.error.message };
 
       const skill = result.data;
       const dir = path.dirname(skill.location);

--- a/packages/server/src/tools/core/task.ts
+++ b/packages/server/src/tools/core/task.ts
@@ -12,7 +12,6 @@ import { messages } from '@/db/schema/sessions.js';
 import * as AbortRegistry from '@/lib/abort-registry.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
-import { isServiceError } from '@/lib/service-result.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { buildSessionLlmMessages } from '@/llm/session-history.js';
 import { runStream } from '@/llm/stream/runner.js';
@@ -64,11 +63,11 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
         title,
         parentSessionId: deps.parentSessionId,
       });
-      if (isServiceError(sessionResult)) {
+      if (sessionResult.error) {
         return {
           childSessionId: null,
           childSessionName: null,
-          summary: `Task failed: could not create child session — ${sessionResult.error}`,
+          summary: `Task failed: could not create child session — ${sessionResult.error.message}`,
         };
       }
       const childSession = sessionResult.data;

--- a/packages/server/src/tools/core/todo.ts
+++ b/packages/server/src/tools/core/todo.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
 import { TODO_PRIORITIES, TODO_STATUSES } from '@stitch/shared/todos/types';
 import type { SessionTodo, TodoInput } from '@stitch/shared/todos/types';
 
-import { isServiceError } from '@/lib/service-result.js';
 import { listSessionTodos, replaceSessionTodos } from '@/todos/service.js';
 import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
@@ -54,7 +53,7 @@ function createTodoTool(context: ToolContext) {
     execute: async (input) => {
       if (input.action === 'read') {
         const result = await listSessionTodos(context.sessionId);
-        if (isServiceError(result)) return { output: result.error };
+        if (result.error) return { output: result.error.message };
 
         return {
           output: formatSummary(result.data),
@@ -70,7 +69,7 @@ function createTodoTool(context: ToolContext) {
         sessionId: context.sessionId,
         todos: input.todos,
       });
-      if (isServiceError(result)) return { output: result.error };
+      if (result.error) return { output: result.error.message };
 
       return {
         output: `Updated session todos:\n${formatSummary(result.data)}`,

--- a/packages/server/src/tools/toolsets/agenda.ts
+++ b/packages/server/src/tools/toolsets/agenda.ts
@@ -13,7 +13,6 @@ import {
   getAgendaLists,
   updateAgendaItem,
 } from '@/agenda/service.js';
-import { isServiceError } from '@/lib/service-result.js';
 import { listSettings } from '@/settings/service.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 import { TOOLSET_SUMMARY_CONTEXT, summarizeTools, type Toolset } from '@/tools/toolsets/types.js';
@@ -78,7 +77,7 @@ function parseDueDate(dateStr: string, timeZone: string): number | null {
 
 async function resolveUserTimezone(): Promise<string> {
   const settingsResult = await listSettings();
-  if (isServiceError(settingsResult)) return 'UTC';
+  if (settingsResult.error) return 'UTC';
   return settingsResult.data['profile.timezone'] || 'UTC';
 }
 
@@ -123,8 +122,8 @@ Use when the user asks to add a todo, task, or follow-up. Default priority is "m
         sourceMessageId: context.messageId,
       });
 
-      if (isServiceError(result)) {
-        return { output: `Failed to create item: ${result.error}` };
+      if (result.error) {
+        return { output: `Failed to create item: ${result.error.message}` };
       }
 
       const item = result.data;
@@ -169,7 +168,7 @@ Use when the user asks to mark something as done, change priority, reschedule, o
         dueAt,
       });
 
-      if (isServiceError(result)) {
+      if (result.error) {
         return { output: `No agenda item found with id: ${input.itemId}` };
       }
 
@@ -193,7 +192,7 @@ Use when the user asks about their tasks, what's pending, or what's due.`,
       let listId: PrefixedString<'alist'> | undefined;
       if (input.listName) {
         const listResult = getAgendaListByName(input.listName);
-        if (!isServiceError(listResult) && listResult.data) listId = listResult.data.id;
+        if (!listResult.error && listResult.data) listId = listResult.data.id;
       }
 
       const result = await getAgendaItems({
@@ -204,8 +203,8 @@ Use when the user asks about their tasks, what's pending, or what's due.`,
         pageSize: 50,
       });
 
-      if (isServiceError(result)) {
-        return { output: `Failed to list items: ${result.error}` };
+      if (result.error) {
+        return { output: `Failed to list items: ${result.error.message}` };
       }
 
       const { items, total } = result.data;
@@ -234,7 +233,7 @@ Use when the user wants to see the complete information about a specific item.`,
     }),
     execute: async (input) => {
       const result = getAgendaItem(input.itemId as PrefixedString<'aitm'>);
-      if (isServiceError(result)) {
+      if (result.error) {
         return { output: `No agenda item found with id: ${input.itemId}` };
       }
 
@@ -268,8 +267,8 @@ Use when the user wants to organize items into a new list/topic.`,
         description: input.description,
       });
 
-      if (isServiceError(result)) {
-        return { output: `Failed to create list: ${result.error}` };
+      if (result.error) {
+        return { output: `Failed to create list: ${result.error.message}` };
       }
 
       const list = result.data;
@@ -284,8 +283,8 @@ Use when the user wants to see what lists exist or get an overview of their agen
     inputSchema: z.object({}),
     execute: async () => {
       const result = getAgendaLists();
-      if (isServiceError(result)) {
-        return { output: `Failed to list agenda lists: ${result.error}` };
+      if (result.error) {
+        return { output: `Failed to list agenda lists: ${result.error.message}` };
       }
 
       const lists = result.data;

--- a/packages/server/src/tools/toolsets/recordings.ts
+++ b/packages/server/src/tools/toolsets/recordings.ts
@@ -28,11 +28,11 @@ Returns status, file path, and Markdown meeting notes.`,
     execute: async (input) => {
       const result = await getRecordingAnalysis(input.recordingId as PrefixedString<'rec'>);
 
-      if ('error' in result) {
+      if (result.error) {
         return {
           recordingId: input.recordingId,
           found: false,
-          message: result.error,
+          message: result.error.message,
         };
       }
 
@@ -95,11 +95,11 @@ Use this when analysis is missing or stale.`,
         templateId: templateId as PrefixedString<'mnt'>,
       });
 
-      if ('error' in result) {
+      if (result.error) {
         return {
           recordingId: input.recordingId,
           ok: false,
-          message: result.error,
+          message: result.error.message,
         };
       }
 

--- a/packages/server/src/usage/service.test.ts
+++ b/packages/server/src/usage/service.test.ts
@@ -4,7 +4,6 @@ import { randomUUID } from 'node:crypto';
 import { getDb } from '@/db/client.js';
 import { llmUsageEvents } from '@/db/schema/usage.js';
 import { setupTestDb } from '@/db/test-helpers.js';
-import { isServiceError } from '@/lib/service-result.js';
 import { getUsageDashboard, usageServiceInternals } from '@/usage/service.js';
 
 setupTestDb();
@@ -98,8 +97,8 @@ describe('getUsageDashboard', () => {
       to: now,
     });
 
-    expect(isServiceError(result)).toBe(false);
-    if (isServiceError(result)) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     expect(result.data.totals.costUsd).toBe(0);
     expect(result.data.totals.tokenMetrics.totalTokens).toBe(0);
@@ -126,8 +125,8 @@ describe('getUsageDashboard', () => {
 
     const result = await getUsageDashboard({ from, to: now });
 
-    expect(isServiceError(result)).toBe(false);
-    if (isServiceError(result)) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     expect(result.data.totals.costUsd).toBeCloseTo(0.03);
   });
@@ -146,8 +145,8 @@ describe('getUsageDashboard', () => {
 
     const result = await getUsageDashboard({ from, to: now });
 
-    expect(isServiceError(result)).toBe(false);
-    if (isServiceError(result)) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     expect(result.data.totals.costUsd).toBe(0);
     expect(result.data.sources).not.toContain('transcription');
@@ -167,8 +166,8 @@ describe('getUsageDashboard', () => {
 
     const result = await getUsageDashboard({ from, to: now });
 
-    expect(isServiceError(result)).toBe(false);
-    if (isServiceError(result)) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     expect(result.data.totals.costUsd).toBe(0);
   });
@@ -188,8 +187,8 @@ describe('getUsageDashboard', () => {
 
     const result = await getUsageDashboard({ from, to: now });
 
-    expect(isServiceError(result)).toBe(false);
-    if (isServiceError(result)) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     expect(result.data.totals.costUsd).toBe(0);
   });
@@ -209,8 +208,8 @@ describe('getUsageDashboard', () => {
 
     const result = await getUsageDashboard({ from, to: now });
 
-    expect(isServiceError(result)).toBe(false);
-    if (isServiceError(result)) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     expect(result.data.totals.costUsd).toBe(0);
   });
@@ -229,8 +228,8 @@ describe('getUsageDashboard', () => {
 
     const result = await getUsageDashboard({ from, to: now });
 
-    expect(isServiceError(result)).toBe(false);
-    if (isServiceError(result)) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     expect(result.data.usedProviders).toContain('anthropic');
     expect(
@@ -262,8 +261,8 @@ describe('getUsageDashboard', () => {
 
     const result = await getUsageDashboard({ from, to: now, providerId: 'openai' });
 
-    expect(isServiceError(result)).toBe(false);
-    if (isServiceError(result)) return;
+    expect(result.error).toBeNull();
+    if (result.error) return;
 
     expect(result.data.totals.costUsd).toBeCloseTo(1.0);
     expect(result.data.usedProviders).toEqual(['openai']);


### PR DESCRIPTION
## 🚀 Change Summary

Refactors server service results into a consistent `{ data, error }` shape and simplifies route response handling around that convention.

### 🛠 Improvements & Refactors
- Standardizes `ServiceResult` success and failure values across server services, routes, tools, and tests.
- Keeps route HTTP error responses stable while simplifying service error access to `result.error.message`.
- Removes `requireFound` from route helpers by moving not-found handling into route-facing services.
- Converts remaining route-facing raw/null service returns to `ServiceResult` so normal routes can consistently use `unwrapResult`.
