### PR TITLE
fix(registries): move validation into tests

### DIFF
--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -28,7 +28,6 @@ jobs:
             ci:
               - '**'
               - '!apps/website/**'
-              - '!registries/**'
               - '!**/*.md'
               - '!**/*.txt'
               - '!LICENSE'

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "apps/desktop": {
       "name": "@stitch/desktop",
-      "version": "0.5.6",
+      "version": "0.6.0",
       "dependencies": {
         "@stitch/audio-capture": "workspace:*",
         "@stitch/shared": "workspace:*",
@@ -33,7 +33,7 @@
     },
     "apps/web": {
       "name": "@stitch/web",
-      "version": "0.5.6",
+      "version": "0.6.0",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@stitch/scheduler": "workspace:*",
@@ -199,12 +199,27 @@
     },
     "registries/embeddings": {
       "name": "@stitch/registry-embeddings",
+      "devDependencies": {
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+        "zod": "catalog:",
+      },
     },
     "registries/mcp": {
       "name": "@stitch/registry-mcp",
+      "devDependencies": {
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+        "zod": "catalog:",
+      },
     },
     "registries/stt": {
       "name": "@stitch/registry-stt",
+      "devDependencies": {
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+        "zod": "catalog:",
+      },
     },
   },
   "catalog": {

--- a/registries/embeddings/package.json
+++ b/registries/embeddings/package.json
@@ -7,5 +7,14 @@
     "./models/nvidia.json": "./models/nvidia.json",
     "./models/openai.json": "./models/openai.json",
     "./models/openrouter.json": "./models/openrouter.json"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "catalog:",
+    "typescript": "catalog:",
+    "zod": "catalog:"
   }
 }

--- a/registries/embeddings/registry.test.ts
+++ b/registries/embeddings/registry.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+type JsonSchema = Parameters<typeof z.fromJSONSchema>[0];
+
+type EmbeddingProvider = {
+  providerId: string;
+  models: Array<{
+    id: string;
+  }>;
+};
+
+const registryDir = import.meta.dir;
+const modelsDir = join(registryDir, 'models');
+const schema = z.fromJSONSchema(
+  readJson(join(registryDir, 'schema', 'embedding-provider.schema.json')) as JsonSchema,
+) as z.ZodType<EmbeddingProvider>;
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function modelFiles() {
+  return readdirSync(modelsDir)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => join(modelsDir, name));
+}
+
+function expectValidProvider(path: string) {
+  const result = schema.safeParse(readJson(path));
+  if (!result.success) {
+    throw new Error(result.error.message);
+  }
+
+  return result.data;
+}
+
+describe('embedding registry', () => {
+  test('provider configs match the schema', () => {
+    for (const filePath of modelFiles()) {
+      expectValidProvider(filePath);
+    }
+  });
+
+  test('provider and model ids are unique', () => {
+    const providerIds = new Set<string>();
+
+    for (const filePath of modelFiles()) {
+      const provider = expectValidProvider(filePath);
+      const modelIds = new Set<string>();
+
+      expect(
+        providerIds.has(provider.providerId),
+        `Duplicate provider id: ${provider.providerId}`,
+      ).toBe(false);
+      providerIds.add(provider.providerId);
+
+      for (const model of provider.models) {
+        expect(modelIds.has(model.id), `${filePath}: duplicate model id ${model.id}`).toBe(false);
+        modelIds.add(model.id);
+      }
+    }
+  });
+});

--- a/registries/embeddings/tsconfig.json
+++ b/registries/embeddings/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["bun"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.test.ts"]
+}

--- a/registries/mcp/package.json
+++ b/registries/mcp/package.json
@@ -1,5 +1,14 @@
 {
   "name": "@stitch/registry-mcp",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "catalog:",
+    "typescript": "catalog:",
+    "zod": "catalog:"
+  }
 }

