### PR TITLE
fix(google): add Drive file upload support

### DIFF
--- a/connectors/google/src/client.ts
+++ b/connectors/google/src/client.ts
@@ -56,7 +56,7 @@ type GoogleErrorResponse = {
 type RequestOptions = {
   method?: string;
   headers?: Record<string, string>;
-  body?: string;
+  body?: string | ArrayBuffer;
   signal?: AbortSignal;
 };
 

--- a/connectors/google/src/drive/api.test.ts
+++ b/connectors/google/src/drive/api.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+import { uploadFile } from './api.js';
+
+import type { GoogleClient } from '../client.js';
+
+describe('Drive API uploadFile', () => {
+  test('uploads a local file with metadata', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'drive-upload-test-'));
+    const filePath = path.join(root, 'report.txt');
+    await fs.writeFile(filePath, 'hello drive');
+
+    let requestUrl = '';
+    let requestOptions: {
+      method?: string;
+      headers?: Record<string, string>;
+      body?: string | ArrayBuffer;
+    } = {};
+    const client = {
+      request: async (url: string, options?: typeof requestOptions) => {
+        requestUrl = url;
+        requestOptions = options ?? {};
+        return {
+          id: 'file-1',
+          name: 'Report.txt',
+          mimeType: 'text/plain',
+          webViewLink: 'https://drive.google.com/file/d/file-1/view',
+        };
+      },
+    } as unknown as GoogleClient;
+
+    const result = await uploadFile(client, filePath, {
+      name: 'Report.txt',
+      mimeType: 'text/plain',
+      parentId: 'folder-1',
+    });
+
+    expect(requestUrl).toBe(
+      'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,mimeType,webViewLink',
+    );
+    expect(requestOptions.method).toBe('POST');
+    expect(requestOptions.headers?.['Content-Type']).toBe(
+      'multipart/related; boundary=drive_upload_boundary',
+    );
+    const requestBody =
+      typeof requestOptions.body === 'string'
+        ? requestOptions.body
+        : Buffer.from(new Uint8Array(requestOptions.body ?? new ArrayBuffer(0))).toString();
+
+    expect(requestBody).toContain('hello drive');
+    expect(requestBody).toContain(
+      JSON.stringify({ name: 'Report.txt', parents: ['folder-1'] }),
+    );
+    expect(result).toEqual({
+      id: 'file-1',
+      name: 'Report.txt',
+      mimeType: 'text/plain',
+      webViewLink: 'https://drive.google.com/file/d/file-1/view',
+    });
+  });
+});

--- a/connectors/google/src/drive/api.test.ts
+++ b/connectors/google/src/drive/api.test.ts
@@ -1,8 +1,7 @@
+import { describe, expect, test } from 'bun:test';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-
-import { describe, expect, test } from 'bun:test';
 
 import { uploadFile } from './api.js';
 
@@ -52,9 +51,8 @@ describe('Drive API uploadFile', () => {
         : Buffer.from(new Uint8Array(requestOptions.body ?? new ArrayBuffer(0))).toString();
 
     expect(requestBody).toContain('hello drive');
-    expect(requestBody).toContain(
-      JSON.stringify({ name: 'Report.txt', parents: ['folder-1'] }),
-    );
+    expect(requestBody).toContain('Content-Type: text/plain\r\n\r\nhello drive');
+    expect(requestBody).toContain(JSON.stringify({ name: 'Report.txt', parents: ['folder-1'] }));
     expect(result).toEqual({
       id: 'file-1',
       name: 'Report.txt',

--- a/connectors/google/src/drive/api.ts
+++ b/connectors/google/src/drive/api.ts
@@ -206,6 +206,7 @@ export async function uploadFile(
         `--${boundary}`,
         `Content-Type: ${mimeType}`,
         '',
+        '',
       ].join('\r\n'),
     ),
     content,

--- a/connectors/google/src/drive/api.ts
+++ b/connectors/google/src/drive/api.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
 import type { GoogleClient } from '../client.js';
 
 const DRIVE_API = 'https://www.googleapis.com/drive/v3';
@@ -170,6 +173,51 @@ export async function createFile(
       method: 'POST',
       headers: { 'Content-Type': `multipart/related; boundary=${boundary}` },
       body,
+    },
+  );
+
+  return {
+    id: raw.id,
+    name: raw.name,
+    mimeType: raw.mimeType,
+    webViewLink: raw.webViewLink,
+  };
+}
+
+export async function uploadFile(
+  client: GoogleClient,
+  filePath: string,
+  options?: { name?: string; mimeType?: string; parentId?: string },
+): Promise<DriveWriteResult> {
+  const content = await fs.readFile(filePath);
+  const name = options?.name ?? path.basename(filePath);
+  const mimeType = options?.mimeType ?? 'application/octet-stream';
+  const metadata: Record<string, unknown> = { name };
+  if (options?.parentId) metadata['parents'] = [options.parentId];
+
+  const boundary = 'drive_upload_boundary';
+  const body = Buffer.concat([
+    Buffer.from(
+      [
+        `--${boundary}`,
+        'Content-Type: application/json; charset=UTF-8',
+        '',
+        JSON.stringify(metadata),
+        `--${boundary}`,
+        `Content-Type: ${mimeType}`,
+        '',
+      ].join('\r\n'),
+    ),
+    content,
+    Buffer.from(`\r\n--${boundary}--`),
+  ]);
+
+  const raw = await client.request<DriveFileRaw>(
+    'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,mimeType,webViewLink',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': `multipart/related; boundary=${boundary}` },
+      body: body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength),
     },
   );
 

