### PR TITLE
fix(google): handle connector reauthorization scopes

### DIFF
--- a/apps/web/src/components/connectors/connector-instance-list.tsx
+++ b/apps/web/src/components/connectors/connector-instance-list.tsx
@@ -183,6 +183,7 @@ export function ConnectorInstanceList({ instances, definitions }: Props) {
         const def = getDefinition(instance.connectorId);
         const statusConfig = getStatusPresentation(instance);
         const isTesting = testingId === instance.id;
+        const canReauthorize = def?.authType === 'oauth2';
 
         return (
           <div
@@ -244,17 +245,31 @@ export function ConnectorInstanceList({ instances, definitions }: Props) {
                   Upgrade
                 </Button>
               )}
-              {(instance.status === 'awaiting_auth' || instance.status === 'error') && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleReauthorize(instance.id)}
-                  disabled={authorizeMutation.isPending}
-                >
-                  <ExternalLinkIcon className="size-3.5" />
-                  {statusConfig.actionLabel}
-                </Button>
-              )}
+              {canReauthorize &&
+                (instance.status === 'awaiting_auth' || instance.status === 'error') && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleReauthorize(instance.id)}
+                    disabled={authorizeMutation.isPending}
+                  >
+                    <ExternalLinkIcon className="size-3.5" />
+                    {statusConfig.actionLabel}
+                  </Button>
+                )}
+              {canReauthorize &&
+                instance.status === 'connected' &&
+                !instance.upgrade?.available && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleReauthorize(instance.id)}
+                    disabled={authorizeMutation.isPending}
+                  >
+                    <ExternalLinkIcon className="size-3.5" />
+                    Reauthorize
+                  </Button>
+                )}
               <Button
                 variant="ghost"
                 size="icon-sm"

--- a/connectors/google/src/client.test.ts
+++ b/connectors/google/src/client.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
 
-import { GoogleClient } from './client.js';
+import { GoogleApiError, GoogleClient } from './client.js';
 import { resetGoogleRateLimitCoordinatorForTests } from './rate-limit.js';
+import { classifyGoogleToolError } from './tool-error.js';
+import { buildGoogleToolsets } from './toolsets.js';
 
 const originalFetch = globalThis.fetch;
 
@@ -101,5 +103,95 @@ describe('GoogleClient', () => {
         headers: expect.objectContaining({ Authorization: 'Bearer fresh-token' }),
       }),
     );