--- a/registries/mcp/registry.test.ts
+++ b/registries/mcp/registry.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+type JsonSchema = Parameters<typeof z.fromJSONSchema>[0];
+
+type McpServer = {
+  id: string;
+};
+
+const registryDir = import.meta.dir;
+const serversDir = join(registryDir, 'servers');
+const schema = z.fromJSONSchema(
+  readJson(join(registryDir, 'schema', 'mcp-server.schema.json')) as JsonSchema,
+) as z.ZodType<McpServer>;
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function expectValidRegistryEntry(path: string) {
+  const result = schema.safeParse(readJson(path));
+  if (!result.success) {
+    throw new Error(result.error.message);
+  }
+
+  return result.data;
+}
+
+function serverEntries() {
+  return readdirSync(serversDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      name: entry.name,
+      configPath: join(serversDir, entry.name, 'config.json'),
+    }));
+}
+
+describe('MCP registry', () => {
+  test('server configs match the schema', () => {
+    for (const entry of serverEntries()) {
+      expectValidRegistryEntry(entry.configPath);
+    }
+  });
+
+  test('server ids match directory names and are unique', () => {
+    const ids = new Set<string>();
+
+    for (const entry of serverEntries()) {
+      const server = expectValidRegistryEntry(entry.configPath);
+
+      expect(server.id).toBe(entry.name);
+      expect(ids.has(server.id), `Duplicate server id: ${server.id}`).toBe(false);
+      ids.add(server.id);
+    }
+  });
+});

--- a/registries/mcp/tsconfig.json
+++ b/registries/mcp/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["bun"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.test.ts"]
+}

--- a/registries/stt/models/assemblyai.json
+++ b/registries/stt/models/assemblyai.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../schema/stt-provider.schema.json",
+  "$schema": "https://usestitch.ai/schemas/stt-provider.schema.json",
   "providerId": "assemblyai",
   "providerName": "AssemblyAI",
   "models": [

--- a/registries/stt/models/elevenlabs.json
+++ b/registries/stt/models/elevenlabs.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../schema/stt-provider.schema.json",
+  "$schema": "https://usestitch.ai/schemas/stt-provider.schema.json",
   "providerId": "elevenlabs",
   "providerName": "ElevenLabs",
   "models": [

--- a/registries/stt/models/openai.json
+++ b/registries/stt/models/openai.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "../schema/stt-provider.schema.json",
+  "$schema": "https://usestitch.ai/schemas/stt-provider.schema.json",
   "providerId": "openai",
   "providerName": "OpenAI",
   "models": [

--- a/registries/stt/package.json
+++ b/registries/stt/package.json
@@ -6,5 +6,14 @@
     "./models/openai.json": "./models/openai.json",
     "./models/elevenlabs.json": "./models/elevenlabs.json",
     "./models/assemblyai.json": "./models/assemblyai.json"
+  },
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/bun": "catalog:",
+    "typescript": "catalog:",
+    "zod": "catalog:"
   }
 }

--- a/registries/stt/registry.test.ts
+++ b/registries/stt/registry.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod';
+
+type JsonSchema = Parameters<typeof z.fromJSONSchema>[0];
+
+type SttProvider = {
+  providerId: string;
+  models: Array<{
+    modelId: string;
+  }>;
+};
+
+const registryDir = import.meta.dir;
+const modelsDir = join(registryDir, 'models');
+const schema = z.fromJSONSchema(
+  readJson(join(registryDir, 'schema', 'stt-provider.schema.json')) as JsonSchema,
+) as z.ZodType<SttProvider>;
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function modelFiles() {
+  return readdirSync(modelsDir)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => join(modelsDir, name));
+}
+
+function expectValidProvider(path: string) {
+  const result = schema.safeParse(readJson(path));
+  if (!result.success) {
+    throw new Error(result.error.message);
+  }
+
+  return result.data;
+}
+
+describe('STT registry', () => {
+  test('provider configs match the schema', () => {
+    for (const filePath of modelFiles()) {
+      expectValidProvider(filePath);
+    }
+  });
+
+  test('provider and model ids are unique', () => {
+    const providerIds = new Set<string>();
+
+    for (const filePath of modelFiles()) {
+      const provider = expectValidProvider(filePath);
+      const modelIds = new Set<string>();
+
+      expect(
+        providerIds.has(provider.providerId),
+        `Duplicate provider id: ${provider.providerId}`,
+      ).toBe(false);
+      providerIds.add(provider.providerId);
+
+      for (const model of provider.models) {
+        expect(
+          modelIds.has(model.modelId),
+          `${filePath}: duplicate model id ${model.modelId}`,
+        ).toBe(false);
+        modelIds.add(model.modelId);
+      }
+    }
+  });
+});