--- a/connectors/google/src/drive/tools.ts
+++ b/connectors/google/src/drive/tools.ts
@@ -49,6 +49,26 @@ const driveWriteSchema = z.object({
     .describe('Optional parent folder ID to place the file in. Defaults to Drive root.'),
 });
 
+const driveUploadSchema = z.object({
+  account: z
+    .string()
+    .optional()
+    .describe('Optional account email or label when multiple Google accounts are connected'),
+  filePath: z.string().describe('Local file path to upload to Google Drive'),
+  name: z
+    .string()
+    .optional()
+    .describe('Optional Google Drive file name. Defaults to the local file basename.'),
+  mimeType: z
+    .string()
+    .optional()
+    .describe('Optional MIME type of the uploaded file. Defaults to application/octet-stream.'),
+  parentId: z
+    .string()
+    .optional()
+    .describe('Optional parent folder ID to place the file in. Defaults to Drive root.'),
+});
+
 export function createDriveTools(
   resolveClient: (
     account?: string,
@@ -106,6 +126,20 @@ export function createDriveTools(
           input.mimeType,
           input.parentId,
         );
+        return { ...result, usedAccount };
+      },
+    });
+    tools['drive_upload'] = tool({
+      description:
+        'Upload a local file path to Google Drive. Optionally override the Drive filename, MIME type, and parent folder.',
+      inputSchema: driveUploadSchema,
+      execute: async (input: z.infer<typeof driveUploadSchema>) => {
+        const { client, usedAccount } = await resolveClient(input.account);
+        const result = await DriveApi.uploadFile(client, input.filePath, {
+          name: input.name,
+          mimeType: input.mimeType,
+          parentId: input.parentId,
+        });
         return { ...result, usedAccount };
       },
     });

--- a/connectors/google/src/rate-limit.test.ts
+++ b/connectors/google/src/rate-limit.test.ts
@@ -76,11 +76,42 @@ describe('resolveGoogleQuotaOperation', () => {
     ).toEqual({ service: 'gmail', quotaCost: 5 });
   });
 
