### PR TITLE
fix(desktop): harden server startup against port races and stale processes

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -61,8 +61,7 @@ const serverState = {
 };
 
 async function startLocalServer(): Promise<string> {
-  const port = await findAvailablePort();
-  return spawnServer(port, { STITCH_BROWSER_BRIDGE_PORT: String(browserBridgePort) });
+  return spawnServer({ STITCH_BROWSER_BRIDGE_PORT: String(browserBridgePort) });
 }
 
 async function resolveServerUrl(): Promise<string> {

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -8,6 +8,10 @@ const HEALTH_POLL_INTERVAL_MS = 100;
 const HEALTH_TIMEOUT_MS = 30_000;
 const KILL_TIMEOUT_MS = 5_000;
 const HOSTNAME = '127.0.0.1';
+const MAX_LOG_BUFFER = 8_000;
+const STALE_KILL_TIMEOUT_MS = 5_000;
+const STALE_POLL_INTERVAL_MS = 100;
+const SPAWN_MAX_ATTEMPTS = 3;
 
 let serverProcess: ChildProcess | null = null;
 
@@ -115,11 +119,29 @@ function killStaleServers(): void {
   }
 }
 
-export async function spawnServer(port: number, extraEnv: NodeJS.ProcessEnv = {}): Promise<string> {
-  if (app.isPackaged) {
-    killStaleServers();
+async function waitForStaleServersGone(): Promise<void> {
+  const deadline = Date.now() + STALE_KILL_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    if (findStalePids().length === 0) return;
+    await new Promise((resolve) => setTimeout(resolve, STALE_POLL_INTERVAL_MS));
   }
 
+  const survivors = findStalePids();
+  for (const pid of survivors) {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // already dead or not owned
+    }
+  }
+}
+
+function isPortInUseError(output: string): boolean {
+  return /EADDRINUSE|address already in use/i.test(output);
+}
+
+async function spawnServerOnce(port: number, extraEnv: NodeJS.ProcessEnv): Promise<string> {
   const { cmd, args, cwd } = getSidecarCommand(port);
   const url = `http://${HOSTNAME}:${port}`;
 
@@ -150,17 +172,34 @@ export async function spawnServer(port: number, extraEnv: NodeJS.ProcessEnv = {}
     ...(cwd && { cwd }),
   });
 
+  let logTail = '';
+  const appendLog = (chunk: string) => {
+    logTail = (logTail + chunk).slice(-MAX_LOG_BUFFER);
+  };
+
   serverProcess.stdout?.on('data', (data: Buffer) => {
-    console.log(`[sidecar:stdout] ${data.toString().trim()}`);
+    const text = data.toString();
+    appendLog(text);
+    console.log(`[sidecar:stdout] ${text.trim()}`);
   });
 
   serverProcess.stderr?.on('data', (data: Buffer) => {
-    console.error(`[sidecar:stderr] ${data.toString().trim()}`);
+    const text = data.toString();
+    appendLog(text);
+    console.error(`[sidecar:stderr] ${text.trim()}`);
   });
 
   const exitPromise = new Promise<never>((_resolve, reject) => {
     serverProcess!.on('exit', (code, signal) => {
-      reject(new Error(`Server exited before becoming healthy (code=${code}, signal=${signal})`));
+      const tail = logTail.trim();
+      const details = tail ? `\n\nServer output:\n${tail}` : ' (no output captured)';
+      const error = new Error(
+        `Server exited before becoming healthy (code=${code}, signal=${signal})${details}`,
+      );
+      if (isPortInUseError(tail)) {
+        (error as Error & { portInUse?: boolean }).portInUse = true;
+      }
+      reject(error);
     });
     serverProcess!.on('error', (err) => {
       reject(new Error(`Failed to spawn server: ${err.message}`));
@@ -170,6 +209,34 @@ export async function spawnServer(port: number, extraEnv: NodeJS.ProcessEnv = {}
   await Promise.race([waitForHealthy(url), exitPromise]);
 
   return url;
+}
+
+export async function spawnServer(extraEnv: NodeJS.ProcessEnv = {}): Promise<string> {
+  if (app.isPackaged) {
+    killStaleServers();
+    await waitForStaleServersGone();
+  }
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= SPAWN_MAX_ATTEMPTS; attempt++) {
+    const port = await findAvailablePort();
+    try {
+      return await spawnServerOnce(port, extraEnv);
+    } catch (error) {
+      lastError = error;
+      const portInUse = (error as Error & { portInUse?: boolean }).portInUse === true;
+      if (!portInUse || attempt === SPAWN_MAX_ATTEMPTS) {
+        throw error;
+      }
+      console.warn(
+        `[sidecar] port ${port} was in use, retrying with a new port (attempt ${attempt}/${SPAWN_MAX_ATTEMPTS})`,
+      );
+      await killServer();
+    }
+  }
+
+  throw lastError;
 }
 
 export async function killServer(): Promise<void> {


### PR DESCRIPTION
## Change Summary

The packaged desktop app intermittently failed to launch with `Server exited before becoming healthy (code=1, signal=null)`, surfaced through an opaque `ChildProcess` stack trace that gave no indication of the real cause. This PR makes server startup observable and resilient to the two most likely intermittent failure modes.

### Bug Fixes

- **Surface the real startup failure**: the sidecar now buffers the server's stdout/stderr and appends the tail to the startup error, so the "Stitch failed to start" dialog shows why the server actually exited instead of a generic Node `ChildProcess` trace.
- **Port race on launch**: spawning now selects the port internally and retries with a fresh port when the server exits due to `EADDRINUSE`, closing the window between `findAvailablePort()` and the server binding the socket.
- **Stale process collisions**: before spawning, the app now waits for any stale `stitch-server` processes to actually exit (`SIGTERM`, then `SIGKILL` for survivors) rather than firing `SIGTERM` and immediately racing the new instance.

### Notes

- `spawnServer(port, extraEnv)` became `spawnServer(extraEnv)` since it now owns port selection; the sole caller (`startLocalServer`) was updated. `findAvailablePort` remains exported (still used for the browser bridge port).
- These address the most probable causes of the intermittent `code=1`; the added logging will confirm the root cause if it recurs.
