### PR TITLE
feat(web): add slash command support

### DIFF
--- a/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
@@ -46,9 +46,10 @@ type ChatInputInnerProps = {
   embedded?: boolean;
   pendingAttachments?: Attachment[];
   onPendingAttachmentsConsumed?: () => void;
+  completionGroups?: TextareaCompletionGroup[];
 };
 
-const CHAT_COMPLETION_GROUPS: TextareaCompletionGroup[] = [];
+const EMPTY_COMPLETION_GROUPS: TextareaCompletionGroup[] = [];
 
 function areHotkeyKeysHeld(hotkey: string, heldKeys: string[]) {
   const parsed = parseHotkey(hotkey);
@@ -74,6 +75,7 @@ export function ChatInputInner({
   embedded,
   pendingAttachments,
   onPendingAttachmentsConsumed,
+  completionGroups = EMPTY_COMPLETION_GROUPS,
 }: ChatInputInnerProps) {
   const { data: providerModels } = useSuspenseQuery(visibleProviderModelsQueryOptions);
   const { data: settings } = useSuspenseQuery(settingsQueryOptions);
@@ -215,7 +217,7 @@ export function ChatInputInner({
         textareaRef={textareaRef}
         value={value}
         onChange={onChange}
-        groups={CHAT_COMPLETION_GROUPS}
+        groups={completionGroups}
         disabled={disabled}
         onKeyDown={handleKeyDown}
       >

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { ChatInputInner } from '@/components/chat/chat-input-parts/chat-input-inner';
 import type { Attachment, ModelSpec } from '@/components/chat/chat-input-parts/types';
+import type { TextareaCompletionGroup } from '@/components/ui/textarea-completions';
 import { cn } from '@/lib/utils';
 
 type ChatInputProps = {
@@ -19,6 +20,7 @@ type ChatInputProps = {
   embedded?: boolean;
   pendingAttachments?: Attachment[];
   onPendingAttachmentsConsumed?: () => void;
+  completionGroups?: TextareaCompletionGroup[];
 };
 
 export function ChatInput({ className, hasDockAbove, embedded, ...props }: ChatInputProps) {

--- a/apps/web/src/components/session/session-chat-pane.tsx
+++ b/apps/web/src/components/session/session-chat-pane.tsx
@@ -17,6 +17,7 @@ import { useSessionDocks } from '@/hooks/session/use-session-docks';
 import { useSessionPendingItems } from '@/hooks/session/use-session-pending-items';
 import { useCompactionUpdates } from '@/hooks/sse/use-compaction-updates';
 import { useSessionStreamState } from '@/hooks/use-session-stream-state';
+import { useSlashCommands } from '@/hooks/use-slash-commands';
 import { setNextSessionInputSeed } from '@/lib/chat-input-transition-seed';
 import {
   flattenMessages,
@@ -73,9 +74,21 @@ export function SessionChatPane({ sessionId }: SessionChatPaneProps) {
   const isStreaming = streamState.isStreaming;
   const canSend = !sendMessage.isPending && !isStreaming && !isCompacting;
 
+  const slashCommands = useSlashCommands({
+    sessionId: id,
+    selectedModel,
+    isStreaming,
+    setInput: setValue,
+  });
+
   async function handleSubmit(text: string, attachments: Attachment[]) {
     if ((!text.trim() && attachments.length === 0) || !selectedModel) return;
     if (!canSend) return;
+
+    if (attachments.length === 0 && (await slashCommands.tryRun(text))) {
+      setValue('');
+      return;
+    }
 
     setValue('');
 
@@ -165,6 +178,7 @@ export function SessionChatPane({ sessionId }: SessionChatPaneProps) {
                         }
                         disabled={isCompacting || !canSend}
                         embedded
+                        completionGroups={slashCommands.completionGroups}
                       />
                     </div>
                   </div>

--- a/apps/web/src/components/session/session-chat-pane.tsx
+++ b/apps/web/src/components/session/session-chat-pane.tsx
@@ -87,7 +87,7 @@ export function SessionChatPane({ sessionId, onGenerateAutomation }: SessionChat
     if ((!text.trim() && attachments.length === 0) || !selectedModel) return;
     if (!canSend) return;
 
-    if (attachments.length === 0 && (await slashCommands.tryRun(text))) {
+    if (attachments.length === 0 && slashCommands.tryRun(text)) {
       setValue('');
       return;
     }

--- a/apps/web/src/components/session/session-chat-pane.tsx
+++ b/apps/web/src/components/session/session-chat-pane.tsx
@@ -32,9 +32,10 @@ import { useStreamStore } from '@/stores/stream-store';
 
 type SessionChatPaneProps = {
   sessionId: string;
+  onGenerateAutomation?: () => Promise<void>;
 };
 
-export function SessionChatPane({ sessionId }: SessionChatPaneProps) {
+export function SessionChatPane({ sessionId, onGenerateAutomation }: SessionChatPaneProps) {
   const id = sessionId;
   const navigate = useNavigate();
   const { data: session } = useSuspenseQuery(sessionQueryOptions(id));
@@ -79,6 +80,7 @@ export function SessionChatPane({ sessionId }: SessionChatPaneProps) {
     selectedModel,
     isStreaming,
     setInput: setValue,
+    onGenerateAutomation,
   });
 
   async function handleSubmit(text: string, attachments: Attachment[]) {

--- a/apps/web/src/components/session/session-page.tsx
+++ b/apps/web/src/components/session/session-page.tsx
@@ -139,7 +139,10 @@ export function SessionPage({ sessionId }: SessionPageProps) {
           className="h-full min-h-0 w-full pt-0 pr-0 pb-0 pl-6"
         >
           <ResizablePanel defaultSize={rightPanelOpen ? '70%' : '100%'} minSize="45%">
-            <SessionChatPane sessionId={sessionId} />
+            <SessionChatPane
+              sessionId={sessionId}
+              onGenerateAutomation={handleGenerateAutomation}
+            />
           </ResizablePanel>
 
           {rightPanelOpen ? (

--- a/apps/web/src/components/ui/textarea-completions.tsx
+++ b/apps/web/src/components/ui/textarea-completions.tsx
@@ -13,6 +13,12 @@ export type TextareaCompletionGroup = {
   prefix: string;
   label: string;
   options: TextareaCompletionOption[];
+  /**
+   * Where the prefix is allowed to trigger completions.
+   * - `word` (default): after any whitespace, like an `@`-mention mid-sentence.
+   * - `start`: only when the prefix is the very first character of the input.
+   */
+  anchor?: 'word' | 'start';
 };
 
 type CompletionState = {
@@ -68,8 +74,12 @@ function getCompletionState(
 
   if (!matchingGroup || anchorIndex < 0) return null;
 
-  const previousCharacter = anchorIndex > 0 ? value[anchorIndex - 1] : '';
-  if (previousCharacter && !/\s/.test(previousCharacter)) return null;
+  if (matchingGroup.anchor === 'start') {
+    if (anchorIndex !== 0) return null;
+  } else {
+    const previousCharacter = anchorIndex > 0 ? value[anchorIndex - 1] : '';
+    if (previousCharacter && !/\s/.test(previousCharacter)) return null;
+  }
 
   const filter = value.slice(anchorIndex + matchingGroup.prefix.length, selectionStart);
   if (/\s/.test(filter)) return null;

--- a/apps/web/src/hooks/use-slash-commands.ts
+++ b/apps/web/src/hooks/use-slash-commands.ts
@@ -1,0 +1,77 @@
+import * as React from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import type { ModelSpec } from '@/components/chat/chat-input-parts/types';
+import type { TextareaCompletionGroup } from '@/components/ui/textarea-completions';
+import { parseSlashCommand } from '@/lib/commands/parse';
+import { buildSlashCompletionGroup, findCommand } from '@/lib/commands/registry';
+import type { CommandContext } from '@/lib/commands/types';
+import { useRequestCompaction } from '@/lib/queries/chat';
+
+type UseSlashCommandsOptions = {
+  sessionId: string | null;
+  selectedModel: ModelSpec | null;
+  isStreaming: boolean;
+  setInput: (value: string) => void;
+};
+
+type UseSlashCommandsResult = {
+  completionGroups: TextareaCompletionGroup[];
+  /**
+   * Runs the input as a slash command when it matches a registered, available
+   * command. Returns true when handled (caller should skip the normal send),
+   * false otherwise (caller should send the input as a normal message).
+   */
+  tryRun: (input: string) => Promise<boolean>;
+};
+
+export function useSlashCommands({
+  sessionId,
+  selectedModel,
+  isStreaming,
+  setInput,
+}: UseSlashCommandsOptions): UseSlashCommandsResult {
+  const queryClient = useQueryClient();
+  const requestCompaction = useRequestCompaction();
+
+  const buildContext = React.useCallback(
+    (): CommandContext => ({
+      sessionId,
+      selectedModel,
+      isStreaming,
+      setInput,
+      queryClient,
+      actions: {
+        requestCompaction: async (id: string) => {
+          await requestCompaction.mutateAsync(id);
+        },
+      },
+    }),
+    [sessionId, selectedModel, isStreaming, setInput, queryClient, requestCompaction],
+  );
+
+  const completionGroups = React.useMemo(
+    () => [buildSlashCompletionGroup(buildContext())],
+    [buildContext],
+  );
+
+  const tryRun = React.useCallback(
+    async (input: string): Promise<boolean> => {
+      const parsed = parseSlashCommand(input);
+      if (!parsed) return false;
+
+      const command = findCommand(parsed.name);
+      if (!command) return false;
+
+      const ctx = buildContext();
+      if (command.isAvailable && !command.isAvailable(ctx)) return false;
+
+      await command.run(parsed.args, ctx);
+      return true;
+    },
+    [buildContext],
+  );
+
+  return { completionGroups, tryRun };
+}

--- a/apps/web/src/hooks/use-slash-commands.ts
+++ b/apps/web/src/hooks/use-slash-commands.ts
@@ -14,6 +14,7 @@ type UseSlashCommandsOptions = {
   selectedModel: ModelSpec | null;
   isStreaming: boolean;
   setInput: (value: string) => void;
+  onGenerateAutomation?: () => Promise<void>;
 };
 
 type UseSlashCommandsResult = {
@@ -31,6 +32,7 @@ export function useSlashCommands({
   selectedModel,
   isStreaming,
   setInput,
+  onGenerateAutomation,
 }: UseSlashCommandsOptions): UseSlashCommandsResult {
   const queryClient = useQueryClient();
   const requestCompaction = useRequestCompaction();
@@ -46,9 +48,20 @@ export function useSlashCommands({
         requestCompaction: async (id: string) => {
           await requestCompaction.mutateAsync(id);
         },
+        generateAutomation: async () => {
+          await onGenerateAutomation?.();
+        },
       },
     }),
-    [sessionId, selectedModel, isStreaming, setInput, queryClient, requestCompaction],
+    [
+      sessionId,
+      selectedModel,
+      isStreaming,
+      setInput,
+      queryClient,
+      requestCompaction,
+      onGenerateAutomation,
+    ],
   );
 
   const completionGroups = React.useMemo(

--- a/apps/web/src/hooks/use-slash-commands.ts
+++ b/apps/web/src/hooks/use-slash-commands.ts
@@ -23,8 +23,11 @@ type UseSlashCommandsResult = {
    * Runs the input as a slash command when it matches a registered, available
    * command. Returns true when handled (caller should skip the normal send),
    * false otherwise (caller should send the input as a normal message).
+   *
+   * The command's async work is fired without being awaited so the caller can
+   * clear the input immediately; handlers own their own success/error feedback.
    */
-  tryRun: (input: string) => Promise<boolean>;
+  tryRun: (input: string) => boolean;
 };
 
 export function useSlashCommands({
@@ -70,7 +73,7 @@ export function useSlashCommands({
   );
 
   const tryRun = React.useCallback(
-    async (input: string): Promise<boolean> => {
+    (input: string): boolean => {
       const parsed = parseSlashCommand(input);
       if (!parsed) return false;
 
@@ -80,7 +83,9 @@ export function useSlashCommands({
       const ctx = buildContext();
       if (command.isAvailable && !command.isAvailable(ctx)) return false;
 
-      await command.run(parsed.args, ctx);
+      void Promise.resolve(command.run(parsed.args, ctx)).catch((error) => {
+        console.error(`Slash command "${command.name}" failed:`, error);
+      });
       return true;
     },
     [buildContext],

--- a/apps/web/src/lib/commands/commands/compact.ts
+++ b/apps/web/src/lib/commands/commands/compact.ts
@@ -1,0 +1,13 @@
+import type { SlashCommand } from '../types.js';
+
+export const compactCommand: SlashCommand = {
+  kind: 'client',
+  name: 'compact',
+  aliases: ['summarize'],
+  description: 'Summarize the conversation so far to reclaim context space',
+  isAvailable: (ctx) => ctx.sessionId !== null && !ctx.isStreaming,
+  run: async (_args, ctx) => {
+    if (!ctx.sessionId) return;
+    await ctx.actions.requestCompaction(ctx.sessionId);
+  },
+};

--- a/apps/web/src/lib/commands/commands/generate-automation.ts
+++ b/apps/web/src/lib/commands/commands/generate-automation.ts
@@ -1,0 +1,12 @@
+import type { SlashCommand } from '../types.js';
+
+export const generateAutomationCommand: SlashCommand = {
+  kind: 'client',
+  name: 'automation',
+  aliases: ['generate-automation'],
+  description: 'Generate an automation draft from this conversation',
+  isAvailable: (ctx) => ctx.sessionId !== null && !ctx.isStreaming,
+  run: async (_args, ctx) => {
+    await ctx.actions.generateAutomation();
+  },
+};

--- a/apps/web/src/lib/commands/parse.test.ts
+++ b/apps/web/src/lib/commands/parse.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parseSlashCommand } from './parse.js';
+
+describe('parseSlashCommand', () => {
+  test('returns null for empty input', () => {
+    expect(parseSlashCommand('')).toBeNull();
+  });
+
+  test('returns null when there is no leading slash', () => {
+    expect(parseSlashCommand('compact')).toBeNull();
+  });
+
+  test('returns null when the slash is not the first character', () => {
+    expect(parseSlashCommand(' /compact')).toBeNull();
+    expect(parseSlashCommand('hey /compact')).toBeNull();
+  });
+
+  test('returns null for a lone slash', () => {
+    expect(parseSlashCommand('/')).toBeNull();
+    expect(parseSlashCommand('/   ')).toBeNull();
+  });
+
+  test('parses a command with no arguments', () => {
+    expect(parseSlashCommand('/compact')).toEqual({ name: 'compact', args: '' });
+  });
+
+  test('lowercases the command name', () => {
+    expect(parseSlashCommand('/Compact')).toEqual({ name: 'compact', args: '' });
+  });
+
+  test('parses arguments after the command name', () => {
+    expect(parseSlashCommand('/rename my new title')).toEqual({
+      name: 'rename',
+      args: 'my new title',
+    });
+  });
+
+  test('trims surrounding whitespace from arguments', () => {
+    expect(parseSlashCommand('/rename   spaced out   ')).toEqual({
+      name: 'rename',
+      args: 'spaced out',
+    });
+  });
+});

--- a/apps/web/src/lib/commands/parse.ts
+++ b/apps/web/src/lib/commands/parse.ts
@@ -1,0 +1,26 @@
+type ParsedSlashCommand = {
+  /** The command name without the leading slash, lowercased (e.g. "compact"). */
+  name: string;
+  /** Everything after the command name and its trailing whitespace, verbatim. */
+  args: string;
+};
+
+/**
+ * Parses a slash command from raw input.
+ *
+ * A slash command is only valid when the slash is the very first character of
+ * the input (no leading whitespace). Returns null when the input is not a
+ * slash command so callers can fall through to sending a normal message.
+ */
+export function parseSlashCommand(input: string): ParsedSlashCommand | null {
+  if (input[0] !== '/') return null;
+
+  const withoutSlash = input.slice(1);
+  const match = /^(\S+)(?:\s+([\s\S]*))?$/.exec(withoutSlash);
+  if (!match) return null;
+
+  return {
+    name: match[1].toLowerCase(),
+    args: match[2]?.trim() ?? '',
+  };
+}

--- a/apps/web/src/lib/commands/registry.ts
+++ b/apps/web/src/lib/commands/registry.ts
@@ -1,9 +1,10 @@
 import { compactCommand } from './commands/compact.js';
+import { generateAutomationCommand } from './commands/generate-automation.js';
 
 import type { CommandContext, SlashCommand } from './types.js';
 import type { TextareaCompletionGroup } from '@/components/ui/textarea-completions';
 
-const COMMANDS: SlashCommand[] = [compactCommand];
+const COMMANDS: SlashCommand[] = [compactCommand, generateAutomationCommand];
 
 export function findCommand(name: string): SlashCommand | null {
   const lowered = name.toLowerCase();

--- a/apps/web/src/lib/commands/registry.ts
+++ b/apps/web/src/lib/commands/registry.ts
@@ -1,0 +1,33 @@
+import type { TextareaCompletionGroup } from '@/components/ui/textarea-completions';
+
+import { compactCommand } from './commands/compact.js';
+import type { CommandContext, SlashCommand } from './types.js';
+
+const COMMANDS: SlashCommand[] = [compactCommand];
+
+export function findCommand(name: string): SlashCommand | null {
+  const lowered = name.toLowerCase();
+  return (
+    COMMANDS.find(
+      (command) =>
+        command.name === lowered || command.aliases?.some((alias) => alias === lowered),
+    ) ?? null
+  );
+}
+
+function isCommandAvailable(command: SlashCommand, ctx: CommandContext): boolean {
+  return command.isAvailable ? command.isAvailable(ctx) : true;
+}
+
+/** Builds the `/`-prefixed completion group, filtered to currently available commands. */
+export function buildSlashCompletionGroup(ctx: CommandContext): TextareaCompletionGroup {
+  return {
+    prefix: '/',
+    label: 'Commands',
+    options: COMMANDS.filter((command) => isCommandAvailable(command, ctx)).map((command) => ({
+      value: command.name,
+      label: command.name,
+      description: command.description,
+    })),
+  };
+}

--- a/apps/web/src/lib/commands/registry.ts
+++ b/apps/web/src/lib/commands/registry.ts
@@ -1,7 +1,7 @@
-import type { TextareaCompletionGroup } from '@/components/ui/textarea-completions';
-
 import { compactCommand } from './commands/compact.js';
+
 import type { CommandContext, SlashCommand } from './types.js';
+import type { TextareaCompletionGroup } from '@/components/ui/textarea-completions';
 
 const COMMANDS: SlashCommand[] = [compactCommand];
 
@@ -9,8 +9,7 @@ export function findCommand(name: string): SlashCommand | null {
   const lowered = name.toLowerCase();
   return (
     COMMANDS.find(
-      (command) =>
-        command.name === lowered || command.aliases?.some((alias) => alias === lowered),
+      (command) => command.name === lowered || command.aliases?.some((alias) => alias === lowered),
     ) ?? null
   );
 }
@@ -24,6 +23,7 @@ export function buildSlashCompletionGroup(ctx: CommandContext): TextareaCompleti
   return {
     prefix: '/',
     label: 'Commands',
+    anchor: 'start',
     options: COMMANDS.filter((command) => isCommandAvailable(command, ctx)).map((command) => ({
       value: command.name,
       label: command.name,

--- a/apps/web/src/lib/commands/types.ts
+++ b/apps/web/src/lib/commands/types.ts
@@ -5,6 +5,7 @@ import type { ModelSpec } from '@/components/chat/chat-input-parts/types';
 /** Server-backed actions a command can invoke, injected by the host hook. */
 export type CommandActions = {
   requestCompaction: (sessionId: string) => Promise<void>;
+  generateAutomation: () => Promise<void>;
 };
 
 /** Runtime context handed to a command handler when it runs. */

--- a/apps/web/src/lib/commands/types.ts
+++ b/apps/web/src/lib/commands/types.ts
@@ -1,0 +1,44 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+import type { ModelSpec } from '@/components/chat/chat-input-parts/types';
+
+/** Server-backed actions a command can invoke, injected by the host hook. */
+export type CommandActions = {
+  requestCompaction: (sessionId: string) => Promise<void>;
+};
+
+/** Runtime context handed to a command handler when it runs. */
+export type CommandContext = {
+  /** Current session, or null on the new-session screen. */
+  sessionId: string | null;
+  /** Model currently selected in the composer, if any. */
+  selectedModel: ModelSpec | null;
+  /** Whether the session is currently streaming a response. */
+  isStreaming: boolean;
+  /** Replace the composer input value. */
+  setInput: (value: string) => void;
+  actions: CommandActions;
+  queryClient: QueryClient;
+};
+
+/**
+ * A command handled in the browser.
+ *
+ * `kind` discriminates how a command is processed. Only `client` exists today;
+ * the field is kept so future kinds (e.g. a command sent on the chat stream)
+ * can be added to the union without reshaping callers.
+ */
+export type ClientCommand = {
+  kind: 'client';
+  name: string;
+  aliases?: string[];
+  description: string;
+  /**
+   * Hides the command from autocomplete and blocks invocation when false.
+   * Used to gate commands that require an active session, etc.
+   */
+  isAvailable?: (ctx: CommandContext) => boolean;
+  run: (args: string, ctx: CommandContext) => void | Promise<void>;
+};
+
+export type SlashCommand = ClientCommand;

--- a/apps/web/src/lib/queries/chat.ts
+++ b/apps/web/src/lib/queries/chat.ts
@@ -293,6 +293,13 @@ export function useRespondDoomLoop() {
   });
 }
 
+export function useRequestCompaction() {
+  return useMutation({
+    mutationFn: (sessionId: string) =>
+      serverRequest<{ ok: true }>(`/chat/sessions/${sessionId}/compact`, { method: 'POST' }),
+  });
+}
+
 export function useGenerateAutomationDraft() {
   const queryClient = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Change Summary

Adds slash command support to the chat composer, including start-anchored command completions and client-side command execution for compacting conversations and generating automation drafts.

### New Features

- **Slash command system**: Adds parsing, command registration, availability checks, aliases, and composer completions for `/` commands.
- **Conversation compaction command**: Adds `/compact` and `/summarize` to request compaction from the current session.
- **Automation draft command**: Adds `/automation` and `/generate-automation` to generate an automation draft from the current conversation.

### Improvements & Refactors

- Allows chat input consumers to provide completion groups.
- Anchors slash command completions to the start of the composer input.
- Clears the composer immediately when a slash command is handled.
