### PR TITLE
feat(settings): add custom agent instructions

### DIFF
--- a/apps/web/src/components/settings/agents.tsx
+++ b/apps/web/src/components/settings/agents.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+
+import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+
+import { SETTINGS_PAGE_BY_ID } from '@/components/settings/settings-metadata';
+import { SettingPage, SettingSection } from '@/components/settings/settings-ui';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { saveSettingMutationOptions, settingsQueryOptions } from '@/lib/queries/settings';
+
+const SETTING_KEY = 'agents.customInstructions';
+
+export function AgentsSettings() {
+  const page = SETTINGS_PAGE_BY_ID.agents;
+  const Icon = page.icon;
+  const { data: settings } = useSuspenseQuery(settingsQueryOptions);
+  const queryClient = useQueryClient();
+  const saveMutation = useMutation(saveSettingMutationOptions(SETTING_KEY, queryClient));
+  const savedInstructions = settings[SETTING_KEY] ?? '';
+  const [instructions, setInstructions] = React.useState(savedInstructions);
+
+  React.useEffect(() => {
+    setInstructions(savedInstructions);
+  }, [savedInstructions]);
+
+  const saveInstructions = () => {
+    if (instructions !== savedInstructions) {
+      saveMutation.mutate(instructions);
+    }
+  };
+
+  return (
+    <SettingPage
+      title={page.title}
+      description={page.description}
+      icon={<Icon className="size-5" />}
+    >
+      <SettingSection
+        title="Custom instructions"
+        description="Write Markdown instructions that Stitch should follow in chat and agent sessions."
+        className="flex min-h-0 flex-1 flex-col"
+      >
+        <div className="flex items-center justify-end">
+          <Button
+            size="sm"
+            onClick={saveInstructions}
+            disabled={instructions === savedInstructions || saveMutation.isPending}
+          >
+            Save
+          </Button>
+        </div>
+        <Textarea
+          value={instructions}
+          onChange={(event) => setInstructions(event.target.value)}
+          onBlur={saveInstructions}
+          placeholder="Example: Prefer concise answers. Ask one focused question when requirements are unclear."
+          className="min-h-90 resize-y font-mono text-sm"
+        />
+      </SettingSection>
+    </SettingPage>
+  );
+}

