### PR TITLE
fix(chat): repair split session behavior

### DIFF
--- a/apps/web/src/hooks/sse/server-event-sync.ts
+++ b/apps/web/src/hooks/sse/server-event-sync.ts
@@ -20,7 +20,7 @@ import { useStreamStore } from '@/stores/stream-store';
 
 type PendingDelta = { sessionId: string; messageId: string; partId: string; delta: PartDelta };
 
-// Helper to mark a session unread in list and infinite list caches
+// Helper to mark a session unread in infinite list caches
 function markSessionUnread(
   queryClient: QueryClient,
   sessionId: string,
@@ -30,7 +30,7 @@ function markSessionUnread(
 
   // Update infinite list queries
   queryClient.setQueriesData<InfiniteData<SessionsPage>>(
-    { queryKey: sessionKeys.list() },
+    { queryKey: sessionKeys.infiniteLists() },
     (prev: InfiniteData<SessionsPage> | undefined) => {
       if (!prev) return prev;
       return {
@@ -42,12 +42,6 @@ function markSessionUnread(
       };
     },
   );
-
-  // Update flat list query
-  queryClient.setQueryData<Session[]>(sessionKeys.list(), (prev: Session[] | undefined) => {
-    if (!prev) return prev;
-    return prev.map((s) => (s.id === sessionId ? { ...s, isUnread: true } : s));
-  });
 }
 
 // Helper to check if sound is enabled
@@ -185,7 +179,7 @@ function useServerEventSync(): void {
     // Session Events
     'session-title-update': ({ sessionId, title }) => {
       queryClient.setQueriesData<InfiniteData<SessionsPage>>(
-        { queryKey: sessionKeys.list() },
+        { queryKey: sessionKeys.infiniteLists() },
         (prev: InfiniteData<SessionsPage> | undefined) => {
           if (!prev) return prev;
           return {

--- a/apps/web/src/lib/queries/chat.test.ts
+++ b/apps/web/src/lib/queries/chat.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+
+import { QueryClient } from '@tanstack/react-query';
+
+import type { Session } from '@stitch/shared/chat/messages';
+import type { PrefixedString } from '@stitch/shared/id';
+
+import { findSessionInListCache, sessionKeys } from './chat.js';
+
+function createSession(id: string): Session {
+  return {
+    id: id as PrefixedString<'ses'>,
+    title: 'Test session',
+    type: 'chat',
+    automationId: null,
+    parentSessionId: null,
+    isUnread: false,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+describe('findSessionInListCache', () => {
+  test('finds sessions in infinite list cache data', () => {
+    const queryClient = new QueryClient();
+    const session = createSession('ses_found');
+
+    queryClient.setQueryData(sessionKeys.infiniteList(''), {
+      pages: [{ sessions: [session], hasMore: false }],
+      pageParams: [undefined],
+    });
+
+    expect(findSessionInListCache(queryClient, session.id)).toEqual(session);
+  });
+
+  test('does not scan the broad list cache key', () => {
+    const queryClient = new QueryClient();
+    const session = createSession('ses_split');
+
+    queryClient.setQueryData(sessionKeys.list(), [session]);
+
+    expect(findSessionInListCache(queryClient, session.id)).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/queries/chat.ts
+++ b/apps/web/src/lib/queries/chat.ts
@@ -37,7 +37,8 @@ const EMPTY_USAGE: LanguageModelUsage = {
 export const sessionKeys = {
   all: ['sessions'] as const,
   list: () => [...sessionKeys.all, 'list'] as const,
-  infiniteList: (search: string) => [...sessionKeys.list(), 'infinite', search] as const,
+  infiniteLists: () => [...sessionKeys.list(), 'infinite'] as const,
+  infiniteList: (search: string) => [...sessionKeys.infiniteLists(), search] as const,
   detail: (id: string) => [...sessionKeys.all, 'detail', id] as const,
   messages: (id: string) => [...sessionKeys.all, 'messages', id] as const,
   stats: (id: string) => [...sessionKeys.all, 'stats', id] as const,
@@ -79,9 +80,9 @@ export const sessionQueryOptions = (id: string) =>
     queryFn: () => serverRequest<Session>(`/chat/sessions/${id}`),
   });
 
-function findSessionInListCache(queryClient: QueryClient, id: string): Session | undefined {
+export function findSessionInListCache(queryClient: QueryClient, id: string): Session | undefined {
   const cacheEntries = queryClient.getQueriesData<InfiniteData<SessionsPage>>({
-    queryKey: sessionKeys.list(),
+    queryKey: sessionKeys.infiniteLists(),
   });
   for (const [, data] of cacheEntries) {
     if (!data) continue;
@@ -242,9 +243,7 @@ export function useSplitSession() {
         method: 'POST',
       }),
     onSuccess: (data) => {
-      queryClient.setQueryData<Session[]>(sessionKeys.list(), (prev) =>
-        prev ? [...prev, data.session] : [data.session],
-      );
+      queryClient.setQueryData(sessionKeys.detail(data.session.id), data.session);
       void queryClient.invalidateQueries({ queryKey: sessionKeys.list() });
     },
   });

--- a/packages/server/src/chat/service.test.ts
+++ b/packages/server/src/chat/service.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+
+import type { StoredPart } from '@stitch/shared/chat/messages';
+
+import { splitSession } from '@/chat/service.js';
+import { getDb } from '@/db/client.js';
+import { messages, sessions } from '@/db/schema/sessions.js';
+import { setupTestDb } from '@/db/test-helpers.js';
+
+setupTestDb();
+
+function textPart(text: string, time: number): StoredPart {
+  return {
+    type: 'text-delta',
+    id: `prt_${time}`,
+    text,
+    startedAt: time,
+    endedAt: time,
+  };
+}
+
+describe('splitSession', () => {
+  test('creates an independent top-level clone session', async () => {
+    const sessionId = 'ses_split_source' as never;
+    const priorMessageId = 'msg_split_prior' as never;
+    const splitMessageId = 'msg_split_user' as never;
+    const now = Date.now();
+
+    await getDb().insert(sessions).values({
+      id: sessionId,
+      title: 'Original',
+      type: 'chat',
+      automationId: null,
+      parentSessionId: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await getDb().insert(messages).values([
+      {
+        id: priorMessageId,
+        sessionId,
+        role: 'assistant',
+        parts: [textPart('Earlier context', now - 2)],
+        modelId: 'test-model',
+        providerId: 'test-provider',
+        costUsd: 0,
+        finishReason: 'stop',
+        isSummary: false,
+        createdAt: now - 2,
+        updatedAt: now - 2,
+        startedAt: now - 2,
+        duration: 0,
+      },
+      {
+        id: splitMessageId,
+        sessionId,
+        role: 'user',
+        parts: [textPart('Continue from here', now - 1)],
+        modelId: 'test-model',
+        providerId: 'test-provider',
+        costUsd: 0,
+        finishReason: null,
+        isSummary: false,
+        createdAt: now - 1,
+        updatedAt: now - 1,
+        startedAt: now - 1,
+        duration: null,
+      },
+    ]);
+
+    const result = await splitSession(sessionId, splitMessageId);
+
+    expect(result.error).toBeNull();
+    expect(result.data?.prefillText).toBe('Continue from here');
+    expect(result.data?.session.parentSessionId).toBeNull();
+
+    const clonedSessionId = result.data!.session.id;
+    const [clonedSession] = await getDb()
+      .select()
+      .from(sessions)
+      .where(eq(sessions.id, clonedSessionId));
+    expect(clonedSession.parentSessionId).toBeNull();
+
+    const clonedMessages = await getDb()
+      .select()
+      .from(messages)
+      .where(eq(messages.sessionId, clonedSessionId));
+    expect(clonedMessages).toHaveLength(1);
+    expect(clonedMessages[0].parts).toEqual([textPart('Earlier context', now - 2)]);
+  });
+});

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -344,7 +344,7 @@ export async function splitSession(
     .values({
       id: newSessionId,
       title: newTitle,
-      parentSessionId: sessionId,
+      parentSessionId: null,
       createdAt: now,
       updatedAt: now,
     })


### PR DESCRIPTION
## 🚀 Change Summary

Fixes chat split sessions so they behave as independent cloned conversations and removes the cache-shape mismatch that could crash route loading after splitting.

### 🐛 Bug Fixes
- **Split session navigation**: Isolates infinite session-list cache updates from the broad list invalidation key so route loading no longer reads flat list data as infinite-query pages.
- **Split session cloning**: Creates split sessions as top-level cloned sessions instead of child sessions, keeping them visible in the chat list and preserving normal chat capabilities.

### 🛠 Improvements & Refactors
- Adds focused regression coverage for split session cache lookup and server-side clone creation.
