### PR TITLE
fix(session): restrict child task browser access

### DIFF
--- a/apps/web/src/components/session/session-page-header.tsx
+++ b/apps/web/src/components/session/session-page-header.tsx
@@ -74,31 +74,29 @@ export function SessionPageHeader({
           </h1>
         </div>
 
-        {isChildSession ? null : (
-          <div className="flex items-center gap-1">
-            {hasBrowser ? (
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className={cn('hidden lg:inline-flex', rightPanel === 'browser' && 'bg-accent')}
-                onClick={onToggleBrowser}
-                aria-label={rightPanel === 'browser' ? 'Hide browser' : 'Show browser'}
-              >
-                <GlobeIcon className="size-4" />
-              </Button>
-            ) : null}
+        <div className="flex items-center gap-1">
+          {!isChildSession && hasBrowser ? (
             <Button
               variant="ghost"
               size="icon-sm"
-              className={cn('hidden lg:inline-flex', rightPanel === 'details' && 'bg-accent')}
-              onClick={onToggleDetails}
-              aria-label={
-                rightPanel === 'details' ? 'Hide session details' : 'Show session details'
-              }
+              className={cn('hidden lg:inline-flex', rightPanel === 'browser' && 'bg-accent')}
+              onClick={onToggleBrowser}
+              aria-label={rightPanel === 'browser' ? 'Hide browser' : 'Show browser'}
             >
-              <InfoIcon className="size-4" />
+              <GlobeIcon className="size-4" />
             </Button>
+          ) : null}
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className={cn('hidden lg:inline-flex', rightPanel === 'details' && 'bg-accent')}
+            onClick={onToggleDetails}
+            aria-label={rightPanel === 'details' ? 'Hide session details' : 'Show session details'}
+          >
+            <InfoIcon className="size-4" />
+          </Button>
 
+          {!isChildSession ? (
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={
@@ -125,8 +123,8 @@ export function SessionPageHeader({
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-          </div>
-        )}
+          ) : null}
+        </div>
       </div>
     </header>
   );

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -225,6 +225,8 @@ export async function sendMessage(
   const assistantMessageId = input.assistantMessageId as PrefixedString<'msg'>;
   const abortSignal = AbortRegistry.register(input.sessionId);
 
+  const isChildSession = session.parentSessionId !== null;
+
   void runStream({
     sessionId: input.sessionId,
     assistantMessageId,
@@ -232,7 +234,8 @@ export async function sendMessage(
     llmMessages,
     credentials: config.credentials,
     abortSignal,
-    allowTaskTool: session.parentSessionId === null,
+    allowTaskTool: !isChildSession,
+    excludedToolsetIds: isChildSession ? ['browser'] : undefined,
   })
     .catch((error) => {
       log.error(

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -1175,6 +1175,8 @@ export async function runStream(opts: {
   activeToolsetIds?: string[];
   /** Child sessions are not allowed to invoke task recursively. */
   allowTaskTool?: boolean;
+  /** Toolset IDs unavailable for this stream. */
+  excludedToolsetIds?: string[];
   model?: ReturnType<ReturnType<typeof createProvider>>;
   deps?: Partial<StreamRunnerDeps>;
 }): Promise<void> {
@@ -1191,6 +1193,7 @@ export async function runStream(opts: {
     llmMessages: opts.llmMessages,
     activeToolsetIds: opts.activeToolsetIds,
     allowTaskTool: canUseTaskTool,
+    excludedToolsetIds: opts.excludedToolsetIds,
   }).assemble();
 
   const transformedMessages = await transformAttachmentsForModel(

--- a/packages/server/src/llm/stream/session-context.test.ts
+++ b/packages/server/src/llm/stream/session-context.test.ts
@@ -4,8 +4,8 @@ import { getDb } from '@/db/client.js';
 import { sessions } from '@/db/schema/sessions.js';
 import { setupTestDb } from '@/db/test-helpers.js';
 import type { ProviderCredentials } from '@/llm/provider/provider.js';
-import { getSessionToolsetState, setSessionToolsetState } from '@/llm/stream/session-toolsets.js';
 import { buildExpiredToolsetsPrompt, SessionContext } from '@/llm/stream/session-context.js';
+import { getSessionToolsetState, setSessionToolsetState } from '@/llm/stream/session-toolsets.js';
 import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
 import type { Toolset } from '@/tools/toolsets/types.js';
 import type { ModelMessage, Tool } from 'ai';
@@ -159,5 +159,33 @@ describe('SessionContext expired toolset handling', () => {
       .join('\n');
     expect(semiStaticContent).toContain('Toolset Expiry Notice');
     expect(expired.toolsetManager.getActiveTools()).not.toHaveProperty('browser_open');
+  });
+
+  test('does not restore excluded active toolsets', async () => {
+    const sessionId = 'ses_excluded_toolsets' as never;
+    getDb().insert(sessions).values({ id: sessionId, title: 'Excluded toolsets test' }).run();
+
+    registerToolset({
+      id: 'browser',
+      kind: 'native',
+      name: 'Browser',
+      description: 'Browser toolset',
+      tools: () => [{ name: 'browser_open', description: 'open' }],
+      activate: async () => ({ browser_open: makeTool('open') }),
+    } satisfies Toolset);
+
+    const assembled = await SessionContext.create({
+      sessionId,
+      messageId: 'msg_excluded_toolsets' as never,
+      streamRunId: 'run_excluded_toolsets',
+      credentials: CREDENTIALS,
+      modelId: 'openai/gpt-5.3-codex',
+      abortSignal: new AbortController().signal,
+      llmMessages: STUB_MESSAGES,
+      activeToolsetIds: ['browser'],
+      excludedToolsetIds: ['browser'],
+    }).assemble();
+
+    expect(assembled.toolsetManager.getActiveTools()).not.toHaveProperty('browser_open');
   });
 });

--- a/packages/server/src/llm/stream/session-context.ts
+++ b/packages/server/src/llm/stream/session-context.ts
@@ -33,6 +33,7 @@ type SessionContextOptions = {
   llmMessages: ModelMessage[];
   activeToolsetIds?: string[];
   allowTaskTool?: boolean;
+  excludedToolsetIds?: string[];
 };
 
 type AssembledResult = {
@@ -114,7 +115,9 @@ export class SessionContext {
       ? ''
       : buildExpiredToolsetsPrompt(expiredEntries);
 
-    const toolsetManager = new ToolsetManager(this.toolContext, activeEntries);
+    const toolsetManager = new ToolsetManager(this.toolContext, activeEntries, {
+      excludedToolsetIds: this.opts.excludedToolsetIds,
+    });
     await this.restoreToolsets(
       toolsetManager,
       activeEntries.map((entry) => entry.id),

--- a/packages/server/src/tools/core/task.ts
+++ b/packages/server/src/tools/core/task.ts
@@ -19,6 +19,7 @@ import type { ToolContext } from '@/tools/runtime/runtime.js';
 import type { ToolsetManager } from '@/tools/toolsets/manager.js';
 
 const log = Log.create({ service: 'task-tool' });
+const CHILD_SESSION_EXCLUDED_TOOLSETS = ['browser'];
 
 const TASK_DESCRIPTION = `Spawn a child session to handle a task independently with its own context window.
 
@@ -151,6 +152,7 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
           abortSignal: childAbortSignal,
           activeToolsetIds: allToolsetIds,
           allowTaskTool: false,
+          excludedToolsetIds: CHILD_SESSION_EXCLUDED_TOOLSETS,
         });
 
         log.info(

--- a/packages/server/src/tools/core/toolset-management.test.ts
+++ b/packages/server/src/tools/core/toolset-management.test.ts
@@ -75,6 +75,47 @@ describe('toolset management tools', () => {
     });
   });
 
+  test('list_toolsets omits excluded toolsets', async () => {
+    registerTestToolset({ id: 'browser', name: 'Browser' });
+    registerTestToolset({ id: 'database', name: 'Database' });
+    const manager = new ToolsetManager(
+      {
+        sessionId: TEST_SESSION_ID,
+        messageId: 'msg_test' as never,
+        streamRunId: 'run_test',
+      },
+      [],
+      { excludedToolsetIds: ['browser'] },
+    );
+    const tools = createToolsetTools(manager, TEST_SESSION_ID);
+    const result = (await tools.list_toolsets.execute?.({}, {} as never)) as {
+      toolsets: { id: string }[];
+    };
+
+    expect(result.toolsets.map((toolset) => toolset.id)).toEqual(['database']);
+  });
+
+  test('excluded toolsets cannot be inspected or activated', async () => {
+    registerTestToolset({ id: 'browser', name: 'Browser' });
+    const manager = new ToolsetManager(
+      {
+        sessionId: TEST_SESSION_ID,
+        messageId: 'msg_test' as never,
+        streamRunId: 'run_test',
+      },
+      [],
+      { excludedToolsetIds: ['browser'] },
+    );
+    const tools = createToolsetTools(manager, TEST_SESSION_ID);
+
+    expect(tools.list_toolsets.execute?.({ toolsetId: 'browser' }, {} as never)).rejects.toThrow(
+      'not in the catalog',
+    );
+    expect(tools.activate_toolset.execute?.({ toolsetId: 'browser' }, {} as never)).rejects.toThrow(
+      'has been disabled',
+    );
+  });
+
   test('activate_toolset omits verbose details by default', async () => {
     registerTestToolset();
     const manager = createManager();

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -100,6 +100,12 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
         return { toolsets: filtered, totalAvailable: fullCatalog.length };
       }
 
+      if (manager.isExcluded(toolsetId)) {
+        throw new Error(
+          `Toolset "${toolsetId}" is not in the catalog. Use list_toolsets with no arguments to see available IDs.`,
+        );
+      }
+
       const toolset = getToolset(toolsetId);
       if (!toolset) {
         throw new Error(

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -25,8 +25,15 @@ export class ToolsetManager {
 
   private readonly context: ToolContext;
 
-  constructor(context: ToolContext, activationState: Iterable<string | SessionActiveToolset> = []) {
+  private readonly excludedToolsetIds: Set<string>;
+
+  constructor(
+    context: ToolContext,
+    activationState: Iterable<string | SessionActiveToolset> = [],
+    options: { excludedToolsetIds?: Iterable<string> } = {},
+  ) {
     this.context = context;
+    this.excludedToolsetIds = new Set(options.excludedToolsetIds ?? []);
     for (const entry of activationState) {
       const state =
         typeof entry === 'string' ? { id: entry, scope: 'until_deactivated' as const } : entry;
@@ -62,6 +69,14 @@ export class ToolsetManager {
         'attempted to activate unknown toolset',
       );
       return { status: 'not_found' };
+    }
+
+    if (this.excludedToolsetIds.has(toolsetId)) {
+      log.info(
+        { event: 'toolset.activate.excluded', toolsetId },
+        'attempted to activate excluded toolset',
+      );
+      return { status: 'disabled' };
     }
 
     const [toolsetEnabled, appEnabled] = await Promise.all([
@@ -209,6 +224,10 @@ export class ToolsetManager {
     return this.activations.get(toolsetId)?.state.scope === 'until_deactivated';
   }
 
+  isExcluded(toolsetId: string): boolean {
+    return this.excludedToolsetIds.has(toolsetId);
+  }
+
   setActivationState(
     toolsetId: string,
     state: { scope: SessionToolsetScope; expiresAtTurn?: number },
@@ -243,7 +262,12 @@ export class ToolsetManager {
       getDisabledAppToolsetIds(),
     ]);
     return listToolsets()
-      .filter((ts) => !disabledIds.has(ts.id) && !disabledAppToolsetIds.has(ts.id))
+      .filter(
+        (ts) =>
+          !this.excludedToolsetIds.has(ts.id) &&
+          !disabledIds.has(ts.id) &&
+          !disabledAppToolsetIds.has(ts.id),
+      )
       .map((ts) =>
         toToolsetView(ts, {
           active: this.isActive(ts.id),


### PR DESCRIPTION
## 🚀 Change Summary

Prevents child (task) sessions from accessing the browser toolset, and cleans up the session header so the browser/details/menu buttons render consistently regardless of session type.

### 🐛 Bug Fixes
- **Toolsets**: `ToolsetManager` now accepts an `excludedToolsetIds` set. Excluded toolsets are hidden from `list_toolsets`, and `activate_toolset` rejects them with a `disabled` status instead of activating them.
- **Task tool**: child sessions spawned via the `task` tool now run with `browser` excluded from their toolset catalog, and can no longer inspect or activate it.
- **Session header**: `SessionPageHeader` no longer hides the entire action button group for child sessions — only the browser toggle and overflow menu are conditionally hidden, so the details button is always available.

### 🧪 Tests
- Added coverage for excluded toolsets in `session-context.test.ts` and `toolset-management.test.ts`.
