### PR TITLE
refactor(web): use recordingsKeys factory instead of hardcoded query keys

### DIFF
--- a/apps/web/src/hooks/sse/server-event-sync.ts
+++ b/apps/web/src/hooks/sse/server-event-sync.ts
@@ -12,6 +12,7 @@ import { sessionKeys } from '@/lib/queries/chat';
 import { mcpKeys } from '@/lib/queries/mcp';
 import { permissionResponseKeys } from '@/lib/queries/permissions';
 import { questionKeys } from '@/lib/queries/questions';
+import { recordingsKeys } from '@/lib/queries/recordings';
 import { settingsQueryOptions } from '@/lib/queries/settings';
 import { todoKeys } from '@/lib/queries/todos';
 import { toolKeys } from '@/lib/queries/tools';
@@ -144,17 +145,17 @@ function useServerEventSync(): void {
 
     // Recording Events
     'recording-started': () => {
-      void queryClient.invalidateQueries({ queryKey: ['recordings', 'list'] });
-      void queryClient.invalidateQueries({ queryKey: ['recordings', 'detail'] });
-      void queryClient.invalidateQueries({ queryKey: ['recordings', 'active'] });
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.lists() });
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.details() });
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.active() });
     },
     'recording-stopped': () => {
-      void queryClient.invalidateQueries({ queryKey: ['recordings', 'list'] });
-      void queryClient.invalidateQueries({ queryKey: ['recordings', 'detail'] });
-      void queryClient.invalidateQueries({ queryKey: ['recordings', 'active'] });
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.lists() });
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.details() });
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.active() });
     },
     'recording-analysis-updated': ({ recordingId }) => {
-      void queryClient.invalidateQueries({ queryKey: ['recordings', 'detail', recordingId] });
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.detail(recordingId) });
     },
 
     // Session Events

--- a/apps/web/src/lib/queries/recordings.ts
+++ b/apps/web/src/lib/queries/recordings.ts
@@ -23,15 +23,17 @@ import type {
 
 import { serverRequest } from '@/lib/api';
 
-const recordingsKeys = {
+export const recordingsKeys = {
   all: ['recordings'] as const,
   lists: () => [...recordingsKeys.all, 'list'] as const,
   list: (page: number, pageSize: number) => [...recordingsKeys.lists(), page, pageSize] as const,
   infiniteList: (pageSize: number) => [...recordingsKeys.lists(), 'infinite', pageSize] as const,
-  detail: (recordingId: string) => [...recordingsKeys.all, 'detail', recordingId] as const,
+  details: () => [...recordingsKeys.all, 'detail'] as const,
+  detail: (recordingId: string) => [...recordingsKeys.details(), recordingId] as const,
   active: () => [...recordingsKeys.all, 'active'] as const,
   devices: () => [...recordingsKeys.all, 'devices'] as const,
   templates: () => [...recordingsKeys.all, 'templates'] as const,
+  permissions: () => [...recordingsKeys.all, 'permissions'] as const,
 };
 
 const RECORDINGS_PAGE_SIZE = 12;
@@ -139,7 +141,7 @@ export const audioDevicesQueryOptions = queryOptions({
 });
 
 export const audioPermissionsQueryOptions = queryOptions({
-  queryKey: ['recordings', 'permissions'] as const,
+  queryKey: recordingsKeys.permissions(),
   queryFn: async (): Promise<AudioPermissionsStatus> => {
     if (!window.api?.recording?.checkPermissions) {
       throw new Error('Audio permissions are only available from the desktop app');


### PR DESCRIPTION
## 🚀 Change Summary

Replace hardcoded TanStack Query key strings with the `recordingsKeys` factory in the recordings queries module, centralizing key derivation for consistency and easier cache invalidation.

### 🛠 Improvements & Refactors
- **recordingsKeys factory**: Updated `apps/web/src/lib/queries/recordings.ts` to export and use the factory
- **SSE sync**: Updated `apps/web/src/hooks/sse/server-event-sync.ts` to use the factory for query invalidation