-  test('maps non-Gmail services to request-count quota units', () => {
+  test('maps Drive endpoints to method-specific quota units', () => {
     expect(
       resolveGoogleQuotaOperation('https://www.googleapis.com/drive/v3/files?q=test', 'GET'),
-    ).toEqual({ service: 'drive', quotaCost: 1 });
+    ).toEqual({ service: 'drive', quotaCost: 100 });
 
+    expect(
+      resolveGoogleQuotaOperation('https://www.googleapis.com/drive/v3/files/file-1', 'GET'),
+    ).toEqual({ service: 'drive', quotaCost: 5 });
+
+    expect(
+      resolveGoogleQuotaOperation(
+        'https://www.googleapis.com/drive/v3/files/file-1?alt=media',
+        'GET',
+      ),
+    ).toEqual({ service: 'drive', quotaCost: 200 });
+
+    expect(
+      resolveGoogleQuotaOperation(
+        'https://www.googleapis.com/drive/v3/files/file-1/export?mimeType=text/plain',
+        'GET',
+      ),
+    ).toEqual({ service: 'drive', quotaCost: 200 });
+
+    expect(
+      resolveGoogleQuotaOperation('https://www.googleapis.com/drive/v3/files/file-1', 'PATCH'),
+    ).toEqual({ service: 'drive', quotaCost: 50 });
+
+    expect(
+      resolveGoogleQuotaOperation(
+        'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart',
+        'POST',
+      ),
+    ).toEqual({ service: 'drive', quotaCost: 5 });
+  });
+
+  test('maps non-Gmail and non-Drive services to request-count quota units', () => {
     expect(
       resolveGoogleQuotaOperation('https://docs.googleapis.com/v1/documents/abc', 'GET'),
     ).toEqual({ service: 'docsRead', quotaCost: 1 });
@@ -112,8 +143,8 @@ describe('GoogleRateLimitCoordinator', () => {
         services: {
           ...DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services,
           drive: {
-            project: { capacity: 100, windowMs: 5 },
-            account: { capacity: 1, windowMs: 5 },
+            project: { capacity: 200, windowMs: 5 },
+            account: { capacity: 100, windowMs: 5 },
           },
         },
       },

--- a/connectors/google/src/rate-limit.ts
+++ b/connectors/google/src/rate-limit.ts
@@ -28,8 +28,8 @@ export const DEFAULT_GOOGLE_RATE_LIMIT_CONFIG: GoogleRateLimitConfig = {
       account: { capacity: 15_000, windowMs: 60_000 },
     },
     drive: {
-      project: { capacity: 12_000, windowMs: 60_000 },
-      account: { capacity: 12_000, windowMs: 60_000 },
+      project: { capacity: 1_000_000, windowMs: 60_000 },
+      account: { capacity: 325_000, windowMs: 60_000 },
     },
     docsRead: {
       project: { capacity: 3000, windowMs: 60_000 },
@@ -65,6 +65,14 @@ const GMAIL_METHOD_COSTS = {
   FILTERS_LIST: 1,
   FILTERS_GET: 1,
   FILTERS_MUTATE: 5,
+  DEFAULT: 5,
+} as const;
+
+const DRIVE_METHOD_COSTS = {
+  FILES_GET: 5,
+  FILES_LIST: 100,
+  FILES_DOWNLOAD: 200,
+  FILES_UPDATE: 50,
   DEFAULT: 5,
 } as const;
 
@@ -130,6 +138,36 @@ function resolveGmailQuotaCost(pathname: string, method: string): number {
   return GMAIL_METHOD_COSTS.DEFAULT;
 }
 
+function resolveDriveQuotaCost(
+  pathname: string,
+  method: string,
+  searchParams: URLSearchParams,
+): number {
+  if (pathname.endsWith('/files') && method === 'GET') {
+    return DRIVE_METHOD_COSTS.FILES_LIST;
+  }
+
+  if (/\/files\/[^/]+\/download$/.test(pathname) && method === 'GET') {
+    return DRIVE_METHOD_COSTS.FILES_DOWNLOAD;
+  }
+
+  if (/\/files\/[^/]+\/export$/.test(pathname) && method === 'GET') {
+    return DRIVE_METHOD_COSTS.FILES_DOWNLOAD;
+  }
+
+  if (/\/files\/[^/]+$/.test(pathname) && method === 'GET') {
+    return searchParams.get('alt') === 'media'
+      ? DRIVE_METHOD_COSTS.FILES_DOWNLOAD
+      : DRIVE_METHOD_COSTS.FILES_GET;
+  }
+
+  if (/\/files\/[^/]+$/.test(pathname) && (method === 'PATCH' || method === 'PUT')) {
+    return DRIVE_METHOD_COSTS.FILES_UPDATE;
+  }
+
+  return DRIVE_METHOD_COSTS.DEFAULT;
+}
+
 export function resolveGoogleQuotaOperation(
   url: string,
   method: string | undefined,
@@ -156,8 +194,11 @@ export function resolveGoogleQuotaOperation(
   }
 
   if (parsed.hostname === 'www.googleapis.com') {
-    if (parsed.pathname.startsWith('/drive/')) {
-      return { service: 'drive', quotaCost: 1 };
+    if (parsed.pathname.startsWith('/drive/') || parsed.pathname.startsWith('/upload/drive/')) {
+      return {
+        service: 'drive',
+        quotaCost: resolveDriveQuotaCost(parsed.pathname, normalizedMethod, parsed.searchParams),
+      };
     }
     if (parsed.pathname.startsWith('/calendar/')) {
       return { service: 'calendar', quotaCost: 1 };

--- a/connectors/google/src/toolsets.test.ts
+++ b/connectors/google/src/toolsets.test.ts
@@ -141,4 +141,31 @@ describe('buildGoogleToolsets', () => {
       ]),
     );
   });
+
+  test('only exposes drive write tools when drive write access exists', () => {
+    const readOnly = buildGoogleToolsets({
+      scopes: ['https://www.googleapis.com/auth/drive.readonly'],
+      capabilities: ['google.drive.read', 'google.drive.write'],
+    }).find((toolset) => toolset.id === 'google-drive');
+
+    const writable = buildGoogleToolsets({
+      scopes: ['https://www.googleapis.com/auth/drive.file'],
+      capabilities: ['google.drive.read', 'google.drive.write'],
+    }).find((toolset) => toolset.id === 'google-drive');
+
+    expect(toolNames(readOnly)).toEqual(
+      expect.arrayContaining(['drive_search', 'drive_read', 'drive_info']),
+    );
+    expect(toolNames(readOnly)).not.toContain('drive_write');
+    expect(toolNames(readOnly)).not.toContain('drive_upload');
+    expect(toolNames(writable)).toEqual(
+      expect.arrayContaining([
+        'drive_search',
+        'drive_read',
+        'drive_info',
+        'drive_write',
+        'drive_upload',
+      ]),
+    );
+  });
 });

--- a/connectors/google/src/toolsets.ts
+++ b/connectors/google/src/toolsets.ts
@@ -175,7 +175,7 @@ function createDriveToolset(scopes: string[], capabilities: string[]): GoogleToo
     name: 'Google Drive',
     icon: { type: 'simpleIcons', slug: 'googledrive' },
     description: canWrite
-      ? 'Search, read, and create text files in Google Drive, including access to Docs, Sheets, PDFs, and other documents.'
+      ? 'Search, read, create text files, and upload local files in Google Drive, including access to Docs, Sheets, PDFs, and other documents.'
       : 'Search and read Google Drive files, including Docs, Sheets, PDFs, and other documents.',
     instructions: [
       EXACT_TOOL_NAME_INSTRUCTION,
@@ -184,7 +184,7 @@ function createDriveToolset(scopes: string[], capabilities: string[]): GoogleToo
       "Combine with: and, or, not. Example: \"name contains 'Q4' and mimeType='application/vnd.google-apps.spreadsheet'\"",
       'Google Docs are exported as plain text, Sheets as CSV. Binary files are downloaded directly.',
       canWrite
-        ? 'You have write access. Use drive_write to create new text or Markdown files.'
+        ? 'You have write access. Use drive_write to create new text or Markdown files, and drive_upload to upload local file paths.'
         : 'You have read-only access. Creating files is not available.',
     ].join('\n'),
     tools: () => summarizeTools(createDriveTools(SUMMARY_RESOLVER, canWrite)),


### PR DESCRIPTION
## 🚀 Change Summary

Adds Google Drive file upload support to the Google connector and updates Drive rate limiting to match the current Google Drive API quota-unit model.

### ✨ New Features
- **Drive File Uploads**: Adds `drive_upload` for uploading local file paths to Google Drive with optional filename, MIME type, and parent folder metadata.

### 🛠 Improvements & Refactors
- **Drive Quota Units**: Updates Drive local rate limiting from request counts to current quota-unit limits and per-method costs.
- **Upload Rate Limiting**: Includes `/upload/drive/...` endpoints in Drive quota accounting.

### 🐛 Bug Fixes
- **Multipart Upload Body**: Fixes Drive multipart upload formatting so Google accepts uploaded file bytes.
