### PR TITLE
fix(providers): split capability-specific provider types

### DIFF
--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -23,6 +23,7 @@ import { runStream } from '@/llm/stream/runner.js';
 import { generateTitle } from '@/llm/title-generator.js';
 import * as Models from '@/models/llm/registry.js';
 import { abortPermissionResponses } from '@/permission/service.js';
+import { isLlmProviderCredentials } from '@/provider/config/schema.js';
 import { listProvidersWithCapabilities, type ProviderWithCapabilities } from '@/provider/service.js';
 import { abortQuestions } from '@/question/service.js';
 import { recordLlmUsage } from '@/usage/ledger.js';
@@ -124,6 +125,10 @@ export async function sendMessage(
   const [config] = await db.select().from(providerConfig).where(eq(providerConfig.providerId, input.providerId));
   if (!config) {
     return err(`Provider "${input.providerId}" is not configured`, 400);
+  }
+
+  if (config.credentials.providerId !== input.providerId || !isLlmProviderCredentials(config.credentials)) {
+    return err(`Provider "${input.providerId}" is not configured for LLM usage`, 400);
   }
 
   await maybeGenerateTitle({

--- a/packages/server/src/llm/cache-control.ts
+++ b/packages/server/src/llm/cache-control.ts
@@ -1,4 +1,4 @@
-import type { ProviderId } from '@stitch/shared/providers/types';
+import type { LlmProviderId } from '@stitch/shared/providers/types';
 
 import type { ModelMessage, JSONValue, Tool } from 'ai';
 
@@ -25,7 +25,7 @@ const OPENROUTER_CACHE: ProviderCacheConfig = {
   breakpointCap: 4,
 };
 
-export function getCacheConfig(providerId: ProviderId, modelId: string): ProviderCacheConfig | null {
+export function getCacheConfig(providerId: LlmProviderId, modelId: string): ProviderCacheConfig | null {
   switch (providerId) {
     case 'anthropic':
       return ANTHROPIC_CACHE;
@@ -52,10 +52,6 @@ export function getCacheConfig(providerId: ProviderId, modelId: string): Provide
     case 'ollama_local':
     // NVIDIA: caching handled by API provider
     case 'nvidia':
-    // ElevenLabs: STT-only, no LLM cache control
-    case 'elevenlabs':
-    // AssemblyAI: STT-only, no LLM cache control
-    case 'assemblyai':
       return null;
   }
 }
@@ -85,7 +81,7 @@ function withCacheMarker(message: ModelMessage, config: ProviderCacheConfig): Mo
  */
 export function addCacheControlToMessages(
   messages: ModelMessage[],
-  providerId: ProviderId,
+  providerId: LlmProviderId,
   modelId: string,
 ): ModelMessage[] {
   if (messages.length === 0) return messages;
@@ -151,7 +147,7 @@ export function addCacheControlToMessages(
  */
 export function addCacheControlToTools(
   tools: Record<string, Tool>,
-  providerId: ProviderId,
+  providerId: LlmProviderId,
   modelId: string,
 ): Record<string, Tool> {
   const config = getCacheConfig(providerId, modelId);

--- a/packages/server/src/llm/provider-options.test.ts
+++ b/packages/server/src/llm/provider-options.test.ts
@@ -21,15 +21,10 @@ describe('getProviderOptions', () => {
     expect(getProviderOptions('vercel', sessionId)).toEqual({ gateway: { caching: 'auto' } });
   });
 
-  test.each([
-    'anthropic',
-    'amazon-bedrock',
-    'google',
-    'google-vertex',
-    'elevenlabs',
-    'assemblyai',
-    'ollama_local',
-  ] as const)('returns undefined for %s provider', (providerId) => {
-    expect(getProviderOptions(providerId, sessionId)).toBeUndefined();
-  });
+  test.each(['anthropic', 'amazon-bedrock', 'google', 'google-vertex', 'ollama_local'] as const)(
+    'returns undefined for %s provider',
+    (providerId) => {
+      expect(getProviderOptions(providerId, sessionId)).toBeUndefined();
+    },
+  );
 });

--- a/packages/server/src/llm/provider-options.ts
+++ b/packages/server/src/llm/provider-options.ts
@@ -1,4 +1,4 @@
-import type { ProviderId } from '@stitch/shared/providers/types';
+import type { LlmProviderId } from '@stitch/shared/providers/types';
 
 import type { JSONValue } from 'ai';
 
@@ -17,7 +17,7 @@ import type { JSONValue } from 'ai';
  *   underlying provider the model routes to.
  */
 export function getProviderOptions(
-  providerId: ProviderId,
+  providerId: LlmProviderId,
   sessionId: string,
 ): Record<string, Record<string, JSONValue>> | undefined {
   switch (providerId) {
@@ -37,8 +37,6 @@ export function getProviderOptions(
     case 'amazon-bedrock':
     case 'google':
     case 'google-vertex':
-    case 'elevenlabs':
-    case 'assemblyai':
     case 'ollama_local':
       return undefined;
   }

--- a/packages/server/src/llm/provider-schema.test.ts
+++ b/packages/server/src/llm/provider-schema.test.ts
@@ -1,7 +1,7 @@
 import { jsonSchema as toJsonSchema, dynamicTool } from 'ai';
 import { describe, expect, test } from 'bun:test';
 
-import type { ProviderId } from '@stitch/shared/providers/types';
+import type { LlmProviderId } from '@stitch/shared/providers/types';
 
 import { sanitizeToolSchemasForProvider } from '@/llm/provider-schema.js';
 import type { JSONSchema7, Schema, Tool } from 'ai';
@@ -26,7 +26,7 @@ describe('sanitizeToolSchemasForProvider', () => {
       },
     };
 
-    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as ProviderId, 'gemini-3.5-flash');
+    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
     const items = (resolvedSchema(out.t).properties!.tasks_attributes as JSONSchema7).items as JSONSchema7;
     const branches = items.anyOf as JSONSchema7[];
@@ -40,7 +40,7 @@ describe('sanitizeToolSchemasForProvider', () => {
       properties: { name: { type: 'string', required: ['x'], properties: { x: {} } } as JSONSchema7 },
     };
 
-    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as ProviderId, 'gemini-3.5-flash');
+    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
     const name = resolvedSchema(out.t).properties!.name as JSONSchema7;
     expect(name.required).toBeUndefined();
@@ -50,7 +50,7 @@ describe('sanitizeToolSchemasForProvider', () => {
   test('filters object required to existing properties only', () => {
     const schema: JSONSchema7 = { type: 'object', properties: { a: { type: 'string' } }, required: ['a', 'missing'] };
 
-    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as ProviderId, 'gemini-3.5-flash');
+    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
     expect(resolvedSchema(out.t).required).toEqual(['a']);
   });
@@ -58,7 +58,7 @@ describe('sanitizeToolSchemasForProvider', () => {
   test('converts integer/number enums to string enums', () => {
     const schema: JSONSchema7 = { type: 'object', properties: { level: { type: 'integer', enum: [1, 2, 3] } } };
 
-    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as ProviderId, 'gemini-3.5-flash');
+    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
     const level = resolvedSchema(out.t).properties!.level as JSONSchema7;
     expect(level.type).toBe('string');
@@ -71,7 +71,7 @@ describe('sanitizeToolSchemasForProvider', () => {
       properties: { value: { type: ['string', 'number', 'null'] } },
     } as unknown as JSONSchema7;
 
-    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as ProviderId, 'gemini-3.5-flash');
+    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
     const value = resolvedSchema(out.t).properties!.value as Record<string, unknown>;
     expect(value.type).toBeUndefined();
@@ -82,7 +82,7 @@ describe('sanitizeToolSchemasForProvider', () => {
   test('defaults missing array items to string', () => {
     const schema = { type: 'object', properties: { tags: { type: 'array' } } } as JSONSchema7;
 
-    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as ProviderId, 'gemini-3.5-flash');
+    const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
     const tags = resolvedSchema(out.t).properties!.tags as JSONSchema7;
     expect(tags.items).toEqual({ type: 'string' });
@@ -90,7 +90,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
   test('passes tools through unchanged for providers needing no sanitization', () => {
     const tools = { t: mcpTool({ type: 'object', properties: {} }) };
-    const out = sanitizeToolSchemasForProvider(tools, 'anthropic' as ProviderId, 'claude');
+    const out = sanitizeToolSchemasForProvider(tools, 'anthropic' as LlmProviderId, 'claude');
     expect(out).toBe(tools);
   });
 
@@ -101,12 +101,16 @@ describe('sanitizeToolSchemasForProvider', () => {
     };
 
     const claudeTools = { t: mcpTool(schema) };
-    const claudeOut = sanitizeToolSchemasForProvider(claudeTools, 'google-vertex' as ProviderId, 'claude-3-7-sonnet');
+    const claudeOut = sanitizeToolSchemasForProvider(
+      claudeTools,
+      'google-vertex' as LlmProviderId,
+      'claude-3-7-sonnet',
+    );
     expect(claudeOut).toBe(claudeTools);
 
     const geminiOut = sanitizeToolSchemasForProvider(
       { t: mcpTool(schema) },
-      'google-vertex' as ProviderId,
+      'google-vertex' as LlmProviderId,
       'gemini-2.5-pro',
     );
     expect((resolvedSchema(geminiOut.t).properties!.p as JSONSchema7).required).toBeUndefined();
@@ -116,7 +120,7 @@ describe('sanitizeToolSchemasForProvider', () => {
     test('replaces const with single-value enum and infers object type', () => {
       const schema = { properties: { mode: { const: 'fast' } } } as unknown as JSONSchema7;
 
-      const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as ProviderId, 'gpt-4o');
+      const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
       const root = resolvedSchema(out.t);
       expect(root.type).toBe('object');
@@ -127,7 +131,7 @@ describe('sanitizeToolSchemasForProvider', () => {
     test('lowers boolean schema nodes to string type', () => {
       const schema = { type: 'object', properties: { anything: true } } as unknown as JSONSchema7;
 
-      const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as ProviderId, 'gpt-4o');
+      const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
       expect(resolvedSchema(out.t).properties!.anything).toEqual({ type: 'string' });
     });
@@ -135,7 +139,7 @@ describe('sanitizeToolSchemasForProvider', () => {
     test('infers array type and defaults missing items to string', () => {
       const schema = { type: 'object', properties: { tags: { items: {} } } } as unknown as JSONSchema7;
 
-      const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as ProviderId, 'gpt-4o');
+      const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
       const tags = resolvedSchema(out.t).properties!.tags as JSONSchema7;
       expect(tags.type).toBe('array');
@@ -147,7 +151,7 @@ describe('sanitizeToolSchemasForProvider', () => {
         properties: { value: { anyOf: [{ type: 'string' }, { type: 'number' }] } },
       } as JSONSchema7;
 
-      const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as ProviderId, 'gpt-4o');
+      const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
       const value = resolvedSchema(out.t).properties!.value as JSONSchema7;
       expect(value.type).toBeUndefined();
@@ -161,7 +165,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
       const out = sanitizeToolSchemasForProvider(
         { t: mcpTool(schema) },
-        'vercel' as ProviderId,
+        'vercel' as LlmProviderId,
         'google/gemini-2.5-pro',
       );
 
@@ -173,7 +177,11 @@ describe('sanitizeToolSchemasForProvider', () => {
     test('applies openai sanitizer for non-gemini models on a gateway provider', () => {
       const schema = { type: 'object', properties: { mode: { const: 'x' } } } as unknown as JSONSchema7;
 
-      const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openrouter' as ProviderId, 'openai/gpt-4o');
+      const out = sanitizeToolSchemasForProvider(
+        { t: mcpTool(schema) },
+        'openrouter' as LlmProviderId,
+        'openai/gpt-4o',
+      );
 
       expect((resolvedSchema(out.t).properties!.mode as JSONSchema7).enum).toEqual(['x']);
     });

--- a/packages/server/src/llm/provider-schema.ts
+++ b/packages/server/src/llm/provider-schema.ts
@@ -1,6 +1,6 @@
 import { jsonSchema as toJsonSchema } from 'ai';
 
-import type { ProviderId } from '@stitch/shared/providers/types';
+import type { LlmProviderId } from '@stitch/shared/providers/types';
 
 import type { JSONSchema7, Schema, Tool } from 'ai';
 
@@ -179,7 +179,7 @@ function modelIsGemini(modelId: string): boolean {
  * (nvidia, ollama, gateways) can proxy to Gemini, so the Gemini pass is also
  * selected whenever the model id looks like a Gemini model.
  */
-function selectSanitizer(providerId: ProviderId, modelId: string): SchemaSanitizer | null {
+function selectSanitizer(providerId: LlmProviderId, modelId: string): SchemaSanitizer | null {
   if (providerId === 'google') return sanitizeGemini;
   if (providerId === 'google-vertex') return modelIsGemini(modelId) ? sanitizeGemini : null;
   if (providerId === 'openai') return sanitizeOpenAI;
@@ -207,7 +207,7 @@ function sanitizeTool(tool: Tool, sanitize: SchemaSanitizer): Tool {
 
 export function sanitizeToolSchemasForProvider(
   tools: Record<string, Tool>,
-  providerId: ProviderId,
+  providerId: LlmProviderId,
   modelId: string,
 ): Record<string, Tool> {
   const sanitize = selectSanitizer(providerId, modelId);

--- a/packages/server/src/llm/provider/provider.ts
+++ b/packages/server/src/llm/provider/provider.ts
@@ -9,11 +9,11 @@ import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { createGateway } from 'ai';
 
-import type { ProviderCredentials } from '@/provider/config/schema.js';
+import type { ModelProviderCredentials } from '@/provider/config/schema.js';
 
 export { type ProviderCredentials } from '@/provider/config/schema.js';
 
-export const createProvider = (credentials: ProviderCredentials) => {
+export const createProvider = (credentials: ModelProviderCredentials) => {
   switch (credentials.providerId) {
     case 'amazon-bedrock': {
       const base = { region: credentials.region };
@@ -94,10 +94,5 @@ export const createProvider = (credentials: ProviderCredentials) => {
         name: 'ollama_local',
         baseURL: (credentials.baseURL ?? 'http://localhost:11434') + '/v1',
       });
-
-    case 'elevenlabs':
-    case 'assemblyai':
-      // STT-only providers — must not be used to create an LLM provider
-      throw new Error(`${credentials.providerId} is STT-only and has no LLM provider`);
   }
 };

--- a/packages/server/src/llm/resolve-model.ts
+++ b/packages/server/src/llm/resolve-model.ts
@@ -1,16 +1,17 @@
 import { eq } from 'drizzle-orm';
 
+import type { LlmProviderId } from '@stitch/shared/providers/types';
 import type { SettingsKey } from '@stitch/shared/settings/types';
 
 import { getDb } from '@/db/client.js';
 import { providerConfig } from '@/db/schema/providers.js';
 import { err, ok, type ServiceResult } from '@/lib/service-result.js';
-import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { isAllowedProvider } from '@/models/llm/registry.js';
 import * as Models from '@/models/llm/registry.js';
+import { isLlmProviderCredentials, type LlmProviderCredentials } from '@/provider/config/schema.js';
 import { getSettings } from '@/settings/service.js';
 
-export type ResolvedModel = { providerId: string; modelId: string; credentials: ProviderCredentials };
+export type ResolvedModel = { providerId: LlmProviderId; modelId: string; credentials: LlmProviderCredentials };
 
 type ResolveModelInput = {
   /** Settings keys to check for user-configured preference */
@@ -103,6 +104,10 @@ export async function resolveModel(input: ResolveModelInput): Promise<ServiceRes
 
   const config = configs.find((c) => c.providerId === targetProviderId);
   if (!config) return err('Provider is not configured', 400);
+
+  if (config.credentials.providerId !== targetProviderId || !isLlmProviderCredentials(config.credentials)) {
+    return err('Provider credentials do not match the resolved LLM provider', 400);
+  }
 
   return ok({ providerId: targetProviderId, modelId: targetModelId, credentials: config.credentials });
 }

--- a/packages/server/src/llm/session-summary.ts
+++ b/packages/server/src/llm/session-summary.ts
@@ -4,7 +4,7 @@ import { eq, asc } from 'drizzle-orm';
 import type { StoredPart } from '@stitch/shared/chat/messages';
 import type { PrefixedString } from '@stitch/shared/id';
 import { createMessageId, createPartId } from '@stitch/shared/id';
-import type { ProviderId } from '@stitch/shared/providers/types';
+import type { LlmProviderId } from '@stitch/shared/providers/types';
 
 import { getDb } from '@/db/client.js';
 import { messages, sessions } from '@/db/schema/sessions.js';
@@ -15,13 +15,13 @@ import { buildHistoryMessages } from '@/llm/history-messages.js';
 import { getPromptUserContext } from '@/llm/prompt/builder.js';
 import { getProviderOptions } from '@/llm/provider-options.js';
 import { createProvider } from '@/llm/provider/provider.js';
-import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
 import { mapAIError, toStreamErrorDetails } from '@/llm/stream/ai-error-mapper.js';
 import { getSessionToolsetState } from '@/llm/stream/session-toolsets.js';
 import { getToolPruneProtectOverrides } from '@/llm/tool-prune-policy.js';
 import * as OllamaModels from '@/models/llm/ollama.js';
 import * as Models from '@/models/llm/registry.js';
+import type { LlmProviderCredentials } from '@/provider/config/schema.js';
 import { getSettings } from '@/settings/service.js';
 import { getSessionTodosPromptBlock } from '@/todos/service.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
@@ -194,7 +194,7 @@ type CompactionSeverity = 'normal' | 'overflow';
 async function resolveCompactionModel(
   fallbackProviderId: string,
   fallbackModelId: string,
-): Promise<{ providerId: string; modelId: string; credentials: ProviderCredentials; limits: ModelLimits }> {
+): Promise<{ providerId: LlmProviderId; modelId: string; credentials: LlmProviderCredentials; limits: ModelLimits }> {
   const resolved = await resolveCheapModel({
     providerIdKey: 'model.compaction.providerId',
     modelIdKey: 'model.compaction.modelId',
@@ -318,8 +318,8 @@ export async function compact(input: {
       { role: 'user', content: severity === 'overflow' ? COMPACTION_PROMPT_OVERFLOW : COMPACTION_PROMPT },
     ];
 
-    const cachedMessages = addCacheControlToMessages(llmMessages, resolved.providerId as ProviderId, resolved.modelId);
-    const providerOptions = getProviderOptions(resolved.providerId as ProviderId, sessionId);
+    const cachedMessages = addCacheControlToMessages(llmMessages, resolved.providerId, resolved.modelId);
+    const providerOptions = getProviderOptions(resolved.providerId, sessionId);
 
     let summaryText = '';
     const result = streamText({

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import type { StoredPart } from '@stitch/shared/chat/messages';
 import { createPartId } from '@stitch/shared/id';
 import type { PrefixedString } from '@stitch/shared/id';
+import type { LlmProviderId } from '@stitch/shared/providers/types';
 
 import { saveAssistantMessage, markSessionUnread } from '@/chat/message-store.js';
 import { internalBus } from '@/lib/internal-bus.js';
@@ -10,7 +11,6 @@ import * as Log from '@/lib/log.js';
 import { transformAttachmentsForModel } from '@/llm/attachment-transform.js';
 import { compactConversationForStep } from '@/llm/context-budget.js';
 import { createProvider } from '@/llm/provider/provider.js';
-import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { isOverflow, compact, getCompactionSettings, getModelLimits, pruneSession } from '@/llm/session-summary.js';
 import { mapAIError, toStreamErrorDetails } from '@/llm/stream/ai-error-mapper.js';
 import { checkAndHandleDoomLoop, type ToolCallRecord } from '@/llm/stream/doom-loop.js';
@@ -29,6 +29,7 @@ import {
   setSessionToolsetState,
 } from '@/llm/stream/session-toolsets.js';
 import { executeStepWithRetry, type StepOptions } from '@/llm/stream/step-executor.js';
+import type { LlmProviderCredentials } from '@/provider/config/schema.js';
 import { MAX_STEPS, MAX_STEPS_WARNING } from '@/tools/runtime/registry.js';
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
@@ -54,7 +55,7 @@ type RunStreamOptions = {
   assistantMessageId: PrefixedString<'msg'>;
   modelId: string;
   llmMessages: ModelMessage[];
-  credentials: ProviderCredentials;
+  credentials: LlmProviderCredentials;
   abortSignal: AbortSignal;
   /** Toolset IDs to pre-activate (e.g. inherited from parent session) */
   activeToolsetIds?: string[];
@@ -78,7 +79,7 @@ type StreamRunnerContext = {
   sessionId: PrefixedString<'ses'>;
   assistantMessageId: PrefixedString<'msg'>;
   modelId: string;
-  providerId: string;
+  providerId: LlmProviderId;
   abortSignal: AbortSignal;
   streamRunId: string;
   startedAt: number;
@@ -1134,7 +1135,7 @@ export async function runStream(opts: {
   assistantMessageId: PrefixedString<'msg'>;
   modelId: string;
   llmMessages: ModelMessage[];
-  credentials: ProviderCredentials;
+  credentials: LlmProviderCredentials;
   abortSignal: AbortSignal;
   /** Toolset IDs to pre-activate (e.g. inherited from parent task) */
   activeToolsetIds?: string[];

--- a/packages/server/src/llm/stream/session-context.ts
+++ b/packages/server/src/llm/stream/session-context.ts
@@ -3,13 +3,13 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { createCodeModeTool } from '@/code-mode/tool.js';
 import * as Log from '@/lib/log.js';
 import { PromptComposer } from '@/llm/prompt/composer.js';
-import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { buildActiveToolsetInstructionsBlock } from '@/llm/session-summary.js';
 import {
   getCurrentSessionToolsetState,
   getSessionToolsetState,
   type SessionExpiredToolset,
 } from '@/llm/stream/session-toolsets.js';
+import type { LlmProviderCredentials } from '@/provider/config/schema.js';
 import { buildSkillsSystemPrompt } from '@/skills/service.js';
 import { createInspectImageTool } from '@/tools/core/inspect-image.js';
 import { createTaskTool } from '@/tools/core/task.js';
@@ -27,7 +27,7 @@ type SessionContextOptions = {
   sessionId: PrefixedString<'ses'>;
   messageId: PrefixedString<'msg'>;
   streamRunId: string;
-  credentials: ProviderCredentials;
+  credentials: LlmProviderCredentials;
   modelId: string;
   abortSignal: AbortSignal;
   llmMessages: ModelMessage[];

--- a/packages/server/src/llm/stream/step-executor.ts
+++ b/packages/server/src/llm/stream/step-executor.ts
@@ -2,7 +2,7 @@ import { streamText, smoothStream } from 'ai';
 
 import type { StoredPart } from '@stitch/shared/chat/messages';
 import type { PrefixedString } from '@stitch/shared/id';
-import type { ProviderId } from '@stitch/shared/providers/types';
+import type { LlmProviderId } from '@stitch/shared/providers/types';
 
 import { StreamAccumulator } from './stream-accumulator.js';
 
@@ -42,7 +42,7 @@ export type StepOptions = {
   model: ReturnType<ReturnType<typeof createProvider>>;
   conversation: ModelMessage[];
   accumulatedParts: StoredPart[];
-  providerId: string;
+  providerId: LlmProviderId;
   tools: Record<string, Tool>;
   abortSignal: AbortSignal;
   streamRunId: string;
@@ -72,10 +72,10 @@ async function executeStep(opts: StepOptions): Promise<StepResult> {
     'step execution started',
   );
 
-  const cachedMessages = addCacheControlToMessages(conversation, opts.providerId as ProviderId, model.modelId);
-  const sanitizedTools = sanitizeToolSchemasForProvider(tools, opts.providerId as ProviderId, model.modelId);
-  const cachedTools = addCacheControlToTools(sanitizedTools, opts.providerId as ProviderId, model.modelId);
-  const providerOptions = getProviderOptions(opts.providerId as ProviderId, opts.sessionId);
+  const cachedMessages = addCacheControlToMessages(conversation, opts.providerId, model.modelId);
+  const sanitizedTools = sanitizeToolSchemasForProvider(tools, opts.providerId, model.modelId);
+  const cachedTools = addCacheControlToTools(sanitizedTools, opts.providerId, model.modelId);
+  const providerOptions = getProviderOptions(opts.providerId, opts.sessionId);
 
   const result = streamText({
     model,

--- a/packages/server/src/llm/title-generator.test.ts
+++ b/packages/server/src/llm/title-generator.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, test, mock } from 'bun:test';
 import { generateTitle } from '@/llm/title-generator.js';
 
 const RESOLVED_MODEL = {
-  providerId: 'openai',
+  providerId: 'openai' as const,
   modelId: 'gpt-5-nano',
   credentials: { providerId: 'openai' as const, auth: { method: 'api-key' as const, apiKey: 'test-key' } },
 };

--- a/packages/server/src/llm/title-generator.ts
+++ b/packages/server/src/llm/title-generator.ts
@@ -3,6 +3,7 @@ import { generateText } from 'ai';
 import * as Log from '@/lib/log.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
+import type { ResolvedModel } from '@/llm/resolve-model.js';
 import { mapAIError } from '@/llm/stream/ai-error-mapper.js';
 import type { LanguageModelUsage } from 'ai';
 
@@ -30,11 +31,7 @@ type GeneratedTitle = { title: string; usage: LanguageModelUsage | null; provide
 
 type TitleGeneratorDeps = {
   resolveModel?: typeof resolveCheapModel;
-  getModel?: (resolved: {
-    providerId: string;
-    modelId: string;
-    credentials: Parameters<typeof createProvider>[0];
-  }) => ReturnType<ReturnType<typeof createProvider>>;
+  getModel?: (resolved: ResolvedModel) => ReturnType<ReturnType<typeof createProvider>>;
 };
 
 export async function generateTitle(

--- a/packages/server/src/models/embedding/factory.ts
+++ b/packages/server/src/models/embedding/factory.ts
@@ -7,6 +7,7 @@ import { getEmbeddingModelDimensions } from '@/llm/provider/service.js';
 import { getMemoryConfig, hasConfiguredEmbeddingModel, invalidateMemoryConfig } from '@/memory/config.js';
 import type { Embedder } from '@/models/embedding/embedder.js';
 import { ProviderEmbedder } from '@/models/embedding/provider-embedder.js';
+import { isEmbeddingProviderCredentials } from '@/provider/config/schema.js';
 
 const log = Log.create({ service: 'embedder' });
 
@@ -48,9 +49,12 @@ export async function createEmbedder(): Promise<Embedder> {
   if (!config_) {
     throw new Error(`Configured embedding provider is unavailable: ${providerId}`);
   }
+  if (config_.credentials.providerId !== providerId || !isEmbeddingProviderCredentials(config_.credentials)) {
+    throw new Error(`Configured provider is not available for embeddings: ${providerId}`);
+  }
 
   const dimensions = (await getEmbeddingModelDimensions(providerId, modelId)) ?? DEFAULT_DIMENSIONS;
   log.info({ providerId, modelId, dimensions }, 'using provider embedder');
-  cachedEmbedder = new ProviderEmbedder(config_.credentials, providerId, modelId, dimensions);
+  cachedEmbedder = new ProviderEmbedder(config_.credentials, config_.credentials.providerId, modelId, dimensions);
   return cachedEmbedder;
 }

--- a/packages/server/src/models/embedding/provider-embedder.ts
+++ b/packages/server/src/models/embedding/provider-embedder.ts
@@ -1,8 +1,10 @@
 import { embed, embedMany, type EmbeddingModel } from 'ai';
 
+import type { EmbeddingProviderId } from '@stitch/shared/providers/types';
+
 import { createProvider } from '@/llm/provider/provider.js';
-import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import type { EmbedManyResult, EmbedResult, Embedder } from '@/models/embedding/embedder.js';
+import type { EmbeddingProviderCredentials } from '@/provider/config/schema.js';
 
 /**
  * Embedding implementation using AI SDK providers (OpenAI, Google, etc.).
@@ -14,7 +16,12 @@ export class ProviderEmbedder implements Embedder {
   readonly modelId: string;
   private readonly model: EmbeddingModel;
 
-  constructor(credentials: ProviderCredentials, providerId: string, modelId: string, dimensions: number) {
+  constructor(
+    credentials: EmbeddingProviderCredentials,
+    providerId: EmbeddingProviderId,
+    modelId: string,
+    dimensions: number,
+  ) {
     const embeddingProvider = createProvider(credentials);
     this.model = embeddingProvider.embeddingModel(modelId);
     this.dimensions = dimensions;

--- a/packages/server/src/models/embedding/registry.ts
+++ b/packages/server/src/models/embedding/registry.ts
@@ -1,3 +1,5 @@
+import { EMBEDDING_PROVIDER_IDS } from '@stitch/shared/providers/types';
+
 import { PATHS } from '@/lib/paths.js';
 import { createRegistryCache, getStitchRegistryUserAgent } from '@/lib/registry-cache.js';
 import {
@@ -10,6 +12,7 @@ import {
 } from '@/models/embedding/schema.js';
 
 const DEFAULT_EMBEDDING_REGISTRY_URL = 'https://usestitch.ai/embedding-models.json';
+const ALLOWED_PROVIDER_IDS = new Set<string>(EMBEDDING_PROVIDER_IDS);
 
 function toResolvedModel(model: EmbeddingModel): ResolvedEmbeddingModel {
   return {
@@ -47,10 +50,9 @@ const embeddingRegistryCache = createRegistryCache<EmbeddingRegistryPayload>({
     const payload = EmbeddingRegistryPayloadSchema.parse(raw);
     return {
       ...payload,
-      providers: payload.providers.map((provider) => ({
-        ...provider,
-        models: provider.models.filter((model) => !model.deprecated),
-      })),
+      providers: payload.providers
+        .filter((provider) => ALLOWED_PROVIDER_IDS.has(provider.providerId))
+        .map((provider) => ({ ...provider, models: provider.models.filter((model) => !model.deprecated) })),
     };
   },
   userAgent: getStitchRegistryUserAgent,

--- a/packages/server/src/models/llm/registry.ts
+++ b/packages/server/src/models/llm/registry.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 
-import { PROVIDER_IDS, type ProviderId } from '@stitch/shared/providers/types';
+import { LLM_PROVIDER_IDS, type LlmProviderId } from '@stitch/shared/providers/types';
 
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
@@ -9,10 +9,10 @@ import { createRegistryCache } from '@/lib/registry-cache.js';
 const log = Log.create({ service: 'models.dev' });
 const MODELS_DEV_URL = 'https://models.dev/api.json';
 
-const ALLOWERD_PROVIDER_IDS = PROVIDER_IDS satisfies readonly ProviderId[];
+const ALLOWED_PROVIDER_IDS = LLM_PROVIDER_IDS satisfies readonly LlmProviderId[];
 
-export function isAllowedProvider(providerId: string): boolean {
-  return (ALLOWERD_PROVIDER_IDS as readonly string[]).includes(providerId);
+export function isAllowedProvider(providerId: string): providerId is LlmProviderId {
+  return (ALLOWED_PROVIDER_IDS as readonly string[]).includes(providerId);
 }
 
 export const ModelSchema = z.object({

--- a/packages/server/src/models/stt/registry.ts
+++ b/packages/server/src/models/stt/registry.ts
@@ -1,8 +1,11 @@
+import { STT_PROVIDER_IDS } from '@stitch/shared/providers/types';
+
 import { PATHS } from '@/lib/paths.js';
 import { createRegistryCache, getStitchRegistryUserAgent } from '@/lib/registry-cache.js';
 import { SttRegistryPayloadSchema, type SttProvider, type SttRegistryPayload } from '@/models/stt/schema.js';
 
 const DEFAULT_STT_REGISTRY_URL = 'https://usestitch.ai/stt-models.json';
+const ALLOWED_PROVIDER_IDS = new Set<string>(STT_PROVIDER_IDS);
 
 function getRegistryUrl(): string {
   return process.env['STITCH_STT_REGISTRY_URL']?.trim() || DEFAULT_STT_REGISTRY_URL;
@@ -17,10 +20,9 @@ const sttRegistryCache = createRegistryCache<SttRegistryPayload>({
     const payload = SttRegistryPayloadSchema.parse(raw);
     return {
       ...payload,
-      providers: payload.providers.map((provider) => ({
-        ...provider,
-        models: provider.models.filter((model) => !model.deprecated),
-      })),
+      providers: payload.providers
+        .filter((provider) => ALLOWED_PROVIDER_IDS.has(provider.providerId))
+        .map((provider) => ({ ...provider, models: provider.models.filter((model) => !model.deprecated) })),
     };
   },
   userAgent: getStitchRegistryUserAgent,

--- a/packages/server/src/provider/config/schema.ts
+++ b/packages/server/src/provider/config/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
-import { AWS_BEDROCK_REGIONS } from '@stitch/shared/providers/types';
-import type { ProviderId } from '@stitch/shared/providers/types';
+import { AWS_BEDROCK_REGIONS, isEmbeddingProviderId, isLlmProviderId } from '@stitch/shared/providers/types';
+import type { EmbeddingProviderId, LlmProviderId, ProviderId } from '@stitch/shared/providers/types';
 
 const AWS_REGION_VALUES = AWS_BEDROCK_REGIONS.map((r) => r.value) as [string, ...string[]];
 
@@ -97,6 +97,22 @@ export const ProviderCredentialsSchema = z.discriminatedUnion('providerId', [
 ]);
 
 export type ProviderCredentials = z.infer<typeof ProviderCredentialsSchema>;
+export type LlmProviderCredentials = Extract<ProviderCredentials, { providerId: LlmProviderId }>;
+export type EmbeddingProviderCredentials = Extract<ProviderCredentials, { providerId: EmbeddingProviderId }>;
+export type ModelProviderCredentials = Extract<
+  ProviderCredentials,
+  { providerId: LlmProviderId | EmbeddingProviderId }
+>;
+
+export function isLlmProviderCredentials(credentials: ProviderCredentials): credentials is LlmProviderCredentials {
+  return isLlmProviderId(credentials.providerId);
+}
+
+export function isEmbeddingProviderCredentials(
+  credentials: ProviderCredentials,
+): credentials is EmbeddingProviderCredentials {
+  return isEmbeddingProviderId(credentials.providerId);
+}
 
 // Compile-time guard: every ProviderId must have a credentials schema entry and vice versa.
 // If you add a new ID to PROVIDER_IDS without a schema, or a schema without an ID, this fails.

--- a/packages/server/src/recordings/analysis-service.test.ts
+++ b/packages/server/src/recordings/analysis-service.test.ts
@@ -111,7 +111,7 @@ describe('recording analysis reruns', () => {
       {
         resolveModel: async () =>
           ok({
-            providerId: 'test-provider',
+            providerId: 'openai',
             modelId: 'test-model',
             credentials: { providerId: 'openai', auth: { method: 'api-key', apiKey: 'test-key' } },
           }),

--- a/packages/server/src/recordings/analysis-service.ts
+++ b/packages/server/src/recordings/analysis-service.ts
@@ -18,8 +18,8 @@ import { resolveRuntimeAssetPath } from '@/lib/runtime-assets.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { createProvider } from '@/llm/provider/provider.js';
-import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { resolveModel } from '@/llm/resolve-model.js';
+import type { LlmProviderCredentials } from '@/provider/config/schema.js';
 import { readRecordingAnalysis, readRecordingTranscript, writeRecordingAnalysis } from '@/recordings/file-store.js';
 import { getMeetingNoteTemplate } from '@/recordings/meeting-note-templates.js';
 import { generateRecordingTitle } from '@/recordings/title-generator.js';
@@ -39,7 +39,7 @@ const ANALYSIS_PROMPT_TEMPLATE = readFileSync(
 
 type AnalysisDeps = {
   resolveModel: typeof resolveModel;
-  createProvider: (credentials: ProviderCredentials) => (modelId: string) => LanguageModel;
+  createProvider: (credentials: LlmProviderCredentials) => (modelId: string) => LanguageModel;
 };
 
 const defaultDeps: AnalysisDeps = { resolveModel, createProvider };
@@ -279,7 +279,7 @@ async function runRecordingAnalysis(
     templateContent: string;
     analysisProviderId: string;
     analysisModelId: string;
-    analysisCredentials: ProviderCredentials;
+    analysisCredentials: LlmProviderCredentials;
     preserveExistingUntilComplete: boolean;
   },
   deps: AnalysisDeps,

--- a/packages/server/src/recordings/title-generator.ts
+++ b/packages/server/src/recordings/title-generator.ts
@@ -2,8 +2,8 @@ import { generateText } from 'ai';
 
 import * as Log from '@/lib/log.js';
 import { createProvider } from '@/llm/provider/provider.js';
-import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
+import type { ResolvedModel } from '@/llm/resolve-model.js';
 import { mapAIError } from '@/llm/stream/ai-error-mapper.js';
 import type { LanguageModelUsage } from 'ai';
 
@@ -13,11 +13,7 @@ type GeneratedRecordingTitle = { title: string; usage: LanguageModelUsage | null
 
 type RecordingTitleGeneratorDeps = {
   resolveModel?: typeof resolveCheapModel;
-  getModel?: (resolved: {
-    providerId: string;
-    modelId: string;
-    credentials: ProviderCredentials;
-  }) => ReturnType<ReturnType<typeof createProvider>>;
+  getModel?: (resolved: ResolvedModel) => ReturnType<ReturnType<typeof createProvider>>;
 };
 
 function buildRecordingTitlePrompt(analysis: string): string {

--- a/packages/server/src/tools/core/inspect-image.ts
+++ b/packages/server/src/tools/core/inspect-image.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import type { StoredPart } from '@stitch/shared/chat/messages';
 import { createMessageId, createPartId } from '@stitch/shared/id';
 import type { PrefixedString } from '@stitch/shared/id';
+import type { LlmProviderId } from '@stitch/shared/providers/types';
 
 import { createSession } from '@/chat/session-crud.js';
 import { getDb } from '@/db/client.js';
@@ -14,9 +15,9 @@ import { messages } from '@/db/schema/sessions.js';
 import * as AbortRegistry from '@/lib/abort-registry.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
-import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { buildSessionLlmMessages } from '@/llm/session-history.js';
 import { runStream } from '@/llm/stream/runner.js';
+import type { LlmProviderCredentials } from '@/provider/config/schema.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 
 const log = Log.create({ service: 'inspect-image-tool' });
@@ -50,9 +51,9 @@ Supported formats: PNG, JPG, JPEG, GIF, WEBP, SVG, BMP.`;
 type InspectImageToolDeps = {
   parentSessionId: PrefixedString<'ses'>;
   parentAbortSignal: AbortSignal;
-  credentials: ProviderCredentials;
+  credentials: LlmProviderCredentials;
   modelId: string;
-  providerId: string;
+  providerId: LlmProviderId;
 };
 
 export function createInspectImageTool(context: ToolContext, deps: InspectImageToolDeps) {

--- a/packages/server/src/tools/core/task.ts
+++ b/packages/server/src/tools/core/task.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import type { StoredPart } from '@stitch/shared/chat/messages';
 import { createMessageId, createPartId } from '@stitch/shared/id';
 import type { PrefixedString } from '@stitch/shared/id';
+import type { LlmProviderId } from '@stitch/shared/providers/types';
 
 import { createSession } from '@/chat/session-crud.js';
 import { getDb } from '@/db/client.js';
@@ -12,9 +13,9 @@ import { messages } from '@/db/schema/sessions.js';
 import * as AbortRegistry from '@/lib/abort-registry.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
-import type { ProviderCredentials } from '@/llm/provider/provider.js';
 import { buildSessionLlmMessages } from '@/llm/session-history.js';
 import { runStream } from '@/llm/stream/runner.js';
+import type { LlmProviderCredentials } from '@/provider/config/schema.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 import type { ToolsetManager } from '@/tools/toolsets/manager.js';
 
@@ -37,9 +38,9 @@ Returns a summary of the completed work. You can also link the user to the child
 type TaskToolDeps = {
   parentSessionId: PrefixedString<'ses'>;
   parentAbortSignal: AbortSignal;
-  credentials: ProviderCredentials;
+  credentials: LlmProviderCredentials;
   modelId: string;
-  providerId: string;
+  providerId: LlmProviderId;
   toolsetManager: ToolsetManager;
 };
 

--- a/packages/shared/src/providers/catalog.ts
+++ b/packages/shared/src/providers/catalog.ts
@@ -78,7 +78,7 @@ export const PROVIDER_META: Record<ProviderId, ProviderMeta> = {
     displayName: 'Google AI',
     description: 'Access to Gemini and other Google AI models',
     api: 'https://generativelanguage.googleapis.com',
-    capabilities: ['llm'],
+    capabilities: ['llm', 'embedding'],
     extraFields: [],
     authMethods: [
       {
@@ -149,7 +149,7 @@ export const PROVIDER_META: Record<ProviderId, ProviderMeta> = {
     displayName: 'NVIDIA',
     description: 'Access to NVIDIA NIM and foundation models',
     api: 'https://integrate.api.nvidia.com',
-    capabilities: ['llm'],
+    capabilities: ['llm', 'embedding'],
     extraFields: [],
     authMethods: [
       {
@@ -174,7 +174,7 @@ export const PROVIDER_META: Record<ProviderId, ProviderMeta> = {
     displayName: 'OpenRouter',
     description: 'Unified API for multiple LLM providers',
     api: 'https://openrouter.ai/api',
-    capabilities: ['llm'],
+    capabilities: ['llm', 'embedding'],
     extraFields: [],
     authMethods: [
       {

--- a/packages/shared/src/providers/types.ts
+++ b/packages/shared/src/providers/types.ts
@@ -37,6 +37,48 @@ export type AuthMethodDef = { method: string; label: string; enabled: boolean; f
 
 export type ProviderCapability = 'llm' | 'stt' | 'embedding';
 
+export const PROVIDER_CAPABILITIES = {
+  'amazon-bedrock': ['llm'],
+  anthropic: ['llm'],
+  assemblyai: ['stt'],
+  elevenlabs: ['stt'],
+  google: ['llm', 'embedding'],
+  'google-vertex': ['llm'],
+  nvidia: ['llm', 'embedding'],
+  ollama_local: ['llm'],
+  openai: ['llm', 'stt', 'embedding'],
+  openrouter: ['llm', 'embedding'],
+  vercel: ['llm'],
+} as const satisfies Record<string, readonly ProviderCapability[]>;
+
+export type ProviderId = keyof typeof PROVIDER_CAPABILITIES;
+
+type ProvidersWithCapability<C extends ProviderCapability> = {
+  [K in ProviderId]: C extends (typeof PROVIDER_CAPABILITIES)[K][number] ? K : never;
+}[ProviderId];
+
+export type LlmProviderId = ProvidersWithCapability<'llm'>;
+type SttProviderId = ProvidersWithCapability<'stt'>;
+export type EmbeddingProviderId = ProvidersWithCapability<'embedding'>;
+
+function hasProviderCapability(providerId: string, capability: ProviderCapability): providerId is ProviderId {
+  return (
+    (PROVIDER_CAPABILITIES as Record<string, readonly ProviderCapability[]>)[providerId]?.includes(capability) ?? false
+  );
+}
+
+export function isLlmProviderId(providerId: string): providerId is LlmProviderId {
+  return hasProviderCapability(providerId, 'llm');
+}
+
+function isSttProviderId(providerId: string): providerId is SttProviderId {
+  return hasProviderCapability(providerId, 'stt');
+}
+
+export function isEmbeddingProviderId(providerId: string): providerId is EmbeddingProviderId {
+  return hasProviderCapability(providerId, 'embedding');
+}
+
 export type ProviderMeta = {
   displayName: string;
   description?: string;
@@ -46,18 +88,7 @@ export type ProviderMeta = {
   authMethods: AuthMethodDef[];
 };
 
-export const PROVIDER_IDS = [
-  'amazon-bedrock',
-  'anthropic',
-  'assemblyai',
-  'elevenlabs',
-  'google',
-  'google-vertex',
-  'nvidia',
-  'ollama_local',
-  'openai',
-  'openrouter',
-  'vercel',
-] as const;
-
-export type ProviderId = (typeof PROVIDER_IDS)[number];
+export const PROVIDER_IDS = Object.keys(PROVIDER_CAPABILITIES) as ProviderId[];
+export const LLM_PROVIDER_IDS = PROVIDER_IDS.filter(isLlmProviderId);
+export const STT_PROVIDER_IDS = PROVIDER_IDS.filter(isSttProviderId);
+export const EMBEDDING_PROVIDER_IDS = PROVIDER_IDS.filter(isEmbeddingProviderId);

--- a/registries/embeddings/models/openai.json
+++ b/registries/embeddings/models/openai.json
@@ -6,7 +6,7 @@
   "models": [
     {
       "id": "text-embedding-3-large",
-      "name": "text-embedding-3-large",
+      "name": "Text Embedding 3 Large",
       "family": "text-embedding",
       "deprecated": false,
       "dimensions": 3072,
@@ -16,7 +16,7 @@
     },
     {
       "id": "text-embedding-3-small",
-      "name": "text-embedding-3-small",
+      "name": "Text Embedding 3 Small",
       "family": "text-embedding",
       "deprecated": false,
       "dimensions": 1536,
@@ -26,7 +26,7 @@
     },
     {
       "id": "text-embedding-ada-002",
-      "name": "text-embedding-ada-002",
+      "name": "Text Embedding Ada 002",
       "family": "text-embedding",
       "deprecated": false,
       "dimensions": 1536,


### PR DESCRIPTION
## 🚀 Change Summary

Introduces capability-specific provider typing so auth/config can continue using the full provider list while LLM, STT, and embedding code use service-specific provider subsets.

### 🛠 Improvements & Refactors
- **Provider Capability Types**: Adds derived LLM, STT, and embedding provider IDs/lists from shared provider capabilities.
- **LLM Provider Narrowing**: Updates LLM cache control, provider options, schema sanitization, streaming, compaction, title generation, and recordings analysis paths to use LLM-specific provider types.
- **Registry Filtering**: Filters LLM, STT, and embedding registries with capability-specific allow lists and deprecated-model filtering.
- **Credential Guards**: Adds runtime guards for persisted credentials before entering LLM or embedding execution paths.
- **Registry Display Names**: Cleans OpenAI embedding model display names while preserving model IDs.

### 🐛 Bug Fixes
- Removes STT-only provider cases from LLM cache-control and provider-options switches.
- Corrects provider metadata for embedding-capable Google, NVIDIA, and OpenRouter providers.