### PR TITLE
fix(session): show zero-cost spend details

### DIFF
--- a/apps/web/src/components/session/session-details-sheet.tsx
+++ b/apps/web/src/components/session/session-details-sheet.tsx
@@ -130,7 +130,7 @@ export function SessionDetailsSheet({
 }: SessionDetailsSheetProps) {
   const hasContextUsage = totalTokens > 0;
   const usageValue = parsePercent(usagePercent);
-  const showSpend = hasContextUsage || currentSessionCostUsd > 0 || childSessionsCostUsd > 0;
+  const showSpend = messagesCount > 0 || currentSessionCostUsd > 0 || childSessionsCostUsd > 0;
   const messageSplit =
     userMessageCount > 0 || assistantMessageCount > 0
       ? `${formatNumber(messagesCount)} total, ${formatNumber(userMessageCount)} user / ${formatNumber(assistantMessageCount)} assistant`


### PR DESCRIPTION
## 🚀 Change Summary

Fixes the session details sheet so spend details show up whenever a session has any messages, not just when there's context usage or a non-zero cost.

### 🐛 Bug Fixes
- **Session details**: `showSpend` now checks `messagesCount > 0` instead of `hasContextUsage`, so zero-cost sessions with messages still show their spend breakdown.
