### PR TITLE
fix(server): stabilize packaged logging

### DIFF
--- a/packages/server/src/lib/log.test.ts
+++ b/packages/server/src/lib/log.test.ts
@@ -157,6 +157,43 @@ describe('Log.create', () => {
   });
 });
 
+describe('Log.close', () => {
+  beforeEach(async () => {
+    await fs.mkdir(PATHS.logDir, { recursive: true });
+    await clearLogDir();
+  });
+
+  afterEach(async () => {
+    await clearLogDir();
+  });
+
+  test('flushes buffered writes before resolving', async () => {
+    const log = Log.create({ service: 'test-close' });
+    await Log.init({});
+    log.info('message before close');
+
+    await Log.close();
+
+    const output = await readLogOutput();
+    expect(output).toContain('message before close');
+  });
+
+  test('writes after close are dropped without throwing', async () => {
+    const log = Log.create({ service: 'test-close-after' });
+    await Log.init({});
+    await Log.close();
+
+    expect(() => log.info('message after close')).not.toThrow();
+
+    const output = await readLogOutput();
+    expect(output).not.toContain('message after close');
+  });
+
+  test('resolves when called before init', async () => {
+    await Log.close();
+  });
+});
+
 describe('Log rotation', () => {
   beforeEach(async () => {
     await fs.mkdir(PATHS.logDir, { recursive: true });

--- a/packages/server/src/lib/log.ts
+++ b/packages/server/src/lib/log.ts
@@ -99,6 +99,15 @@ export async function init(options: Options): Promise<void> {
   initialized = true;
 }
 
+export async function close(): Promise<void> {
+  const current = stream;
+  stream = undefined;
+  currentDate = undefined;
+  initialized = false;
+  if (!current) return;
+  await new Promise<void>((resolve) => current.end(resolve));
+}
+
 // Log filename format: <prefix>.<date>.<count>.log
 // e.g. app.2025-08-19.1.log or dev.2025-08-19.1.log
 const LOG_FILE_PATTERN = /^.+\.\d{4}-\d{2}-\d{2}\.\d+\.log$/;

--- a/packages/server/src/lib/paths.test.ts
+++ b/packages/server/src/lib/paths.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test';
+import path from 'node:path';
+
+import { createPaths, resolveAppName } from '@/lib/paths.js';
+
+const EMPTY_ENV: NodeJS.ProcessEnv = {};
+
+describe('resolveAppName', () => {
+  test('uses stitch in production-like environments', () => {
+    expect(resolveAppName({ env: EMPTY_ENV })).toBe('stitch');
+  });
+
+  test('uses stitch-dev in development', () => {
+    expect(resolveAppName({ env: { NODE_ENV: 'development' } })).toBe('stitch-dev');
+  });
+
+  test('uses stitch-test in tests', () => {
+    expect(resolveAppName({ env: { NODE_ENV: 'test' } })).toBe('stitch-test');
+  });
+
+  test('uses safe STITCH_APP_NAME over environment defaults', () => {
+    expect(resolveAppName({ env: { NODE_ENV: 'test', STITCH_APP_NAME: 'custom-app' } })).toBe(
+      'custom-app',
+    );
+  });
+
+  test('falls back when STITCH_APP_NAME is unsafe', () => {
+    expect(resolveAppName({ env: { NODE_ENV: 'test', STITCH_APP_NAME: '../stitch' } })).toBe(
+      'stitch-test',
+    );
+  });
+
+  test('explicit appName overrides environment app name', () => {
+    expect(resolveAppName({ appName: 'explicit-app', env: { STITCH_APP_NAME: 'env-app' } })).toBe(
+      'explicit-app',
+    );
+  });
+
+  test('rejects unsafe explicit appName', () => {
+    expect(() => resolveAppName({ appName: 'bad/name', env: EMPTY_ENV })).toThrow(
+      'Unsafe filename',
+    );
+  });
+});
+
+describe('createPaths', () => {
+  test('creates Windows paths with the resolved app name', () => {
+    const paths = createPaths({
+      env: { APPDATA: 'C:\\Users\\test\\AppData\\Roaming', LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local' },
+      platform: 'win32',
+      homedir: 'C:\\Users\\test',
+      tmpdir: 'C:\\Users\\test\\AppData\\Local\\Temp',
+      appName: 'stitch-custom',
+    });
+
+    expect(paths.appName).toBe('stitch-custom');
+    expect(paths.dataDir).toBe(path.join('C:\\Users\\test\\AppData\\Local', 'stitch-custom', 'Data'));
+    expect(paths.configDir).toBe(
+      path.join('C:\\Users\\test\\AppData\\Roaming', 'stitch-custom', 'Config'),
+    );
+    expect(paths.logDir).toBe(path.join('C:\\Users\\test\\AppData\\Local', 'stitch-custom', 'Log'));
+    expect(paths.filePaths.db).toBe(path.join(paths.dataDir, 'stitch-custom.db'));
+    expect(paths.dirPaths.recordings).toBe(path.join(paths.dataDir, 'recordings'));
+  });
+
+  test('keeps test paths isolated from production paths', () => {
+    const paths = createPaths({
+      env: { NODE_ENV: 'test' },
+      platform: 'linux',
+      homedir: '/home/tester',
+      tmpdir: '/tmp',
+    });
+
+    expect(paths.appName).toBe('stitch-test');
+    expect(paths.logDir).toBe(path.join('/home/tester/.local/state', 'stitch-test'));
+    expect(paths.filePaths.db).toBe(path.join(paths.dataDir, 'stitch-test.db'));
+  });
+
+  test('uses XDG directories on Linux when provided', () => {
+    const paths = createPaths({
+      env: {
+        XDG_DATA_HOME: '/xdg/data',
+        XDG_CONFIG_HOME: '/xdg/config',
+        XDG_CACHE_HOME: '/xdg/cache',
+        XDG_STATE_HOME: '/xdg/state',
+      },
+      platform: 'linux',
+      homedir: '/home/tester',
+      tmpdir: '/tmp',
+      appName: 'stitch-custom',
+    });
+
+    expect(paths.dataDir).toBe(path.join('/xdg/data', 'stitch-custom'));
+    expect(paths.configDir).toBe(path.join('/xdg/config', 'stitch-custom'));
+    expect(paths.cacheDir).toBe(path.join('/xdg/cache', 'stitch-custom'));
+    expect(paths.logDir).toBe(path.join('/xdg/state', 'stitch-custom'));
+    expect(paths.tempDir).toBe(path.join('/tmp', 'tester', 'stitch-custom'));
+  });
+
+  test('creates macOS paths with the resolved app name', () => {
+    const paths = createPaths({
+      env: EMPTY_ENV,
+      platform: 'darwin',
+      homedir: '/Users/tester',
+      tmpdir: '/var/folders/tmp',
+      appName: 'stitch-custom',
+    });
+
+    expect(paths.dataDir).toBe(
+      path.join('/Users/tester', 'Library', 'Application Support', 'stitch-custom'),
+    );
+    expect(paths.configDir).toBe(
+      path.join('/Users/tester', 'Library', 'Preferences', 'stitch-custom'),
+    );
+    expect(paths.cacheDir).toBe(path.join('/Users/tester', 'Library', 'Caches', 'stitch-custom'));
+    expect(paths.logDir).toBe(path.join('/Users/tester', 'Library', 'Logs', 'stitch-custom'));
+    expect(paths.tempDir).toBe(path.join('/var/folders/tmp', 'stitch-custom'));
+  });
+});

--- a/packages/server/src/lib/paths.ts
+++ b/packages/server/src/lib/paths.ts
@@ -4,6 +4,48 @@ import path from 'node:path';
 const homedir = os.homedir();
 const tmpdir = os.tmpdir();
 
+type BaseDirs = {
+  data: string;
+  config: string;
+  cache: string;
+  log: string;
+  temp: string;
+};
+
+export type ServerPaths = {
+  appName: string;
+  configDir: string;
+  dataDir: string;
+  cacheDir: string;
+  logDir: string;
+  tempDir: string;
+  filePaths: {
+    db: string;
+    models: string;
+    embeddingModelsRegistry: string;
+    sttModelsRegistry: string;
+    mcpRegistry: string;
+  };
+  dirPaths: {
+    toolOutput: string;
+    skills: string;
+    providerLogos: string;
+    mcpRegistryLogos: string;
+    mcpIcons: string;
+    connectorIcons: string;
+    simpleIcons: string;
+    recordings: string;
+  };
+};
+
+export type CreatePathsOptions = {
+  appName?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  homedir?: string;
+  tmpdir?: string;
+};
+
 function isSafeFilename(filename: string): boolean {
   const trimmed = filename.trim();
   return (
@@ -22,83 +64,104 @@ function assertSafeFilename(filename: string): void {
   }
 }
 
-type EnvPaths = {
-  data: string;
-  config: string;
-  cache: string;
-  log: string;
-  temp: string;
-};
+function defaultAppName(env: NodeJS.ProcessEnv): string {
+  if (env.NODE_ENV === 'test') return 'stitch-test';
+  if (env.NODE_ENV === 'development') return 'stitch-dev';
+  return 'stitch';
+}
 
-function envPaths(name: string, { suffix = 'nodejs' } = {}): EnvPaths {
-  assertSafeFilename(name);
+export function resolveAppName(options: Pick<CreatePathsOptions, 'appName' | 'env'> = {}): string {
+  const env = options.env ?? process.env;
+  const explicitAppName = options.appName?.trim();
+  if (explicitAppName) {
+    assertSafeFilename(explicitAppName);
+    return explicitAppName;
+  }
 
-  const fullName = suffix ? `${name}-${suffix}` : name;
-  assertSafeFilename(fullName);
+  const envAppName = env['STITCH_APP_NAME']?.trim();
+  return envAppName && isSafeFilename(envAppName) ? envAppName : defaultAppName(env);
+}
 
-  if (process.platform === 'darwin') {
-    const library = path.join(homedir, 'Library');
+function getBaseDirs(options: {
+  appName: string;
+  platform: NodeJS.Platform;
+  homedir: string;
+  tmpdir: string;
+  env: NodeJS.ProcessEnv;
+}): BaseDirs {
+  const { appName, platform, env } = options;
+  assertSafeFilename(appName);
+
+  if (platform === 'darwin') {
+    const library = path.join(options.homedir, 'Library');
     return {
-      data: path.join(library, 'Application Support', fullName),
-      config: path.join(library, 'Preferences', fullName),
-      cache: path.join(library, 'Caches', fullName),
-      log: path.join(library, 'Logs', fullName),
-      temp: path.join(tmpdir, fullName),
+      data: path.join(library, 'Application Support', appName),
+      config: path.join(library, 'Preferences', appName),
+      cache: path.join(library, 'Caches', appName),
+      log: path.join(library, 'Logs', appName),
+      temp: path.join(options.tmpdir, appName),
     };
   }
 
-  if (process.platform === 'win32') {
-    const appData = process.env.APPDATA ?? path.join(homedir, 'AppData', 'Roaming');
-    const localAppData = process.env.LOCALAPPDATA ?? path.join(homedir, 'AppData', 'Local');
+  if (platform === 'win32') {
+    const appData = env.APPDATA ?? path.join(options.homedir, 'AppData', 'Roaming');
+    const localAppData = env.LOCALAPPDATA ?? path.join(options.homedir, 'AppData', 'Local');
     return {
-      data: path.join(localAppData, fullName, 'Data'),
-      config: path.join(appData, fullName, 'Config'),
-      cache: path.join(localAppData, fullName, 'Cache'),
-      log: path.join(localAppData, fullName, 'Log'),
-      temp: path.join(tmpdir, fullName),
+      data: path.join(localAppData, appName, 'Data'),
+      config: path.join(appData, appName, 'Config'),
+      cache: path.join(localAppData, appName, 'Cache'),
+      log: path.join(localAppData, appName, 'Log'),
+      temp: path.join(options.tmpdir, appName),
     };
   }
 
-  // Linux / XDG
-  const username = path.basename(homedir);
+  const username = path.basename(options.homedir);
   return {
-    data: path.join(process.env.XDG_DATA_HOME ?? path.join(homedir, '.local', 'share'), fullName),
-    config: path.join(process.env.XDG_CONFIG_HOME ?? path.join(homedir, '.config'), fullName),
-    cache: path.join(process.env.XDG_CACHE_HOME ?? path.join(homedir, '.cache'), fullName),
-    log: path.join(process.env.XDG_STATE_HOME ?? path.join(homedir, '.local', 'state'), fullName),
-    temp: path.join(tmpdir, username, fullName),
+    data: path.join(env.XDG_DATA_HOME ?? path.join(options.homedir, '.local', 'share'), appName),
+    config: path.join(env.XDG_CONFIG_HOME ?? path.join(options.homedir, '.config'), appName),
+    cache: path.join(env.XDG_CACHE_HOME ?? path.join(options.homedir, '.cache'), appName),
+    log: path.join(env.XDG_STATE_HOME ?? path.join(options.homedir, '.local', 'state'), appName),
+    temp: path.join(options.tmpdir, username, appName),
   };
 }
 
-const envAppName = process.env['STITCH_APP_NAME']?.trim();
-const isDev = process.env.NODE_ENV === 'development';
-const APP_NAME =
-  envAppName && isSafeFilename(envAppName) ? envAppName : isDev ? 'stitch-dev' : 'stitch';
-const paths = envPaths(APP_NAME, { suffix: '' });
+export function createPaths(options: CreatePathsOptions = {}): ServerPaths {
+  const appName = resolveAppName(options);
+  const paths = getBaseDirs({
+    appName,
+    env: options.env ?? process.env,
+    platform: options.platform ?? process.platform,
+    homedir: options.homedir ?? homedir,
+    tmpdir: options.tmpdir ?? tmpdir,
+  });
 
-export const PATHS = {
-  configDir: paths.config,
-  dataDir: paths.data,
-  cacheDir: paths.cache,
-  logDir: paths.log,
-  tempDir: paths.temp,
+  return {
+    appName,
+    configDir: paths.config,
+    dataDir: paths.data,
+    cacheDir: paths.cache,
+    logDir: paths.log,
+    tempDir: paths.temp,
 
-  filePaths: {
-    db: path.join(paths.data, `${APP_NAME}.db`),
-    models: path.join(paths.cache, 'models.json'),
-    embeddingModelsRegistry: path.join(paths.cache, 'embedding-models-registry.json'),
-    sttModelsRegistry: path.join(paths.cache, 'stt-models-registry.json'),
-    mcpRegistry: path.join(paths.cache, 'mcp-registry.json'),
-  },
+    filePaths: {
+      db: path.join(paths.data, `${appName}.db`),
+      models: path.join(paths.cache, 'models.json'),
+      embeddingModelsRegistry: path.join(paths.cache, 'embedding-models-registry.json'),
+      sttModelsRegistry: path.join(paths.cache, 'stt-models-registry.json'),
+      mcpRegistry: path.join(paths.cache, 'mcp-registry.json'),
+    },
 
-  dirPaths: {
-    toolOutput: path.join(paths.data, 'tool-output'),
-    skills: path.join(paths.data, 'skills'),
-    providerLogos: path.join(paths.cache, 'provider-logos'),
-    mcpRegistryLogos: path.join(paths.cache, 'mcp-registry-logos'),
-    mcpIcons: path.join(paths.cache, 'mcp-icons'),
-    connectorIcons: path.join(paths.cache, 'connector-icons'),
-    simpleIcons: path.join(paths.cache, 'simple-icons'),
-    recordings: path.join(paths.data, 'recordings'),
-  },
-} as const;
+    dirPaths: {
+      toolOutput: path.join(paths.data, 'tool-output'),
+      skills: path.join(paths.data, 'skills'),
+      providerLogos: path.join(paths.cache, 'provider-logos'),
+      mcpRegistryLogos: path.join(paths.cache, 'mcp-registry-logos'),
+      mcpIcons: path.join(paths.cache, 'mcp-icons'),
+      connectorIcons: path.join(paths.cache, 'connector-icons'),
+      simpleIcons: path.join(paths.cache, 'simple-icons'),
+      recordings: path.join(paths.data, 'recordings'),
+    },
+  };
+}
+
+export const PATHS = createPaths();

--- a/packages/server/src/shutdown.ts
+++ b/packages/server/src/shutdown.ts
@@ -14,6 +14,7 @@ async function shutdown(signal: string) {
   });
   await shutdownConnectorRuntime();
   closeDb();
+  await Log.close();
   process.exit(0);
 }
 


### PR DESCRIPTION
## 🚀 Change Summary

Stabilizes server-side logging for the packaged Electron sidecar and makes server path resolution explicit and testable. This prevents test runs from writing to production app directories and ensures buffered log writes are flushed during normal shutdown.

### 🛠 Improvements & Refactors
- **Path Resolution Factory**: Adds `createPaths()` and `resolveAppName()` so server paths can be resolved with explicit app, environment, platform, home, and temp inputs while preserving the existing `PATHS` singleton.
- **Test Path Isolation**: Defaults `NODE_ENV=test` to `stitch-test`, preventing tests from touching production `stitch` data, config, cache, or log directories.

### 🐛 Bug Fixes
- **Packaged Logging Flush**: Adds `Log.close()` and flushes the log stream during shutdown before `process.exit(0)`.
- **Log Test Safety**: Adds coverage for log stream flushing and path resolution behavior across app-name and platform variants.