### PR TITLE
fix(usage): preserve tiny cost formatting

### DIFF
--- a/apps/web/src/components/usage/utils/usage-dashboard-utils.test.ts
+++ b/apps/web/src/components/usage/utils/usage-dashboard-utils.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, test } from 'bun:test';
 import { formatCost } from '@/components/usage/utils/usage-dashboard-utils';
 
 describe('formatCost', () => {
-  test('keeps zero at cent precision', () => {
-    expect(formatCost(0)).toBe('$0.00');
+  test('shows exact zero without decimal precision', () => {
+    expect(formatCost(0)).toBe('$0');
   });
 
   test('shows non-zero sub-cent costs', () => {
@@ -13,6 +13,10 @@ describe('formatCost', () => {
 
   test('trims trailing zeroes from sub-cent costs', () => {
     expect(formatCost(0.001)).toBe('$0.001');
+  });
+
+  test('preserves tiny non-zero costs', () => {
+    expect(formatCost(0.00001234)).toBe('$0.000012');
   });
 
   test('uses cent precision for cent-level costs', () => {

--- a/apps/web/src/lib/format-cost.ts
+++ b/apps/web/src/lib/format-cost.ts
@@ -1,10 +1,11 @@
 export function formatUsdCost(costUsd: number): string {
   if (costUsd === 0) {
-    return '$0.00';
+    return '$0';
   }
 
   if (Math.abs(costUsd) < 0.01) {
-    return `$${costUsd.toFixed(4).replace(/0+$/, '')}`;
+    const precision = Math.min(Math.ceil(-Math.log10(Math.abs(costUsd))) + 1, 8);
+    return `$${costUsd.toFixed(precision).replace(/0+$/, '')}`;
   }
 
   return `$${costUsd.toFixed(2)}`;


### PR DESCRIPTION
## 🚀 Change Summary

Fixes cost formatting so very small non-zero costs aren't rounded down to `$0`.

### 🐛 Bug Fixes
- **Usage**: `formatUsdCost` now scales decimal precision based on magnitude for sub-cent costs (up to 8 decimal places), so tiny costs like `$0.00001234` render correctly instead of collapsing to zero.
- Exact zero now renders as `$0` instead of `$0.00`.
