### PR TITLE
refactor(shared): add desktop bridge seam

### DIFF
--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 import type { ElectronBrowserState } from '@stitch/shared/browser/electron';
+import type { DesktopBridge, ElectronBridge } from '@stitch/shared/desktop/bridge';
 import type {
   IpcContract,
   IpcEventContract,
@@ -31,7 +32,7 @@ function onIpc<TKey extends keyof IpcEventContract>(
   return () => ipcRenderer.removeListener(channel, subscription);
 }
 
-contextBridge.exposeInMainWorld('electron', {
+const electronBridge = {
   platform: process.platform,
   send: (channel: string, data?: unknown) => ipcRenderer.send(channel, data),
   on: (channel: string, callback: (...args: unknown[]) => void) => {
@@ -39,7 +40,9 @@ contextBridge.exposeInMainWorld('electron', {
     ipcRenderer.on(channel, subscription);
     return () => ipcRenderer.removeListener(channel, subscription);
   },
-});
+} satisfies ElectronBridge;
+
+contextBridge.exposeInMainWorld('electron', electronBridge);
 
 const api = {
   getServerConfig: () => invokeIpc('get-server-config'),
@@ -122,8 +125,6 @@ const api = {
     onStateChanged: (callback: (state: ElectronBrowserState) => void) => onIpc('browser:state-changed', callback),
     onShowRequested: (callback: () => void) => onIpc('browser:show-requested', callback),
   },
-};
+} satisfies DesktopBridge;
 
 contextBridge.exposeInMainWorld('api', api);
-
-export type DesktopApi = typeof api;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { DesktopApi } from '../../../desktop/src/preload/index';
+import type { DesktopBridge, ElectronBridge } from '@stitch/shared/desktop/bridge';
 
 export type ContextMenuParams = {
   x: number;
@@ -27,12 +27,8 @@ export type ServerConnectionConfig = { url: string; mode: ServerMode; remoteUrl:
 
 declare global {
   interface Window {
-    electron?: {
-      platform: NodeJS.Platform;
-      send: (channel: string, data?: unknown) => void;
-      on: (channel: string, callback: (...args: unknown[]) => void) => () => void;
-    };
-    api?: DesktopApi;
+    electron?: ElectronBridge;
+    api?: DesktopBridge;
   }
 }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -38,6 +38,7 @@
     "./tools/types": "./src/tools/types.ts",
     "./usage/types": "./src/usage/types.ts",
     "./connectors/types": "./src/connectors/types.ts",
+    "./desktop/bridge": "./src/desktop/bridge.ts",
     "./embedding/types": "./src/embedding/types.ts",
     "./memory/types": "./src/memory/types.ts",
     "./agenda/types": "./src/agenda/types.ts",

--- a/packages/shared/src/desktop/bridge.ts
+++ b/packages/shared/src/desktop/bridge.ts
@@ -1,0 +1,104 @@
+import type { ElectronBrowserState } from '../browser/electron.js';
+import type {
+  BrowserNavigateResult,
+  DesktopNotificationEvent,
+  MeetingCallDetectedPayload,
+  MeetingCallDismissedPayload,
+  MeetingCallEndedPayload,
+  RecordingDeviceChangedPayload,
+  RecordingDevicesPayload,
+  RecordingPermissionsPayload,
+  RecordingWarningPayload,
+  ServerConfigPayload,
+  ServerTestRemoteResult,
+  StartRecordingInput,
+  StartRecordingResponse,
+  StopRecordingResponse,
+  UpdaterStatePayload,
+} from '../ipc/types.js';
+
+export type DesktopPlatform = NodeJS.Platform;
+
+export type DesktopBridge = {
+  getServerConfig: () => Promise<ServerConfigPayload>;
+  server: {
+    testRemote: (url: string) => Promise<ServerTestRemoteResult>;
+    setConfig: (config: { mode: 'local' | 'remote'; remoteUrl: string | null }) => Promise<ServerConfigPayload>;
+    onConfigChanged: (callback: (config: ServerConfigPayload) => void) => () => void;
+  };
+  window: {
+    minimize: () => Promise<void>;
+    maximize: () => Promise<void>;
+    close: () => Promise<void>;
+    isMaximized: () => Promise<boolean>;
+    isFullScreen: () => Promise<boolean>;
+  };
+  devtools: {
+    toggle: () => Promise<void>;
+    inspect: (x: number, y: number) => Promise<void>;
+  };
+  shell: { openExternal: (url: string) => Promise<void> };
+  files: {
+    writeTmp: (data: ArrayBuffer, ext: string) => Promise<string>;
+    openPath: () => Promise<string[]>;
+  };
+  updater: {
+    check: () => Promise<UpdaterStatePayload>;
+    getState: () => Promise<UpdaterStatePayload>;
+    install: () => Promise<boolean>;
+    openManualUpdateAndQuit: () => Promise<boolean>;
+  };
+  spellcheck: {
+    replaceMisspelling: (word: string) => Promise<void>;
+    addToDictionary: (word: string) => Promise<void>;
+  };
+  permissions: {
+    requestMicrophone: () => Promise<boolean>;
+    getScreenCaptureStatus: () => Promise<string>;
+    openScreenCaptureSettings: () => Promise<void>;
+  };
+  meeting: {
+    dismissCall: (key: string) => Promise<void>;
+    onCallDetected: (callback: (payload: MeetingCallDetectedPayload) => void) => () => void;
+    onCallEnded: (callback: (payload: MeetingCallEndedPayload) => void) => () => void;
+    onCallDismissed: (callback: (payload: MeetingCallDismissedPayload) => void) => () => void;
+  };
+  recording: {
+    start: (input: StartRecordingInput) => Promise<StartRecordingResponse>;
+    stop: () => Promise<StopRecordingResponse>;
+    listDevices: () => Promise<RecordingDevicesPayload>;
+    checkPermissions: () => Promise<RecordingPermissionsPayload>;
+    primeSystemAudio: () => Promise<RecordingPermissionsPayload>;
+    onWarning: (callback: (payload: RecordingWarningPayload) => void) => () => void;
+    onDeviceChanged: (callback: (payload: RecordingDeviceChangedPayload) => void) => () => void;
+  };
+  notifications: {
+    dismiss: (id: string) => Promise<void>;
+    setHeight: (height: number) => Promise<void>;
+    onShow: (callback: (event: DesktopNotificationEvent) => void) => () => void;
+    onDismissed: (callback: (id: string) => void) => () => void;
+  };
+  browser: {
+    getState: () => Promise<ElectronBrowserState>;
+    registerWebview: (webContentsId: number, sessionId: string) => Promise<ElectronBrowserState>;
+    switchSession: (sessionId: string) => Promise<ElectronBrowserState>;
+    show: () => Promise<ElectronBrowserState>;
+    hide: () => Promise<ElectronBrowserState>;
+    userNavigate: (url: string) => Promise<BrowserNavigateResult>;
+    goBack: () => Promise<void>;
+    goForward: () => Promise<void>;
+    reload: () => Promise<void>;
+    newTab: (url?: string) => Promise<ElectronBrowserState>;
+    focusTab: (tabId: string) => Promise<ElectronBrowserState>;
+    closeTab: (tabId: string) => Promise<ElectronBrowserState>;
+    recordHumanInput: () => Promise<void>;
+    onStateChanged: (callback: (state: ElectronBrowserState) => void) => () => void;
+    onShowRequested: (callback: () => void) => () => void;
+  };
+};
+
+export type ElectronBridge = {
+  platform: DesktopPlatform;
+  send: (channel: string, data?: unknown) => void;
+  on: (channel: string, callback: (...args: unknown[]) => void) => () => void;
+};


### PR DESCRIPTION
## 🚀 Change Summary

Add a desktop bridge seam in the shared package, so web code can invoke desktop APIs without a hard import on Electron internals.

### ✨ New Features
- **Desktop Bridge**: New `packages/shared/src/desktop/bridge.ts` module that abstracts `window.desktopBridge` access, with typed methods for common operations
- **Preload Refactor**: Updated `apps/desktop/src/preload/index.ts` to expose the bridge via the shared module's interface
- **API Layer**: Simplified `apps/web/src/lib/api.ts` to use the shared bridge seam instead of inline Electron checks