+  });
+
+  test('preserves Google error signals for tool error classification', async () => {
+    const fetchMock = mock<typeof fetch>().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 403,
+            message: 'Request had insufficient authentication scopes.',
+            status: 'PERMISSION_DENIED',
+            details: [{ reason: 'ACCESS_TOKEN_SCOPE_INSUFFICIENT' }],
+          },
+        }),
+        {
+          status: 403,
+          statusText: 'Forbidden',
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ),
+    );
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const client = new GoogleClient({
+      getAccessToken: async () => 'token',
+      quotaAccountKey: 'scope-test-account',
+    });
+
+    try {
+      await client.request('https://www.googleapis.com/drive/v3/files');
+      throw new Error('Expected request to fail');
+    } catch (error) {
+      expect(error).toBeInstanceOf(GoogleApiError);
+      expect((error as GoogleApiError).reasons).toContain('ACCESS_TOKEN_SCOPE_INSUFFICIENT');
+      expect(classifyGoogleToolError(error)).toEqual({
+        error: 'insufficient_google_permissions',
+        message:
+          "You aren't allowed to perform this action because the connected Google account does not have enough permissions.",
+        retryable: false,
+      });
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns insufficient scope as a tool result instead of throwing', async () => {
+    const fetchMock = mock<typeof fetch>().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: {
+            code: 403,
+            message: 'Insufficient Permission',
+            status: 'PERMISSION_DENIED',
+            errors: [{ reason: 'insufficientPermissions' }],
+          },
+        }),
+        {
+          status: 403,
+          statusText: 'Forbidden',
+          headers: {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': 'Bearer error="insufficient_scope"',
+          },
+        },
+      ),
+    );
+
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const client = new GoogleClient({
+      getAccessToken: async () => 'token',
+      quotaAccountKey: 'tool-scope-test-account',
+    });
+    const driveToolset = buildGoogleToolsets({
+      scopes: ['https://www.googleapis.com/auth/drive.readonly'],
+      capabilities: ['google.drive.read'],
+    }).find((toolset) => toolset.id === 'google-drive');
+    const tools = driveToolset?.activate(async () => ({ client, usedAccount: 'me@example.com' }));
+
+    const result = await tools?.drive_info.execute?.(
+      { fileId: 'file-1' },
+      { toolCallId: 'call-1', messages: [] },
+    );
+
+    expect(result).toEqual({
+      error: 'insufficient_google_permissions',
+      message:
+        "You aren't allowed to perform this action because the connected Google account does not have enough permissions.",
+      retryable: false,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/connectors/google/src/client.ts
+++ b/connectors/google/src/client.ts
@@ -24,22 +24,32 @@ type GoogleClientConfig = {
   rateLimits?: Partial<GoogleRateLimitConfig>;
 };
 
-class GoogleApiError extends Error {
+export class GoogleApiError extends Error {
   readonly status: number;
   readonly code: string | undefined;
   readonly reason: string | undefined;
+  readonly reasons: string[];
+  readonly authChallenge: string | undefined;
   readonly retryAfterMs: number | undefined;
 
   constructor(
     status: number,
     message: string,
-    options?: { code?: string; reason?: string; retryAfterMs?: number },
+    options?: {
+      code?: string;
+      reason?: string;
+      reasons?: string[];
+      authChallenge?: string;
+      retryAfterMs?: number;
+    },
   ) {
     super(message);
     this.name = 'GoogleApiError';
     this.status = status;
     this.code = options?.code;
     this.reason = options?.reason;
+    this.reasons = options?.reasons ?? [];
+    this.authChallenge = options?.authChallenge;
     this.retryAfterMs = options?.retryAfterMs;
   }
 }
@@ -50,6 +60,7 @@ type GoogleErrorResponse = {
     code?: number;
     status?: string;
     errors?: Array<{ reason?: string; message?: string }>;
+    details?: Array<{ reason?: string; domain?: string; metadata?: Record<string, string> }>;
   };
 };
 
@@ -138,6 +149,8 @@ export class GoogleClient {
       const apiError = new GoogleApiError(response.status, parsedError.message, {
         code: parsedError.code,
         reason: parsedError.reason,
+        reasons: parsedError.reasons,
+        authChallenge: parsedError.authChallenge,
         retryAfterMs: parsedError.retryAfterMs,
       });
 
@@ -208,6 +221,8 @@ type ParsedApiError = {
   message: string;
   code: string | undefined;
   reason: string | undefined;
+  reasons: string[];
+  authChallenge: string | undefined;
   retryAfterMs: number | undefined;
 };
 
@@ -237,6 +252,7 @@ function mergeRateLimitConfig(
 async function parseGoogleApiError(response: Response): Promise<ParsedApiError> {
   const fallbackMessage = `Google API error: ${response.status} ${response.statusText}`;
   const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
+  const authChallenge = response.headers.get('www-authenticate') ?? undefined;
 
   let bodyText = '';
   try {
@@ -246,6 +262,8 @@ async function parseGoogleApiError(response: Response): Promise<ParsedApiError> 
       message: fallbackMessage,
       code: undefined,
       reason: undefined,
+      reasons: [],
+      authChallenge,
       retryAfterMs,
     };
   }
@@ -255,6 +273,8 @@ async function parseGoogleApiError(response: Response): Promise<ParsedApiError> 
       message: fallbackMessage,
       code: undefined,
       reason: undefined,
+      reasons: [],
+      authChallenge,
       retryAfterMs,
     };
   }
@@ -263,11 +283,17 @@ async function parseGoogleApiError(response: Response): Promise<ParsedApiError> 
     const parsed = JSON.parse(bodyText) as GoogleErrorResponse;
     const message = parsed.error?.message ?? fallbackMessage;
     const code = parsed.error?.status;
-    const reason = parsed.error?.errors?.[0]?.reason;
+    const reasons = [
+      ...(parsed.error?.errors?.flatMap((item) => (item.reason ? [item.reason] : [])) ?? []),
+      ...(parsed.error?.details?.flatMap((item) => (item.reason ? [item.reason] : [])) ?? []),
+    ];
+    const reason = reasons[0];
     return {
       message,
       code,
       reason,
+      reasons,
+      authChallenge,
       retryAfterMs,
     };
   } catch {
@@ -275,6 +301,8 @@ async function parseGoogleApiError(response: Response): Promise<ParsedApiError> 
       message: fallbackMessage,
       code: undefined,
       reason: undefined,
+      reasons: [],
+      authChallenge,
       retryAfterMs,
     };
   }

