### PR TITLE
refactor(web): add shared confirm dialog

### DIFF
--- a/apps/web/src/components/agenda/agenda-item-detail.tsx
+++ b/apps/web/src/components/agenda/agenda-item-detail.tsx
@@ -8,7 +8,7 @@ import { PRIORITY_LABELS, STATUS_LABELS } from '@/components/agenda/constants';
 import { formatDateInTz, useUserTimezone } from '@/components/agenda/utils';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -270,22 +270,14 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
         </SheetContent>
       </Sheet>
 
-      <Dialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>Delete item?</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">This agenda item will be permanently removed.</p>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmDeleteOpen(false)}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={handleDelete} disabled={deleteMutation.isPending}>
-              {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        onOpenChange={setConfirmDeleteOpen}
+        title="Delete item?"
+        description="This agenda item will be permanently removed."
+        onConfirm={handleDelete}
+        isPending={deleteMutation.isPending}
+      />
     </>
   );
 }

--- a/apps/web/src/components/agenda/agenda-page.tsx
+++ b/apps/web/src/components/agenda/agenda-page.tsx
@@ -24,6 +24,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import { Checkbox } from '@/components/ui/checkbox';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
 import { Input } from '@/components/ui/input';
@@ -552,44 +553,25 @@ export function AgendaPage({ listId }: { listId?: string }) {
       </Dialog>
 
       {/* Bulk delete confirmation */}
-      <Dialog open={bulkDeleteOpen} onOpenChange={setBulkDeleteOpen}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>
-              Delete {selectedIds.size} item{selectedIds.size === 1 ? '' : 's'}?
-            </DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">These items will be permanently removed.</p>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setBulkDeleteOpen(false)}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={handleBulkDelete} disabled={deleteMutation.isPending}>
-              {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={bulkDeleteOpen}
+        onOpenChange={setBulkDeleteOpen}
+        title={`Delete ${selectedIds.size} item${selectedIds.size === 1 ? '' : 's'}?`}
+        description="These items will be permanently removed."
+        onConfirm={handleBulkDelete}
+        isPending={deleteMutation.isPending}
+      />
 
       {/* Delete list confirmation */}
-      <Dialog open={deleteListOpen} onOpenChange={setDeleteListOpen}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>Delete list "{currentList?.name}"?</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            This will permanently delete the list and all {total} item{total === 1 ? '' : 's'} in it.
-          </p>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setDeleteListOpen(false)}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={handleDeleteList} disabled={deleteListMutation.isPending}>
-              {deleteListMutation.isPending ? 'Deleting...' : 'Delete List'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={deleteListOpen}
+        onOpenChange={setDeleteListOpen}
+        title={`Delete list "${currentList?.name}"?`}
+        description={`This will permanently delete the list and all ${total} item${total === 1 ? '' : 's'} in it.`}
+        onConfirm={handleDeleteList}
+        confirmLabel="Delete List"
+        isPending={deleteListMutation.isPending}
+      />
     </Page>
   );
 }

--- a/apps/web/src/components/automations/automations-page.tsx
+++ b/apps/web/src/components/automations/automations-page.tsx
@@ -11,14 +11,7 @@ import { AutomationDialog } from '@/components/automations/automation-dialog';
 import { AutomationRunsTable } from '@/components/automations/automation-runs-table';
 import { AutomationsTable } from '@/components/automations/automations-table';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Empty, EmptyDescription, EmptyTitle } from '@/components/ui/empty';
 import {
   Page,
@@ -299,25 +292,16 @@ export function AutomationsPage({ automationId }: AutomationsPageProps) {
         }}
       />
 
-      <Dialog open={automationToDelete !== null} onOpenChange={(open) => !open && setAutomationToDelete(null)}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Automation</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete the automation "{automationToDelete?.title}"? This action cannot be
-              undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setAutomationToDelete(null)}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={() => void confirmDelete()} disabled={deleteAutomation.isPending}>
-              Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={automationToDelete !== null}
+        onOpenChange={(open) => !open && setAutomationToDelete(null)}
+        title="Delete Automation"
+        description={`Are you sure you want to delete the automation "${automationToDelete?.title}"? This action cannot be undone.`}
+        onConfirm={() => void confirmDelete()}
+        confirmLabel="Delete"
+        pendingLabel="Delete"
+        isPending={deleteAutomation.isPending}
+      />
     </Page>
   );
 }