--- a/registries/stt/tsconfig.json
+++ b/registries/stt/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext"],
+    "types": ["bun"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.test.ts"]
+}

--- a/scripts/build-website-registries.mjs
+++ b/scripts/build-website-registries.mjs
@@ -12,239 +12,17 @@ function readJson(path) {
   return JSON.parse(readFileSync(path, 'utf8'));
 }
 
-function assert(condition, message) {
-  if (!condition) {
-    throw new Error(message);
-  }
-}
-
-// --- Validation helpers ---
-
-function assertNonEmptyString(value, filePath, field) {
-  assert(typeof value === 'string' && value.length > 0, `${filePath}: ${field} is required`);
-}
-
-function assertObject(value, filePath, field) {
-  assert(value && typeof value === 'object', `${filePath}: ${field} is required`);
-}
-
-function assertPositiveInt(value, filePath, field) {
-  assert(Number.isInteger(value) && value > 0, `${filePath}: ${field} must be a positive integer`);
-}
-
-function assertNonEmptyArray(value, filePath, field) {
-  assert(
-    Array.isArray(value) && value.length > 0,
-    `${filePath}: ${field} must be a non-empty array`,
-  );
-}
-
-function assertOneOf(value, allowed, filePath, field) {
-  assert(allowed.includes(value), `${filePath}: ${field} must be ${allowed.join(' or ')}`);
-}
-
-function assertOptionalNonEmptyArray(value, filePath, field) {
-  if (value === undefined) return;
-  assertNonEmptyArray(value, filePath, field);
-}
-
-function assertOptionalNumber(value, filePath, field) {
-  if (value === undefined) return;
-  assert(typeof value === 'number', `${filePath}: ${field} must be a number`);
-}
-
-// --- Auth config validation ---
-
-function assertAuthConfig(authConfig, filePath) {
-  assertObject(authConfig, filePath, 'install.authConfig');
-  assert(
-    typeof authConfig.type === 'string',
-    `${filePath}: install.authConfig.type must be a string`,
-  );
-
-  if (authConfig.type === 'none') return;
-
-  if (authConfig.type === 'api_key') {
-    assert(
-      typeof authConfig.apiKey === 'string' && authConfig.apiKey.length > 0,
-      `${filePath}: api_key auth requires apiKey`,
-    );
-    return;
-  }
-
-  if (authConfig.type === 'headers') {
-    assert(
-      authConfig.headers && typeof authConfig.headers === 'object',
-      `${filePath}: headers auth requires headers object`,
-    );
-    for (const [header, value] of Object.entries(authConfig.headers)) {
-      assert(
-        typeof header === 'string' && header.length > 0,
-        `${filePath}: header names must be non-empty strings`,
-      );
-      assert(typeof value === 'string', `${filePath}: header values must be strings`);
-    }
-    return;
-  }
-
-  if (authConfig.type === 'oauth') {
-    if (authConfig.scopes !== undefined) {
-      assertNonEmptyArray(authConfig.scopes, filePath, 'oauth scopes');
-      for (const scope of authConfig.scopes) {
-        assert(
-          typeof scope === 'string' && scope.length > 0,
-          `${filePath}: oauth scopes must be non-empty strings`,
-        );
-      }
-    }
-    if (authConfig.clientId !== undefined) {
-      assertNonEmptyString(authConfig.clientId, filePath, 'oauth clientId');
-    }
-    if (authConfig.clientSecret !== undefined) {
-      assertNonEmptyString(authConfig.clientSecret, filePath, 'oauth clientSecret');
-    }
-    return;
-  }
-
-  throw new Error(`${filePath}: unsupported auth type ${String(authConfig.type)}`);
-}
-
-// --- MCP server validation ---
-
-function assertServerConfig(server, filePath) {
-  assertObject(server, filePath, 'config');
-  assertNonEmptyString(server.id, filePath, 'id');
-  assertNonEmptyString(server.name, filePath, 'name');
-  assertNonEmptyString(server.description, filePath, 'description');
-  assertNonEmptyString(server.docsUrl, filePath, 'docsUrl');
-
-  if (server.logoUrl !== undefined) {
-    assertNonEmptyString(server.logoUrl, filePath, 'logoUrl');
-  }
-
-  assertNonEmptyArray(server.tags, filePath, 'tags');
-
-  const install = server.install;
-  assertObject(install, filePath, 'install');
-  assertNonEmptyString(install.name, filePath, 'install.name');
-  assertOneOf(install.transport, ['http', 'stdio'], filePath, 'install.transport');
-  assertNonEmptyString(install.url, filePath, 'install.url');
-  assertAuthConfig(install.authConfig, filePath);
-
-  if (install.optionalAuthConfigs !== undefined) {
-    assert(
-      Array.isArray(install.optionalAuthConfigs),
-      `${filePath}: install.optionalAuthConfigs must be an array`,
-    );
-    for (const authConfig of install.optionalAuthConfigs) {
-      assertAuthConfig(authConfig, filePath);
-    }
-  }
-}
-
-// --- Embedding model validation ---
-
-function assertEmbeddingModel(model, filePath) {
-  assertObject(model, filePath, 'model');
-  assertNonEmptyString(model.id, filePath, 'model.id');
-  assertNonEmptyString(model.name, filePath, 'model.name');
-  assertPositiveInt(model.dimensions, filePath, 'model.dimensions');
-  assertNonEmptyString(model.release_date, filePath, 'model.release_date');
-  assertPositiveInt(model.context, filePath, 'model.context');
-  assertOptionalNonEmptyArray(model.inputModalities, filePath, 'model.inputModalities');
-  assertOptionalNonEmptyArray(model.outputModalities, filePath, 'model.outputModalities');
-  assertObject(model.cost, filePath, 'model.cost');
-  assert(typeof model.cost.input === 'number', `${filePath}: model.cost.input must be a number`);
-  assertOptionalNumber(model.cost.inputImage, filePath, 'model.cost.inputImage');
-  assertOptionalNumber(model.cost.inputAudio, filePath, 'model.cost.inputAudio');
-  assertOptionalNumber(model.cost.inputVideo, filePath, 'model.cost.inputVideo');
-  assert(typeof model.cost.output === 'number', `${filePath}: model.cost.output must be a number`);
-}
-
-function assertEmbeddingProviderConfig(provider, filePath) {
-  assertObject(provider, filePath, 'config');
-  assertNonEmptyString(provider.providerId, filePath, 'providerId');
-  assertNonEmptyString(provider.providerName, filePath, 'providerName');
-  assertNonEmptyArray(provider.models, filePath, 'models');
-  assertUniqueIds(provider.models, (m) => m.id, filePath);
-  for (const model of provider.models) {
-    assertEmbeddingModel(model, filePath);
-  }
-}
-
-// --- STT model validation ---
-
-function assertSttModel(model, filePath) {
-  assertObject(model, filePath, 'model');
-  assertNonEmptyString(model.modelId, filePath, 'model.modelId');
-  assertNonEmptyString(model.displayName, filePath, 'model.displayName');
-  assertObject(model.capabilities, filePath, 'model.capabilities');
-  assertObject(model.inputFormat, filePath, 'model.inputFormat');
-  assertOneOf(
-    model.inputFormat.encoding,
-    ['pcm_s16le', 'f32le'],
-    filePath,
-    'model.inputFormat.encoding',
-  );
-  assert(
-    Number.isInteger(model.inputFormat.sampleRateHz) && model.inputFormat.sampleRateHz >= 8000,
-    `${filePath}: model.inputFormat.sampleRateHz must be an integer >= 8000`,
-  );
-  assertPositiveInt(model.inputFormat.channels, filePath, 'model.inputFormat.channels');
-  assertOneOf(
-    model.partialStrategy,
-    ['cumulative', 'incremental'],
-    filePath,
-    'model.partialStrategy',
-  );
-  assertObject(model.buffer, filePath, 'model.buffer');
-  assertObject(model.reconnect, filePath, 'model.reconnect');
-  assertObject(model.pricing, filePath, 'model.pricing');
-  assertOneOf(model.pricing.type, ['token', 'duration'], filePath, 'model.pricing.type');
-}
-
-function assertSttProviderConfig(provider, filePath) {
-  assertObject(provider, filePath, 'config');
-  assertNonEmptyString(provider.providerId, filePath, 'providerId');
-  assertNonEmptyString(provider.providerName, filePath, 'providerName');
-  assertNonEmptyArray(provider.models, filePath, 'models');
-  assertUniqueIds(provider.models, (m) => m.modelId, filePath);
-  for (const model of provider.models) {
-    assertSttModel(model, filePath);
-  }
-}
-
 // --- Generic loading helpers ---
 