--- a/connectors/google/src/connector.ts
+++ b/connectors/google/src/connector.ts
@@ -33,7 +33,7 @@ const SERVICE_ACCESS_OPTIONS = [
     label: 'Gmail',
     description: 'Search, read, and draft emails',
     readScopes: [GOOGLE_SCOPE_GMAIL_READONLY],
-    writeScopes: [GOOGLE_SCOPE_GMAIL_MODIFY],
+    writeScopes: [GOOGLE_SCOPE_GMAIL_MODIFY, GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC],
   },
   {
     id: 'drive',
@@ -64,6 +64,7 @@ const GOOGLE_SCOPES = {
   [GOOGLE_SCOPE_GMAIL_READONLY]: 'Read your Gmail messages',
   [GOOGLE_SCOPE_GMAIL_SEND]: 'Send emails on your behalf',
   [GOOGLE_SCOPE_GMAIL_MODIFY]: 'Read, send, and manage your Gmail',
+  [GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC]: 'Create and manage Gmail filters and settings',
   [GOOGLE_SCOPE_DRIVE_READONLY]: 'View files in your Google Drive',
   [GOOGLE_SCOPE_DRIVE_FILE]: 'Create and edit files in Google Drive',
   [GOOGLE_SCOPE_DRIVE]: 'Full access to Google Drive',
@@ -78,6 +79,7 @@ const GOOGLE_SCOPE_API_MAP: Record<string, string> = {
   [GOOGLE_SCOPE_GMAIL_READONLY]: 'gmail.googleapis.com',
   [GOOGLE_SCOPE_GMAIL_SEND]: 'gmail.googleapis.com',
   [GOOGLE_SCOPE_GMAIL_MODIFY]: 'gmail.googleapis.com',
+  [GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC]: 'gmail.googleapis.com',
   [GOOGLE_SCOPE_DRIVE_READONLY]: 'drive.googleapis.com',
   [GOOGLE_SCOPE_DRIVE_FILE]: 'drive.googleapis.com',
   [GOOGLE_SCOPE_DRIVE]: 'drive.googleapis.com',
@@ -95,7 +97,7 @@ export const googleConnectorModule: ConnectorModule = {
     description: 'Connect Gmail, Drive, and Calendar in one place.',
     icon: { type: 'simpleIcons', slug: 'google' },
     enabled: true,
-    currentVersion: 3,
+    currentVersion: 4,
     versionHistory: [
       {
         version: 1,
@@ -124,6 +126,14 @@ export const googleConnectorModule: ConnectorModule = {
         version: 3,
         title: 'Gmail filter management',
         description: 'Adds tools to create, view, and delete Gmail inbox filters.',
+        action: 'reauthorize',
+        capabilities: [],
+        requiredScopes: [GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC],
+      },
+      {
+        version: 4,
+        title: 'Gmail filter permissions update',
+        description: 'Requests the required Gmail settings scope for managing filters.',
         action: 'reauthorize',
         capabilities: [],
         requiredScopes: [GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC],

--- a/connectors/google/src/connector.ts
+++ b/connectors/google/src/connector.ts
@@ -158,6 +158,12 @@ export const googleConnectorModule: ConnectorModule = {
         access_type: 'offline',
         prompt: 'consent',
       },
+      incrementalAuth: {
+        enabled: true,
+        params: {
+          include_granted_scopes: 'true',
+        },
+      },
     },
     setupInstructions: [
       {

--- a/connectors/google/src/scopes.ts
+++ b/connectors/google/src/scopes.ts
@@ -29,7 +29,6 @@ const GMAIL_SCOPES = [
   GOOGLE_SCOPE_GMAIL_READONLY,
   GOOGLE_SCOPE_GMAIL_SEND,
   GOOGLE_SCOPE_GMAIL_MODIFY,
-  GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC,
 ] as const;
 
 const DRIVE_SCOPES = [
@@ -104,7 +103,5 @@ export function hasGmailModifyAccess(grantedScopes: string[]): boolean {
 
 /** Check if granted scopes can manage Gmail settings (filters, etc.). */
 export function hasGmailSettingsAccess(grantedScopes: string[]): boolean {
-  return grantedScopes.some(
-    (s) => s === GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC || s === GOOGLE_SCOPE_GMAIL_MODIFY,
-  );
+  return grantedScopes.some((s) => s === GOOGLE_SCOPE_GMAIL_SETTINGS_BASIC);
 }

--- a/connectors/google/src/tool-error.ts
+++ b/connectors/google/src/tool-error.ts
@@ -1,0 +1,94 @@
+import type { Tool, ToolExecuteFunction } from 'ai';
+
+import { GoogleApiError } from './client.js';
+
+type GoogleToolErrorResult = {
+  error: string;
+  message: string;
+  retryable: boolean;
+};
+
+type GoogleToolErrorClassifier = {
+  error: string;
+  message: string;
+  retryable: boolean;
+  matches: (error: GoogleApiError) => boolean;
+};
+
+const GOOGLE_TOOL_ERROR_CLASSIFIERS: GoogleToolErrorClassifier[] = [
+  {
+    error: 'insufficient_google_permissions',
+    message:
+      "You aren't allowed to perform this action because the connected Google account does not have enough permissions.",
+    retryable: false,
+    matches: isInsufficientScopeError,
+  },
+];
+
+export function wrapGoogleToolErrors(tools: Record<string, Tool>): Record<string, Tool> {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, currentTool]) => [name, wrapGoogleToolError(currentTool)]),
+  );
+}
+
+function wrapGoogleToolError(currentTool: Tool): Tool {
+  if (!currentTool.execute) {
+    return currentTool;
+  }
+
+  const execute = currentTool.execute as ToolExecuteFunction<unknown, unknown>;
+
+  return {
+    ...currentTool,
+    execute: async (input, options) => {
+      try {
+        return await execute(input, options);
+      } catch (error) {
+        const result = classifyGoogleToolError(error);
+
+        if (!result) {
+          throw error;
+        }
+
+        return result;
+      }
+    },
+  };
+}
+
+export function classifyGoogleToolError(error: unknown): GoogleToolErrorResult | null {
+  if (!(error instanceof GoogleApiError)) {
+    return null;
+  }
+
+  const classifier = GOOGLE_TOOL_ERROR_CLASSIFIERS.find((item) => item.matches(error));
+  if (!classifier) {
+    return null;
+  }
+
+  return {
+    error: classifier.error,
+    message: classifier.message,
+    retryable: classifier.retryable,
+  };
+}
+
+function isInsufficientScopeError(error: GoogleApiError): boolean {
+  if (error.status !== 403) {
+    return false;
+  }
+
+  if (error.authChallenge?.toLowerCase().includes('insufficient_scope')) {
+    return true;
+  }
+
+  if (error.reasons.includes('ACCESS_TOKEN_SCOPE_INSUFFICIENT')) {
+    return true;
+  }
+
+  if (error.reasons.some((reason) => reason.toLowerCase() === 'insufficientpermissions')) {
+    return true;
+  }
+
+  return /insufficient authentication scopes|insufficient permission/i.test(error.message);
+}

--- a/connectors/google/src/toolsets.test.ts
+++ b/connectors/google/src/toolsets.test.ts
@@ -43,18 +43,17 @@ describe('buildGoogleToolsets', () => {
     expect(toolNames(sendOnly)).not.toContain('gmail_modify_messages');
 
     expect(toolNames(modify)).toEqual(
-      expect.arrayContaining([
-        'gmail_send',
-        'gmail_modify_labels',
-        'gmail_modify_messages',
-        'gmail_filters',
-      ]),
+      expect.arrayContaining(['gmail_send', 'gmail_modify_labels', 'gmail_modify_messages']),
     );
+    expect(toolNames(modify)).not.toContain('gmail_filters');
   });
 
   test('exposes gmail_filters with gmail.settings.basic scope but not modify tools', () => {
     const settingsOnly = buildGoogleToolsets({
-      scopes: ['https://www.googleapis.com/auth/gmail.settings.basic'],
+      scopes: [
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/gmail.settings.basic',
+      ],
       capabilities: ['google.gmail.read', 'google.gmail.write'],
     }).find((toolset) => toolset.id === 'google-gmail');
 

--- a/connectors/google/src/toolsets.ts
+++ b/connectors/google/src/toolsets.ts
@@ -19,6 +19,7 @@ import {
   hasServiceAccess,
   hasWriteAccess,
 } from './scopes.js';
+import { wrapGoogleToolErrors } from './tool-error.js';
 
 import type { GoogleClient } from './client.js';
 import type { Tool } from 'ai';
@@ -162,7 +163,8 @@ function createGmailToolset(
       'Do not add SPAM and TRASH in the same gmail_modify_messages call. Apply those actions in separate steps if needed.',
     ].join('\n'),
     tools: () => summarizeTools(createGmailTools(SUMMARY_RESOLVER, permissions, config)),
-    activate: (resolveClient) => createGmailTools(resolveClient, permissions, config),
+    activate: (resolveClient) =>
+      wrapGoogleToolErrors(createGmailTools(resolveClient, permissions, config)),
   };
 }
 
@@ -188,7 +190,7 @@ function createDriveToolset(scopes: string[], capabilities: string[]): GoogleToo
         : 'You have read-only access. Creating files is not available.',
     ].join('\n'),
     tools: () => summarizeTools(createDriveTools(SUMMARY_RESOLVER, canWrite)),
-    activate: (resolveClient) => createDriveTools(resolveClient, canWrite),
+    activate: (resolveClient) => wrapGoogleToolErrors(createDriveTools(resolveClient, canWrite)),
   };
 }
 
@@ -215,7 +217,7 @@ function createCalendarToolset(scopes: string[], capabilities: string[]): Google
         : 'You have read-only access. Creating, updating, and deleting events is not available.',
     ].join('\n'),
     tools: () => summarizeTools(createCalendarTools(SUMMARY_RESOLVER, canWrite)),
-    activate: (resolveClient) => createCalendarTools(resolveClient, canWrite),
+    activate: (resolveClient) => wrapGoogleToolErrors(createCalendarTools(resolveClient, canWrite)),
   };
 }
 