--- a/apps/web/src/components/memories/memories-page.tsx
+++ b/apps/web/src/components/memories/memories-page.tsx
@@ -8,7 +8,7 @@ import { CATEGORY_LABELS, CATEGORY_VARIANTS, CONFIDENCE_LABELS } from '@/compone
 import { MemoryDetailSheet } from '@/components/memories/memory-detail-sheet';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
 import { Input } from '@/components/ui/input';
 import {
@@ -400,26 +400,15 @@ export function MemoriesPage() {
       <MemoryDetailSheet memory={sheetMemory} open={sheetOpen} onOpenChange={setSheetOpen} />
 
       {/* Bulk delete confirmation */}
-      <Dialog open={bulkDeleteOpen} onOpenChange={setBulkDeleteOpen}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>
-              Delete {selectedIds.size} {selectedIds.size === 1 ? 'memory' : 'memories'}?
-            </DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            These memories will be permanently removed and cannot be recovered.
-          </p>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setBulkDeleteOpen(false)}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={handleBulkDelete} disabled={bulkDeleteMutation.isPending}>
-              {bulkDeleteMutation.isPending ? 'Deleting…' : 'Delete'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={bulkDeleteOpen}
+        onOpenChange={setBulkDeleteOpen}
+        title={`Delete ${selectedIds.size} ${selectedIds.size === 1 ? 'memory' : 'memories'}?`}
+        description="These memories will be permanently removed and cannot be recovered."
+        onConfirm={handleBulkDelete}
+        pendingLabel="Deleting…"
+        isPending={bulkDeleteMutation.isPending}
+      />
     </Page>
   );
 }

--- a/apps/web/src/components/memories/memory-detail-sheet.tsx
+++ b/apps/web/src/components/memories/memory-detail-sheet.tsx
@@ -5,7 +5,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { CATEGORY_LABELS, CONFIDENCE_LABELS } from '@/components/memories/constants';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from '@/components/ui/sheet';
@@ -193,24 +193,15 @@ export function MemoryDetailSheet({ memory, open, onOpenChange }: Props) {
         </SheetContent>
       </Sheet>
 
-      <Dialog open={confirmDeleteOpen} onOpenChange={setConfirmDeleteOpen}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>Delete memory?</DialogTitle>
-          </DialogHeader>
-          <p className="text-sm text-muted-foreground">
-            This memory will be permanently removed and cannot be recovered.
-          </p>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmDeleteOpen(false)}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={handleDelete} disabled={deleteMutation.isPending}>
-              {deleteMutation.isPending ? 'Deleting…' : 'Delete'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={confirmDeleteOpen}
+        onOpenChange={setConfirmDeleteOpen}
+        title="Delete memory?"
+        description="This memory will be permanently removed and cannot be recovered."
+        onConfirm={handleDelete}
+        pendingLabel="Deleting…"
+        isPending={deleteMutation.isPending}
+      />
     </>
   );
 }

--- a/apps/web/src/components/recordings/shared/delete-recording-dialog.tsx
+++ b/apps/web/src/components/recordings/shared/delete-recording-dialog.tsx
@@ -1,14 +1,6 @@
 import type { Recording } from '@stitch/shared/recordings/types';
 
