### PR TITLE
refactor(web): support serverRequest query params

### DIFF
--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'bun:test';
+
+import { toQueryString } from '@/lib/api';
+
+describe('toQueryString', () => {
+  it('serializes values and skips undefined', () => {
+    expect(toQueryString({ page: 2, pageSize: 30, listId: undefined })).toBe('?page=2&pageSize=30');
+  });
+
+  it('returns an empty string when no values are set', () => {
+    expect(toQueryString({})).toBe('');
+    expect(toQueryString({ q: undefined })).toBe('');
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -66,8 +66,20 @@ export async function serverFetch(path: string, init?: RequestInit): Promise<Res
   return fetch(`${baseUrl}${path}`, init);
 }
 
-export async function serverRequest<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await serverFetch(path, init);
+type QueryParams = Record<string, string | number | undefined>;
+
+export function toQueryString(params: QueryParams): string {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) searchParams.set(key, String(value));
+  }
+  const query = searchParams.toString();
+  return query ? `?${query}` : '';
+}
+
+export async function serverRequest<T>(path: string, init?: RequestInit & { params?: QueryParams }): Promise<T> {
+  const { params, ...requestInit } = init ?? {};
+  const res = await serverFetch(params ? `${path}${toQueryString(params)}` : path, requestInit);
   if (!res.ok) {
     let errorMsg = `Request failed with status ${res.status}`;
     try {

--- a/apps/web/src/lib/queries/agenda.ts
+++ b/apps/web/src/lib/queries/agenda.ts
@@ -22,11 +22,10 @@ const agendaKeys = {
 export function agendaListsQueryOptions(includeArchived = false) {
   return queryOptions({
     queryKey: [...agendaKeys.lists(), includeArchived],
-    queryFn: () => {
-      const params = new URLSearchParams();
-      if (includeArchived) params.set('includeArchived', 'true');
-      return serverRequest<{ lists: AgendaListWithCounts[] }>(`/agenda/lists?${params.toString()}`);
-    },
+    queryFn: () =>
+      serverRequest<{ lists: AgendaListWithCounts[] }>('/agenda/lists', {
+        params: { includeArchived: includeArchived ? 'true' : undefined },
+      }),
   });
 }
 
@@ -46,13 +45,16 @@ export function agendaItemsQueryOptions(input: {
       input.page,
       input.pageSize,
     ],
-    queryFn: () => {
-      const params = new URLSearchParams({ page: String(input.page), pageSize: String(input.pageSize) });
-      if (input.listId) params.set('listId', input.listId);
-      if (input.status) params.set('status', input.status);
-      if (input.priority) params.set('priority', input.priority);
-      return serverRequest<ListAgendaItemsResponse>(`/agenda/items?${params.toString()}`);
-    },
+    queryFn: () =>
+      serverRequest<ListAgendaItemsResponse>('/agenda/items', {
+        params: {
+          page: input.page,
+          pageSize: input.pageSize,
+          listId: input.listId,
+          status: input.status,
+          priority: input.priority,
+        },
+      }),
   });
 }
 

--- a/apps/web/src/lib/queries/automations.ts
+++ b/apps/web/src/lib/queries/automations.ts
@@ -22,18 +22,17 @@ const automationKeys = {
 export function automationsPageQueryOptions(input: { page: number; pageSize: number }) {
   return queryOptions({
     queryKey: automationKeys.page(input.page, input.pageSize),
-    queryFn: () => {
-      const params = new URLSearchParams({ page: String(input.page), pageSize: String(input.pageSize) });
-      return serverRequest<ListAutomationsResponse>(`/automations?${params.toString()}`);
-    },
+    queryFn: () =>
+      serverRequest<ListAutomationsResponse>('/automations', {
+        params: { page: input.page, pageSize: input.pageSize },
+      }),
   });
 }
 
 export const automationsSidebarListQueryOptions = queryOptions({
   queryKey: automationKeys.sidebarList(),
   queryFn: async (): Promise<Automation[]> => {
-    const params = new URLSearchParams({ page: '1', pageSize: '100' });
-    const data = await serverRequest<ListAutomationsResponse>(`/automations?${params.toString()}`);
+    const data = await serverRequest<ListAutomationsResponse>('/automations', { params: { page: 1, pageSize: 100 } });
     return data.automations;
   },
 });

--- a/apps/web/src/lib/queries/chat.ts
+++ b/apps/web/src/lib/queries/chat.ts
@@ -45,17 +45,10 @@ const SESSION_PAGE_SIZE = 30;
 export const sessionsInfiniteQueryOptions = (search: string) =>
   infiniteQueryOptions({
     queryKey: sessionKeys.infiniteList(search),
-    queryFn: ({ pageParam }): Promise<SessionsPage> => {
-      const params = new URLSearchParams({ type: 'chat', limit: String(SESSION_PAGE_SIZE) });
-      if (search) {
-        params.set('q', search);
-      }
-      if (pageParam !== undefined) {
-        params.set('cursor', String(pageParam));
-      }
-
-      return serverRequest<SessionsPage>(`/chat/sessions?${params.toString()}`);
-    },
+    queryFn: ({ pageParam }): Promise<SessionsPage> =>
+      serverRequest<SessionsPage>('/chat/sessions', {
+        params: { type: 'chat', limit: SESSION_PAGE_SIZE, q: search || undefined, cursor: pageParam },
+      }),
     initialPageParam: undefined as number | undefined,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
       if (!lastPage.hasMore || lastPage.sessions.length === 0) return undefined;
@@ -114,13 +107,8 @@ const PAGE_SIZE = 50;
 export const sessionMessagesInfiniteQueryOptions = (id: string) =>
   infiniteQueryOptions({
     queryKey: sessionKeys.messages(id),
-    queryFn: ({ pageParam }): Promise<MessagesPage> => {
-      const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
-      if (pageParam !== undefined) {
-        params.set('cursor', String(pageParam));
-      }
-      return serverRequest<MessagesPage>(`/chat/sessions/${id}/messages?${params.toString()}`);
-    },
+    queryFn: ({ pageParam }): Promise<MessagesPage> =>
+      serverRequest<MessagesPage>(`/chat/sessions/${id}/messages`, { params: { limit: PAGE_SIZE, cursor: pageParam } }),
     initialPageParam: undefined as number | undefined,
     getNextPageParam: (lastPage, _allPages, lastPageParam) => {
       if (!lastPage.hasMore || lastPage.messages.length === 0) return undefined;

--- a/apps/web/src/lib/queries/memories.ts
+++ b/apps/web/src/lib/queries/memories.ts
@@ -43,16 +43,10 @@ export const semanticMemoriesQueryOptions = (input: {
 }) =>
   queryOptions({
     queryKey: [...memoriesKeys.semantic(), input.source ?? 'all', input.category ?? 'all', input.page, input.pageSize],
-    queryFn: () => {
-      const params = new URLSearchParams();
-      params.set('page', String(input.page));
-      params.set('pageSize', String(input.pageSize));
-      if (input.source) params.set('source', input.source);
-      if (input.category) params.set('category', input.category);
-      return serverRequest<import('@stitch/shared/memory/types').ListSemanticMemoriesResponse>(
-        `/memory/semantic?${params.toString()}`,
-      );
-    },
+    queryFn: () =>
+      serverRequest<import('@stitch/shared/memory/types').ListSemanticMemoriesResponse>('/memory/semantic', {
+        params: { page: input.page, pageSize: input.pageSize, source: input.source, category: input.category },
+      }),
   });
 
 export const semanticMemorySearchQueryOptions = (input: {
@@ -70,14 +64,16 @@ export const semanticMemorySearchQueryOptions = (input: {
       input.page,
       input.pageSize,
     ],
-    queryFn: () => {
-      const params = new URLSearchParams({ q: input.q, page: String(input.page), pageSize: String(input.pageSize) });
-      if (input.source) params.set('source', input.source);
-      if (input.category) params.set('category', input.category);
-      return serverRequest<import('@stitch/shared/memory/types').SearchSemanticMemoriesResponse>(
-        `/memory/semantic?${params.toString()}`,
-      );
-    },
+    queryFn: () =>
+      serverRequest<import('@stitch/shared/memory/types').SearchSemanticMemoriesResponse>('/memory/semantic', {
+        params: {
+          q: input.q,
+          page: input.page,
+          pageSize: input.pageSize,
+          source: input.source,
+          category: input.category,
+        },
+      }),
     enabled: input.q.trim().length > 0,
   });
 

--- a/apps/web/src/lib/queries/recordings.ts
+++ b/apps/web/src/lib/queries/recordings.ts
@@ -39,10 +39,8 @@ const RECORDINGS_PAGE_SIZE = 12;
 export function recordingsQueryOptions(input: { page: number; pageSize: number }) {
   return queryOptions({
     queryKey: recordingsKeys.list(input.page, input.pageSize),
-    queryFn: () => {
-      const params = new URLSearchParams({ page: String(input.page), pageSize: String(input.pageSize) });
-      return serverRequest<ListRecordingsResponse>(`/recordings?${params.toString()}`);
-    },
+    queryFn: () =>
+      serverRequest<ListRecordingsResponse>('/recordings', { params: { page: input.page, pageSize: input.pageSize } }),
     placeholderData: keepPreviousData,
   });
 }
@@ -50,10 +48,10 @@ export function recordingsQueryOptions(input: { page: number; pageSize: number }
 export const recordingsInfiniteQueryOptions = () =>
   infiniteQueryOptions({
     queryKey: recordingsKeys.infiniteList(RECORDINGS_PAGE_SIZE),
-    queryFn: ({ pageParam }) => {
-      const params = new URLSearchParams({ page: String(pageParam), pageSize: String(RECORDINGS_PAGE_SIZE) });
-      return serverRequest<ListRecordingsResponse>(`/recordings?${params.toString()}`);
-    },
+    queryFn: ({ pageParam }) =>
+      serverRequest<ListRecordingsResponse>('/recordings', {
+        params: { page: pageParam, pageSize: RECORDINGS_PAGE_SIZE },
+      }),
     initialPageParam: 1,
     getNextPageParam: (lastPage) => {
       if (lastPage.page >= lastPage.totalPages) return undefined;
@@ -289,21 +287,13 @@ export function useStartRecordingAnalysis() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (input: { recordingId: string; force?: boolean; templateId: string }) => {
-      const params = new URLSearchParams();
-      if (input.force) {
-        params.set('force', '1');
-      }
-      const suffix = params.toString();
-      return serverRequest<StartRecordingAnalysisResponse>(
-        `/recordings/${input.recordingId}/analyze${suffix ? `?${suffix}` : ''}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ templateId: input.templateId }),
-        },
-      );
-    },
+    mutationFn: (input: { recordingId: string; force?: boolean; templateId: string }) =>
+      serverRequest<StartRecordingAnalysisResponse>(`/recordings/${input.recordingId}/analyze`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ templateId: input.templateId }),
+        params: { force: input.force ? '1' : undefined },
+      }),
     onSuccess: (_, variables) => {
       void queryClient.invalidateQueries({ queryKey: recordingsKeys.detail(variables.recordingId) });
     },

--- a/apps/web/src/lib/queries/usage.ts
+++ b/apps/web/src/lib/queries/usage.ts
@@ -24,50 +24,23 @@ const usageKeys = {
   embeddingDashboard: (filters: UsageDashboardFilters) => [...usageKeys.all, 'embedding-dashboard', filters] as const,
 };
 
-function buildQueryString(filters: UsageDashboardFilters): string {
-  const params = new URLSearchParams();
-
-  if (filters.providerId) params.set('providerId', filters.providerId);
-  if (filters.modelId) params.set('modelId', filters.modelId);
-  if (filters.range) params.set('range', filters.range);
-  if (filters.from) params.set('from', String(filters.from));
-  if (filters.to) params.set('to', String(filters.to));
-
-  return params.toString();
-}
-
 export const usageDashboardQueryOptions = (filters: UsageDashboardFilters) =>
   queryOptions({
     queryKey: usageKeys.dashboard(filters),
-    queryFn: () => {
-      const query = buildQueryString(filters);
-      const path = query.length > 0 ? `/usage?${query}` : '/usage';
-
-      return serverRequest<UsageDashboardResponse>(path);
-    },
+    queryFn: () => serverRequest<UsageDashboardResponse>('/usage', { params: filters }),
     staleTime: 30_000,
   });
 
 export const sttUsageDashboardQueryOptions = (filters: UsageDashboardFilters) =>
   queryOptions({
     queryKey: usageKeys.sttDashboard(filters),
-    queryFn: () => {
-      const query = buildQueryString(filters);
-      const path = query.length > 0 ? `/usage/stt?${query}` : '/usage/stt';
-
-      return serverRequest<SttUsageDashboardResponse>(path);
-    },
+    queryFn: () => serverRequest<SttUsageDashboardResponse>('/usage/stt', { params: filters }),
     staleTime: 30_000,
   });
 
 export const embeddingUsageDashboardQueryOptions = (filters: UsageDashboardFilters) =>
   queryOptions({
     queryKey: usageKeys.embeddingDashboard(filters),
-    queryFn: () => {
-      const query = buildQueryString(filters);
-      const path = query.length > 0 ? `/usage/embedding?${query}` : '/usage/embedding';
-
-      return serverRequest<EmbeddingUsageDashboardResponse>(path);
-    },
+    queryFn: () => serverRequest<EmbeddingUsageDashboardResponse>('/usage/embedding', { params: filters }),
     staleTime: 30_000,
   });


### PR DESCRIPTION
## 🚀 Change Summary

Adds query parameter support to `serverRequest` and migrates query helpers away from manual URLSearchParams boilerplate.

### 🛠 Improvements & Refactors
- **serverRequest params**: Adds typed query param handling for `serverRequest`.
- **Query cleanup**: Simplifies agenda, automations, chat, memories, recordings, and usage query helpers.
