### PR TITLE
fix(desktop): stop resetting macOS mic permissions on upgrade for signed builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,36 @@ jobs:
           APPLE_TEAM_ID: ${{ matrix.os == 'macos' && secrets.APPLE_TEAM_ID || '' }}
         run: bun run ${{ matrix.package_script || 'package' }}
 
+      - name: Verify macOS code signing and notarization
+        if: matrix.os == 'macos'
+        working-directory: apps/desktop
+        run: |
+          set -euo pipefail
+
+          APP_PATH=$(find dist -maxdepth 2 -name '*.app' -type d | head -n1)
+          if [ -z "$APP_PATH" ]; then
+            echo "::error::No .app bundle found under dist/ — packaging may have failed."
+            exit 1
+          fi
+          echo "Verifying $APP_PATH"
+
+          # Reject ad-hoc signing: the designated requirement must anchor to Apple
+          # and a Developer ID, otherwise TCC grants break on every upgrade.
+          if ! codesign --verify --deep --strict --test-requirement="anchor apple generic and certificate leaf[subject.OU] exists" "$APP_PATH"; then
+            echo "::error::App is not Developer ID signed (ad-hoc or unsigned). Check CSC_LINK/CSC_KEY_PASSWORD."
+            codesign -d -r- "$APP_PATH" 2>&1 || true
+            exit 1
+          fi
+
+          # Reject un-notarized builds: Gatekeeper must accept the bundle as notarized.
+          if ! spctl -a -vvv --type exec "$APP_PATH" 2>&1 | tee /tmp/spctl.out | grep -q "source=Notarized Developer ID"; then
+            echo "::error::App is not notarized. Check APPLE_API_KEY/APPLE_API_KEY_ID/APPLE_API_ISSUER."
+            cat /tmp/spctl.out
+            exit 1
+          fi
+
+          echo "Developer ID signed and notarized."
+
       - name: Upload desktop artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/apps/desktop/src/main/tcc-permissions.ts
+++ b/apps/desktop/src/main/tcc-permissions.ts
@@ -1,9 +1,30 @@
 import { app } from 'electron';
+import { execFileSync } from 'node:child_process';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
+const BUNDLE_ID = 'com.stitch.desktop';
+
+// Developer-ID-signed builds key TCC grants on the stable team identity, so they
+// survive upgrades. Ad-hoc builds key on the cdhash, which churns every build.
+function isDeveloperIdSigned(): boolean {
+  try {
+    execFileSync(
+      'codesign',
+      ['--verify', '--test-requirement=anchor apple generic', app.getPath('exe')],
+      { timeout: 5_000, stdio: 'ignore' },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function resetTccPermissionsIfVersionChanged(): Promise<boolean> {
   if (process.platform !== 'darwin' || !app.isPackaged) return false;
+
+  // Resetting a signed build would force users to re-approve on every update.
+  if (isDeveloperIdSigned()) return false;
 
   const versionFile = join(app.getPath('userData'), '.last-tcc-version');
   const currentVersion = app.getVersion();
@@ -15,12 +36,9 @@ export async function resetTccPermissionsIfVersionChanged(): Promise<boolean> {
     // File doesn't exist — first run or upgrade from before this logic
   }
 
-  const { execSync } = await import('node:child_process');
-  const bundleId = 'com.stitch.desktop';
-
   for (const service of ['Microphone', 'ScreenCapture', 'AudioCapture']) {
     try {
-      execSync(`tccutil reset ${service} ${bundleId}`, { timeout: 5_000 });
+      execFileSync('tccutil', ['reset', service, BUNDLE_ID], { timeout: 5_000 });
     } catch {
       // tccutil may fail if no entry exists
     }


### PR DESCRIPTION
## 🚀 Change Summary

Stops macOS from forcing users to re-approve microphone (and screen/audio) permissions on every app upgrade. The previous logic reset TCC entries via `tccutil` on every version change — a workaround for ad-hoc dev signing — which also ran in signed production builds where it was actively harmful.

### 🐛 Bug Fixes
- **Mic permission re-approval on upgrade**: macOS TCC keys grants on the app's code-signing identity. Developer-ID-signed + notarized builds are pinned to the stable team identity, so grants already survive upgrades. The version-change `tccutil reset` was deleting those grants and forcing re-approval. The reset now only runs for ad-hoc/unsigned (dev) builds, detected via `codesign --verify --test-requirement="anchor apple generic"`.

### 🛠 Improvements & Refactors
- Switched the `tccutil`/`codesign` invocations from `execSync` with string interpolation to `execFileSync` with an argument array.
- Added a release CI step that verifies the packaged macOS `.app` is Developer-ID signed (rejects ad-hoc/unsigned, recursively via `--deep --strict`) and notarized (`spctl` must report `source=Notarized Developer ID`), failing the build otherwise.