-function assertUniqueIds(items, getId, filePath) {
-  const ids = new Set();
-  for (const item of items) {
-    const id = getId(item);
-    assert(!ids.has(id), `${filePath}: duplicate model id ${id}`);
-    ids.add(id);
-  }
-}
-
-function assertUniqueProviderIds(providers, label) {
-  const ids = new Set();
-  for (const provider of providers) {
-    assert(!ids.has(provider.providerId), `Duplicate ${label} provider id: ${provider.providerId}`);
-    ids.add(provider.providerId);
-  }
-}
-
-function loadProviderConfigs(modelsDir, validator, label) {
+function loadProviderConfigs(modelsDir) {
   const files = readdirSync(modelsDir)
     .filter((name) => name.endsWith('.json'))
     .map((name) => join(modelsDir, name));
 
   const providers = files.map((filePath) => {
-    const parsed = readJson(filePath);
-    validator(parsed, filePath);
-    return parsed;
+    return readJson(filePath);
   });
 
-  assertUniqueProviderIds(providers, label);
   return providers.toSorted((a, b) => a.providerName.localeCompare(b.providerName));
 }
 
@@ -261,10 +39,7 @@ function loadServerConfigs() {
     const filePath = join(serverDir, 'config.json');
     const logoPath = join(serverDir, 'logo.svg');
 
-    assert(existsSync(filePath), `${serverDir}: config.json is required`);
     const parsed = readJson(filePath);
-    assertServerConfig(parsed, filePath);
-    assert(parsed.id === entry.name, `${filePath}: id must match directory name ${entry.name}`);
 
     if (!existsSync(logoPath)) return parsed;
 
@@ -273,12 +48,6 @@ function loadServerConfigs() {
       logoUrl: `${WEBSITE_BASE_URL}/mcp/servers/${parsed.id}/logo.svg`,
     };
   });