@@ -239,7 +241,7 @@ function createDocsToolset(scopes: string[], capabilities: string[]): GoogleTool
         : 'You have read-only access. Creating and updating docs is not available.',
     ].join('\n'),
     tools: () => summarizeTools(createDocsTools(SUMMARY_RESOLVER, canWrite)),
-    activate: (resolveClient) => createDocsTools(resolveClient, canWrite),
+    activate: (resolveClient) => wrapGoogleToolErrors(createDocsTools(resolveClient, canWrite)),
   };
 }
 

--- a/packages/server/src/connectors/auth/oauth2.ts
+++ b/packages/server/src/connectors/auth/oauth2.ts
@@ -109,6 +109,7 @@ export async function startOAuthFlow(
   clientId: string,
   clientSecret: string,
   scopes: string[],
+  options?: { additionalParams?: Record<string, string> },
 ): Promise<{ authUrl: string; waitForTokens: () => Promise<OAuthTokens> }> {
   const port = await findFreePort();
   const redirectUri = `http://127.0.0.1:${port}/callback`;
@@ -125,6 +126,7 @@ export async function startOAuthFlow(
     code_challenge: codeChallenge,
     code_challenge_method: 'S256',
     ...config.additionalParams,
+    ...options?.additionalParams,
   });
 
   const authUrl = `${config.authUrl}?${authParams.toString()}`;

