### PR TITLE
fix(recordings): always confirm deletion

### DIFF
--- a/apps/web/src/components/recordings/recording-analysis-page.tsx
+++ b/apps/web/src/components/recordings/recording-analysis-page.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from '@tanstack/react-router';
 
 import { AnalysisHeader } from './analysis/analysis-header';
 import { TranscriptSidebar } from './analysis/transcript-sidebar';
-import { getErrorMessage, shouldConfirmRecordingDelete } from './shared/actions';
+import { getErrorMessage } from './shared/actions';
 import { DeleteRecordingDialog } from './shared/delete-recording-dialog';
 
 import ChatMarkdown from '@/components/chat/chat-markdown';
@@ -104,12 +104,8 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
             );
           }}
           onDelete={() => {
-            if (!recording || shouldConfirmRecordingDelete(recording)) {
-              setShowDeleteConfirm(true);
-              return;
-            }
-
-            deleteRecordingById();
+            if (!recording) return;
+            setShowDeleteConfirm(true);
           }}
         />
 

--- a/apps/web/src/components/recordings/recordings-page.tsx
+++ b/apps/web/src/components/recordings/recordings-page.tsx
@@ -11,7 +11,7 @@ import type { Recording } from '@stitch/shared/recordings/types';
 import { RecordingStartStopBar } from './list/recording-start-stop-bar';
 import { RecordingsPagination } from './list/recordings-pagination';
 import { RecordingsTable } from './list/recordings-table';
-import { getErrorMessage, shouldConfirmRecordingDelete } from './shared/actions';
+import { getErrorMessage } from './shared/actions';
 import { DeleteRecordingDialog } from './shared/delete-recording-dialog';
 
 import type { SttModelSelection } from '@/components/model-selectors/stt-model-selector-popover';
@@ -64,17 +64,9 @@ export function RecordingsPage() {
     [deleteRecording],
   );
 
-  const handleDelete = React.useCallback(
-    (recording: Recording) => {
-      if (shouldConfirmRecordingDelete(recording)) {
-        setRecordingToDelete(recording);
-        return;
-      }
-
-      deleteById(recording.id);
-    },
-    [deleteById],
-  );
+  const handleDelete = React.useCallback((recording: Recording) => {
+    setRecordingToDelete(recording);
+  }, []);
 
   return (
     <Page>

--- a/apps/web/src/components/recordings/shared/actions.ts
+++ b/apps/web/src/components/recordings/shared/actions.ts
@@ -1,11 +1,3 @@
-import type { Recording } from '@stitch/shared/recordings/types';
-
-const DELETE_WITHOUT_CONFIRMATION_MAX_MS = 30_000;
-
 export function getErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
-}
-
-export function shouldConfirmRecordingDelete(recording: Pick<Recording, 'durationMs'>): boolean {
-  return recording.durationMs === null || recording.durationMs > DELETE_WITHOUT_CONFIRMATION_MAX_MS;
 }


### PR DESCRIPTION
## 🚀 Change Summary

Always require confirmation before deleting recordings so short recordings cannot be deleted immediately from the recordings list or analysis page.

### 🐛 Bug Fixes
- **Recording deletion confirmation**: Removes the duration-based skip path and always opens the delete confirmation dialog before deletion.
