### PR TITLE
fix(server): prevent semantic table creation race

### DIFF
--- a/packages/server/src/memory/store/tables.test.ts
+++ b/packages/server/src/memory/store/tables.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, mock, test } from 'bun:test';
+import type { Table as LanceTable } from '@lancedb/lancedb';
+
+describe('getSemanticTable', () => {
+  test('shares one table creation across concurrent callers', async () => {
+    const table = { name: 'semantic_memories' } as unknown as LanceTable;
+    const calls = { tableNames: 0, createEmptyTable: 0 };
+
+    void mock.module('@/memory/store/connection.js', () => ({
+      getConnection: async () => ({
+        tableNames: async () => {
+          calls.tableNames++;
+          return [];
+        },
+        createEmptyTable: async () => {
+          calls.createEmptyTable++;
+          return table;
+        },
+      }),
+    }));
+
+    const { getSemanticTable } = await import('@/memory/store/tables.js');
+
+    const [first, second] = await Promise.all([getSemanticTable(1536), getSemanticTable(1536)]);
+
+    expect(first).toBe(table);
+    expect(second).toBe(table);
+    expect(calls.tableNames).toBe(1);
+    expect(calls.createEmptyTable).toBe(1);
+  });
+});

--- a/packages/server/src/memory/store/tables.ts
+++ b/packages/server/src/memory/store/tables.ts
@@ -9,6 +9,7 @@ const log = Log.create({ service: 'memory-tables' });
 const SEMANTIC_TABLE = 'semantic_memories';
 
 let cachedTable: LanceTable | null = null;
+let cachedTablePromise: Promise<LanceTable> | null = null;
 
 function semanticSchema(dimensions: number): Schema {
   return new Schema([
@@ -29,18 +30,30 @@ function semanticSchema(dimensions: number): Schema {
 
 export async function getSemanticTable(dimensions: number): Promise<LanceTable> {
   if (cachedTable) return cachedTable;
+  if (cachedTablePromise) return cachedTablePromise;
 
-  const db = await getConnection();
-  const names = await db.tableNames();
+  cachedTablePromise = (async () => {
+    const db = await getConnection();
+    const names = await db.tableNames();
 
-  if (names.includes(SEMANTIC_TABLE)) {
-    cachedTable = await db.openTable(SEMANTIC_TABLE);
-  } else {
-    log.info({ dimensions }, 'creating semantic_memories table');
-    cachedTable = await db.createEmptyTable(SEMANTIC_TABLE, semanticSchema(dimensions));
+    if (names.includes(SEMANTIC_TABLE)) {
+      cachedTable = await db.openTable(SEMANTIC_TABLE);
+    } else {
+      log.info({ dimensions }, 'creating semantic_memories table');
+      cachedTable = await db.createEmptyTable(SEMANTIC_TABLE, semanticSchema(dimensions), {
+        mode: 'create',
+        existOk: true,
+      });
+    }
+
+    return cachedTable;
+  })();
+
+  try {
+    return await cachedTablePromise;
+  } finally {
+    cachedTablePromise = null;
   }
-
-  return cachedTable;
 }
 
 export async function dropSemanticTable(): Promise<void> {
@@ -49,6 +62,7 @@ export async function dropSemanticTable(): Promise<void> {
   if (names.includes(SEMANTIC_TABLE)) {
     await db.dropTable(SEMANTIC_TABLE);
     cachedTable = null;
+    cachedTablePromise = null;
     log.info('dropped semantic_memories table');
   }
 }


### PR DESCRIPTION
## 🚀 Change Summary

Prevents concurrent memory table initialization from surfacing LanceDB `table already exists` errors when embedding-model changes reset semantic memory storage.

### 🐛 Bug Fixes
- **Semantic memory table initialization**: Shares a single in-flight `getSemanticTable()` initialization across concurrent callers.
- **Idempotent LanceDB creation**: Uses LanceDB `existOk` creation semantics so duplicate table creation attempts do not fail.

### 🛠 Improvements & Refactors
- Added a focused regression test covering concurrent semantic table creation.
