### PR TITLE
fix(ci): update checks and stats query

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,8 +20,8 @@
     "@tanstack/react-virtual": "^3.14.1",
     "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "cnfast": "^0.0.7",
     "date-fns": "^4.1.0",
     "katex": "^0.16.38",
     "lucide-react": "^0.577.0",
@@ -37,7 +37,6 @@
     "shadcn": "^4.0.5",
     "shiki": "^4.0.2",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "use-stick-to-bottom": "^1.1.3",
     "zustand": "^5.0.11"

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,6 +1,1 @@
-import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export { cn } from 'cnfast';

--- a/bun.lock
+++ b/bun.lock
@@ -45,8 +45,8 @@
         "@tanstack/react-virtual": "^3.14.1",
         "chart.js": "^4.5.1",
         "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "cnfast": "^0.0.7",
         "date-fns": "^4.1.0",
         "katex": "^0.16.38",
         "lucide-react": "^0.577.0",
@@ -62,7 +62,6 @@
         "shadcn": "^4.0.5",
         "shiki": "^4.0.2",
         "sonner": "^2.0.7",
-        "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "use-stick-to-bottom": "^1.1.3",
         "zustand": "^5.0.11",
@@ -1268,6 +1267,8 @@
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
+
+    "cnfast": ["cnfast@0.0.7", "", { "bin": { "cnfast": "bin/cli.js" } }, "sha512-03wkOzgQaRe1kq0OQCB5h8cCUTnHv1s/+Pi6uDNNwLWJoOTfpnyGd13ThML1b1EhJzOXnPK1l0WRiNYjPPnBaw=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -4,14 +4,23 @@ import { spawnSync } from 'bun';
 const steps = [
   { name: 'knip', cmd: ['bunx', 'knip', '--fix', '--allow-remove-files'] },
   { name: 'typecheck', cmd: ['bun', 'run', 'typecheck'] },
-  { name: 'test', cmd: ['bun', 'run', '--filter', '*', 'test'] },
+  { name: 'test', cmd: ['bun', 'run', 'test'] },
   {
     name: 'lint',
-    cmd: ['bunx', 'oxlint', '--config', 'oxlint.json', '--fix', '--fix-suggestions', '.'],
+    cmd: [
+      'bunx',
+      'oxlint',
+      '--config',
+      'oxlint.json',
+      '--type-aware',
+      '--fix',
+      '--fix-suggestions',
+      '.',
+    ],
   },
   {
     name: 'lint:check',
-    cmd: ['bunx', 'oxlint', '--config', 'oxlint.json', '--deny-warnings', '.'],
+    cmd: ['bunx', 'oxlint', '--config', 'oxlint.json', '--type-aware', '--deny-warnings', '.'],
   },
   { name: 'catalogs', cmd: ['bun', 'run', 'scripts/check-catalogs.ts'] },
   {

--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -16,13 +16,13 @@ interface CloudflareGraphQLResponse<T> {
 }
 
 interface RegistryStatsGroup {
+  count: number;
   dimensions: {
     clientRequestPath: string;
     userAgent: string;
   };
   sum: {
-    requests: number;
-    bytes: number;
+    edgeResponseBytes: number;
   };
 }
 
@@ -112,8 +112,8 @@ function aggregateRegistryStats(
   const perUserAgent = new Map<string, { requests: number; bytes: number }>();
 
   for (const group of groups) {
-    const requests = group.sum.requests;
-    const bytes = group.sum.bytes;
+    const requests = group.count;
+    const bytes = group.sum.edgeResponseBytes;
     const path = group.dimensions.clientRequestPath || 'unknown';
     const userAgent = group.dimensions.userAgent || 'unknown';
 
@@ -131,8 +131,8 @@ function aggregateRegistryStats(
   return {
     since,
     until,
-    total: groups.reduce((sum, group) => sum + group.sum.requests, 0),
-    bytes: groups.reduce((sum, group) => sum + group.sum.bytes, 0),
+    total: groups.reduce((sum, group) => sum + group.count, 0),
+    bytes: groups.reduce((sum, group) => sum + group.sum.edgeResponseBytes, 0),
     per_path: [...perPath.entries()].map(([path, stats]) => ({ path, ...stats })),
     per_user_agent: [...perUserAgent.entries()]
       .map(([user_agent, stats]) => ({ user_agent, ...stats }))
@@ -165,13 +165,13 @@ async function fetchCloudflareRegistryStats(): Promise<RegistryStats | null> {
               clientRequestPath_in: $paths
             }
           ) {
+            count
             dimensions {
               clientRequestPath
               userAgent
             }
             sum {
-              requests
-              bytes
+              edgeResponseBytes
             }
           }
         }


### PR DESCRIPTION
## 🚀 Change Summary

Updates project maintenance tooling and Cloudflare registry stats reporting while switching the web class name helper to cnfast.

### 🛠 Improvements & Refactors
- Replace the local clsx/tailwind-merge class helper implementation with cnfast.
- Update the repository check script to use the main test command and type-aware oxlint checks.
- Adjust the Cloudflare stats query and aggregation to use count and edgeResponseBytes fields.

