### PR TITLE
feat(onboarding): add appearance selector step

### DIFF
--- a/apps/web/src/components/onboarding/onboarding-dialog.tsx
+++ b/apps/web/src/components/onboarding/onboarding-dialog.tsx
@@ -1,3 +1,4 @@
+import { AppearanceStep } from './steps/appearance-step';
 import { AppsStep } from './steps/apps-step';
 import { MemoryStep } from './steps/memory-step';
 import { ProfileStep } from './steps/profile-step';
@@ -34,6 +35,10 @@ export function OnboardingDialog() {
               isSaving={state.isSavingProfile}
               onContinue={state.saveProfileAndAdvance}
             />
+          )}
+
+          {state.step === 'appearance' && (
+            <AppearanceStep onContinue={() => state.goToStep('apps')} />
           )}
 
           {state.step === 'apps' && (

--- a/apps/web/src/components/onboarding/steps/appearance-step.tsx
+++ b/apps/web/src/components/onboarding/steps/appearance-step.tsx
@@ -1,0 +1,27 @@
+import { AppearanceSelector } from '@/components/settings/appearance';
+import { Button } from '@/components/ui/button';
+
+type Props = {
+  onContinue: () => void;
+};
+
+export function AppearanceStep({ onContinue }: Props) {
+  return (
+    <div className="mx-auto flex h-full w-full max-w-xl flex-col justify-center gap-6">
+      <div className="space-y-2 text-center">
+        <h2 className="text-2xl font-semibold tracking-tight">Make Stitch yours</h2>
+        <p className="text-sm text-muted-foreground">
+          Choose a mode and theme now. You can change this later in Settings.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        <AppearanceSelector />
+      </div>
+
+      <div className="flex justify-center">
+        <Button onClick={onContinue}>Continue</Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/onboarding/use-onboarding-state.ts
+++ b/apps/web/src/components/onboarding/use-onboarding-state.ts
@@ -5,7 +5,14 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { providersQueryOptions } from '@/lib/queries/providers';
 import { saveSettingMutationOptions, settingsQueryOptions } from '@/lib/queries/settings';
 
-type OnboardingStep = 'welcome' | 'profile' | 'apps' | 'provider' | 'memory' | 'success';
+type OnboardingStep =
+  | 'welcome'
+  | 'profile'
+  | 'appearance'
+  | 'apps'
+  | 'provider'
+  | 'memory'
+  | 'success';
 
 const SUCCESS_CLOSE_DELAY_MS = 1200;
 const CURRENT_ONBOARDING_VERSION = '4';
@@ -71,7 +78,7 @@ export function useOnboardingState(): OnboardingState {
   function saveProfileAndAdvance(name: string, timezone: string) {
     void Promise.all([saveProfileName.mutateAsync(name), saveProfileTimezone.mutateAsync(timezone)])
       .then(() => {
-        setStep('apps');
+        setStep('appearance');
         return undefined;
       })
       .catch(() => undefined);

--- a/apps/web/src/components/settings/appearance.tsx
+++ b/apps/web/src/components/settings/appearance.tsx
@@ -17,6 +17,19 @@ const MODE_LABELS: Record<AppearanceMode, string> = {
 export function AppearanceSettings() {
   const page = SETTINGS_PAGE_BY_ID.appearance;
   const Icon = page.icon;
+
+  return (
+    <SettingPage
+      title={page.title}
+      description={page.description}
+      icon={<Icon className="size-5" />}
+    >
+      <AppearanceSelector />
+    </SettingPage>
+  );
+}
+
+export function AppearanceSelector() {
   const { mode, themeName, setMode, setTheme } = useTheme();
 
   const effectiveMode =
@@ -27,11 +40,7 @@ export function AppearanceSettings() {
       : mode;
 
   return (
-    <SettingPage
-      title={page.title}
-      description={page.description}
-      icon={<Icon className="size-5" />}
-    >
+    <>
       <SettingSection title="Mode">
         <div className="flex gap-2">
           {APPEARANCE_MODES.map((m) => (
@@ -52,7 +61,7 @@ export function AppearanceSettings() {
       </SettingSection>
 
       <SettingSection title="Theme">
-        <div className="grid grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {THEMES.map((t) => (
             <button
               key={t.name}
@@ -70,7 +79,7 @@ export function AppearanceSettings() {
           ))}
         </div>
       </SettingSection>
-    </SettingPage>
+    </>
   );
 }
 


### PR DESCRIPTION
## 🚀 Change Summary

Adds the existing appearance selector to onboarding so new users can choose their mode and theme before selecting mini-apps.

### ✨ New Features
- **Onboarding Appearance Step**: Lets users configure light/dark/system mode and theme during onboarding using the same selector as Settings.

### 🛠 Improvements & Refactors
- Reuses the Settings appearance selector as a shared component and keeps the theme grid responsive for onboarding-sized layouts.
