### PR TITLE
fix(chat): remove sidebar chat row icons

### DIFF
--- a/apps/web/src/components/chat/chat-sidebar.tsx
+++ b/apps/web/src/components/chat/chat-sidebar.tsx
@@ -1,4 +1,4 @@
-import { Loader2Icon, MessageCircleIcon, MessageSquareIcon, PlusIcon } from 'lucide-react';
+import { Loader2Icon, MessageCircleIcon, PlusIcon } from 'lucide-react';
 import * as React from 'react';
 
 import type { InfiniteData } from '@tanstack/react-query';
@@ -51,7 +51,7 @@ const SessionStatusIcon = React.memo(function SessionStatusIcon({
     );
   }
 
-  return <MessageSquareIcon className="size-3.5 shrink-0 text-muted-foreground" />;
+  return null;
 });
 
 export function ChatSidebarContent() {


### PR DESCRIPTION
## 🚀 Change Summary

Removes the redundant message-square icon shown next to non-status chat rows in the sidebar.

### 🐛 Bug Fixes
- **Chat sidebar**: `SessionStatusIcon` now renders nothing for idle sessions instead of a generic message icon, cleaning up the sidebar row.