-
-  const ids = new Set();
-  for (const server of servers) {
-    assert(!ids.has(server.id), `Duplicate server id: ${server.id}`);
-    ids.add(server.id);
-  }
 
   return servers.toSorted((a, b) => a.name.localeCompare(b.name));
 }
@@ -356,14 +125,8 @@ function main() {
   const servers = loadServerConfigs();
   const embeddingProviders = loadProviderConfigs(
     join(rootDir, 'registries', 'embeddings', 'models'),
-    assertEmbeddingProviderConfig,
-    'embedding',
   );
-  const sttProviders = loadProviderConfigs(
-    join(rootDir, 'registries', 'stt', 'models'),
-    assertSttProviderConfig,
-    'STT',
-  );
+  const sttProviders = loadProviderConfigs(join(rootDir, 'registries', 'stt', 'models'));
 
   writeOutput(servers, embeddingProviders, sttProviders);
 


### PR DESCRIPTION
## 🚀 Change Summary

Moves registry validation out of the website build step and into the registry packages so PR checks validate registry data directly while website builds only generate output artifacts.

### 🛠 Improvements & Refactors
- Added package-level registry tests for MCP, embedding, and STT registries using Zod JSON Schema validation.
- Added custom registry integrity checks for duplicate IDs and MCP server directory alignment.
- Simplified `build-website-registries.mjs` to only read, sort, copy assets/schemas, and emit generated registry files.

### 🐛 Bug Fixes
- Updated STT model `$schema` references to use the hosted schema URL.
