### PR TITLE
refactor(web): migrate mutations to serverRequest

### DIFF
--- a/apps/web/src/components/settings/providers/ollama-models-panel.tsx
+++ b/apps/web/src/components/settings/providers/ollama-models-panel.tsx
@@ -11,7 +11,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 import { getErrorMessage } from '@/lib/errors';
 import {
   discoverOllamaModelsQueryOptions,
@@ -347,18 +347,12 @@ export function OllamaModelsPanel({ baseURL }: Props) {
   const [showAddForm, setShowAddForm] = React.useState(false);
 
   const upsertMutation = useMutation({
-    mutationFn: async (input: OllamaModelInput) => {
-      const res = await serverFetch('/llm/ollama/models', {
+    mutationFn: (input: OllamaModelInput) =>
+      serverRequest<unknown>('/llm/ollama/models', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
-      });
-      if (!res.ok) {
-        const payload = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(payload.error ?? 'Failed to save model');
-      }
-      return res.json();
-    },
+      }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ollamaModelKeys.list() });
       setShowAddForm(false);
@@ -371,10 +365,8 @@ export function OllamaModelsPanel({ baseURL }: Props) {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: async (id: string) => {
-      const res = await serverFetch(`/llm/ollama/models/${encodeURIComponent(id)}`, { method: 'DELETE' });
-      if (!res.ok) throw new Error('Failed to delete model');
-    },
+    mutationFn: (id: string) =>
+      serverRequest<void>(`/llm/ollama/models/${encodeURIComponent(id)}`, { method: 'DELETE' }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ollamaModelKeys.list() });
       toast.success('Model deleted', { id: 'ollama-model-delete' });

--- a/apps/web/src/lib/mutations/provider-config.ts
+++ b/apps/web/src/lib/mutations/provider-config.ts
@@ -2,7 +2,7 @@ import { toast } from 'sonner';
 
 import { useMutation, type QueryClient } from '@tanstack/react-query';
 
-import { serverFetch } from '@/lib/api';
+import { serverRequest } from '@/lib/api';
 import { getErrorMessage } from '@/lib/errors';
 import { providerKeys } from '@/lib/queries/providers';
 
@@ -43,17 +43,11 @@ export function useSaveProviderConfigMutation({
 }: SaveProviderConfigMutationOptions) {
   return useMutation({
     mutationFn: async (body: ProviderConfigBody) => {
-      const res = await serverFetch(`/llm/provider/${providerId}/config`, {
+      await serverRequest<void>(`/llm/provider/${providerId}/config`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       });
-
-      if (!res.ok) {
-        const payload = (await res.json().catch(() => ({}))) as { error?: string };
-        throw new Error(payload.error ?? errorMessage);
-      }
-
       return body;
     },
     onSuccess: async (savedConfig) => {
@@ -77,10 +71,7 @@ export function useDeleteProviderConfigMutation({
   onSuccess,
 }: DeleteProviderConfigMutationOptions) {
   return useMutation({
-    mutationFn: async () => {
-      const res = await serverFetch(`/llm/provider/${providerId}/config`, { method: 'DELETE' });
-      if (!res.ok) throw new Error(errorMessage);
-    },
+    mutationFn: () => serverRequest<void>(`/llm/provider/${providerId}/config`, { method: 'DELETE' }),
     onSuccess: async () => {
       queryClient.setQueryData(providerKeys.config(providerId), null);
       await invalidateProviderQueries(queryClient);


### PR DESCRIPTION
## 🚀 Change Summary

Migrates remaining raw serverFetch mutation code to serverRequest for provider configuration and Ollama model mutations.

### 🛠 Improvements & Refactors
- **Mutation cleanup**: Uses `serverRequest` for save/delete provider config and Ollama model mutations.
- **Shared request errors**: Relies on the centralized serverRequest error handling instead of repeated response parsing.