--- a/apps/web/src/components/settings/settings-metadata.tsx
+++ b/apps/web/src/components/settings/settings-metadata.tsx
@@ -1,4 +1,5 @@
 import {
+  BotIcon,
   BrainIcon,
   CpuIcon,
   GlobeIcon,
@@ -89,6 +90,15 @@ export const SETTINGS_PAGES = [
     to: '/settings/agenda',
     section: 'Apps',
     icon: ListTodoIcon,
+  },
+  {
+    id: 'agents',
+    label: 'Agents',
+    title: 'Agents',
+    description: 'Customize the instructions Stitch follows in every conversation.',
+    to: '/settings/agents',
+    section: 'AI',
+    icon: BotIcon,
   },
   {
     id: 'providers',

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as SettingsGeneralRouteImport } from './routes/settings/general'
 import { Route as SettingsConnectionRouteImport } from './routes/settings/connection'
 import { Route as SettingsBrowserRouteImport } from './routes/settings/browser'
 import { Route as SettingsAppearanceRouteImport } from './routes/settings/appearance'
+import { Route as SettingsAgentsRouteImport } from './routes/settings/agents'
 import { Route as SettingsAgendaRouteImport } from './routes/settings/agenda'
 import { Route as SessionIdRouteImport } from './routes/session.$id'
 import { Route as RecordingsIdRouteImport } from './routes/recordings/$id'
@@ -160,6 +161,11 @@ const SettingsAppearanceRoute = SettingsAppearanceRouteImport.update({
   path: '/appearance',
   getParentRoute: () => SettingsRouteRoute,
 } as any)
+const SettingsAgentsRoute = SettingsAgentsRouteImport.update({
+  id: '/agents',
+  path: '/agents',
+  getParentRoute: () => SettingsRouteRoute,
+} as any)
 const SettingsAgendaRoute = SettingsAgendaRouteImport.update({
   id: '/agenda',
   path: '/agenda',
@@ -205,6 +211,7 @@ export interface FileRoutesByFullPath {
   '/recordings/$id': typeof RecordingsIdRoute
   '/session/$id': typeof SessionIdRoute
   '/settings/agenda': typeof SettingsAgendaRoute
+  '/settings/agents': typeof SettingsAgentsRoute
   '/settings/appearance': typeof SettingsAppearanceRoute
   '/settings/browser': typeof SettingsBrowserRoute
   '/settings/connection': typeof SettingsConnectionRoute
@@ -233,6 +240,7 @@ export interface FileRoutesByTo {
   '/recordings/$id': typeof RecordingsIdRoute
   '/session/$id': typeof SessionIdRoute
   '/settings/agenda': typeof SettingsAgendaRoute
+  '/settings/agents': typeof SettingsAgentsRoute
   '/settings/appearance': typeof SettingsAppearanceRoute
   '/settings/browser': typeof SettingsBrowserRoute
   '/settings/connection': typeof SettingsConnectionRoute
@@ -266,6 +274,7 @@ export interface FileRoutesById {
   '/recordings/$id': typeof RecordingsIdRoute
   '/session/$id': typeof SessionIdRoute
   '/settings/agenda': typeof SettingsAgendaRoute
+  '/settings/agents': typeof SettingsAgentsRoute
   '/settings/appearance': typeof SettingsAppearanceRoute
   '/settings/browser': typeof SettingsBrowserRoute
   '/settings/connection': typeof SettingsConnectionRoute
@@ -300,6 +309,7 @@ export interface FileRouteTypes {
     | '/recordings/$id'
     | '/session/$id'
     | '/settings/agenda'
+    | '/settings/agents'
     | '/settings/appearance'
     | '/settings/browser'
     | '/settings/connection'
@@ -328,6 +338,7 @@ export interface FileRouteTypes {
     | '/recordings/$id'
     | '/session/$id'
     | '/settings/agenda'
+    | '/settings/agents'
     | '/settings/appearance'
     | '/settings/browser'
     | '/settings/connection'
@@ -360,6 +371,7 @@ export interface FileRouteTypes {
     | '/recordings/$id'
     | '/session/$id'
     | '/settings/agenda'
+    | '/settings/agents'
     | '/settings/appearance'
     | '/settings/browser'
     | '/settings/connection'
@@ -561,6 +573,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsAppearanceRouteImport
       parentRoute: typeof SettingsRouteRoute
     }
+    '/settings/agents': {
+      id: '/settings/agents'
+      path: '/agents'
+      fullPath: '/settings/agents'
+      preLoaderRoute: typeof SettingsAgentsRouteImport
+      parentRoute: typeof SettingsRouteRoute
+    }
     '/settings/agenda': {
       id: '/settings/agenda'
       path: '/agenda'
@@ -651,6 +670,7 @@ const RecordingsRouteRouteWithChildren = RecordingsRouteRoute._addFileChildren(
 
 interface SettingsRouteRouteChildren {
   SettingsAgendaRoute: typeof SettingsAgendaRoute
+  SettingsAgentsRoute: typeof SettingsAgentsRoute
   SettingsAppearanceRoute: typeof SettingsAppearanceRoute
   SettingsBrowserRoute: typeof SettingsBrowserRoute
   SettingsConnectionRoute: typeof SettingsConnectionRoute
@@ -668,6 +688,7 @@ interface SettingsRouteRouteChildren {
 
 const SettingsRouteRouteChildren: SettingsRouteRouteChildren = {
   SettingsAgendaRoute: SettingsAgendaRoute,
+  SettingsAgentsRoute: SettingsAgentsRoute,
   SettingsAppearanceRoute: SettingsAppearanceRoute,
   SettingsBrowserRoute: SettingsBrowserRoute,
   SettingsConnectionRoute: SettingsConnectionRoute,

--- a/apps/web/src/routes/settings/agents.tsx
+++ b/apps/web/src/routes/settings/agents.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { AgentsSettings } from '@/components/settings/agents';
+import { settingsQueryOptions } from '@/lib/queries/settings';
+
+export const Route = createFileRoute('/settings/agents')({
+  loader: ({ context }) => context.queryClient.ensureQueryData(settingsQueryOptions),
+  component: AgentsSettings,
+});

--- a/packages/server/src/llm/compaction.test.ts
+++ b/packages/server/src/llm/compaction.test.ts
@@ -351,7 +351,9 @@ describe('buildHistoryMessages', () => {
     expect(systemMessages.length).toBeGreaterThanOrEqual(2);
     // Semi-static layer contains env and custom prompt
     expect(systemMessages[1].content).toContain('<env>');
+    expect(systemMessages[1].content).toContain('<user-instructions>');
     expect(systemMessages[1].content).toContain('Custom system prompt for testing');
+    expect(systemMessages[1].content).toContain('</user-instructions>');
   });
 
   test('appends custom system prompt when base prompt is enabled', () => {
@@ -378,7 +380,34 @@ describe('buildHistoryMessages', () => {
     expect(systemMessages.length).toBeGreaterThanOrEqual(2);
     // Semi-static layer contains env and user instruction
     expect(systemMessages[1].content).toContain('<env>');
+    expect(systemMessages[1].content).toContain('<user-instructions>');
     expect(systemMessages[1].content).toContain('Extra user instruction');
+    expect(systemMessages[1].content).toContain('</user-instructions>');
+  });
+
+  test('omits user instructions block when custom system prompt is empty', () => {
+    const result = buildHistoryMessages(
+      [
+        {
+          role: 'user',
+          isSummary: false,
+          modelId: 'openai/gpt-5.3-codex',
+          parts: [textPart('hello')],
+        },
+      ],
+      {
+        useBasePrompt: true,
+        systemPrompt: '   ',
+        userName: '',
+        userTimezone: '',
+        memoryContext: null,
+        todoContext: null,
+      },
+    );
+
+    const systemMessages = result.filter((m) => m.role === 'system');
+    expect(systemMessages[1].content).toContain('<env>');
+    expect(systemMessages[1].content).not.toContain('<user-instructions>');
   });
 
   test('includes user profile name in system prompt when provided', () => {

--- a/packages/server/src/llm/prompt/builder.ts
+++ b/packages/server/src/llm/prompt/builder.ts
@@ -23,6 +23,14 @@ type SystemPromptLayers = {
   dynamic: string;
 };
 
+function buildUserInstructionsPrompt(userPrompt: string): string {
+  return `<user-instructions>
+The following are custom instructions provided by the user. Adhere to them unless they conflict with safety or core system rules.
+
+${userPrompt}
+</user-instructions>`;
+}
+
 export async function getPromptUserContext(): Promise<{
   userName: string;
   userTimezone: string;
@@ -76,7 +84,7 @@ export function buildSystemPromptLayers(input: PromptConfig): SystemPromptLayers
   const envBlock = buildPromptEnvironment({ userTimezone: input.userTimezone });
   const semiStaticParts = [envBlock];
   if (userPrompt.length > 0) {
-    semiStaticParts.push(userPrompt);
+    semiStaticParts.push(buildUserInstructionsPrompt(userPrompt));
   }
   const semiStaticContent = semiStaticParts.join('\n\n');
 

--- a/packages/server/src/llm/session-history.ts
+++ b/packages/server/src/llm/session-history.ts
@@ -9,6 +9,7 @@ import { buildHistoryMessages } from '@/llm/history-messages.js';
 import { getPromptUserContext } from '@/llm/prompt/builder.js';
 import type { PromptConfig } from '@/llm/prompt/builder.js';
 import { retrieveMemoryContext } from '@/memory/retriever.js';
+import { getSettings } from '@/settings/service.js';
 import { getSessionTodosPromptBlock } from '@/todos/service.js';
 import type { ModelMessage } from 'ai';
 
@@ -21,13 +22,14 @@ export async function buildSessionLlmMessages(
 ): Promise<ModelMessage[]> {
   const db = getDb();
 
-  const [msgs, promptUserContext, sessionRow, todoContext] = await Promise.all([
+  const [msgs, promptUserContext, promptSettings, sessionRow, todoContext] = await Promise.all([
     db
       .select()
       .from(messages)
       .where(eq(messages.sessionId, sessionId))
       .orderBy(asc(messages.createdAt)),
     getPromptUserContext(),
+    getSettings(['agents.customInstructions'] as const),
     db.select({ type: sessions.type }).from(sessions).where(eq(sessions.id, sessionId)).limit(1),
     getSessionTodosPromptBlock(sessionId),
   ]);
@@ -58,7 +60,7 @@ export async function buildSessionLlmMessages(
 
   return buildHistoryMessages(msgs.slice(startIndex), {
     useBasePrompt: promptConfig.useBasePrompt,
-    systemPrompt: promptConfig.systemPrompt,
+    systemPrompt: promptConfig.systemPrompt ?? promptSettings['agents.customInstructions'],
     userName: promptUserContext.userName,
     userTimezone: promptUserContext.userTimezone,
     memoryContext,

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -38,6 +38,7 @@ export const SETTINGS_KEYS = [
   'memory.retrieval.maxResults',
   'memory.retrieval.minScore',
   'memory.retrieval.recencyBoost',
+  'agents.customInstructions',
   'recordings.autoAnalyze',
   'recordings.inputDeviceId',
   'recordings.outputDeviceId',
@@ -94,6 +95,7 @@ export const SETTINGS_SCHEMAS = {
   'memory.retrieval.maxResults': z.coerce.number().int().min(1),
   'memory.retrieval.minScore': z.coerce.number().min(0).max(1),
   'memory.retrieval.recencyBoost': booleanSetting,
+  'agents.customInstructions': z.string().max(20_000),
   'recordings.autoAnalyze': booleanSetting,
   'recordings.inputDeviceId': z.string(),
   'recordings.outputDeviceId': z.string(),
@@ -309,6 +311,12 @@ export const SETTINGS_DEFAULTS: SettingDefault[] = [
     key: 'memory.retrieval.recencyBoost',
     value: 'true',
     description: 'Boost recently-accessed memories in ranking.',
+  },
+  {
+    key: 'agents.customInstructions',
+    value: '',
+    description:
+      'Custom Markdown instructions appended to the system prompt for every conversation.',
   },
   {
     key: 'recordings.autoAnalyze',


### PR DESCRIPTION
## 🚀 Change Summary

Adds user-configurable custom agent instructions that are appended to Stitch's existing system prompt for chat and agent sessions.

### ✨ New Features
- **Custom Agent Instructions**: Adds an Agents settings page under AI where users can write Markdown instructions that Stitch should follow.
- **Prompt Injection**: Stores instructions as a user setting and injects them into session prompt construction in a labeled `<user-instructions>` block without replacing the base system prompt.

### 🛠 Improvements & Refactors
- Adds the `agents.customInstructions` setting with schema validation and defaults.
- Extends prompt coverage tests for wrapped custom instructions and empty custom prompts.
