### PR TITLE
improvement(settings): UI polish, consistency fixes, and misc improvements

### DIFF
--- a/apps/web/src/components/navigation/internal-sidebar.tsx
+++ b/apps/web/src/components/navigation/internal-sidebar.tsx
@@ -105,8 +105,8 @@ function Group({
   );
 }
 
-function List(props: React.ComponentProps<typeof SidebarMenu>) {
-  return <SidebarMenu {...props} />;
+function List({ className, ...props }: React.ComponentProps<typeof SidebarMenu>) {
+  return <SidebarMenu className={cn('px-1', className)} {...props} />;
 }
 
 function Item({

--- a/apps/web/src/components/settings/agenda.tsx
+++ b/apps/web/src/components/settings/agenda.tsx
@@ -12,7 +12,7 @@ export function AgendaSettings() {
       description={page.description}
       icon={<Icon className="size-5" />}
     >
-      <SettingSection>
+      <SettingSection title="App">
         <SettingRows>
           <AppEnableSetting appId="agenda" label="Agenda" />
         </SettingRows>

--- a/apps/web/src/components/settings/agents.tsx
+++ b/apps/web/src/components/settings/agents.tsx
@@ -15,7 +15,11 @@ export function AgentsSettings() {
   const Icon = page.icon;
   const { data: settings } = useSuspenseQuery(settingsQueryOptions);
   const queryClient = useQueryClient();
-  const saveMutation = useMutation(saveSettingMutationOptions(SETTING_KEY, queryClient));
+  const saveMutation = useMutation(
+    saveSettingMutationOptions(SETTING_KEY, queryClient, {
+      successMessage: 'Custom instructions saved',
+    }),
+  );
   const savedInstructions = settings[SETTING_KEY] ?? '';
   const [instructions, setInstructions] = React.useState(savedInstructions);
 

--- a/apps/web/src/components/settings/appearance.tsx
+++ b/apps/web/src/components/settings/appearance.tsx
@@ -39,10 +39,10 @@ export function AppearanceSettings() {
               key={m}
               onClick={() => setMode(m)}
               className={cn(
-                'flex-1 rounded-lg border px-3 py-2.5 text-sm font-medium transition-colors',
+                'flex-1 rounded-xl border px-3 py-3 text-sm font-medium transition-all text-center',
                 mode === m
-                  ? 'border-primary bg-primary text-primary-foreground shadow-sm'
-                  : 'border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent',
+                  ? 'border-primary bg-primary/5 ring-2 ring-primary/20 text-foreground shadow-sm'
+                  : 'border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent/50',
               )}
             >
               {MODE_LABELS[m]}
@@ -60,8 +60,8 @@ export function AppearanceSettings() {
               className={cn(
                 'rounded-xl border p-3 text-left transition-all space-y-2',
                 themeName === t.name
-                  ? 'border-primary ring-2 ring-primary/30 shadow-sm'
-                  : 'border-border hover:border-foreground/30',
+                  ? 'border-primary bg-primary/5 ring-2 ring-primary/20 shadow-sm'
+                  : 'border-border bg-background hover:bg-accent/50 hover:border-foreground/20',
               )}
             >
               <ThemePreview tokens={effectiveMode === 'dark' ? t.dark : t.light} />

--- a/apps/web/src/components/settings/browser.tsx
+++ b/apps/web/src/components/settings/browser.tsx
@@ -12,7 +12,7 @@ export function BrowserSettings() {
       description={page.description}
       icon={<Icon className="size-5" />}
     >
-      <SettingSection>
+      <SettingSection title="App">
         <SettingRows>
           <AppEnableSetting appId="browser" label="Browser" />
         </SettingRows>

--- a/apps/web/src/components/settings/connection.tsx
+++ b/apps/web/src/components/settings/connection.tsx
@@ -115,7 +115,7 @@ function ConnectionContent() {
           </div>
         </SettingSection>
 
-        <SettingSection>
+        <SettingSection title="Connection details">
           <div>
             <Label htmlFor="remote-server-url" className="text-sm font-medium">
               Remote server URL

--- a/apps/web/src/components/settings/general.tsx
+++ b/apps/web/src/components/settings/general.tsx
@@ -56,7 +56,9 @@ function SttModelSelect() {
     saveSettingMutationOptions('stt.default.providerId', queryClient, { silent: true }),
   );
   const saveModelMutation = useMutation(
-    saveSettingMutationOptions('stt.default.modelId', queryClient),
+    saveSettingMutationOptions('stt.default.modelId', queryClient, {
+      successMessage: 'STT model saved',
+    }),
   );
   const deleteProviderMutation = useMutation(
     deleteSettingMutationOptions('stt.default.providerId', queryClient, { silent: true }),

--- a/apps/web/src/components/settings/general.tsx
+++ b/apps/web/src/components/settings/general.tsx
@@ -129,11 +129,6 @@ function ModelsContent() {
           </SettingRowControl>
         </SettingRow>
       ))}
-      <SettingRow label="STT Model" description="Used for live speech-to-text in the chat input">
-        <SettingRowControl>
-          <SttModelSelect />
-        </SettingRowControl>
-      </SettingRow>
     </SettingRows>
   );
 }
@@ -148,7 +143,7 @@ export function GeneralSettings() {
       description={page.description}
       icon={<Icon className="size-5" />}
     >
-      <SettingSection title="Models">
+      <SettingSection title="Preferred LLMs">
         <ModelsContent />
       </SettingSection>
       <SettingSection title="Dictation">
@@ -263,11 +258,18 @@ function DictationContent() {
   const { data: settings } = useSuspenseQuery(settingsQueryOptions);
 
   return (
-    <SwitchSettingRow
-      settingKey="stt.holdToTalk"
-      label="Hold to talk"
-      description="Record only while the dictation shortcut is held, finalizing on release. When off, the shortcut toggles recording on and off."
-      checked={settings['stt.holdToTalk'] === 'true'}
-    />
+    <SettingRows>
+      <SettingRow label="STT Model" description="Used for live speech-to-text in the chat input">
+        <SettingRowControl>
+          <SttModelSelect />
+        </SettingRowControl>
+      </SettingRow>
+      <SwitchSettingRow
+        settingKey="stt.holdToTalk"
+        label="Hold to talk"
+        description="Record only while the dictation shortcut is held, finalizing on release. When off, the shortcut toggles recording on and off."
+        checked={settings['stt.holdToTalk'] === 'true'}
+      />
+    </SettingRows>
   );
 }

--- a/apps/web/src/components/settings/mcp-servers.tsx
+++ b/apps/web/src/components/settings/mcp-servers.tsx
@@ -13,15 +13,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 type Tab = 'configured' | 'marketplace';
 
-function McpTabSwitcher() {
-  return (
-    <TabsList variant="line">
-      <TabsTrigger value="configured">Configured</TabsTrigger>
-      <TabsTrigger value="marketplace">Marketplace</TabsTrigger>
-    </TabsList>
-  );
-}
-
 function McpServersContent() {
   const page = SETTINGS_PAGE_BY_ID['mcp-servers'];
   const Icon = page.icon;
@@ -51,27 +42,35 @@ function McpServersContent() {
   }
 
   return (
-    <Tabs value={view.tab} onValueChange={(tab) => setView({ type: 'home', tab: tab as Tab })}>
-      <SettingPage
-        title={page.title}
-        description={page.description}
-        icon={<Icon className="size-5" />}
-        actions={<McpTabSwitcher />}
+    <SettingPage
+      title={page.title}
+      description={page.description}
+      icon={<Icon className="size-5" />}
+    >
+      <Tabs
+        value={view.tab}
+        onValueChange={(tab) => setView({ type: 'home', tab: tab as Tab })}
+        className="space-y-4"
       >
-        <TabsContent value="configured">
+        <TabsList variant="line">
+          <TabsTrigger value="configured">Configured</TabsTrigger>
+          <TabsTrigger value="marketplace">Marketplace</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="configured" className="mt-0">
           <McpServerList
             onAdd={() => setView({ type: 'add-custom', returnTab: 'configured' })}
             onPreview={(server) => setView({ type: 'preview', server, returnTab: 'configured' })}
           />
         </TabsContent>
-        <TabsContent value="marketplace">
+        <TabsContent value="marketplace" className="mt-0">
           <McpRegistryList
             onAddCustom={() => setView({ type: 'add-custom', returnTab: 'marketplace' })}
             onInstall={(server) => setView({ type: 'install', server, returnTab: 'marketplace' })}
           />
         </TabsContent>
-      </SettingPage>
-    </Tabs>
+      </Tabs>
+    </SettingPage>
   );
 }
 

--- a/apps/web/src/components/settings/model-select.tsx
+++ b/apps/web/src/components/settings/model-select.tsx
@@ -25,12 +25,18 @@ export function SettingsModelSelect({
 }: SettingsModelSelectProps) {
   const queryClient = useQueryClient();
 
-  const saveProviderMutation = useMutation(saveSettingMutationOptions(providerIdKey, queryClient));
+  const saveProviderMutation = useMutation(
+    saveSettingMutationOptions(providerIdKey, queryClient, {
+      successMessage: 'Model preference saved',
+    }),
+  );
   const saveModelMutation = useMutation(
     saveSettingMutationOptions(modelIdKey, queryClient, { silent: true }),
   );
   const deleteProviderMutation = useMutation(
-    deleteSettingMutationOptions(providerIdKey, queryClient),
+    deleteSettingMutationOptions(providerIdKey, queryClient, {
+      successMessage: 'Model preference reset',
+    }),
   );
   const deleteModelMutation = useMutation(
     deleteSettingMutationOptions(modelIdKey, queryClient, { silent: true }),

--- a/apps/web/src/components/settings/models.tsx
+++ b/apps/web/src/components/settings/models.tsx
@@ -6,7 +6,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { buildDefaultVisibleSet, isModelVisible } from '@stitch/shared/providers/model-visibility';
 
 import { SETTINGS_PAGE_BY_ID } from '@/components/settings/settings-metadata';
-import { SettingPage } from '@/components/settings/settings-ui';
+import { SettingPage, SettingSection, SettingRows } from '@/components/settings/settings-ui';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -31,8 +31,8 @@ type ModelRowProps = {
 
 function ModelRow({ modelName, checked, onToggle }: ModelRowProps) {
   return (
-    <div className="flex items-center justify-between gap-4 border-b border-border/50 py-3 last:border-none">
-      <span className="truncate text-sm text-foreground">{modelName}</span>
+    <div className="flex items-center justify-between gap-4 py-3">
+      <span className="truncate text-sm font-medium text-foreground">{modelName}</span>
       <Switch checked={checked} onCheckedChange={onToggle} aria-label={`Toggle ${modelName}`} />
     </div>
   );
@@ -161,11 +161,8 @@ function ModelsListContent() {
       )}
 
       {filtered.map((provider) => (
-        <div key={provider.providerId}>
-          <p className="mb-1 text-xs font-medium tracking-wider text-muted-foreground uppercase">
-            {provider.providerName}
-          </p>
-          <div>
+        <SettingSection key={provider.providerId} title={provider.providerName}>
+          <SettingRows>
             {provider.models.map((model) => (
               <ModelRow
                 key={model.id}
@@ -179,8 +176,8 @@ function ModelsListContent() {
                 onToggle={(checked) => void handleToggle(provider, model.id, checked)}
               />
             ))}
-          </div>
-        </div>
+          </SettingRows>
+        </SettingSection>
       ))}
     </div>
   );

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -53,7 +53,7 @@ import {
   useSetToolEnabledState,
 } from '@/lib/queries/tools';
 
-type ScopeFilter = 'stitch' | 'native' | 'connectors' | 'mcp';
+type ScopeFilter = 'stitch' | 'native' | 'connectors' | 'mcp' | 'settings';
 type ToolsetDefaultScope = 'current_run' | 'ttl_turns' | 'until_deactivated';
 
 const DEFAULT_TOOLSET_SCOPE = 'ttl_turns' satisfies ToolsetDefaultScope;
@@ -205,17 +205,17 @@ function ToolsContent() {
       icon={<Icon className="size-5" />}
     >
       <div className="space-y-5">
-        <ToolsetActivationSettings />
-
-        <div className="relative">
-          <SearchIcon className="absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            className="pl-8"
-            placeholder="Search by tool, toolset, or MCP server..."
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-          />
-        </div>
+        {scope !== 'settings' && (
+          <div className="relative">
+            <SearchIcon className="absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              className="pl-8"
+              placeholder="Search by tool, toolset, or MCP server..."
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </div>
+        )}
 
         <Tabs
           value={scope}
@@ -227,6 +227,7 @@ function ToolsContent() {
             <TabsTrigger value="native">Native toolsets</TabsTrigger>
             <TabsTrigger value="connectors">Connector tools</TabsTrigger>
             <TabsTrigger value="mcp">MCP servers</TabsTrigger>
+            <TabsTrigger value="settings">Settings</TabsTrigger>
           </TabsList>
 
           <TabsContent value="stitch">
@@ -360,6 +361,10 @@ function ToolsContent() {
               isMutating={isMutating}
               onEditTarget={setEditingTarget}
             />
+          </TabsContent>
+
+          <TabsContent value="settings">
+            <ToolsetActivationSettings />
           </TabsContent>
         </Tabs>
 

--- a/apps/web/src/components/settings/providers.tsx
+++ b/apps/web/src/components/settings/providers.tsx
@@ -8,7 +8,7 @@ import { PROVIDER_IDS, type ProviderId } from '@stitch/shared/providers/types';
 import { ProviderConfig } from '@/components/settings/providers/provider-config';
 import { ProviderRow } from '@/components/settings/providers/provider-row';
 import { SETTINGS_PAGE_BY_ID } from '@/components/settings/settings-metadata';
-import { SettingPage } from '@/components/settings/settings-ui';
+import { SettingPage, SettingSection } from '@/components/settings/settings-ui';
 import { providersQueryOptions, type ProviderSummary } from '@/lib/queries/providers';
 
 function ProviderList({ onSelect }: { onSelect: (provider: ProviderSummary) => void }) {
@@ -26,8 +26,7 @@ function ProviderList({ onSelect }: { onSelect: (provider: ProviderSummary) => v
   return (
     <div className="flex flex-col gap-6">
       {connected.length > 0 && (
-        <div className="flex flex-col">
-          <h3 className="mb-2 text-[13px] font-semibold">Connected providers</h3>
+        <SettingSection title="Connected providers" className="mt-0">
           <div className="flex flex-col">
             {connected.map((provider) => (
               <ProviderRow
@@ -37,12 +36,14 @@ function ProviderList({ onSelect }: { onSelect: (provider: ProviderSummary) => v
               />
             ))}
           </div>
-        </div>
+        </SettingSection>
       )}
 
       {unconnected.length > 0 && (
-        <div className="flex flex-col">
-          <h3 className="mb-2 text-[13px] font-semibold">Popular providers</h3>
+        <SettingSection
+          title="Popular providers"
+          className={connected.length > 0 ? 'mt-6' : 'mt-0'}
+        >
           <div className="flex flex-col">
             {unconnected.map((provider) => (
               <ProviderRow
@@ -52,7 +53,7 @@ function ProviderList({ onSelect }: { onSelect: (provider: ProviderSummary) => v
               />
             ))}
           </div>
-        </div>
+        </SettingSection>
       )}
     </div>
   );

--- a/apps/web/src/components/settings/providers/provider-config.tsx
+++ b/apps/web/src/components/settings/providers/provider-config.tsx
@@ -1,4 +1,3 @@
-import { ArrowLeftIcon } from 'lucide-react';
 import * as React from 'react';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -16,6 +15,7 @@ import {
   resolveDefaultAuthMethod,
   type FieldValues,
 } from '@/components/settings/providers/utils';
+import { SettingSubPage } from '@/components/settings/settings-ui';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
@@ -174,33 +174,27 @@ export function ProviderConfig({
   const activeMethodDef = enabledAuthMethods.find((m) => m.method === activeTab);
 
   return (
-    <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="mb-6 flex items-center gap-2">
-        <Button variant="ghost" size="icon-sm" onClick={onBack} aria-label="Back to providers">
-          <ArrowLeftIcon className="size-4" />
-        </Button>
-        <div className="shrink-0 text-muted-foreground">
+    <SettingSubPage
+      title={meta.displayName}
+      description={provider.capabilities.join(', ')}
+      onBack={onBack}
+      backLabel="Back to providers"
+      actions={
+        <div className="flex items-center gap-3">
           <ProviderLogo
             providerId={provider.id}
             providerName={meta.displayName}
             className="size-5"
           />
+          {provider.enabled && (
+            <span className="flex items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+              <span className="inline-block size-1.5 rounded-full bg-emerald-500" />
+              Connected
+            </span>
+          )}
         </div>
-        <div>
-          <h2 className="text-sm font-semibold">{meta.displayName}</h2>
-          <p className="text-xs text-muted-foreground capitalize">
-            {provider.capabilities.join(', ')}
-          </p>
-        </div>
-        {provider.enabled && (
-          <span className="ml-auto flex items-center gap-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
-            <span className="inline-block size-1.5 rounded-full bg-emerald-500" />
-            Connected
-          </span>
-        )}
-      </div>
-
+      }
+    >
       {provider.id === 'ollama_local' && provider.enabled ? (
         <div className="flex flex-1 flex-col gap-5">
           <OllamaModelsPanel
@@ -283,6 +277,6 @@ export function ProviderConfig({
           </div>
         </div>
       )}
-    </div>
+    </SettingSubPage>
   );
 }

--- a/apps/web/src/components/settings/recordings.tsx
+++ b/apps/web/src/components/settings/recordings.tsx
@@ -576,7 +576,7 @@ export function RecordingsSettings() {
             </SettingRows>
           </SettingSection>
           <PermissionStatus />
-          <SettingSection title="Audio Devices" className="mt-4">
+          <SettingSection title="Audio Devices">
             <AudioDeviceSettings />
           </SettingSection>
           <SettingSection title="Analysis">

--- a/apps/web/src/components/settings/shortcuts.tsx
+++ b/apps/web/src/components/settings/shortcuts.tsx
@@ -9,7 +9,12 @@ import { SETTINGS_DEFAULTS, isValidLeaderKeyHotkey } from '@stitch/shared/settin
 import { SHORTCUT_CATEGORIES, SHORTCUT_DEFAULTS } from '@stitch/shared/shortcuts/types';
 
 import { SETTINGS_PAGE_BY_ID } from '@/components/settings/settings-metadata';
-import { SettingPage } from '@/components/settings/settings-ui';
+import {
+  SettingPage,
+  SettingSection,
+  SettingRows,
+  SettingRow,
+} from '@/components/settings/settings-ui';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -298,26 +303,28 @@ function ShortcutsContent() {
         </Button>
       </div>
 
-      <div className="flex items-center justify-between rounded-xl border border-border/50 bg-card p-4 shadow-sm">
-        <div className="flex min-w-0 flex-col gap-0.5">
-          <p className="text-sm font-bold tracking-tight">Leader key</p>
-          <p className="text-sm text-muted-foreground">Used as the prefix for LEADER+ shortcuts</p>
-        </div>
-        <button
-          onClick={handleStartLeaderKeyRecording}
-          className={cn(
-            'text-sm rounded-md px-2 py-1.5 transition-colors hover:bg-accent/60 cursor-pointer',
-            recordingId === LEADER_KEY_RECORDING_ID &&
-              'text-foreground bg-accent shadow-inner ring-1 ring-ring/50',
-          )}
-        >
-          {recordingId === LEADER_KEY_RECORDING_ID ? (
-            <span className="text-xs font-medium text-muted-foreground italic">Press keys...</span>
-          ) : (
-            <HotkeyBadge hotkey={leaderKey} isSequence={false} />
-          )}
-        </button>
-      </div>
+      <SettingSection title="Leader Key">
+        <SettingRows>
+          <SettingRow label="Leader key" description="Used as the prefix for LEADER+ shortcuts">
+            <button
+              onClick={handleStartLeaderKeyRecording}
+              className={cn(
+                'text-sm rounded-md px-2 py-1.5 transition-colors hover:bg-accent/60 cursor-pointer',
+                recordingId === LEADER_KEY_RECORDING_ID &&
+                  'text-foreground bg-accent shadow-inner ring-1 ring-ring/50',
+              )}
+            >
+              {recordingId === LEADER_KEY_RECORDING_ID ? (
+                <span className="text-xs font-medium text-muted-foreground italic">
+                  Press keys...
+                </span>
+              ) : (
+                <HotkeyBadge hotkey={leaderKey} isSequence={false} />
+              )}
+            </button>
+          </SettingRow>
+        </SettingRows>
+      </SettingSection>
 
       <Tabs defaultValue={SHORTCUT_CATEGORIES[0]} className="gap-4">
         <TabsList variant="line">
@@ -331,9 +338,9 @@ function ShortcutsContent() {
         {SHORTCUT_CATEGORIES.map((category) => {
           const entries = groups.get(category) ?? [];
           return (
-            <TabsContent key={category} value={category} className="mt-0">
+            <TabsContent key={category} value={category} className="mt-4">
               {entries.length > 0 ? (
-                <div className="overflow-hidden rounded-xl border border-border/50 bg-card shadow-sm">
+                <SettingRows>
                   {entries.map((entry) => (
                     <ShortcutRow
                       key={entry.actionId}
@@ -344,7 +351,7 @@ function ShortcutsContent() {
                       onStartRecording={handleStartRecording}
                     />
                   ))}
-                </div>
+                </SettingRows>
               ) : (
                 <p className="rounded-xl border border-dashed border-border/70 bg-muted/20 px-4 py-8 text-center text-sm font-medium text-muted-foreground">
                   No {category.toLowerCase()} shortcuts match "{search}"

--- a/apps/web/src/components/settings/skills.tsx
+++ b/apps/web/src/components/settings/skills.tsx
@@ -6,7 +6,12 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import type { Skill } from '@stitch/shared/skills/types';
 
 import { SETTINGS_PAGE_BY_ID } from '@/components/settings/settings-metadata';
-import { SettingPage, SettingSubPage } from '@/components/settings/settings-ui';
+import {
+  SettingPage,
+  SettingSubPage,
+  SettingSection,
+  SettingRows,
+} from '@/components/settings/settings-ui';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
 import { Input } from '@/components/ui/input';
@@ -246,49 +251,48 @@ export function SkillsSettings() {
         </div>
       }
     >
-      <div className="overflow-hidden rounded-xl border border-border/60 bg-card/40">
-        {skills.length === 0 ? (
-          <div className="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center">
-            <p className="text-sm font-medium">No skills yet</p>
-            <p className="max-w-sm text-xs text-muted-foreground">
-              Create a skill with a trigger-focused description and Markdown instructions.
-            </p>
-          </div>
-        ) : (
-          skills.map((skill) => (
-            <div
-              key={skill.name}
-              className="flex items-center justify-between gap-4 border-b border-border/50 px-4 py-3 last:border-b-0"
-            >
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium">{skill.name}</p>
-                <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
-                  {skill.description}
-                </p>
+      {skills.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border/70 bg-muted/10 px-6 py-12 text-center">
+          <p className="text-sm font-medium">No skills yet</p>
+          <p className="max-w-sm text-xs text-muted-foreground">
+            Create a skill with a trigger-focused description and Markdown instructions.
+          </p>
+        </div>
+      ) : (
+        <SettingSection title="My Skills">
+          <SettingRows>
+            {skills.map((skill) => (
+              <div key={skill.name} className="flex items-center justify-between gap-4 py-3">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{skill.name}</p>
+                  <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                    {skill.description}
+                  </p>
+                </div>
+                <ButtonGroup>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => handleEdit(skill)}
+                    aria-label={`View ${skill.name}`}
+                  >
+                    <EyeIcon className="size-4" />
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="icon"
+                    onClick={() => handleDelete(skill)}
+                    disabled={deleteSkill.isPending}
+                    aria-label={`Delete ${skill.name}`}
+                  >
+                    <Trash2Icon className="size-4" />
+                  </Button>
+                </ButtonGroup>
               </div>
-              <ButtonGroup>
-                <Button
-                  variant="outline"
-                  size="icon"
-                  onClick={() => handleEdit(skill)}
-                  aria-label={`View ${skill.name}`}
-                >
-                  <EyeIcon className="size-4" />
-                </Button>
-                <Button
-                  variant="destructive"
-                  size="icon"
-                  onClick={() => handleDelete(skill)}
-                  disabled={deleteSkill.isPending}
-                  aria-label={`Delete ${skill.name}`}
-                >
-                  <Trash2Icon className="size-4" />
-                </Button>
-              </ButtonGroup>
-            </div>
-          ))
-        )}
-      </div>
+            ))}
+          </SettingRows>
+        </SettingSection>
+      )}
     </SettingPage>
   );
 }

--- a/apps/web/src/components/tools/tool-icons.tsx
+++ b/apps/web/src/components/tools/tool-icons.tsx
@@ -11,7 +11,6 @@ import {
   ImageIcon,
   ListTodoIcon,
   MicIcon,
-  PanelTopIcon,
   PencilIcon,
   SearchIcon,
   ServerIcon,
@@ -88,7 +87,7 @@ export function ToolKindIcon({ kind, className }: { kind: ToolIconKind; classNam
     case 'agenda':
       return <CalendarCheckIcon className={className} />;
     case 'browser':
-      return <PanelTopIcon className={className} />;
+      return <GlobeIcon className={className} />;
     case 'recordings':
       return <MicIcon className={className} />;
     case 'inspect-image':
@@ -114,7 +113,7 @@ export function NativeToolsetIcon({
   className?: string;
 }) {
   if (toolsetId === 'agenda') return <CalendarCheckIcon className={className} />;
-  if (toolsetId === 'browser') return <PanelTopIcon className={className} />;
+  if (toolsetId === 'browser') return <GlobeIcon className={className} />;
   if (toolsetId === 'recordings') return <MicIcon className={className} />;
   if (toolsetId === 'session-history') return <HistoryIcon className={className} />;
 

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -15,6 +15,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps['theme']}
       className="toaster group"
+      closeButton
       icons={{
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,

--- a/apps/web/src/lib/queries/settings.ts
+++ b/apps/web/src/lib/queries/settings.ts
@@ -19,7 +19,7 @@ export const settingsQueryOptions = queryOptions({
 export function saveSettingMutationOptions(
   key: string,
   queryClient: QueryClient,
-  options?: { silent?: boolean },
+  options?: { silent?: boolean; successMessage?: string },
 ): MutationOptions<void, Error, string> {
   return {
     mutationFn: (value: string) =>
@@ -30,7 +30,7 @@ export function saveSettingMutationOptions(
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: settingsKeys.all });
-      if (!options?.silent) toast.success('Model preference saved');
+      if (!options?.silent) toast.success(options?.successMessage ?? 'Setting Saved');
     },
     onError: (err: Error) => toast.error(err.message),
   };
@@ -39,7 +39,7 @@ export function saveSettingMutationOptions(
 export function deleteSettingMutationOptions(
   key: string,
   queryClient: QueryClient,
-  options?: { silent?: boolean },
+  options?: { silent?: boolean; successMessage?: string },
 ): MutationOptions<void, Error, void> {
   return {
     mutationFn: () =>
@@ -49,7 +49,7 @@ export function deleteSettingMutationOptions(
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: settingsKeys.all });
-      if (!options?.silent) toast.success('Model preference reset');
+      if (!options?.silent) toast.success(options?.successMessage ?? 'Setting Reset');
     },
     onError: (err: Error) => toast.error(err.message),
   };

--- a/packages/server/src/permission/default-permissions.ts
+++ b/packages/server/src/permission/default-permissions.ts
@@ -22,6 +22,7 @@ function allowDirectory(toolName: string, directory: string): DefaultPermissionR
 function getDefaultPermissionRules(): DefaultPermissionRule[] {
   return [
     allowDirectory('read', PATHS.dirPaths.skills),
+    allowDirectory('write', PATHS.dirPaths.skills),
     allowDirectory('read', PATHS.dirPaths.recordings),
     allowDirectory('write', PATHS.dirPaths.recordings),
     allowDirectory('grep', PATHS.dirPaths.recordings),


### PR DESCRIPTION
## Change Summary

A batch of UI polish, settings consistency improvements, and small functional fixes across the settings experience, tool icons, and permissions system.

### New Features
- **Permissions Settings Tab**: Added a dedicated "Settings" tab in the Permissions page that houses the toolset activation settings, keeping the main tools view cleaner
- **Dismissible Toasts**: Toasts now render with a close button for manual dismissal

### Improvements & Refactors
- **Settings UI Consistency**: Standardized use of `SettingSection`, `SettingRows`, and `SettingRow` components across Agenda, Browser, Connection, General, Models, Providers, Shortcuts, and Skills settings pages
- **MCP Servers Layout**: Moved the tab switcher inside the page body for a cleaner header
- **Shortcuts**: Leader key config now uses `SettingSection`/`SettingRow`; shortcut category lists use `SettingRows`
- **General Settings**: Moved the STT model selector into the Dictation section where it belongs; renamed "Models" section to "Preferred LLMs"
- **Provider Config**: Refactored to use `SettingSubPage` component, removing custom header markup
- **Skills**: Replaced custom card container with `SettingSection`/`SettingRows`; improved empty state style
- **Sidebar Highlight**: Added `px-1` padding to `SidebarMenu` list for correct inset highlight rendering
- **successMessage Option**: `saveSettingMutationOptions` and `deleteSettingMutationOptions` now accept a `successMessage` option so each callsite can show a contextual toast
- **GlobeIcon for Browser**: Replaced `PanelTopIcon` with `GlobeIcon` for the browser toolset icon
- **Appearance Toggles**: Tweaked mode and theme button styles for a more consistent selected state

### Bug Fixes
- **Skills Write Permission**: Added `write` default permission for the skills directory so the agent can create/edit skill files without prompting