-import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 
 interface DeleteRecordingDialogProps {
   recording: Recording | null | undefined;
@@ -19,23 +11,13 @@ interface DeleteRecordingDialogProps {
 
 export function DeleteRecordingDialog({ recording, isDeleting, onOpenChange, onConfirm }: DeleteRecordingDialogProps) {
   return (
-    <Dialog open={Boolean(recording)} onOpenChange={onOpenChange}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Delete recording?</DialogTitle>
-          <DialogDescription>
-            This permanently deletes &quot;{recording?.title}&quot; and its local audio file.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button variant="destructive" onClick={onConfirm} disabled={isDeleting}>
-            {isDeleting ? 'Deleting...' : 'Delete'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <ConfirmDialog
+      open={Boolean(recording)}
+      onOpenChange={onOpenChange}
+      title="Delete recording?"
+      description={`This permanently deletes "${recording?.title}" and its local audio file.`}
+      onConfirm={onConfirm}
+      isPending={isDeleting}
+    />
   );
 }

--- a/apps/web/src/components/session/session-delete-dialog.tsx
+++ b/apps/web/src/components/session/session-delete-dialog.tsx
@@ -2,15 +2,7 @@ import { useNavigate } from '@tanstack/react-router';
 
 import type { PrefixedString } from '@stitch/shared/id';
 
-import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { useDeleteSession } from '@/lib/queries/chat';
 
 type SessionDeleteDialogProps = {
@@ -32,28 +24,15 @@ export function SessionDeleteDialog({ sessionId, open, onOpenChange, onDeleted }
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Delete session?</DialogTitle>
-          <DialogDescription>
-            This permanently removes the session and all of its messages. This action cannot be undone.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => onOpenChange(false)}>
-            Cancel
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={() => {
-              void handleDeleteSession();
-            }}
-            disabled={deleteSession.isPending}>
-            {deleteSession.isPending ? 'Deleting...' : 'Delete session'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <ConfirmDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Delete session?"
+      description="This permanently removes the session and all of its messages. This action cannot be undone."
+      onConfirm={() => void handleDeleteSession()}
+      confirmLabel="Delete session"
+      isPending={deleteSession.isPending}
+      contentClassName="max-w-sm"
+    />
   );
 }

--- a/apps/web/src/components/settings/memory.tsx
+++ b/apps/web/src/components/settings/memory.tsx
@@ -16,15 +16,7 @@ import {
   SliderSettingRow,
   SwitchSettingRow,
 } from '@/components/settings/settings-ui';
-import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -101,24 +93,16 @@ function EmbeddingModelSelect({
         showClear={false}
       />
 
-      <Dialog open={pendingValue !== undefined} onOpenChange={(open) => !open && handleCancel()}>
-        <DialogContent className="max-w-sm">
-          <DialogHeader>
-            <DialogTitle>Change embedding model?</DialogTitle>
-            <DialogDescription>
-              Switching the embedding model will permanently delete all stored memories. This action cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={handleCancel} disabled={isConfirming}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={() => void handleConfirm()} disabled={isConfirming}>
-              {isConfirming ? 'Deleting...' : 'Delete memories & switch'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <ConfirmDialog
+        open={pendingValue !== undefined}
+        onOpenChange={(open) => !open && handleCancel()}
+        title="Change embedding model?"
+        description="Switching the embedding model will permanently delete all stored memories. This action cannot be undone."
+        onConfirm={() => void handleConfirm()}
+        confirmLabel="Delete memories & switch"
+        isPending={isConfirming}
+        contentClassName="max-w-sm"
+      />
     </>
   );
 }

--- a/apps/web/src/components/settings/recordings.tsx
+++ b/apps/web/src/components/settings/recordings.tsx
@@ -15,20 +15,9 @@ import {
   SettingSection,
   SettingsIconButtonTooltip,
 } from '@/components/settings/settings-ui';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogMedia,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import {
   Dialog,
   DialogContent,
@@ -432,46 +421,32 @@ function MeetingNoteTemplatesSettings() {
             New Template
           </Button>
           <MarkdownHelpDialog />
-          <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-            <Tooltip>
-              <AlertDialogTrigger
-                render={
-                  <TooltipTrigger
-                    render={
-                      <Button
-                        variant="destructive"
-                        size="icon-sm"
-                        aria-label="Delete template"
-                        disabled={!selectedTemplate || deleteMutation.isPending}>
-                        <TrashIcon />
-                      </Button>
-                    }
-                  />
-                }
-              />
-              <TooltipContent>Delete template</TooltipContent>
-            </Tooltip>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogMedia>
-                  <TrashIcon />
-                </AlertDialogMedia>
-                <AlertDialogTitle>Delete template?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will permanently delete “{selectedTemplate?.name ?? 'this template'}”. This cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
-                <AlertDialogAction
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
                   variant="destructive"
-                  disabled={deleteMutation.isPending}
-                  onClick={handleDeleteTemplate}>
-                  Delete
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+                  size="icon-sm"
+                  aria-label="Delete template"
+                  disabled={!selectedTemplate || deleteMutation.isPending}
+                  onClick={() => setDeleteOpen(true)}>
+                  <TrashIcon />
+                </Button>
+              }
+            />
+            <TooltipContent>Delete template</TooltipContent>
+          </Tooltip>
+          <ConfirmDialog
+            open={deleteOpen}
+            onOpenChange={setDeleteOpen}
+            icon={<TrashIcon />}
+            title="Delete template?"
+            description={`This will permanently delete “${selectedTemplate?.name ?? 'this template'}”. This cannot be undone.`}
+            onConfirm={handleDeleteTemplate}
+            confirmLabel="Delete"
+            pendingLabel="Delete"
+            isPending={deleteMutation.isPending}
+          />
           <SettingsIconButtonTooltip label="Save template">
             <Button
               size="icon-sm"

--- a/apps/web/src/components/ui/confirm-dialog.tsx
+++ b/apps/web/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,62 @@
+import type * as React from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { cn } from '@/lib/utils';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: React.ReactNode;
+  description: React.ReactNode;
+  onConfirm: () => void;
+  confirmLabel?: string;
+  pendingLabel?: string;
+  cancelLabel?: string;
+  isPending?: boolean;
+  variant?: 'destructive' | 'default';
+  icon?: React.ReactNode;
+  contentClassName?: string;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  onConfirm,
+  confirmLabel = 'Delete',
+  pendingLabel = 'Deleting...',
+  cancelLabel = 'Cancel',
+  isPending = false,
+  variant = 'destructive',
+  icon,
+  contentClassName,
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className={cn(contentClassName)}>
+        <AlertDialogHeader>
+          {icon && <AlertDialogMedia>{icon}</AlertDialogMedia>}
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction variant={variant} onClick={onConfirm} disabled={isPending}>
+            {isPending ? pendingLabel : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION
## 🚀 Change Summary

Consolidates repeated destructive confirmation dialogs onto a shared AlertDialog-based ConfirmDialog component.

### 🛠 Improvements & Refactors
- **Shared ConfirmDialog**: Replaces hand-rolled destructive confirmation dialogs across agenda, automations, memories, recordings, sessions, and settings.
- **Consistent confirmation UX**: Uses the semantically correct AlertDialog primitive for destructive confirmation flows.
