### PR TITLE
fix(desktop): sign meeting detection addon on macos

### DIFF
--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -21,6 +21,8 @@ const meetingDetectionResource = {
 
 const hasMeetingDetectionResource = existsSync(meetingDetectionResource.from);
 
+const meetingDetectionDarwinBinary = `Contents/Resources/meeting-detection/index.darwin-${process.arch}.node`;
+
 const shouldNotarize = Boolean(
   process.env.APPLE_API_KEY && process.env.APPLE_API_KEY_ID && process.env.APPLE_API_ISSUER,
 );
@@ -111,7 +113,7 @@ const config: Configuration = {
       'Contents/Resources/stitch-server',
       'Contents/Resources/stitch-sandbox',
       'Contents/Resources/audio-capture/stitch-audio-capture',
-      'Contents/Resources/meeting-detection/*.node',
+      meetingDetectionDarwinBinary,
     ],
     target: ['dmg', 'zip'],
   },


### PR DESCRIPTION
## 🚀 Change Summary

Fixes macOS release packaging by signing the concrete meeting detection NAPI addon file instead of passing an unexpanded wildcard to codesign.

### 🐛 Bug Fixes
- **macOS release packaging**: Targets the generated index.darwin-${process.arch}.node addon for electron-builder binary signing so codesign can find the file.
