### PR TITLE
fix(usage): round chart bar tops

### DIFF
--- a/apps/web/src/components/usage/charts/usage-chart-utils.tsx
+++ b/apps/web/src/components/usage/charts/usage-chart-utils.tsx
@@ -33,15 +33,11 @@ export function getStackSegmentRadius(ctx: ScriptableContext<'bar'>, radius = 5)
   const hasAbove = datasets
     .slice(datasetIndex + 1)
     .some((dataset) => getNumericValue(dataset.data?.[dataIndex]) > 0);
-  const hasBelow = datasets
-    .slice(0, datasetIndex)
-    .some((dataset) => getNumericValue(dataset.data?.[dataIndex]) > 0);
-
   return {
     topLeft: hasAbove ? 0 : radius,
     topRight: hasAbove ? 0 : radius,
-    bottomLeft: hasBelow ? 0 : radius,
-    bottomRight: hasBelow ? 0 : radius,
+    bottomLeft: 0,
+    bottomRight: 0,
   };
 }
 


### PR DESCRIPTION
## 🚀 Change Summary

Fixes stacked usage chart bars so only the topmost segment gets rounded corners.

### 🐛 Bug Fixes
- **Usage charts**: `getStackSegmentRadius` no longer rounds the bottom corners of a stacked bar segment based on whether a segment exists below it — bottoms are now always square, so only the top of the full stack is rounded.
