### PR TITLE
fix(desktop): bundle shared package in main process

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   main: {
     build: {
       externalizeDeps: {
-        exclude: ['@stitch/audio-capture', '@stitch/meeting-detection'],
+        exclude: ['@stitch/audio-capture', '@stitch/meeting-detection', '@stitch/shared'],
       },
     },
   },


### PR DESCRIPTION
## 🚀 Change Summary

Bundles the workspace `@stitch/shared` package into the Electron desktop main process build so packaged Windows installs no longer try to load raw `.ts` files from `node_modules` at startup.

### 🐛 Bug Fixes
- Prevents the packaged desktop app from crashing with `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` when Electron resolves `@stitch/shared/logger` from `app.asar`.
