### PR TITLE
feat(apps): add mini-app enable settings

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -29,6 +29,7 @@ runs:
           apps/*/node_modules
           packages/*/node_modules
           connectors/*/node_modules
+          registries/*/node_modules
         key: ${{ runner.os }}-node_modules-${{ hashFiles('**/bun.lock') }}
         restore-keys: |
           ${{ runner.os }}-node_modules-

--- a/apps/web/src/components/navigation/activity-bar.tsx
+++ b/apps/web/src/components/navigation/activity-bar.tsx
@@ -12,8 +12,11 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { Link, useRouterState } from '@tanstack/react-router';
 
+import type { AppId } from '@stitch/shared/apps/types';
+
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useFullScreen } from '@/hooks/ui/use-fullscreen';
+import { appEnabledStatesQueryOptions } from '@/lib/queries/apps';
 import { connectorInstancesQueryOptions } from '@/lib/queries/connectors';
 import { cn } from '@/lib/utils';
 import { hasUpdaterBadge, useUpdaterStore } from '@/stores/updater-store';
@@ -24,6 +27,7 @@ type NavItemData = {
   label: string;
   to: string;
   matchPrefix: string;
+  appId?: AppId;
 };
 
 const TOP_ITEMS: NavItemData[] = [
@@ -47,6 +51,7 @@ const TOP_ITEMS: NavItemData[] = [
     label: 'Recordings',
     to: '/recordings',
     matchPrefix: '/recordings',
+    appId: 'recordings',
   },
   {
     id: 'agenda',
@@ -54,6 +59,7 @@ const TOP_ITEMS: NavItemData[] = [
     label: 'Agenda',
     to: '/agenda',
     matchPrefix: '/agenda',
+    appId: 'agenda',
   },
 ];
 
@@ -132,6 +138,7 @@ function NavLink({
 
 export function ActivityBar() {
   const currentPath = useRouterState({ select: (state) => state.location.pathname });
+  const { data: appEnabledStates = [] } = useQuery(appEnabledStatesQueryOptions);
   const { data: connectorInstances = [] } = useQuery(connectorInstancesQueryOptions);
   const pendingConnectorUpdates = connectorInstances.filter(
     (instance) => instance.upgrade?.available,
@@ -141,6 +148,10 @@ export function ActivityBar() {
   const isMac = window.electron?.platform === 'darwin';
   const isFullScreen = useFullScreen();
   const showTrafficLightPadding = isMac && !isFullScreen;
+  const disabledAppIds = new Set(
+    appEnabledStates.filter((state) => !state.enabled).map((state) => state.appId),
+  );
+  const topItems = TOP_ITEMS.filter((item) => !item.appId || !disabledAppIds.has(item.appId));
 
   return (
     <TooltipProvider>
@@ -154,7 +165,7 @@ export function ActivityBar() {
           <div className="pointer-events-none absolute top-9 right-0 bottom-0 border-r border-border/50" />
         )}
         <div className="flex w-full flex-col items-center gap-2">
-          {TOP_ITEMS.map((item) => (
+          {topItems.map((item) => (
             <NavLink
               key={item.id}
               to={item.to}

--- a/apps/web/src/components/onboarding/onboarding-dialog.tsx
+++ b/apps/web/src/components/onboarding/onboarding-dialog.tsx
@@ -1,3 +1,4 @@
+import { AppsStep } from './steps/apps-step';
 import { MemoryStep } from './steps/memory-step';
 import { ProfileStep } from './steps/profile-step';
 import { ProviderStep } from './steps/provider-step';
@@ -32,6 +33,12 @@ export function OnboardingDialog() {
               initialTimezone={state.profileTimezone}
               isSaving={state.isSavingProfile}
               onContinue={state.saveProfileAndAdvance}
+            />
+          )}
+
+          {state.step === 'apps' && (
+            <AppsStep
+              onContinue={() => state.goToStep(state.hasEnabledProvider ? 'memory' : 'provider')}
             />
           )}
 

--- a/apps/web/src/components/onboarding/steps/apps-step.tsx
+++ b/apps/web/src/components/onboarding/steps/apps-step.tsx
@@ -1,0 +1,77 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { APP_IDS, type AppId } from '@stitch/shared/apps/types';
+
+import { SETTINGS_PAGE_BY_ID } from '@/components/settings/settings-metadata';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { appEnabledStatesQueryOptions, useSetAppEnabledState } from '@/lib/queries/apps';
+
+type Props = {
+  onContinue: () => void;
+};
+
+export function AppsStep({ onContinue }: Props) {
+  const { data: appEnabledStates } = useQuery(appEnabledStatesQueryOptions);
+  const setAppEnabledState = useSetAppEnabledState();
+
+  function isEnabled(appId: AppId): boolean {
+    return appEnabledStates?.find((state) => state.appId === appId)?.enabled ?? true;
+  }
+
+  function handleToggle(appId: AppId, enabled: boolean) {
+    setAppEnabledState.mutate({ appId, enabled });
+  }
+
+  return (
+    <div className="mx-auto flex h-full w-full max-w-xl flex-col justify-center gap-6">
+      <div className="space-y-2 text-center">
+        <h2 className="text-2xl font-semibold tracking-tight">Choose your mini-apps</h2>
+        <p className="text-sm text-muted-foreground">
+          Pick what should appear in Stitch. You can change these later in Settings.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {APP_IDS.map((appId) => {
+          const page = SETTINGS_PAGE_BY_ID[appId];
+          const Icon = page.icon;
+          const toggleId = `onboarding-${appId}-app-toggle`;
+          return (
+            <div
+              key={appId}
+              className="flex items-center justify-between gap-4 rounded-xl border border-border/70 bg-card px-4 py-3"
+            >
+              <div className="flex min-w-0 items-start gap-3">
+                <div className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+                  <Icon className="size-4" />
+                </div>
+                <div className="min-w-0">
+                  <label htmlFor={toggleId} className="text-sm font-medium">
+                    {page.label}
+                  </label>
+                  <p className="mt-1 text-sm text-muted-foreground">{page.description}</p>
+                </div>
+              </div>
+              <Switch
+                id={toggleId}
+                checked={isEnabled(appId)}
+                disabled={setAppEnabledState.isPending}
+                onCheckedChange={(checked) => handleToggle(appId, checked)}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex justify-center gap-2">
+        <Button variant="outline" onClick={onContinue} disabled={setAppEnabledState.isPending}>
+          Skip
+        </Button>
+        <Button onClick={onContinue} disabled={setAppEnabledState.isPending}>
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/onboarding/use-onboarding-state.ts
+++ b/apps/web/src/components/onboarding/use-onboarding-state.ts
@@ -5,7 +5,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { providersQueryOptions } from '@/lib/queries/providers';
 import { saveSettingMutationOptions, settingsQueryOptions } from '@/lib/queries/settings';
 
-type OnboardingStep = 'welcome' | 'profile' | 'provider' | 'memory' | 'success';
+type OnboardingStep = 'welcome' | 'profile' | 'apps' | 'provider' | 'memory' | 'success';
 
 const SUCCESS_CLOSE_DELAY_MS = 1200;
 const CURRENT_ONBOARDING_VERSION = '4';
@@ -69,12 +69,9 @@ export function useOnboardingState(): OnboardingState {
   }, [step]);
 
   function saveProfileAndAdvance(name: string, timezone: string) {
-    void Promise.all([
-      saveProfileName.mutateAsync(name),
-      saveProfileTimezone.mutateAsync(timezone),
-    ])
+    void Promise.all([saveProfileName.mutateAsync(name), saveProfileTimezone.mutateAsync(timezone)])
       .then(() => {
-        setStep(hasEnabledProvider ? 'memory' : 'provider');
+        setStep('apps');
         return undefined;
       })
       .catch(() => undefined);

--- a/apps/web/src/components/session/session-page.tsx
+++ b/apps/web/src/components/session/session-page.tsx
@@ -18,6 +18,7 @@ import {
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { useSessionDetailsStats } from '@/hooks/session/use-session-details-stats';
 import { useSessionStreamState } from '@/hooks/use-session-stream-state';
+import { appEnabledStatesQueryOptions } from '@/lib/queries/apps';
 import { useCreateAutomation } from '@/lib/queries/automations';
 import { useGenerateAutomationDraft, useMarkSessionRead } from '@/lib/queries/chat';
 import { visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
@@ -31,6 +32,7 @@ export function SessionPage({ sessionId }: SessionPageProps) {
   const navigate = useNavigate();
   const { mutate: markReadMutate } = useMarkSessionRead();
   const { data: providerModels } = useSuspenseQuery(visibleProviderModelsQueryOptions);
+  const { data: appEnabledStates } = useQuery(appEnabledStatesQueryOptions);
   const { data: settings } = useQuery(settingsQueryOptions);
   const createAutomation = useCreateAutomation();
   const generateAutomation = useGenerateAutomationDraft();
@@ -49,7 +51,10 @@ export function SessionPage({ sessionId }: SessionPageProps) {
 
   const rightPanelOpen = rightPanel !== 'closed';
 
-  const hasBrowser = typeof window !== 'undefined' && Boolean(window.api?.browser);
+  const browserAppEnabled =
+    appEnabledStates?.find((state) => state.appId === 'browser')?.enabled ?? true;
+  const hasBrowser =
+    typeof window !== 'undefined' && Boolean(window.api?.browser) && browserAppEnabled;
 
   const toggleDetails = React.useCallback(() => {
     setRightPanel((previous) => (previous === 'details' ? 'closed' : 'details'));
@@ -60,8 +65,16 @@ export function SessionPage({ sessionId }: SessionPageProps) {
   }, []);
 
   React.useEffect(() => {
-    return window.api?.browser.onShowRequested(() => setRightPanel('browser'));
-  }, []);
+    return window.api?.browser.onShowRequested(() => {
+      if (browserAppEnabled) setRightPanel('browser');
+    });
+  }, [browserAppEnabled]);
+
+  React.useEffect(() => {
+    if (!hasBrowser && rightPanel === 'browser') {
+      setRightPanel('closed');
+    }
+  }, [hasBrowser, rightPanel]);
 
   React.useEffect(() => {
     lastReadCompletedMessageIdRef.current = null;

--- a/apps/web/src/components/settings/agenda.tsx
+++ b/apps/web/src/components/settings/agenda.tsx
@@ -2,8 +2,8 @@ import { AppEnableSetting } from '@/components/settings/app-enable-setting';
 import { SETTINGS_PAGE_BY_ID } from '@/components/settings/settings-metadata';
 import { SettingPage, SettingRows, SettingSection } from '@/components/settings/settings-ui';
 
-export function BrowserSettings() {
-  const page = SETTINGS_PAGE_BY_ID.browser;
+export function AgendaSettings() {
+  const page = SETTINGS_PAGE_BY_ID.agenda;
   const Icon = page.icon;
 
   return (
@@ -14,7 +14,7 @@ export function BrowserSettings() {
     >
       <SettingSection>
         <SettingRows>
-          <AppEnableSetting appId="browser" label="Browser" />
+          <AppEnableSetting appId="agenda" label="Agenda" />
         </SettingRows>
       </SettingSection>
     </SettingPage>

--- a/apps/web/src/components/settings/app-enable-setting.tsx
+++ b/apps/web/src/components/settings/app-enable-setting.tsx
@@ -1,0 +1,37 @@
+import { toast } from 'sonner';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import type { AppId } from '@stitch/shared/apps/types';
+
+import { SettingRow } from '@/components/settings/settings-ui';
+import { Switch } from '@/components/ui/switch';
+import { appEnabledStatesQueryOptions, useSetAppEnabledState } from '@/lib/queries/apps';
+
+export function AppEnableSetting({ appId, label }: { appId: AppId; label: string }) {
+  const { data: enabledStates } = useSuspenseQuery(appEnabledStatesQueryOptions);
+  const setAppEnabledState = useSetAppEnabledState();
+  const enabled = enabledStates.find((state) => state.appId === appId)?.enabled ?? true;
+  const toggleId = `${appId}-app-toggle`;
+
+  function handleToggle(checked: boolean) {
+    void setAppEnabledState.mutateAsync({ appId, enabled: checked }).catch((error: unknown) => {
+      toast.error(error instanceof Error ? error.message : `Failed to update ${label}`);
+    });
+  }
+
+  return (
+    <SettingRow
+      label={`Enable ${label}`}
+      description={`${label} is ${enabled ? 'visible and available to the agent' : 'hidden and unavailable to the agent'}.`}
+      htmlFor={toggleId}
+    >
+      <Switch
+        id={toggleId}
+        checked={enabled}
+        onCheckedChange={handleToggle}
+        disabled={setAppEnabledState.isPending}
+      />
+    </SettingRow>
+  );
+}

--- a/apps/web/src/components/settings/recordings.tsx
+++ b/apps/web/src/components/settings/recordings.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 
 import ChatMarkdown from '@/components/chat/chat-markdown';
+import { AppEnableSetting } from '@/components/settings/app-enable-setting';
 import { SettingsModelSelect } from '@/components/settings/model-select';
 import { SETTINGS_PAGE_BY_ID } from '@/components/settings/settings-metadata';
 import {
@@ -569,6 +570,11 @@ export function RecordingsSettings() {
         </TabsList>
 
         <TabsContent value="settings" className="pt-4">
+          <SettingSection title="App">
+            <SettingRows>
+              <AppEnableSetting appId="recordings" label="Recordings" />
+            </SettingRows>
+          </SettingSection>
           <PermissionStatus />
           <SettingSection title="Audio Devices" className="mt-4">
             <AudioDeviceSettings />

--- a/apps/web/src/components/settings/settings-metadata.tsx
+++ b/apps/web/src/components/settings/settings-metadata.tsx
@@ -3,6 +3,7 @@ import {
   CpuIcon,
   GlobeIcon,
   KeyboardIcon,
+  ListTodoIcon,
   MicIcon,
   MonitorIcon,
   NetworkIcon,
@@ -79,6 +80,15 @@ export const SETTINGS_PAGES = [
     to: '/settings/recordings',
     section: 'Apps',
     icon: MicIcon,
+  },
+  {
+    id: 'agenda',
+    label: 'Agenda',
+    title: 'Agenda',
+    description: 'Configure task tracking and agenda tools.',
+    to: '/settings/agenda',
+    section: 'Apps',
+    icon: ListTodoIcon,
   },
   {
     id: 'providers',

--- a/apps/web/src/lib/queries/apps.ts
+++ b/apps/web/src/lib/queries/apps.ts
@@ -1,0 +1,38 @@
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { AppEnabledState, AppId } from '@stitch/shared/apps/types';
+
+import { serverRequest } from '@/lib/api';
+import { toolKeys } from '@/lib/queries/tools';
+
+const appKeys = {
+  all: ['apps-config'] as const,
+  enabledStates: () => [...appKeys.all, 'enabled-states'] as const,
+};
+
+export const appEnabledStatesQueryOptions = queryOptions({
+  queryKey: appKeys.enabledStates(),
+  queryFn: async (): Promise<AppEnabledState[]> => {
+    const data = await serverRequest<{ states: AppEnabledState[] }>('/config/apps/enabled');
+    return data.states;
+  },
+});
+
+export function useSetAppEnabledState() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { appId: AppId; enabled: boolean }) =>
+      serverRequest<void>('/config/tools/enabled', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scope: 'app', identifier: input.appId, enabled: input.enabled }),
+      }),
+    onSuccess: () => {
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: appKeys.enabledStates() }),
+        queryClient.invalidateQueries({ queryKey: toolKeys.enabledStates() }),
+        queryClient.invalidateQueries({ queryKey: toolKeys.knownToolsets() }),
+      ]);
+    },
+  });
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as SettingsGeneralRouteImport } from './routes/settings/general'
 import { Route as SettingsConnectionRouteImport } from './routes/settings/connection'
 import { Route as SettingsBrowserRouteImport } from './routes/settings/browser'
 import { Route as SettingsAppearanceRouteImport } from './routes/settings/appearance'
+import { Route as SettingsAgendaRouteImport } from './routes/settings/agenda'
 import { Route as SessionIdRouteImport } from './routes/session.$id'
 import { Route as RecordingsIdRouteImport } from './routes/recordings/$id'
 import { Route as AutomationsAutomationIdRouteImport } from './routes/automations/$automationId'
@@ -159,6 +160,11 @@ const SettingsAppearanceRoute = SettingsAppearanceRouteImport.update({
   path: '/appearance',
   getParentRoute: () => SettingsRouteRoute,
 } as any)
+const SettingsAgendaRoute = SettingsAgendaRouteImport.update({
+  id: '/agenda',
+  path: '/agenda',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
 const SessionIdRoute = SessionIdRouteImport.update({
   id: '/session/$id',
   path: '/session/$id',
@@ -198,6 +204,7 @@ export interface FileRoutesByFullPath {
   '/automations/$automationId': typeof AutomationsAutomationIdRoute
   '/recordings/$id': typeof RecordingsIdRoute
   '/session/$id': typeof SessionIdRoute
+  '/settings/agenda': typeof SettingsAgendaRoute
   '/settings/appearance': typeof SettingsAppearanceRoute
   '/settings/browser': typeof SettingsBrowserRoute
   '/settings/connection': typeof SettingsConnectionRoute
@@ -225,6 +232,7 @@ export interface FileRoutesByTo {
   '/automations/$automationId': typeof AutomationsAutomationIdRoute
   '/recordings/$id': typeof RecordingsIdRoute
   '/session/$id': typeof SessionIdRoute
+  '/settings/agenda': typeof SettingsAgendaRoute
   '/settings/appearance': typeof SettingsAppearanceRoute
   '/settings/browser': typeof SettingsBrowserRoute
   '/settings/connection': typeof SettingsConnectionRoute
@@ -257,6 +265,7 @@ export interface FileRoutesById {
   '/automations/$automationId': typeof AutomationsAutomationIdRoute
   '/recordings/$id': typeof RecordingsIdRoute
   '/session/$id': typeof SessionIdRoute
+  '/settings/agenda': typeof SettingsAgendaRoute
   '/settings/appearance': typeof SettingsAppearanceRoute
   '/settings/browser': typeof SettingsBrowserRoute
   '/settings/connection': typeof SettingsConnectionRoute
@@ -290,6 +299,7 @@ export interface FileRouteTypes {
     | '/automations/$automationId'
     | '/recordings/$id'
     | '/session/$id'
+    | '/settings/agenda'
     | '/settings/appearance'
     | '/settings/browser'
     | '/settings/connection'
@@ -317,6 +327,7 @@ export interface FileRouteTypes {
     | '/automations/$automationId'
     | '/recordings/$id'
     | '/session/$id'
+    | '/settings/agenda'
     | '/settings/appearance'
     | '/settings/browser'
     | '/settings/connection'
@@ -348,6 +359,7 @@ export interface FileRouteTypes {
     | '/automations/$automationId'
     | '/recordings/$id'
     | '/session/$id'
+    | '/settings/agenda'
     | '/settings/appearance'
     | '/settings/browser'
     | '/settings/connection'
@@ -549,6 +561,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsAppearanceRouteImport
       parentRoute: typeof SettingsRouteRoute
     }
+    '/settings/agenda': {
+      id: '/settings/agenda'
+      path: '/agenda'
+      fullPath: '/settings/agenda'
+      preLoaderRoute: typeof SettingsAgendaRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
     '/session/$id': {
       id: '/session/$id'
       path: '/session/$id'
@@ -631,6 +650,7 @@ const RecordingsRouteRouteWithChildren = RecordingsRouteRoute._addFileChildren(
 )
 
 interface SettingsRouteRouteChildren {
+  SettingsAgendaRoute: typeof SettingsAgendaRoute
   SettingsAppearanceRoute: typeof SettingsAppearanceRoute
   SettingsBrowserRoute: typeof SettingsBrowserRoute
   SettingsConnectionRoute: typeof SettingsConnectionRoute
@@ -647,6 +667,7 @@ interface SettingsRouteRouteChildren {
 }
 
 const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
+  SettingsAgendaRoute: SettingsAgendaRoute,
   SettingsAppearanceRoute: SettingsAppearanceRoute,
   SettingsBrowserRoute: SettingsBrowserRoute,
   SettingsConnectionRoute: SettingsConnectionRoute,

--- a/apps/web/src/routes/agenda/route.tsx
+++ b/apps/web/src/routes/agenda/route.tsx
@@ -1,8 +1,20 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { toast } from 'sonner';
+
+import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
 import { agendaListsQueryOptions } from '@/lib/queries/agenda';
+import { appEnabledStatesQueryOptions } from '@/lib/queries/apps';
 
 export const Route = createFileRoute('/agenda')({
-  loader: ({ context }) => context.queryClient.ensureQueryData(agendaListsQueryOptions()),
+  loader: async ({ context }) => {
+    const appStates = await context.queryClient.ensureQueryData(appEnabledStatesQueryOptions);
+    const agendaEnabled = appStates.find((state) => state.appId === 'agenda')?.enabled ?? true;
+    if (!agendaEnabled) {
+      toast.warning('Agenda is disabled. Enable it in Settings > Agenda.');
+      throw redirect({ to: '/' });
+    }
+
+    return context.queryClient.ensureQueryData(agendaListsQueryOptions());
+  },
   component: Outlet,
 });

--- a/apps/web/src/routes/recordings/route.tsx
+++ b/apps/web/src/routes/recordings/route.tsx
@@ -1,5 +1,18 @@
-import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { toast } from 'sonner';
+
+import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
+
+import { appEnabledStatesQueryOptions } from '@/lib/queries/apps';
 
 export const Route = createFileRoute('/recordings')({
+  loader: async ({ context }) => {
+    const appStates = await context.queryClient.ensureQueryData(appEnabledStatesQueryOptions);
+    const recordingsEnabled =
+      appStates.find((state) => state.appId === 'recordings')?.enabled ?? true;
+    if (!recordingsEnabled) {
+      toast.warning('Recordings is disabled. Enable it in Settings > Recordings.');
+      throw redirect({ to: '/' });
+    }
+  },
   component: Outlet,
 });

--- a/apps/web/src/routes/settings/agenda.tsx
+++ b/apps/web/src/routes/settings/agenda.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { AgendaSettings } from '@/components/settings/agenda';
+import { appEnabledStatesQueryOptions } from '@/lib/queries/apps';
+
+export const Route = createFileRoute('/settings/agenda')({
+  loader: ({ context }) => context.queryClient.ensureQueryData(appEnabledStatesQueryOptions),
+  component: AgendaSettings,
+});

--- a/apps/web/src/routes/settings/browser.tsx
+++ b/apps/web/src/routes/settings/browser.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
 
 import { BrowserSettings } from '@/components/settings/browser';
-import { toolEnabledStatesQueryOptions } from '@/lib/queries/tools';
+import { appEnabledStatesQueryOptions } from '@/lib/queries/apps';
 
 export const Route = createFileRoute('/settings/browser')({
   loader: ({ context }) => {
-    return context.queryClient.ensureQueryData(toolEnabledStatesQueryOptions);
+    return context.queryClient.ensureQueryData(appEnabledStatesQueryOptions);
   },
   component: BrowserSettings,
 });

--- a/apps/web/src/routes/settings/recordings.tsx
+++ b/apps/web/src/routes/settings/recordings.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 
 import { RecordingsSettings } from '@/components/settings/recordings';
+import { appEnabledStatesQueryOptions } from '@/lib/queries/apps';
 import {
   enabledProviderModelsQueryOptions,
   sttProviderModelsQueryOptions,
@@ -15,6 +16,7 @@ import { settingsQueryOptions } from '@/lib/queries/settings';
 export const Route = createFileRoute('/settings/recordings')({
   loader: ({ context }) =>
     Promise.all([
+      context.queryClient.ensureQueryData(appEnabledStatesQueryOptions),
       context.queryClient.ensureQueryData(settingsQueryOptions),
       context.queryClient.ensureQueryData(sttProviderModelsQueryOptions),
       context.queryClient.ensureQueryData(enabledProviderModelsQueryOptions),

--- a/packages/server/src/apps/registry.ts
+++ b/packages/server/src/apps/registry.ts
@@ -1,0 +1,29 @@
+import type { AppId } from '@stitch/shared/apps/types';
+
+type AppManifest = {
+  id: AppId;
+  toolsetIds: string[];
+  skillNames: string[];
+};
+
+export const APP_MANIFESTS: readonly AppManifest[] = [
+  {
+    id: 'browser',
+    toolsetIds: ['browser'],
+    skillNames: ['browser-automation'],
+  },
+  {
+    id: 'recordings',
+    toolsetIds: ['recordings'],
+    skillNames: [],
+  },
+  {
+    id: 'agenda',
+    toolsetIds: ['agenda'],
+    skillNames: [],
+  },
+];
+
+export function findAppByToolsetId(toolsetId: string): AppManifest | undefined {
+  return APP_MANIFESTS.find((app) => app.toolsetIds.includes(toolsetId));
+}

--- a/packages/server/src/apps/service.ts
+++ b/packages/server/src/apps/service.ts
@@ -1,0 +1,50 @@
+import type { AppEnabledState, AppId } from '@stitch/shared/apps/types';
+
+import { APP_MANIFESTS, findAppByToolsetId } from '@/apps/registry.js';
+import { isToolEnabled } from '@/tools/enabled-service.js';
+
+async function isAppEnabled(appId: AppId): Promise<boolean> {
+  return isToolEnabled({ scope: 'app', identifier: appId });
+}
+
+export async function getAppEnabledStates(): Promise<AppEnabledState[]> {
+  return Promise.all(
+    APP_MANIFESTS.map(async (app) => ({
+      appId: app.id,
+      enabled: await isAppEnabled(app.id),
+    })),
+  );
+}
+
+export async function isToolsetEnabledByApp(toolsetId: string): Promise<boolean> {
+  const app = findAppByToolsetId(toolsetId);
+  if (!app) return true;
+  return isAppEnabled(app.id);
+}
+
+export async function getDisabledAppToolsetIds(): Promise<Set<string>> {
+  const states = await getAppEnabledStates();
+  const disabledAppIds = new Set(
+    states.filter((state) => !state.enabled).map((state) => state.appId),
+  );
+
+  return new Set(
+    APP_MANIFESTS.filter((app) => disabledAppIds.has(app.id)).flatMap((app) => app.toolsetIds),
+  );
+}
+
+export async function getDisabledAppSkillNames(): Promise<Set<string>> {
+  const states = await getAppEnabledStates();
+  const disabledAppIds = new Set(
+    states.filter((state) => !state.enabled).map((state) => state.appId),
+  );
+
+  return new Set(
+    APP_MANIFESTS.filter((app) => disabledAppIds.has(app.id)).flatMap((app) => app.skillNames),
+  );
+}
+
+export async function isSkillEnabledByApp(skillName: string): Promise<boolean> {
+  const disabledSkillNames = await getDisabledAppSkillNames();
+  return !disabledSkillNames.has(skillName);
+}

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -6,6 +6,7 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { formatMcpToolName } from '@stitch/shared/mcp/types';
 import { TOOL_ENABLED_SCOPES } from '@stitch/shared/tools/types';
 
+import { getAppEnabledStates } from '@/apps/service.js';
 import { getMcpServersWithCachedTools } from '@/mcp/service.js';
 import { getMcpServerPresentation } from '@/mcp/tool-executor.js';
 import { deletePerm, getPerms, upsertPerm } from '@/permission/service.js';
@@ -89,6 +90,11 @@ configRouter.get('/toolsets', async (c) => {
 
 configRouter.get('/tools/enabled', async (c) => {
   const states = await getToolEnabledStates();
+  return c.json({ states });
+});
+
+configRouter.get('/apps/enabled', async (c) => {
+  const states = await getAppEnabledStates();
   return c.json({ states });
 });
 

--- a/packages/server/src/skills/service.ts
+++ b/packages/server/src/skills/service.ts
@@ -15,6 +15,7 @@ import type {
   SkillUpdateInput,
 } from '@stitch/shared/skills/types';
 
+import { getDisabledAppSkillNames } from '@/apps/service.js';
 import * as Log from '@/lib/log.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
@@ -345,6 +346,11 @@ export async function buildSkillsSystemPrompt(): Promise<string> {
   const result = await listSkills();
   if (result.error || result.data.length === 0) return '';
 
-  const lines = result.data.map((skill) => `- ${skill.name}: ${skill.description}`);
+  const disabledSkillNames = await getDisabledAppSkillNames();
+  const lines = result.data
+    .filter((skill) => !disabledSkillNames.has(skill.name))
+    .map((skill) => `- ${skill.name}: ${skill.description}`);
+  if (lines.length === 0) return '';
+
   return `Available skills provide task-specific instructions. Use the \`skill\` tool to load a skill when the user's request matches its description.\n\n${lines.join('\n')}`;
 }

--- a/packages/server/src/tools/core/skill.ts
+++ b/packages/server/src/tools/core/skill.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { z } from 'zod';
 
+import { isSkillEnabledByApp } from '@/apps/service.js';
 import { getSkillByName } from '@/skills/service.js';
 import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
 
@@ -18,6 +19,9 @@ export const definition: ToolDefinition = {
       'Load a specialized skill when the task at hand matches one of the skills listed in the system prompt.\n\nUse this tool to inject the skill\'s instructions and resources into current conversation. The output may contain detailed workflow guidance as well as references to scripts, files, etc in the same directory as the skill.\n\nThe skill name must match one of the skills listed in your system prompt.\n\nLoad a specialized skill that provides domain-specific instructions and workflows.\n\nWhen you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.\n\nThe skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.\n\nTool output includes a `<skill_content name="...">` block with the loaded content.',
     inputSchema: skillInputSchema,
     execute: async ({ name }) => {
+      const enabled = await isSkillEnabledByApp(name);
+      if (!enabled) return { error: `Skill "${name}" is disabled.` };
+
       const result = await getSkillByName(name);
       if (result.error) return { error: result.error.message };
 

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -1,3 +1,4 @@
+import { getDisabledAppToolsetIds, isToolsetEnabledByApp } from '@/apps/service.js';
 import * as Log from '@/lib/log.js';
 import type { SessionActiveToolset, SessionToolsetScope } from '@/llm/stream/session-toolsets.js';
 import { getDisabledToolIdentifiers, isToolEnabled } from '@/tools/enabled-service.js';
@@ -63,8 +64,11 @@ export class ToolsetManager {
       return { status: 'not_found' };
     }
 
-    const toolsetEnabled = await isToolEnabled({ scope: 'toolset', identifier: toolsetId });
-    if (!toolsetEnabled) {
+    const [toolsetEnabled, appEnabled] = await Promise.all([
+      isToolEnabled({ scope: 'toolset', identifier: toolsetId }),
+      isToolsetEnabledByApp(toolsetId),
+    ]);
+    if (!toolsetEnabled || !appEnabled) {
       log.info(
         { event: 'toolset.activate.disabled', toolsetId },
         'attempted to activate disabled toolset',
@@ -234,9 +238,12 @@ export class ToolsetManager {
    * Used by the list_toolsets meta-tool.
    */
   async getCatalogWithState(options?: { includeTools?: boolean }): Promise<ToolsetView[]> {
-    const disabledIds = await getDisabledToolIdentifiers('toolset');
+    const [disabledIds, disabledAppToolsetIds] = await Promise.all([
+      getDisabledToolIdentifiers('toolset'),
+      getDisabledAppToolsetIds(),
+    ]);
     return listToolsets()
-      .filter((ts) => !disabledIds.has(ts.id))
+      .filter((ts) => !disabledIds.has(ts.id) && !disabledAppToolsetIds.has(ts.id))
       .map((ts) =>
         toToolsetView(ts, {
           active: this.isActive(ts.id),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./apps/types": "./src/apps/types.ts",
     "./appearance/types": "./src/appearance/types.ts",
     "./automations/types": "./src/automations/types.ts",
     "./browser/electron": "./src/browser/electron.ts",

--- a/packages/shared/src/apps/types.ts
+++ b/packages/shared/src/apps/types.ts
@@ -1,0 +1,8 @@
+export const APP_IDS = ['browser', 'recordings', 'agenda'] as const;
+
+export type AppId = (typeof APP_IDS)[number];
+
+export type AppEnabledState = {
+  appId: AppId;
+  enabled: boolean;
+};

--- a/packages/shared/src/tools/types.ts
+++ b/packages/shared/src/tools/types.ts
@@ -2,7 +2,7 @@ export const TOOL_TYPES = ['stitch', 'mcp', 'plugin'] as const;
 
 export type ToolType = (typeof TOOL_TYPES)[number];
 
-export const TOOL_ENABLED_SCOPES = ['tool', 'toolset', 'mcp_tool'] as const;
+export const TOOL_ENABLED_SCOPES = ['tool', 'toolset', 'mcp_tool', 'app'] as const;
 
 export type ToolEnabledScope = (typeof TOOL_ENABLED_SCOPES)[number];
 


### PR DESCRIPTION
## 🚀 Change Summary

Adds a cohesive mini-app enablement system for Browser, Recordings, and Agenda so users can control which built-in apps are visible and available across Stitch.

### ✨ New Features
- **Mini-App Enablement**: Adds app-level enable state for Browser, Recordings, and Agenda backed by the existing tool enablement storage.
- **Settings Controls**: Adds shared app toggles to Browser and Recordings settings, plus a new Agenda settings page.
- **Onboarding Selection**: Adds a skippable onboarding step for choosing enabled mini-apps without bumping onboarding version.

### 🛠 Improvements & Refactors
- Hides disabled apps from the Activity Bar and Browser chat header control.
- Gates app-owned toolsets and built-in skills when the owning app is disabled.
- Redirects direct navigation to disabled Recordings or Agenda routes back to chat with a toast.