--- a/packages/server/src/connectors/service.test.ts
+++ b/packages/server/src/connectors/service.test.ts
@@ -134,14 +134,23 @@ describe('connector service', () => {
       accountInfo: null,
     });
 
-    const fakeStartOAuthFlow = async () => ({
-      authUrl: 'https://example.com/authorize',
-      waitForTokens: async () => ({
-        accessToken: 'new-access-token',
-        refreshToken: 'new-refresh-token',
-        expiresIn: 3600,
-      }),
-    });
+    let requestedScopes: string[] = [];
+    const fakeStartOAuthFlow = async (
+      _config: unknown,
+      _id: string,
+      _secret: string,
+      scopes: string[],
+    ) => {
+      requestedScopes = scopes;
+      return {
+        authUrl: 'https://example.com/authorize',
+        waitForTokens: async () => ({
+          accessToken: 'new-access-token',
+          refreshToken: 'new-refresh-token',
+          expiresIn: 3600,
+        }),
+      };
+    };
 
     const result = await upgradeConnectorInstance(
       instanceId,
@@ -167,6 +176,83 @@ describe('connector service', () => {
     // After token exchange the instance should be connected with the new key and merged scopes
     expect(row?.apiKey).toBe('new-key');
     expect((row?.scopes as string[])?.includes('scope:admin')).toBe(true);
+    expect(requestedScopes).toEqual(['scope:read', 'scope:admin']);
+  });
+
+  test('upgrade uses only missing scopes for incremental oauth connectors', async () => {
+    const definition = oauthDefinition({
+      authConfig: {
+        authUrl: 'https://example.com/auth',
+        tokenUrl: 'https://example.com/token',
+        defaultScopes: ['scope:read'],
+        scopeDescriptions: { 'scope:read': 'Read', 'scope:admin': 'Admin' },
+        incrementalAuth: {
+          enabled: true,
+          params: { include_granted_scopes: 'true' },
+        },
+      },
+    });
+    registerConnector(definition);
+
+    const db = getDb();
+    const instanceId = 'conn_test_incremental' as never;
+    await db.insert(connectorInstances).values({
+      id: instanceId,
+      connectorId: definition.id,
+      label: 'Example',
+      appliedVersion: 2,
+      capabilities: ['example.read', 'example.write'],
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      apiKey: null,
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      tokenExpiresAt: Date.now() + 60_000,
+      scopes: ['scope:read'],
+      status: 'connected',
+      authIssue: null,
+      accountEmail: null,
+      accountInfo: null,
+    });
+
+    let requestedScopes: string[] = [];
+    let requestedParams: Record<string, string> | undefined;
+    const fakeStartOAuthFlow = async (
+      _config: unknown,
+      _id: string,
+      _secret: string,
+      scopes: string[],
+      options?: { additionalParams?: Record<string, string> },
+    ) => {
+      requestedScopes = scopes;
+      requestedParams = options?.additionalParams;
+      return {
+        authUrl: 'https://example.com/authorize',
+        waitForTokens: async () => ({
+          accessToken: 'new-access-token',
+          refreshToken: 'new-refresh-token',
+          expiresIn: 3600,
+        }),
+      };
+    };
+
+    const result = await upgradeConnectorInstance(
+      instanceId,
+      {},
+      { startOAuthFlow: fakeStartOAuthFlow },
+    );
+
+    expect(result.error).toBeNull();
+    expect(requestedScopes).toEqual(['scope:admin']);
+    expect(requestedParams).toEqual({ include_granted_scopes: 'true' });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const [row] = await db
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, instanceId));
+    expect(row?.scopes).toEqual(['scope:read', 'scope:admin']);
   });
 
   test('disabled connectors cannot be created', async () => {
@@ -324,6 +410,70 @@ describe('connector service', () => {
     expect(row?.appliedVersion).toBe(definition.currentVersion);
     expect(row?.capabilities).toEqual(['example.read', 'example.write', 'example.admin']);
     expect(typeof row?.tokenExpiresAt).toBe('number');
+  });
+
+  test('authorizeOAuthInstance uses default scopes for connected incremental oauth reauth', async () => {
+    const definition = oauthDefinition({
+      authConfig: {
+        authUrl: 'https://example.com/auth',
+        tokenUrl: 'https://example.com/token',
+        defaultScopes: ['scope:read'],
+        scopeDescriptions: { 'scope:read': 'Read', 'scope:docs': 'Docs' },
+        incrementalAuth: {
+          enabled: true,
+          params: { include_granted_scopes: 'true' },
+        },
+      },
+    });
+    registerConnector(definition);
+
+    const db = getDb();
+    const instanceId = 'conn_auth_incremental_reauth' as never;
+    await db.insert(connectorInstances).values({
+      id: instanceId,
+      connectorId: definition.id,
+      label: 'Example OAuth',
+      appliedVersion: definition.currentVersion,
+      capabilities: ['example.read', 'example.write', 'example.admin'],
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      apiKey: null,
+      accessToken: 'old-access-token',
+      refreshToken: 'existing-refresh-token',
+      tokenExpiresAt: Date.now() - 1_000,
+      scopes: ['scope:read', 'scope:docs'],
+      status: 'connected',
+      authIssue: null,
+      accountEmail: null,
+      accountInfo: null,
+    });
+
+    let requestedScopes: string[] = [];
+    let requestedParams: Record<string, string> | undefined;
+    const fakeStartOAuthFlow = async (
+      _config: unknown,
+      _id: string,
+      _secret: string,
+      scopes: string[],
+      options?: { additionalParams?: Record<string, string> },
+    ) => {
+      requestedScopes = scopes;
+      requestedParams = options?.additionalParams;
+      return {
+        authUrl: 'https://example.com/authorize',
+        waitForTokens: async () => ({
+          accessToken: 'new-access-token',
+          refreshToken: null,
+          expiresIn: 3600,
+        }),
+      };
+    };
+
+    const result = await authorizeOAuthInstance(instanceId, { startOAuthFlow: fakeStartOAuthFlow });
+
+    expect(result.error).toBeNull();
+    expect(requestedScopes).toEqual(['scope:read']);
+    expect(requestedParams).toEqual({ include_granted_scopes: 'true' });
   });
 
   test('authorizeOAuthInstance preserves existing refresh token when provider omits one', async () => {

--- a/packages/server/src/connectors/service.ts
+++ b/packages/server/src/connectors/service.ts
@@ -191,6 +191,7 @@ export async function createApiKeyConnectorInstance(input: {
 export async function authorizeOAuthInstance(
   instanceId: string,
   deps?: { startOAuthFlow?: typeof StartOAuthFlowFn },
+  options?: { scopes?: string[]; additionalParams?: Record<string, string> },
 ): Promise<ServiceResult<{ authUrl: string; waitForTokens: () => Promise<void> }>> {
   const db = getDb();
   const [instance] = await db
@@ -211,13 +212,25 @@ export async function authorizeOAuthInstance(
   }
 
   const config = definition.authConfig as OAuthConfig;
-  const scopes = (instance.scopes as string[]) ?? config.defaultScopes;
+  const useIncrementalRefresh =
+    options?.scopes === undefined &&
+    config.incrementalAuth?.enabled === true &&
+    instance.status === 'connected';
+  const scopes =
+    options?.scopes ??
+    (useIncrementalRefresh
+      ? config.defaultScopes
+      : (instance.scopes as string[]) || config.defaultScopes);
+  const additionalParams =
+    options?.additionalParams ??
+    (useIncrementalRefresh ? config.incrementalAuth?.params : undefined);
 
   const { authUrl, waitForTokens } = await (deps?.startOAuthFlow ?? startOAuthFlowDefault)(
     config,
     resolvedOAuthCredentials.clientId,
     resolvedOAuthCredentials.clientSecret,
     scopes,
+    { additionalParams },
   );
 
   const tokenHandler = async (): Promise<void> => {
@@ -410,7 +423,12 @@ export async function upgradeConnectorInstance(
       .set(setValues)
       .where(eq(connectorInstances.id, typedInstanceId));
 
-    const auth = await authorizeOAuthInstance(instanceId, deps);
+    const config = definition.authConfig as OAuthConfig;
+    const authScopes = config.incrementalAuth?.enabled ? upgrade.missingScopes : nextScopes;
+    const auth = await authorizeOAuthInstance(instanceId, deps, {
+      scopes: authScopes.length > 0 ? authScopes : nextScopes,
+      additionalParams: config.incrementalAuth?.params,
+    });
     if (auth.error) {
       return auth;
     }

--- a/packages/shared/src/connectors/types.ts
+++ b/packages/shared/src/connectors/types.ts
@@ -35,6 +35,10 @@ export type OAuthConfig = {
   serviceAccessOptions?: OAuthServiceAccessOption[];
 
   additionalParams?: Record<string, string>;
+  incrementalAuth?: {
+    enabled: boolean;
+    params?: Record<string, string>;
+  };
   /** Maps scopes to the API IDs they require (for generating "Enable APIs" links) */
   scopeApiMap?: Record<string, string>;
 };


### PR DESCRIPTION
## 🚀 Change Summary

Improves Google Workspace connector authorization so missing Google permissions are handled gracefully, Gmail filter tools request the correct scope, and users can manually reauthorize OAuth connectors without forcing unrelated Google scopes back onto the consent screen.

### 🛠 Improvements & Refactors
- Added structured Google API tool error classification for insufficient-scope responses so tools return a non-retryable permission result instead of throwing into the model loop.
- Added Google incremental OAuth support so connector upgrades request only missing scopes while preserving existing grants.
- Added a manual Reauthorize button for connected OAuth connector instances when no upgrade is pending.

### 🐛 Bug Fixes
- Required `gmail.settings.basic` for Gmail filter tools and added a Google connector version bump so existing users are prompted to grant the missing filter-management scope.
- Prevented Gmail filter tools from appearing when only `gmail.modify` is granted.
