### PR TITLE
feat: add skillify slash command

### DIFF
--- a/apps/web/src/components/session/session-chat-pane.tsx
+++ b/apps/web/src/components/session/session-chat-pane.tsx
@@ -75,11 +75,30 @@ export function SessionChatPane({ sessionId, onGenerateAutomation }: SessionChat
   const isStreaming = streamState.isStreaming;
   const canSend = !sendMessage.isPending && !isStreaming && !isCompacting;
 
+  const submitTextMessage = React.useCallback(
+    async (text: string) => {
+      if (!selectedModel || !canSend) return;
+
+      const assistantMessageId = createMessageId();
+      startStream(id, assistantMessageId);
+
+      await sendMessage.mutateAsync({
+        sessionId: id as PrefixedString<'ses'>,
+        content: text,
+        providerId: selectedModel.providerId,
+        modelId: selectedModel.modelId,
+        assistantMessageId,
+      });
+    },
+    [canSend, id, selectedModel, sendMessage, startStream],
+  );
+
   const slashCommands = useSlashCommands({
     sessionId: id,
     selectedModel,
     isStreaming,
     setInput: setValue,
+    onSubmitPrompt: submitTextMessage,
     onGenerateAutomation,
   });
 
@@ -94,21 +113,23 @@ export function SessionChatPane({ sessionId, onGenerateAutomation }: SessionChat
 
     setValue('');
 
+    if (attachments.length === 0) {
+      await submitTextMessage(text);
+      return;
+    }
+
     const assistantMessageId = createMessageId();
     startStream(id, assistantMessageId);
 
     await sendMessage.mutateAsync({
       sessionId: id as PrefixedString<'ses'>,
       content: text,
-      attachments:
-        attachments.length > 0
-          ? attachments.map((a) => ({
-              path: a.path,
-              previewUrl: a.previewUrl,
-              mime: a.mime,
-              filename: a.filename,
-            }))
-          : undefined,
+      attachments: attachments.map((a) => ({
+        path: a.path,
+        previewUrl: a.previewUrl,
+        mime: a.mime,
+        filename: a.filename,
+      })),
       providerId: selectedModel.providerId,
       modelId: selectedModel.modelId,
       assistantMessageId,

--- a/apps/web/src/hooks/use-slash-commands.ts
+++ b/apps/web/src/hooks/use-slash-commands.ts
@@ -14,6 +14,7 @@ type UseSlashCommandsOptions = {
   selectedModel: ModelSpec | null;
   isStreaming: boolean;
   setInput: (value: string) => void;
+  onSubmitPrompt: (content: string) => Promise<void>;
   onGenerateAutomation?: () => Promise<void>;
 };
 
@@ -35,6 +36,7 @@ export function useSlashCommands({
   selectedModel,
   isStreaming,
   setInput,
+  onSubmitPrompt,
   onGenerateAutomation,
 }: UseSlashCommandsOptions): UseSlashCommandsResult {
   const queryClient = useQueryClient();
@@ -54,6 +56,7 @@ export function useSlashCommands({
         generateAutomation: async () => {
           await onGenerateAutomation?.();
         },
+        submitPrompt: onSubmitPrompt,
       },
     }),
     [
@@ -63,6 +66,7 @@ export function useSlashCommands({
       setInput,
       queryClient,
       requestCompaction,
+      onSubmitPrompt,
       onGenerateAutomation,
     ],
   );
@@ -82,6 +86,14 @@ export function useSlashCommands({
 
       const ctx = buildContext();
       if (command.isAvailable && !command.isAvailable(ctx)) return false;
+
+      if (command.kind === 'prompt') {
+        const prompt = command.buildPrompt(parsed.args, ctx);
+        void ctx.actions.submitPrompt(prompt).catch((error) => {
+          console.error(`Slash command "${command.name}" failed:`, error);
+        });
+        return true;
+      }
 
       void Promise.resolve(command.run(parsed.args, ctx)).catch((error) => {
         console.error(`Slash command "${command.name}" failed:`, error);

--- a/apps/web/src/lib/commands/commands/skillify.test.ts
+++ b/apps/web/src/lib/commands/commands/skillify.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+
+import { findCommand } from '../registry.js';
+
+describe('skillifyCommand', () => {
+  test('is registered as a prompt command', () => {
+    const command = findCommand('skillify');
+
+    expect(command).toMatchObject({
+      kind: 'prompt',
+      name: 'skillify',
+      description: 'Turn this conversation into a reusable skill',
+    });
+  });
+
+  test('builds prompt with optional user description', () => {
+    const command = findCommand('skillify');
+    if (!command || command.kind !== 'prompt') throw new Error('skillify command not found');
+
+    const prompt = command.buildPrompt('my release workflow', {} as never);
+
+    expect(prompt).toContain('Use the skillify skill');
+    expect(prompt).toContain('User description: my release workflow');
+  });
+
+  test('supports create-skill alias', () => {
+    expect(findCommand('create-skill')?.name).toBe('skillify');
+  });
+});

--- a/apps/web/src/lib/commands/commands/skillify.ts
+++ b/apps/web/src/lib/commands/commands/skillify.ts
@@ -1,0 +1,19 @@
+import type { SlashCommand } from '../types.js';
+
+export const skillifyCommand: SlashCommand = {
+  kind: 'prompt',
+  name: 'skillify',
+  aliases: ['create-skill'],
+  description: 'Turn this conversation into a reusable skill',
+  isAvailable: (ctx) => ctx.sessionId !== null && !ctx.isStreaming,
+  buildPrompt: (args) => {
+    const description = args.trim();
+    return [
+      'Use the skillify skill to capture this session\'s repeatable process as a reusable skill.',
+      '',
+      description ? `User description: ${description}` : null,
+    ]
+      .filter(Boolean)
+      .join('\n');
+  },
+};

--- a/apps/web/src/lib/commands/registry.ts
+++ b/apps/web/src/lib/commands/registry.ts
@@ -1,10 +1,11 @@
 import { compactCommand } from './commands/compact.js';
 import { generateAutomationCommand } from './commands/generate-automation.js';
+import { skillifyCommand } from './commands/skillify.js';
 
 import type { CommandContext, SlashCommand } from './types.js';
 import type { TextareaCompletionGroup } from '@/components/ui/textarea-completions';
 
-const COMMANDS: SlashCommand[] = [compactCommand, generateAutomationCommand];
+const COMMANDS: SlashCommand[] = [compactCommand, generateAutomationCommand, skillifyCommand];
 
 export function findCommand(name: string): SlashCommand | null {
   const lowered = name.toLowerCase();

--- a/apps/web/src/lib/commands/types.ts
+++ b/apps/web/src/lib/commands/types.ts
@@ -6,6 +6,7 @@ import type { ModelSpec } from '@/components/chat/chat-input-parts/types';
 export type CommandActions = {
   requestCompaction: (sessionId: string) => Promise<void>;
   generateAutomation: () => Promise<void>;
+  submitPrompt: (content: string) => Promise<void>;
 };
 
 /** Runtime context handed to a command handler when it runs. */
@@ -42,4 +43,13 @@ export type ClientCommand = {
   run: (args: string, ctx: CommandContext) => void | Promise<void>;
 };
 
-export type SlashCommand = ClientCommand;
+export type PromptCommand = {
+  kind: 'prompt';
+  name: string;
+  aliases?: string[];
+  description: string;
+  isAvailable?: (ctx: CommandContext) => boolean;
+  buildPrompt: (args: string, ctx: CommandContext) => string;
+};
+
+export type SlashCommand = ClientCommand | PromptCommand;

--- a/packages/server/src/skills/built-ins/skillify/SKILL.md
+++ b/packages/server/src/skills/built-ins/skillify/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: skillify
+description: Capture the current chat's repeatable process as a reusable skill when the user asks to turn a conversation, workflow, or process into a skill.
+---
+
+# Skillify
+
+You are capturing this session's repeatable process as a reusable skill.
+
+## Goal
+
+Create a high-quality skill that can be reused in future chats. The saved skill should preserve the user's preferences, constraints, checkpoints, and success criteria from this conversation.
+
+## Process
+
+### 1. Analyze The Session
+
+Review the current conversation before asking questions. Identify:
+
+- The repeatable process that was performed or designed.
+- The inputs or arguments a future user would provide.
+- The major steps in order.
+- The success criteria for each step.
+- Places where the user corrected, constrained, or steered the work.
+- Tools, permissions, files, applications, or external services required.
+- Whether any work should be delegated to `task`.
+- The artifacts the skill should produce.
+
+Success criteria: You can summarize the candidate skill name, goal, inputs, steps, and output artifacts in concrete terms.
+
+### 2. Interview The User
+
+Use the `question` tool for clarification. Do not ask questions in plain text when you need a user decision.
+
+Ask only what is needed. For a simple workflow, one short confirmation round is enough.
+
+Clarify:
+
+- Skill name and one-line description.
+- Goal and completion criteria.
+- Inputs or arguments the future skill needs.
+- Required tools or toolsets.
+- Any human checkpoints before irreversible actions.
+- Whether the skill should run inline in the main chat or delegate self-contained work to `task`.
+- Trigger phrases or requests that should cause the model to load the skill in future chats.
+
+Success criteria: The user has confirmed the important behavior, or the remaining details are obvious from the conversation.
+
+### 3. Draft The Skill
+
+Draft the full skill content before saving it. Use this structure:
+
+```markdown
+# Skill Title
+
+Describe when to use this skill, including trigger phrases and example user requests.
+
+## Inputs
+
+- `input_name`: Description of the input.
+
+## Goal
+
+State the artifact or outcome this skill must produce.
+
+## Steps
+
+### 1. Step Name
+
+Specific instruction for this step.
+
+Success criteria: State how to know this step is complete.
+
+### 2. Step Name
+
+Specific instruction for this step.
+
+Success criteria: State how to know this step is complete.
+
+## Rules
+
+- Hard constraints and preferences from the user.
+```
+
+Rules for the generated skill:
+
+- Keep the skill focused on one repeatable workflow.
+- Include concrete success criteria for every major step.
+- Include user corrections as rules when they are likely to matter later.
+- Prefer direct execution in the current chat unless the work is self-contained and does not need mid-process user input.
+- If delegation is useful, say exactly when to use `task` and what result it should return.
+- Do not add broad flexibility, extra features, or speculative tools.
+
+Success criteria: The draft is complete enough to save without additional hidden assumptions.
+
+### 4. Confirm And Save
+
+Show the user the proposed skill name, description, and full content. Then use the `question` tool to ask whether it should be saved.
+
+Only after confirmation, call `create_skill` with:
+
+- `name`: lowercase letters, numbers, and single hyphens only.
+- `description`: concise one-line description.
+- `content`: the final Markdown body, without YAML frontmatter.
+
+After saving, tell the user:
+
+- The skill name.
+- Where it was saved.
+- That future chats can invoke it by matching the skill description, and `/skillify` can be used again to create more skills.
+
+Success criteria: The skill is saved successfully and the user knows how it will be reused.

--- a/packages/server/src/tools/core/catalog.ts
+++ b/packages/server/src/tools/core/catalog.ts
@@ -2,6 +2,7 @@ import { isDbInitialized } from '@/db/client.js';
 import { listEnabledProviderEmbeddingModels } from '@/llm/provider/service.js';
 import { getMemoryConfig, hasConfiguredEmbeddingModel } from '@/memory/config.js';
 import { definition as bash } from '@/tools/core/bash.js';
+import { definition as createSkill } from '@/tools/core/create-skill.js';
 import { definition as edit } from '@/tools/core/edit.js';
 import { definition as glob } from '@/tools/core/glob.js';
 import { definition as grep } from '@/tools/core/grep.js';
@@ -44,6 +45,7 @@ export const CORE_TOOL_CATALOG: CatalogEntry[] = [
   { kind: 'static', definition: write },
   { kind: 'static', definition: renderUi },
   { kind: 'static', definition: skill },
+  { kind: 'static', definition: createSkill },
   {
     kind: 'contextual',
     name: 'question',

--- a/packages/server/src/tools/core/create-skill.test.ts
+++ b/packages/server/src/tools/core/create-skill.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { PATHS } from '@/lib/paths.js';
+import { createSkillFromTool } from '@/tools/core/create-skill.js';
+
+let tempDir: string;
+let originalSkillsDir: string;
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stitch-create-skill-tool-'));
+  originalSkillsDir = PATHS.dirPaths.skills;
+  (PATHS.dirPaths as { skills: string }).skills = tempDir;
+});
+
+afterEach(async () => {
+  (PATHS.dirPaths as { skills: string }).skills = originalSkillsDir;
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+describe('createSkillFromTool', () => {
+  test('creates a managed skill file', async () => {
+    const result = await createSkillFromTool({
+      name: 'release-flow',
+      description: 'Run the release flow.',
+      content: '# Release Flow\n\nDo the release.',
+    });
+
+    expect(result).toMatchObject({
+      name: 'release-flow',
+      description: 'Run the release flow.',
+    });
+    expect(await fs.readFile(path.join(tempDir, 'release-flow', 'SKILL.md'), 'utf8')).toContain(
+      '# Release Flow',
+    );
+  });
+
+  test('returns an error when the skill already exists', async () => {
+    const input = {
+      name: 'release-flow',
+      description: 'Run the release flow.',
+      content: '# Release Flow\n\nDo the release.',
+    };
+
+    await createSkillFromTool(input);
+    const result = await createSkillFromTool(input);
+
+    expect(result).toMatchObject({ error: 'Skill name "release-flow" already exists' });
+  });
+});

--- a/packages/server/src/tools/core/create-skill.ts
+++ b/packages/server/src/tools/core/create-skill.ts
@@ -1,0 +1,35 @@
+import { tool } from 'ai';
+
+import { createSkillSchema } from '@stitch/shared/skills/types';
+
+import { createSkill } from '@/skills/service.js';
+import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
+
+const createSkillInputSchema = createSkillSchema.describe('A reusable skill to save for future use');
+
+export async function createSkillFromTool(input: unknown) {
+  const parsed = createSkillSchema.parse(input);
+  const result = await createSkill(parsed);
+  if (result.error) {
+    return { error: result.error.message };
+  }
+
+  return {
+    name: result.data.name,
+    description: result.data.description,
+    location: result.data.location,
+    output: `Created skill "${result.data.name}" at ${result.data.location}`,
+  };
+}
+
+export const definition: ToolDefinition = {
+  name: 'create_skill',
+  displayName: 'Create Skill',
+  tool: tool({
+    description: `Create a reusable skill from finalized skill content.
+
+Use this only after the user has confirmed the skill name, description, and instructions. This writes a managed SKILL.md into the user's skills directory. The name must use lowercase letters, numbers, and single hyphens only.`,
+    inputSchema: createSkillInputSchema,
+    execute: createSkillFromTool,
+  }),
+};


### PR DESCRIPTION
## 🚀 Change Summary

Adds a reusable prompt-based slash command path and introduces `/skillify`, allowing users to turn the current conversation into a reusable skill from the chat composer.

### ✨ New Features
- **Prompt Slash Commands**: Adds a `prompt` command kind so slash commands can submit generated prompts through the normal chat flow.
- **Skillify Command**: Adds `/skillify` with a `/create-skill` alias to start a same-session skill creation workflow.
- **Skill Persistence Tool**: Adds `create_skill` so confirmed generated skills can be saved through the managed skills service.

### 🛠 Improvements & Refactors
- Reuses the existing chat submit path for prompt commands to keep slash-command behavior consistent with regular messages.
- Adds a built-in `skillify` skill with guided interview, draft, confirmation, and save steps.
