### PR TITLE
feat(connectors): separate credentials from accounts

### DIFF
--- a/apps/web/src/components/connectors/connectors-page.tsx
+++ b/apps/web/src/components/connectors/connectors-page.tsx
@@ -20,10 +20,15 @@ import {
   PageTitle,
 } from '@/components/ui/page';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { connectorDefinitionsQueryOptions, connectorInstancesQueryOptions } from '@/lib/queries/connectors';
+import {
+  connectorDefinitionsQueryOptions,
+  connectorInstancesQueryOptions,
+  connectorsQueryOptions,
+} from '@/lib/queries/connectors';
 
 export function ConnectorsPage() {
   const { data: definitions } = useSuspenseQuery(connectorDefinitionsQueryOptions);
+  const { data: connectors } = useSuspenseQuery(connectorsQueryOptions);
   const { data: instances } = useSuspenseQuery(connectorInstancesQueryOptions);
   const [setupConnector, setSetupConnector] = useState<ConnectorDefinition | null>(null);
   const [search, setSearch] = useState('');
@@ -116,7 +121,13 @@ export function ConnectorsPage() {
         </Tabs>
       </PageContent>
 
-      {setupConnector && <SetupWizard definition={setupConnector} onClose={() => setSetupConnector(null)} />}
+      {setupConnector && (
+        <SetupWizard
+          definition={setupConnector}
+          connectors={connectors.filter((connector) => connector.connectorId === setupConnector.id)}
+          onClose={() => setSetupConnector(null)}
+        />
+      )}
     </Page>
   );
 }

--- a/apps/web/src/components/connectors/setup-wizard.tsx
+++ b/apps/web/src/components/connectors/setup-wizard.tsx
@@ -6,6 +6,7 @@ import type {
   ConnectorDefinition,
   OAuthConfig,
   ApiKeyConfig,
+  ConnectorSafe,
   ConnectorSetupInstruction,
 } from '@stitch/shared/connectors/types';
 
@@ -23,20 +24,27 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { getErrorMessage } from '@/lib/errors';
-import { useCreateOAuthConnector, useCreateApiKeyConnector, useAuthorizeConnector } from '@/lib/queries/connectors';
+import {
+  useCreateOAuthConnectorCredentials,
+  useCreateOAuthConnectorAccount,
+  useCreateApiKeyConnector,
+  useAuthorizeConnector,
+} from '@/lib/queries/connectors';
 
-type Props = { definition: ConnectorDefinition; onClose: () => void };
+type Props = { definition: ConnectorDefinition; connectors: ConnectorSafe[]; onClose: () => void };
 
-type WizardStep = 'instructions' | 'credentials' | 'scopes' | 'authorizing' | 'done';
+type WizardStep = 'instructions' | 'connector' | 'account' | 'scopes' | 'authorizing' | 'done';
 
-export function SetupWizard({ definition, onClose }: Props) {
+export function SetupWizard({ definition, connectors, onClose }: Props) {
   const [step, setStep] = useState<WizardStep>('instructions');
   const [label, setLabel] = useState('');
 
   // OAuth fields
   const [clientId, setClientId] = useState('');
   const [clientSecret, setClientSecret] = useState('');
+  const [selectedConnectorRefId, setSelectedConnectorRefId] = useState<string>(connectors[0]?.id ?? 'new');
   const [selectedScopes, setSelectedScopes] = useState<string[]>(
     definition.authType === 'oauth2' ? (definition.authConfig as OAuthConfig).defaultScopes : [],
   );
@@ -44,13 +52,15 @@ export function SetupWizard({ definition, onClose }: Props) {
   // API key fields
   const [apiKey, setApiKey] = useState('');
 
-  const createOAuth = useCreateOAuthConnector();
+  const createOAuthCredentials = useCreateOAuthConnectorCredentials();
+  const createOAuthAccount = useCreateOAuthConnectorAccount();
   const createApiKey = useCreateApiKeyConnector();
   const authorize = useAuthorizeConnector();
 
   const isOAuth = definition.authType === 'oauth2';
   const oauthConfig = isOAuth ? (definition.authConfig as OAuthConfig) : null;
   const apiKeyConfig = !isOAuth ? (definition.authConfig as ApiKeyConfig) : null;
+  const isCreatingConnector = selectedConnectorRefId === 'new';
 
   const initialServiceAccess = useMemo(() => {
     if (!oauthConfig?.serviceAccessOptions) return {} as Record<string, 'none' | 'read' | 'write'>;
@@ -79,17 +89,32 @@ export function SetupWizard({ definition, onClose }: Props) {
       setStep('authorizing');
 
       try {
-        if (!clientId.trim() || !clientSecret.trim()) {
+        let connectorRefId = selectedConnectorRefId;
+        if (isCreatingConnector) {
+          if (!clientId.trim() || !clientSecret.trim()) {
+            toast.error('Client ID and Client Secret are required', { id: 'connector-setup-credentials' });
+            setStep('connector');
+            return;
+          }
+
+          const connector = await createOAuthCredentials.mutateAsync({
+            connectorId: definition.id,
+            label: label.trim() || definition.name,
+            clientId: clientId.trim(),
+            clientSecret: clientSecret.trim(),
+          });
+          connectorRefId = connector.id;
+        }
+
+        if (!connectorRefId || connectorRefId === 'new') {
           toast.error('Client ID and Client Secret are required', { id: 'connector-setup-credentials' });
-          setStep('credentials');
+          setStep('connector');
           return;
         }
 
-        const instance = await createOAuth.mutateAsync({
-          connectorId: definition.id,
+        const instance = await createOAuthAccount.mutateAsync({
+          connectorRefId,
           label: label.trim() || definition.name,
-          clientId: clientId.trim(),
-          clientSecret: clientSecret.trim(),
           scopes: scopesToUse,
         });
 
@@ -98,7 +123,7 @@ export function SetupWizard({ definition, onClose }: Props) {
         setStep('done');
       } catch (e) {
         toast.error(getErrorMessage(e, 'Failed to create connector'), { id: 'connector-setup-create' });
-        setStep('scopes');
+        setStep('connector');
       }
     } else {
       if (!apiKey.trim()) {
@@ -119,7 +144,7 @@ export function SetupWizard({ definition, onClose }: Props) {
         toast.success('Connector created successfully', { id: 'connector-setup-create' });
       } catch (e) {
         toast.error(getErrorMessage(e, 'Failed to create connector'), { id: 'connector-setup-create' });
-        setStep('credentials');
+        setStep('connector');
       }
     }
   }
@@ -135,7 +160,8 @@ export function SetupWizard({ definition, onClose }: Props) {
           <WizardProgress step={step} isOAuth={isOAuth} />
           <DialogDescription>
             {step === 'instructions' && 'Follow these steps to set up your credentials.'}
-            {step === 'credentials' && 'Enter your credentials below.'}
+            {step === 'connector' && 'Choose or create connector credentials.'}
+            {step === 'account' && 'Name the account connection.'}
             {step === 'scopes' && 'Choose which permissions to grant.'}
             {step === 'authorizing' && 'Setting up your connection...'}
             {step === 'done' &&
@@ -145,30 +171,41 @@ export function SetupWizard({ definition, onClose }: Props) {
 
         <div className="min-h-0 flex-1">
           {step === 'instructions' && (
-            <InstructionsStep instructions={definition.setupInstructions} onNext={() => setStep('credentials')} />
+            <InstructionsStep instructions={definition.setupInstructions} onNext={() => setStep('connector')} />
           )}
 
-          {step === 'credentials' && (
-            <CredentialsStep
+          {step === 'connector' && (
+            <ConnectorCredentialsStep
               isOAuth={isOAuth}
-              label={label}
-              setLabel={setLabel}
               clientId={clientId}
               setClientId={setClientId}
               clientSecret={clientSecret}
               setClientSecret={setClientSecret}
+              connectors={connectors}
+              selectedConnectorRefId={selectedConnectorRefId}
+              setSelectedConnectorRefId={setSelectedConnectorRefId}
+              isCreatingConnector={isCreatingConnector}
               apiKey={apiKey}
               setApiKey={setApiKey}
               apiKeyConfig={apiKeyConfig}
-              definitionName={definition.name}
               onBack={() => setStep('instructions')}
               onNext={() => {
                 if (isOAuth && oauthConfig) {
-                  setStep('scopes');
+                  setStep('account');
                 } else {
                   void handleCreateAndAuthorize();
                 }
               }}
+            />
+          )}
+
+          {step === 'account' && (
+            <ConnectorAccountStep
+              label={label}
+              setLabel={setLabel}
+              definitionName={definition.name}
+              onBack={() => setStep('connector')}
+              onNext={() => setStep('scopes')}
             />
           )}
 
@@ -179,7 +216,7 @@ export function SetupWizard({ definition, onClose }: Props) {
               toggleScope={toggleScope}
               serviceAccess={serviceAccess}
               setServiceAccess={setServiceAccess}
-              onBack={() => setStep('credentials')}
+              onBack={() => setStep('account')}
               onNext={(scopes) => {
                 setSelectedScopes(scopes);
                 void handleCreateAndAuthorize(scopes);
@@ -256,69 +293,87 @@ function InstructionsStep({ instructions, onNext }: { instructions: ConnectorSet
   );
 }
 
-function CredentialsStep({
+function ConnectorCredentialsStep({
   isOAuth,
-  label,
-  setLabel,
   clientId,
   setClientId,
   clientSecret,
   setClientSecret,
+  connectors,
+  selectedConnectorRefId,
+  setSelectedConnectorRefId,
+  isCreatingConnector,
   apiKey,
   setApiKey,
   apiKeyConfig,
-  definitionName,
   onBack,
   onNext,
 }: {
   isOAuth: boolean;
-  label: string;
-  setLabel: (v: string) => void;
   clientId: string;
   setClientId: (v: string) => void;
   clientSecret: string;
   setClientSecret: (v: string) => void;
+  connectors: ConnectorSafe[];
+  selectedConnectorRefId: string;
+  setSelectedConnectorRefId: (v: string) => void;
+  isCreatingConnector: boolean;
   apiKey: string;
   setApiKey: (v: string) => void;
   apiKeyConfig: ApiKeyConfig | null;
-  definitionName: string;
   onBack: () => void;
   onNext: () => void;
 }) {
   return (
     <div className="flex h-full min-h-0 flex-col gap-3">
       <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
-        <div className="space-y-1.5">
-          <Label htmlFor="label">Label</Label>
-          <Input
-            id="label"
-            placeholder={`e.g. Work ${definitionName}, Personal ${definitionName}`}
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-          />
-        </div>
-
         {isOAuth ? (
           <>
             <div className="space-y-1.5">
-              <Label htmlFor="clientId">Client ID</Label>
-              <Input
-                id="clientId"
-                placeholder="Your OAuth Client ID"
-                value={clientId}
-                onChange={(e) => setClientId(e.target.value)}
-              />
+              <Label>Connector Credentials</Label>
+              <Select
+                value={selectedConnectorRefId}
+                onValueChange={(value) => setSelectedConnectorRefId(value ?? 'new')}>
+                <SelectTrigger className="w-full">
+                  <SelectValue>
+                    {isCreatingConnector
+                      ? 'Create new connector credentials'
+                      : connectors.find((connector) => connector.id === selectedConnectorRefId)?.label}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {connectors.map((connector) => (
+                    <SelectItem key={connector.id} value={connector.id}>
+                      {connector.label}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value="new">Create new connector credentials</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="clientSecret">Client Secret</Label>
-              <Input
-                id="clientSecret"
-                type="password"
-                placeholder="Your OAuth Client Secret"
-                value={clientSecret}
-                onChange={(e) => setClientSecret(e.target.value)}
-              />
-            </div>
+            {isCreatingConnector ? (
+              <>
+                <div className="space-y-1.5">
+                  <Label htmlFor="clientId">Client ID</Label>
+                  <Input
+                    id="clientId"
+                    placeholder="Your OAuth Client ID"
+                    value={clientId}
+                    onChange={(e) => setClientId(e.target.value)}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="clientSecret">Client Secret</Label>
+                  <Input
+                    id="clientSecret"
+                    type="password"
+                    placeholder="Your OAuth Client Secret"
+                    value={clientSecret}
+                    onChange={(e) => setClientSecret(e.target.value)}
+                  />
+                </div>
+              </>
+            ) : null}
           </>
         ) : (
           <div className="space-y-1.5">
@@ -356,7 +411,47 @@ function CredentialsStep({
           Back
         </Button>
         <Button onClick={onNext}>
-          {isOAuth ? 'Choose Scopes' : 'Connect'}
+          {isOAuth ? 'Continue' : 'Connect'}
+          <ArrowRightIcon className="size-3.5" />
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+}
+
+function ConnectorAccountStep({
+  label,
+  setLabel,
+  definitionName,
+  onBack,
+  onNext,
+}: {
+  label: string;
+  setLabel: (v: string) => void;
+  definitionName: string;
+  onBack: () => void;
+  onNext: () => void;
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3">
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
+        <div className="space-y-1.5">
+          <Label htmlFor="label">Account Label</Label>
+          <Input
+            id="label"
+            placeholder={`e.g. Work ${definitionName}, Personal ${definitionName}`}
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+          />
+        </div>
+      </div>
+      <DialogFooter className="shrink-0">
+        <Button variant="outline" onClick={onBack}>
+          <ArrowLeftIcon className="size-3.5" />
+          Back
+        </Button>
+        <Button onClick={onNext}>
+          Choose Scopes
           <ArrowRightIcon className="size-3.5" />
         </Button>
       </DialogFooter>
@@ -510,14 +605,15 @@ function WizardProgress({ step, isOAuth }: { step: WizardStep; isOAuth: boolean 
   const steps: Array<{ id: WizardStep; label: string }> = isOAuth
     ? [
         { id: 'instructions', label: 'Instructions' },
-        { id: 'credentials', label: 'Credentials' },
+        { id: 'connector', label: 'Connector' },
+        { id: 'account', label: 'Account' },
         { id: 'scopes', label: 'Access' },
         { id: 'authorizing', label: 'Authorize' },
         { id: 'done', label: 'Done' },
       ]
     : [
         { id: 'instructions', label: 'Instructions' },
-        { id: 'credentials', label: 'Credentials' },
+        { id: 'connector', label: 'Connector' },
         { id: 'authorizing', label: 'Connect' },
         { id: 'done', label: 'Done' },
       ];
@@ -525,7 +621,7 @@ function WizardProgress({ step, isOAuth }: { step: WizardStep; isOAuth: boolean 
   const activeIndex = steps.findIndex((item) => item.id === step);
 
   return (
-    <div className={`mt-2 grid gap-2 ${isOAuth ? 'grid-cols-2 sm:grid-cols-5' : 'grid-cols-2 sm:grid-cols-4'}`}>
+    <div className={`mt-2 grid gap-2 ${isOAuth ? 'grid-cols-2 sm:grid-cols-6' : 'grid-cols-2 sm:grid-cols-4'}`}>
       {steps.map((item, index) => (
         <div
           key={item.id}

--- a/apps/web/src/lib/queries/connectors.ts
+++ b/apps/web/src/lib/queries/connectors.ts
@@ -1,11 +1,12 @@
 import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
 
-import type { ConnectorDefinition, ConnectorInstanceSafe } from '@stitch/shared/connectors/types';
+import type { ConnectorDefinition, ConnectorInstanceSafe, ConnectorSafe } from '@stitch/shared/connectors/types';
 
 import { serverRequest } from '@/lib/api';
 
 const connectorKeys = {
   all: ['connectors'] as const,
+  configured: () => [...connectorKeys.all, 'configured'] as const,
   definitions: () => [...connectorKeys.all, 'definitions'] as const,
   instances: () => [...connectorKeys.all, 'instances'] as const,
   instance: (id: string) => [...connectorKeys.all, 'instance', id] as const,
@@ -14,6 +15,11 @@ const connectorKeys = {
 export const connectorDefinitionsQueryOptions = queryOptions({
   queryKey: connectorKeys.definitions(),
   queryFn: () => serverRequest<ConnectorDefinition[]>('/connectors/definitions'),
+});
+
+export const connectorsQueryOptions = queryOptions({
+  queryKey: connectorKeys.configured(),
+  queryFn: () => serverRequest<ConnectorSafe[]>('/connectors'),
 });
 
 export const connectorInstancesQueryOptions = queryOptions({
@@ -26,16 +32,25 @@ export const connectorInstancesQueryOptions = queryOptions({
   queryFn: () => serverRequest<ConnectorInstanceSafe[]>('/connectors/instances'),
 });
 
-export function useCreateOAuthConnector() {
+export function useCreateOAuthConnectorCredentials() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (input: {
-      connectorId: string;
-      label: string;
-      clientId: string;
-      clientSecret: string;
-      scopes: string[];
-    }) =>
+    mutationFn: (input: { connectorId: string; label: string; clientId: string; clientSecret: string }) =>
+      serverRequest<ConnectorSafe>('/connectors/oauth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: connectorKeys.all });
+    },
+  });
+}
+
+export function useCreateOAuthConnectorAccount() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { connectorRefId: string; label: string; scopes: string[] }) =>
       serverRequest<ConnectorInstanceSafe>('/connectors/instances/oauth', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/connectors/sdk/src/types.ts
+++ b/connectors/sdk/src/types.ts
@@ -29,12 +29,10 @@ export type ConnectorDefinitionInput = {
 export type ConnectorInstanceRecord = {
   id: string;
   connectorId: string;
+  connectorRefId: string;
   label: string;
   appliedVersion: number;
   capabilities: string[];
-  clientId: string | null;
-  clientSecret: string | null;
-  apiKey: string | null;
   accessToken: string | null;
   refreshToken: string | null;
   tokenExpiresAt: number | null;

--- a/packages/server/drizzle/0037_rich_maelstrom.sql
+++ b/packages/server/drizzle/0037_rich_maelstrom.sql
@@ -1,0 +1,45 @@
+CREATE TABLE `connectors` (
+	`id` text PRIMARY KEY NOT NULL,
+	`connector_id` text NOT NULL,
+	`auth_type` text NOT NULL,
+	`label` text NOT NULL,
+	`client_id` text,
+	`client_secret` text,
+	`api_key` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	CONSTRAINT "connectors_auth_type_check" CHECK("connectors"."auth_type" in ('oauth2', 'api_key'))
+);
+--> statement-breakpoint
+INSERT INTO `connectors` (`id`, `connector_id`, `auth_type`, `label`, `client_id`, `client_secret`, `api_key`, `created_at`, `updated_at`)
+SELECT 'cnr_migrated_' || `id`, `connector_id`, CASE WHEN `api_key` IS NOT NULL AND (`client_id` IS NULL OR `client_secret` IS NULL) THEN 'api_key' ELSE 'oauth2' END, `label` || ' Connector', `client_id`, `client_secret`, `api_key`, `created_at`, `updated_at`
+FROM `connector_instances`;--> statement-breakpoint
+CREATE TABLE `__new_connector_instances` (
+	`id` text PRIMARY KEY NOT NULL,
+	`connector_id` text NOT NULL,
+	`connector_ref_id` text NOT NULL,
+	`label` text NOT NULL,
+	`applied_version` integer DEFAULT 1 NOT NULL,
+	`capabilities` blob DEFAULT '[]' NOT NULL,
+	`access_token` text,
+	`refresh_token` text,
+	`token_expires_at` integer,
+	`scopes` blob,
+	`status` text DEFAULT 'pending_setup' NOT NULL,
+	`auth_issue` text,
+	`account_email` text,
+	`account_info` blob,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`connector_ref_id`) REFERENCES `connectors`(`id`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "connector_status_check" CHECK(`status` in ('pending_setup', 'awaiting_auth', 'connected', 'error'))
+);
+--> statement-breakpoint
+INSERT INTO `__new_connector_instances` (`id`, `connector_id`, `connector_ref_id`, `label`, `applied_version`, `capabilities`, `access_token`, `refresh_token`, `token_expires_at`, `scopes`, `status`, `auth_issue`, `account_email`, `account_info`, `created_at`, `updated_at`)
+SELECT `id`, `connector_id`, 'cnr_migrated_' || `id`, `label`, `applied_version`, `capabilities`, `access_token`, `refresh_token`, `token_expires_at`, `scopes`, `status`, `auth_issue`, `account_email`, `account_info`, `created_at`, `updated_at`
+FROM `connector_instances`;--> statement-breakpoint
+DROP TABLE `connector_instances`;--> statement-breakpoint
+ALTER TABLE `__new_connector_instances` RENAME TO `connector_instances`;--> statement-breakpoint
+CREATE INDEX `connectors_connector_id_idx` ON `connectors` (`connector_id`);--> statement-breakpoint
+CREATE INDEX `connector_instances_connector_id_idx` ON `connector_instances` (`connector_id`);--> statement-breakpoint
+CREATE INDEX `connector_instances_connector_ref_id_idx` ON `connector_instances` (`connector_ref_id`);

--- a/packages/server/drizzle/meta/0037_snapshot.json
+++ b/packages/server/drizzle/meta/0037_snapshot.json
@@ -1,0 +1,2695 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3fce8741-ec77-45b1-9d65-e4d5d0b30a2d",
+  "prevId": "a4b4d535-d3fd-4105-aa0c-ac89b56beccb",
+  "tables": {
+    "agenda_items": {
+      "name": "agenda_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'todo'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_items_list_id_idx": {
+          "name": "agenda_items_list_id_idx",
+          "columns": [
+            "list_id"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_status_idx": {
+          "name": "agenda_items_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_due_at_idx": {
+          "name": "agenda_items_due_at_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_created_at_idx": {
+          "name": "agenda_items_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_items_list_id_agenda_lists_id_fk": {
+          "name": "agenda_items_list_id_agenda_lists_id_fk",
+          "tableFrom": "agenda_items",
+          "tableTo": "agenda_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_items_type_check": {
+          "name": "agenda_items_type_check",
+          "value": "\"agenda_items\".\"type\" in ('todo', 'reminder', 'checkup')"
+        },
+        "agenda_items_status_check": {
+          "name": "agenda_items_status_check",
+          "value": "\"agenda_items\".\"status\" in ('open', 'in_progress', 'done', 'cancelled')"
+        },
+        "agenda_items_priority_check": {
+          "name": "agenda_items_priority_check",
+          "value": "\"agenda_items\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      }
+    },
+    "agenda_lists": {
+      "name": "agenda_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_lists_name_uidx": {
+          "name": "agenda_lists_name_uidx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "agenda_lists_created_at_idx": {
+          "name": "agenda_lists_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_ref_id": {
+          "name": "connector_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "auth_issue": {
+          "name": "auth_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instances_connector_ref_id_idx": {
+          "name": "connector_instances_connector_ref_id_idx",
+          "columns": [
+            "connector_ref_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connector_instances_connector_ref_id_connectors_id_fk": {
+          "name": "connector_instances_connector_ref_id_connectors_id_fk",
+          "tableFrom": "connector_instances",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "connectors": {
+      "name": "connectors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connectors_connector_id_idx": {
+          "name": "connectors_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connectors_auth_type_check": {
+          "name": "connectors_auth_type_check",
+          "value": "\"connectors\".\"auth_type\" in ('oauth2', 'api_key')"
+        }
+      }
+    },
+    "lance_migrations": {
+      "name": "lance_migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "prev_id": {
+          "name": "prev_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'applied'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_oauth_sessions": {
+      "name": "mcp_oauth_sessions",
+      "columns": {
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_information": {
+          "name": "client_information",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovery_state": {
+          "name": "discovery_state",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_oauth_sessions_server_id_mcp_servers_id_fk": {
+          "name": "mcp_oauth_sessions_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_oauth_sessions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_status": {
+          "name": "auth_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_enabled": {
+      "name": "tool_enabled",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_enabled_scope_identifier_uidx": {
+          "name": "tool_enabled_scope_identifier_uidx",
+          "columns": [
+            "scope",
+            "identifier"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": [
+            "tool_name",
+            "pattern"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ollama_models": {
+      "name": "ollama_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_limit": {
+          "name": "input_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_limit": {
+          "name": "output_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_cost_per_million": {
+          "name": "input_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_cost_per_million": {
+          "name": "output_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_cost_per_million": {
+          "name": "cache_read_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_per_million": {
+          "name": "cache_write_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_tool_calls": {
+          "name": "supports_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_vision": {
+          "name": "supports_vision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_reasoning": {
+          "name": "supports_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meeting_note_templates": {
+      "name": "meeting_note_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meeting_note_templates_updated_at_idx": {
+          "name": "meeting_note_templates_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_analyses": {
+      "name": "recording_analyses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_provider_id": {
+          "name": "transcription_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_model_id": {
+          "name": "transcription_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_provider_id": {
+          "name": "analysis_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_model_id": {
+          "name": "analysis_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recording_analyses_recording_id_uidx": {
+          "name": "recording_analyses_recording_id_uidx",
+          "columns": [
+            "recording_id"
+          ],
+          "isUnique": true
+        },
+        "recording_analyses_status_idx": {
+          "name": "recording_analyses_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recording_analyses_recording_id_recordings_id_fk": {
+          "name": "recording_analyses_recording_id_recordings_id_fk",
+          "tableFrom": "recording_analyses",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recording_analyses_status_check": {
+          "name": "recording_analyses_status_check",
+          "value": "\"recording_analyses\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "recordings": {
+      "name": "recordings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'recording'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recordings_created_at_idx": {
+          "name": "recordings_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "recordings_status_idx": {
+          "name": "recordings_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recordings_status_check": {
+          "name": "recordings_status_check",
+          "value": "\"recordings\".\"status\" in ('recording', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": [
+            "job_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": [
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_reason": {
+          "name": "archived_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_todos": {
+      "name": "session_todos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_todos_session_id_idx": {
+          "name": "session_todos_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "session_todos_order_idx": {
+          "name": "session_todos_order_idx",
+          "columns": [
+            "session_id",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_todos_session_id_sessions_id_fk": {
+          "name": "session_todos_session_id_sessions_id_fk",
+          "tableFrom": "session_todos",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "toolset_state": {
+          "name": "toolset_state",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_reason": {
+          "name": "archived_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_automation_id_automations_id_fk": {
+          "name": "sessions_automation_id_automations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_usage_events": {
+      "name": "embedding_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "embedding_usage_events_created_at_idx": {
+          "name": "embedding_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "embedding_usage_events_provider_model_idx": {
+          "name": "embedding_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "is_attributable": {
+          "name": "is_attributable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "step_index": {
+          "name": "step_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempt_index": {
+          "name": "attempt_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_run_id_idx": {
+          "name": "llm_usage_events_run_id_idx",
+          "columns": [
+            "run_id"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stt_usage_events": {
+      "name": "stt_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stt_usage_events_service_idx": {
+          "name": "stt_usage_events_service_idx",
+          "columns": [
+            "service"
+          ],
+          "isUnique": false
+        },
+        "stt_usage_events_created_at_idx": {
+          "name": "stt_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "stt_usage_events_provider_model_idx": {
+          "name": "stt_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "stt_usage_events_service_check": {
+          "name": "stt_usage_events_service_check",
+          "value": "\"stt_usage_events\".\"service\" in ('chat-input', 'meeting-recording')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -44,6 +44,7 @@
     { "idx": 33, "version": "6", "when": 1781297017613, "tag": "0033_glossy_gressill", "breakpoints": true },
     { "idx": 34, "version": "6", "when": 1781653056873, "tag": "0034_acoustic_eternity", "breakpoints": true },
     { "idx": 35, "version": "6", "when": 1782067742555, "tag": "0035_slim_sumo", "breakpoints": true },
-    { "idx": 36, "version": "6", "when": 1783382634204, "tag": "0036_perfect_mauler", "breakpoints": true }
+    { "idx": 36, "version": "6", "when": 1783382634204, "tag": "0036_perfect_mauler", "breakpoints": true },
+    { "idx": 37, "version": "6", "when": 1783471267511, "tag": "0037_rich_maelstrom", "breakpoints": true }
   ]
 }

--- a/packages/server/src/connectors/auth/oauth-credentials.ts
+++ b/packages/server/src/connectors/auth/oauth-credentials.ts
@@ -1,10 +1,19 @@
-type OAuthCredentialCarrier = { clientId: string | null; clientSecret: string | null };
+import { eq } from 'drizzle-orm';
+
+import type { PrefixedString } from '@stitch/shared/id';
+
+import { getDb } from '@/db/client.js';
+import { connectors } from '@/db/schema/connectors.js';
+
+type OAuthCredentialCarrier = { connectorRefId: PrefixedString<'cnr'> };
 
 export async function resolveOAuthCredentials(
   instance: OAuthCredentialCarrier,
 ): Promise<{ clientId: string; clientSecret: string } | null> {
-  if (instance.clientId && instance.clientSecret) {
-    return { clientId: instance.clientId, clientSecret: instance.clientSecret };
+  const db = getDb();
+  const [connector] = await db.select().from(connectors).where(eq(connectors.id, instance.connectorRefId));
+  if (connector?.clientId && connector.clientSecret) {
+    return { clientId: connector.clientId, clientSecret: connector.clientSecret };
   }
   return null;
 }

--- a/packages/server/src/connectors/auth/token-refresh.test.ts
+++ b/packages/server/src/connectors/auth/token-refresh.test.ts
@@ -8,7 +8,7 @@ import { OAuthRefreshError } from '@/connectors/auth/oauth2.js';
 import { refreshExpiringTokens } from '@/connectors/auth/token-refresh.js';
 import { registerConnector, unregisterConnector } from '@/connectors/registry.js';
 import { getDb } from '@/db/client.js';
-import { connectorInstances } from '@/db/schema/connectors.js';
+import { connectorInstances, connectors } from '@/db/schema/connectors.js';
 import { setupTestDb } from '@/db/test-helpers.js';
 
 setupTestDb();
@@ -34,17 +34,28 @@ function createDefinition(): ConnectorDefinition {
 }
 
 async function insertExpiredInstance(id: string) {
+  const connectorRefId = `cnr_${id}` as PrefixedString<'cnr'>;
+  await getDb()
+    .insert(connectors)
+    .values({
+      id: connectorRefId,
+      connectorId: 'google',
+      authType: 'oauth2',
+      label: 'Google OAuth App',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      apiKey: null,
+    });
+
   await getDb()
     .insert(connectorInstances)
     .values({
       id: id as PrefixedString<'conn'>,
       connectorId: 'google',
+      connectorRefId,
       label: 'Google Account',
       appliedVersion: 1,
       capabilities: ['google.drive.read'],
-      clientId: 'client-id',
-      clientSecret: 'client-secret',
-      apiKey: null,
       accessToken: 'access-token',
       refreshToken: 'refresh-token',
       tokenExpiresAt: Date.now() - 1_000,

--- a/packages/server/src/connectors/google-toolsets.ts
+++ b/packages/server/src/connectors/google-toolsets.ts
@@ -59,8 +59,7 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
             accessToken: connectorInstances.accessToken,
             refreshToken: connectorInstances.refreshToken,
             tokenExpiresAt: connectorInstances.tokenExpiresAt,
-            clientId: connectorInstances.clientId,
-            clientSecret: connectorInstances.clientSecret,
+            connectorRefId: connectorInstances.connectorRefId,
             connectorId: connectorInstances.connectorId,
             status: connectorInstances.status,
             scopes: connectorInstances.scopes,
@@ -107,8 +106,7 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
                 accessToken: connectorInstances.accessToken,
                 refreshToken: connectorInstances.refreshToken,
                 tokenExpiresAt: connectorInstances.tokenExpiresAt,
-                clientId: connectorInstances.clientId,
-                clientSecret: connectorInstances.clientSecret,
+                connectorRefId: connectorInstances.connectorRefId,
               })
               .from(connectorInstances)
               .where(eq(connectorInstances.id, chosen.id));

--- a/packages/server/src/connectors/service.test.ts
+++ b/packages/server/src/connectors/service.test.ts
@@ -6,12 +6,12 @@ import type { ConnectorDefinition } from '@stitch/shared/connectors/types';
 import { registerConnector, unregisterConnector } from '@/connectors/registry.js';
 import {
   authorizeOAuthInstance,
+  createOAuthConnector,
   createApiKeyConnectorInstance,
-  createOAuthConnectorInstance,
   upgradeConnectorInstance,
 } from '@/connectors/service.js';
 import { getDb } from '@/db/client.js';
-import { connectorInstances } from '@/db/schema/connectors.js';
+import { connectorInstances, connectors } from '@/db/schema/connectors.js';
 import { setupTestDb } from '@/db/test-helpers.js';
 
 setupTestDb();
@@ -54,6 +54,20 @@ function oauthDefinition(overrides: Partial<ConnectorDefinition> = {}): Connecto
   };
 }
 
+async function insertOAuthConnector(connectorRefId: string, connectorId = 'example'): Promise<void> {
+  await getDb()
+    .insert(connectors)
+    .values({
+      id: connectorRefId as never,
+      connectorId,
+      authType: 'oauth2',
+      label: 'Example OAuth App',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      apiKey: 'old-key',
+    });
+}
+
 describe('connector service', () => {
   beforeEach(() => {
     unregisterConnector('example');
@@ -68,17 +82,17 @@ describe('connector service', () => {
     // Create an instance at v1 so upgrade sees rotate + reauthorize actions
     const db = getDb();
     const instanceId = 'conn_test_upgrade' as never;
+    const connectorRefId = 'cnr_test_upgrade';
+    await insertOAuthConnector(connectorRefId, definition.id);
     await db
       .insert(connectorInstances)
       .values({
         id: instanceId,
         connectorId: definition.id,
+        connectorRefId: connectorRefId as never,
         label: 'Example',
         appliedVersion: 1,
         capabilities: ['example.read'],
-        clientId: 'client-id',
-        clientSecret: 'client-secret',
-        apiKey: 'old-key',
         accessToken: 'token',
         refreshToken: 'refresh',
         tokenExpiresAt: Date.now() + 60_000,
@@ -108,17 +122,17 @@ describe('connector service', () => {
 
     const db = getDb();
     const instanceId = 'conn_test_mixed' as never;
+    const connectorRefId = 'cnr_test_mixed';
+    await insertOAuthConnector(connectorRefId, definition.id);
     await db
       .insert(connectorInstances)
       .values({
         id: instanceId,
         connectorId: definition.id,
+        connectorRefId: connectorRefId as never,
         label: 'Example',
         appliedVersion: 1,
         capabilities: ['example.read'],
-        clientId: 'client-id',
-        clientSecret: 'client-secret',
-        apiKey: 'old-key',
         accessToken: 'token',
         refreshToken: 'refresh',
         tokenExpiresAt: Date.now() + 60_000,
@@ -157,8 +171,12 @@ describe('connector service', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     const [row] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId));
+    const [connector] = await db
+      .select()
+      .from(connectors)
+      .where(eq(connectors.id, connectorRefId as never));
     // After token exchange the instance should be connected with the new key and merged scopes
-    expect(row?.apiKey).toBe('new-key');
+    expect(connector?.apiKey).toBe('new-key');
     expect((row?.scopes as string[])?.includes('scope:admin')).toBe(true);
     expect(requestedScopes).toEqual(['scope:read', 'scope:admin']);
   });
@@ -177,17 +195,17 @@ describe('connector service', () => {
 
     const db = getDb();
     const instanceId = 'conn_test_incremental' as never;
+    const connectorRefId = 'cnr_test_incremental';
+    await insertOAuthConnector(connectorRefId, definition.id);
     await db
       .insert(connectorInstances)
       .values({
         id: instanceId,
         connectorId: definition.id,
+        connectorRefId: connectorRefId as never,
         label: 'Example',
         appliedVersion: 2,
         capabilities: ['example.read', 'example.write'],
-        clientId: 'client-id',
-        clientSecret: 'client-secret',
-        apiKey: null,
         accessToken: 'token',
         refreshToken: 'refresh',
         tokenExpiresAt: Date.now() + 60_000,
@@ -248,12 +266,11 @@ describe('connector service', () => {
       setupInstructions: [],
     });
 
-    const oauthResult = await createOAuthConnectorInstance({
+    const oauthConnectorResult = await createOAuthConnector({
       connectorId: 'disabled-oauth',
       label: 'Disabled OAuth',
       clientId: 'client-id',
       clientSecret: 'client-secret',
-      scopes: ['scope:read'],
     });
 
     const apiKeyResult = await createApiKeyConnectorInstance({
@@ -262,9 +279,9 @@ describe('connector service', () => {
       apiKey: 'secret',
     });
 
-    expect(oauthResult.error).not.toBeNull();
+    expect(oauthConnectorResult.error).not.toBeNull();
     expect(apiKeyResult.error).not.toBeNull();
-    if (oauthResult.error) expect(oauthResult.error.message).toBe('Connector is currently disabled');
+    if (oauthConnectorResult.error) expect(oauthConnectorResult.error.message).toBe('Connector is currently disabled');
     if (apiKeyResult.error) expect(apiKeyResult.error.message).toBe('Connector is currently disabled');
 
     // Nothing written to DB
@@ -281,17 +298,17 @@ describe('connector service', () => {
 
     const db = getDb();
     const instanceId = 'conn_auth_fail' as never;
+    const connectorRefId = 'cnr_auth_fail';
+    await insertOAuthConnector(connectorRefId, definition.id);
     await db
       .insert(connectorInstances)
       .values({
         id: instanceId,
         connectorId: definition.id,
+        connectorRefId: connectorRefId as never,
         label: 'Example OAuth',
         appliedVersion: 1,
         capabilities: ['example.read'],
-        clientId: 'client-id',
-        clientSecret: 'client-secret',
-        apiKey: null,
         accessToken: null,
         refreshToken: null,
         tokenExpiresAt: null,
@@ -332,17 +349,17 @@ describe('connector service', () => {
 
     const db = getDb();
     const instanceId = 'conn_auth_success' as never;
+    const connectorRefId = 'cnr_auth_success';
+    await insertOAuthConnector(connectorRefId, definition.id);
     await db
       .insert(connectorInstances)
       .values({
         id: instanceId,
         connectorId: definition.id,
+        connectorRefId: connectorRefId as never,
         label: 'Example OAuth',
         appliedVersion: 1,
         capabilities: ['example.read'],
-        clientId: 'client-id',
-        clientSecret: 'client-secret',
-        apiKey: null,
         accessToken: null,
         refreshToken: null,
         tokenExpiresAt: null,
@@ -392,17 +409,17 @@ describe('connector service', () => {
 
     const db = getDb();
     const instanceId = 'conn_auth_incremental_reauth' as never;
+    const connectorRefId = 'cnr_auth_incremental_reauth';
+    await insertOAuthConnector(connectorRefId, definition.id);
     await db
       .insert(connectorInstances)
       .values({
         id: instanceId,
         connectorId: definition.id,
+        connectorRefId: connectorRefId as never,
         label: 'Example OAuth',
         appliedVersion: definition.currentVersion,
         capabilities: ['example.read', 'example.write', 'example.admin'],
-        clientId: 'client-id',
-        clientSecret: 'client-secret',
-        apiKey: null,
         accessToken: 'old-access-token',
         refreshToken: 'existing-refresh-token',
         tokenExpiresAt: Date.now() - 1_000,
@@ -443,17 +460,17 @@ describe('connector service', () => {
 
     const db = getDb();
     const instanceId = 'conn_auth_preserve_refresh' as never;
+    const connectorRefId = 'cnr_auth_preserve_refresh';
+    await insertOAuthConnector(connectorRefId, definition.id);
     await db
       .insert(connectorInstances)
       .values({
         id: instanceId,
         connectorId: definition.id,
+        connectorRefId: connectorRefId as never,
         label: 'Example OAuth',
         appliedVersion: 1,
         capabilities: ['example.read'],
-        clientId: 'client-id',
-        clientSecret: 'client-secret',
-        apiKey: null,
         accessToken: 'old-access-token',
         refreshToken: 'existing-refresh-token',
         tokenExpiresAt: Date.now() - 1_000,

--- a/packages/server/src/connectors/service.ts
+++ b/packages/server/src/connectors/service.ts
@@ -3,13 +3,15 @@ import { asc, eq } from 'drizzle-orm';
 import { buildUpgradeState, getCapabilitiesForVersion } from '@stitch-connectors/sdk/upgrade';
 
 import type {
+  Connector,
   ConnectorDefinition,
   ConnectorInstance,
   ConnectorInstanceSafe,
+  ConnectorSafe,
   ConnectorStatus,
   OAuthConfig,
 } from '@stitch/shared/connectors/types';
-import { createConnectorInstanceId } from '@stitch/shared/id';
+import { createConnectorId, createConnectorInstanceId } from '@stitch/shared/id';
 import type { PrefixedString } from '@stitch/shared/id';
 
 import { resolveOAuthCredentials } from '@/connectors/auth/oauth-credentials.js';
@@ -23,7 +25,7 @@ import { withRefreshLock } from '@/connectors/auth/refresh-lock.js';
 import { getConnectorDefinition } from '@/connectors/registry.js';
 import { getConnectorModule, refreshConnectorToolsetsFor } from '@/connectors/runtime.js';
 import { getDb } from '@/db/client.js';
-import { connectorInstances } from '@/db/schema/connectors.js';
+import { connectorInstances, connectors } from '@/db/schema/connectors.js';
 import * as Log from '@/lib/log.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
@@ -32,7 +34,7 @@ const log = Log.create({ service: 'connectors' });
 const REFRESH_BUFFER_MS = 60_000;
 
 function toSafe(instance: ConnectorInstance, definition: ConnectorDefinition | undefined): ConnectorInstanceSafe {
-  const { clientSecret, accessToken, refreshToken, apiKey, ...rest } = instance;
+  const { accessToken, refreshToken, ...rest } = instance;
   const appliedVersion = Number.isFinite(instance.appliedVersion) ? instance.appliedVersion : 1;
   const storedCapabilities = Array.isArray(instance.capabilities) ? instance.capabilities : [];
   const effectiveCapabilities =
@@ -51,12 +53,109 @@ function toSafe(instance: ConnectorInstance, definition: ConnectorDefinition | u
     ...rest,
     appliedVersion,
     capabilities: effectiveCapabilities,
-    hasClientSecret: clientSecret !== null && clientSecret !== '',
     hasAccessToken: accessToken !== null && accessToken !== '',
     hasRefreshToken: refreshToken !== null && refreshToken !== '',
-    hasApiKey: apiKey !== null && apiKey !== '',
     upgrade,
   };
+}
+
+function toConnector(row: typeof connectors.$inferSelect): Connector {
+  if (row.authType === 'oauth2') {
+    return {
+      id: row.id,
+      connectorId: row.connectorId,
+      authType: row.authType,
+      label: row.label,
+      clientId: row.clientId ?? '',
+      clientSecret: row.clientSecret ?? '',
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  return {
+    id: row.id,
+    connectorId: row.connectorId,
+    authType: row.authType,
+    label: row.label,
+    apiKey: row.apiKey ?? '',
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function toConnectorSafe(connector: Connector): ConnectorSafe {
+  if (connector.authType === 'oauth2') {
+    const { clientSecret, ...rest } = connector;
+    return { ...rest, hasClientSecret: clientSecret !== '' };
+  }
+
+  const { apiKey, ...rest } = connector;
+  return { ...rest, hasApiKey: apiKey !== '' };
+}
+
+export async function listConnectors(): Promise<ServiceResult<ConnectorSafe[]>> {
+  const db = getDb();
+  const rows = await db.select().from(connectors).orderBy(asc(connectors.createdAt));
+  return ok(rows.map((row) => toConnectorSafe(toConnector(row))));
+}
+
+export async function createOAuthConnector(input: {
+  connectorId: string;
+  label: string;
+  clientId: string;
+  clientSecret: string;
+}): Promise<ServiceResult<ConnectorSafe>> {
+  const definition = getConnectorDefinition(input.connectorId);
+  if (!definition) return err('Unknown connector type', 400);
+  if (!definition.enabled) return err('Connector is currently disabled', 400);
+  if (definition.authType !== 'oauth2') return err('Connector does not use OAuth2', 400);
+
+  const clientId = input.clientId.trim();
+  const clientSecret = input.clientSecret.trim();
+  if (!clientId || !clientSecret) {
+    return err('Client credentials are required', 400);
+  }
+
+  const db = getDb();
+  const id = createConnectorId();
+  const connector = {
+    id,
+    connectorId: input.connectorId,
+    authType: 'oauth2' as const,
+    label: input.label,
+    clientId,
+    clientSecret,
+    apiKey: null,
+  };
+
+  await db.insert(connectors).values(connector);
+
+  log.info(
+    { event: 'connector.credentials.created', connectorRefId: id, connectorId: input.connectorId },
+    'Connector created',
+  );
+
+  const [row] = await db.select().from(connectors).where(eq(connectors.id, id));
+  return ok(toConnectorSafe(toConnector(row)));
+}
+
+export async function deleteConnector(connectorRefId: string): Promise<ServiceResult<null>> {
+  const db = getDb();
+  const typedConnectorRefId = connectorRefId as PrefixedString<'cnr'>;
+  const [existing] = await db.select().from(connectors).where(eq(connectors.id, typedConnectorRefId));
+
+  if (!existing) return err('Connector not found', 404);
+
+  await db.delete(connectors).where(eq(connectors.id, typedConnectorRefId));
+  await refreshConnectorToolsetsFor(existing.connectorId);
+
+  log.info(
+    { event: 'connector.credentials.deleted', connectorRefId, connectorId: existing.connectorId },
+    `Connector deleted: ${existing.label}`,
+  );
+
+  return ok(null);
 }
 
 export async function listConnectorInstances(): Promise<ServiceResult<ConnectorInstanceSafe[]>> {
@@ -83,35 +182,33 @@ export async function getConnectorInstance(id: string): Promise<ServiceResult<Co
 }
 
 export async function createOAuthConnectorInstance(input: {
-  connectorId: string;
+  connectorRefId: string;
   label: string;
-  clientId: string;
-  clientSecret: string;
   scopes: string[];
 }): Promise<ServiceResult<ConnectorInstanceSafe>> {
-  const definition = getConnectorDefinition(input.connectorId);
+  const db = getDb();
+  const [connector] = await db
+    .select()
+    .from(connectors)
+    .where(eq(connectors.id, input.connectorRefId as PrefixedString<'cnr'>));
+
+  if (!connector) return err('Connector not found', 404);
+
+  const definition = getConnectorDefinition(connector.connectorId);
   if (!definition) return err('Unknown connector type', 400);
   if (!definition.enabled) return err('Connector is currently disabled', 400);
   if (definition.authType !== 'oauth2') return err('Connector does not use OAuth2', 400);
+  if (!connector.clientId || !connector.clientSecret) return err('OAuth credentials not configured', 400);
 
-  const db = getDb();
   const id = createConnectorInstanceId();
-
-  const clientId = input.clientId.trim();
-  const clientSecret = input.clientSecret.trim();
-  if (!clientId || !clientSecret) {
-    return err('Client credentials are required', 400);
-  }
 
   const instance = {
     id,
-    connectorId: input.connectorId,
+    connectorId: connector.connectorId,
+    connectorRefId: connector.id,
     label: input.label,
     appliedVersion: definition.currentVersion,
     capabilities: getCapabilitiesForVersion(definition, definition.currentVersion),
-    clientId,
-    clientSecret,
-    apiKey: null,
     accessToken: null,
     refreshToken: null,
     tokenExpiresAt: null,
@@ -125,7 +222,12 @@ export async function createOAuthConnectorInstance(input: {
   await db.insert(connectorInstances).values(instance);
 
   log.info(
-    { event: 'connector.created', instanceId: id, connectorId: input.connectorId },
+    {
+      event: 'connector.account.created',
+      instanceId: id,
+      connectorRefId: connector.id,
+      connectorId: connector.connectorId,
+    },
     `Connector instance created: ${input.label}`,
   );
 
@@ -144,17 +246,28 @@ export async function createApiKeyConnectorInstance(input: {
   if (definition.authType !== 'api_key') return err('Connector does not use API key', 400);
 
   const db = getDb();
+  const connectorRefId = createConnectorId();
   const id = createConnectorInstanceId();
+
+  await db
+    .insert(connectors)
+    .values({
+      id: connectorRefId,
+      connectorId: input.connectorId,
+      authType: 'api_key',
+      label: input.label,
+      clientId: null,
+      clientSecret: null,
+      apiKey: input.apiKey,
+    });
 
   const instance = {
     id,
     connectorId: input.connectorId,
+    connectorRefId,
     label: input.label,
     appliedVersion: definition.currentVersion,
     capabilities: getCapabilitiesForVersion(definition, definition.currentVersion),
-    clientId: null,
-    clientSecret: null,
-    apiKey: input.apiKey,
     accessToken: null,
     refreshToken: null,
     tokenExpiresAt: null,
@@ -339,9 +452,13 @@ export async function upgradeConnectorInstance(
 
   if (requiresApiKeyRotation && !requiresReauthorize) {
     await db
+      .update(connectors)
+      .set({ apiKey: input.apiKey?.trim() ?? null, updatedAt: now })
+      .where(eq(connectors.id, instance.connectorRefId));
+
+    await db
       .update(connectorInstances)
       .set({
-        apiKey: input.apiKey?.trim() ?? null,
         appliedVersion: definition.currentVersion,
         capabilities: getCapabilitiesForVersion(definition, definition.currentVersion),
         status: 'connected' as ConnectorStatus,
@@ -362,16 +479,18 @@ export async function upgradeConnectorInstance(
     const scopeSet = new Set([...currentScopes, ...upgrade.missingScopes]);
     const nextScopes = [...scopeSet];
 
-    const setValues: {
-      scopes: string[];
-      status: ConnectorStatus;
-      authIssue: null;
-      updatedAt: number;
-      apiKey?: string | null;
-    } = { scopes: nextScopes, status: 'awaiting_auth' as ConnectorStatus, authIssue: null, updatedAt: now };
+    const setValues: { scopes: string[]; status: ConnectorStatus; authIssue: null; updatedAt: number } = {
+      scopes: nextScopes,
+      status: 'awaiting_auth' as ConnectorStatus,
+      authIssue: null,
+      updatedAt: now,
+    };
 
     if (requiresApiKeyRotation) {
-      setValues.apiKey = input.apiKey?.trim() ?? null;
+      await db
+        .update(connectors)
+        .set({ apiKey: input.apiKey?.trim() ?? null, updatedAt: now })
+        .where(eq(connectors.id, instance.connectorRefId));
     }
 
     await db.update(connectorInstances).set(setValues).where(eq(connectorInstances.id, typedInstanceId));
@@ -480,7 +599,9 @@ export async function testConnectorInstance(instanceId: string): Promise<Service
 
     if (definition.authType === 'oauth2' && testedInstance.accessToken) {
       return ok(true);
-    } else if (definition.authType === 'api_key' && instance.apiKey) {
+    } else if (definition.authType === 'api_key') {
+      const [connector] = await db.select().from(connectors).where(eq(connectors.id, instance.connectorRefId));
+      if (!connector?.apiKey) return err('Connector has no credentials to test', 400);
       return err('Connector test is not supported for this connector type', 400);
     } else {
       return err('Connector has no credentials to test', 400);

--- a/packages/server/src/db/schema/connectors.ts
+++ b/packages/server/src/db/schema/connectors.ts
@@ -2,19 +2,44 @@ import { sql } from 'drizzle-orm';
 import { blob, check, index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
 import type { ConnectorStatus } from '@stitch/shared/connectors/types';
+import type { ConnectorAuthType } from '@stitch/shared/connectors/types';
 import type { PrefixedString } from '@stitch/shared/id';
+
+export const connectors = sqliteTable(
+  'connectors',
+  {
+    id: text('id').$type<PrefixedString<'cnr'>>().primaryKey(),
+    connectorId: text('connector_id').notNull(),
+    authType: text('auth_type').$type<ConnectorAuthType>().notNull(),
+    label: text('label').notNull(),
+    clientId: text('client_id'),
+    clientSecret: text('client_secret'),
+    apiKey: text('api_key'),
+    createdAt: integer('created_at', { mode: 'number' })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+    updatedAt: integer('updated_at', { mode: 'number' })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (table) => [
+    index('connectors_connector_id_idx').on(table.connectorId),
+    check('connectors_auth_type_check', sql`${table.authType} in ('oauth2', 'api_key')`),
+  ],
+);
 
 export const connectorInstances = sqliteTable(
   'connector_instances',
   {
     id: text('id').$type<PrefixedString<'conn'>>().primaryKey(),
     connectorId: text('connector_id').notNull(),
+    connectorRefId: text('connector_ref_id')
+      .$type<PrefixedString<'cnr'>>()
+      .notNull()
+      .references(() => connectors.id, { onDelete: 'cascade' }),
     label: text('label').notNull(),
     appliedVersion: integer('applied_version').notNull().default(1),
     capabilities: blob('capabilities', { mode: 'json' }).$type<string[]>().notNull().default([]),
-    clientId: text('client_id'),
-    clientSecret: text('client_secret'),
-    apiKey: text('api_key'),
     accessToken: text('access_token'),
     refreshToken: text('refresh_token'),
     tokenExpiresAt: integer('token_expires_at', { mode: 'number' }),
@@ -32,6 +57,7 @@ export const connectorInstances = sqliteTable(
   },
   (table) => [
     index('connector_instances_connector_id_idx').on(table.connectorId),
+    index('connector_instances_connector_ref_id_idx').on(table.connectorRefId),
     check('connector_status_check', sql`${table.status} in ('pending_setup', 'awaiting_auth', 'connected', 'error')`),
   ],
 );

--- a/packages/server/src/routes/connectors.ts
+++ b/packages/server/src/routes/connectors.ts
@@ -4,12 +4,15 @@ import { z } from 'zod';
 
 import { listConnectorDefinitions } from '@/connectors/registry.js';
 import {
+  listConnectors,
   listConnectorInstances,
   getConnectorInstance,
+  createOAuthConnector,
   createOAuthConnectorInstance,
   createApiKeyConnectorInstance,
   authorizeOAuthInstance,
   updateConnectorInstance,
+  deleteConnector,
   deleteConnectorInstance,
   testConnectorInstance,
   upgradeConnectorInstance,
@@ -24,6 +27,26 @@ const log = Log.create({ service: 'connectors-route' });
 connectorsRouter.get('/definitions', (c) => {
   const definitions = listConnectorDefinitions();
   return c.json(definitions);
+});
+
+// List configured connector credentials
+connectorsRouter.get('/', async (c) => {
+  const result = await listConnectors();
+  return unwrapResult(c, result);
+});
+
+// Create OAuth connector credentials
+const createConnectorOAuthSchema = z.object({
+  connectorId: z.string().min(1),
+  label: z.string().min(1),
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+});
+
+connectorsRouter.post('/oauth', zValidator('json', createConnectorOAuthSchema), async (c) => {
+  const body = c.req.valid('json');
+  const result = await createOAuthConnector(body);
+  return unwrapResult(c, result, 201);
 });
 
 // List all connector instances
@@ -41,10 +64,8 @@ connectorsRouter.get('/instances/:id', async (c) => {
 
 // Create an OAuth connector instance
 const createOAuthSchema = z.object({
-  connectorId: z.string().min(1),
+  connectorRefId: z.string().min(1),
   label: z.string().min(1),
-  clientId: z.string().min(1),
-  clientSecret: z.string().min(1),
   scopes: z.array(z.string()).min(1),
 });
 
@@ -101,6 +122,13 @@ connectorsRouter.patch('/instances/:id', zValidator('json', updateSchema), async
 connectorsRouter.delete('/instances/:id', async (c) => {
   const id = c.req.param('id');
   const result = await deleteConnectorInstance(id);
+  return unwrapResult(c, result, 204);
+});
+
+// Delete connector credentials and all linked accounts
+connectorsRouter.delete('/:id', async (c) => {
+  const id = c.req.param('id');
+  const result = await deleteConnector(id);
   return unwrapResult(c, result, 204);
 });
 

--- a/packages/shared/src/connectors/types.ts
+++ b/packages/shared/src/connectors/types.ts
@@ -52,6 +52,26 @@ export type ConnectorDefinition = {
   setupInstructions: ConnectorSetupInstruction[];
 };
 
+export type ConnectorBase = {
+  id: PrefixedString<'cnr'>;
+  connectorId: string;
+  label: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type OAuthConnector = ConnectorBase & { authType: 'oauth2'; clientId: string; clientSecret: string };
+
+export type ApiKeyConnector = ConnectorBase & { authType: 'api_key'; apiKey: string };
+
+export type Connector = OAuthConnector | ApiKeyConnector;
+
+export type OAuthConnectorSafe = Omit<OAuthConnector, 'clientSecret'> & { hasClientSecret: boolean };
+
+export type ApiKeyConnectorSafe = Omit<ApiKeyConnector, 'apiKey'> & { hasApiKey: boolean };
+
+export type ConnectorSafe = OAuthConnectorSafe | ApiKeyConnectorSafe;
+
 export type ConnectorVersion = {
   version: number;
   title: string;
@@ -64,12 +84,10 @@ export type ConnectorVersion = {
 export type ConnectorInstance = {
   id: PrefixedString<'conn'>;
   connectorId: string;
+  connectorRefId: PrefixedString<'cnr'>;
   label: string;
   appliedVersion: number;
   capabilities: string[];
-  clientId: string | null;
-  clientSecret: string | null;
-  apiKey: string | null;
   accessToken: string | null;
   refreshToken: string | null;
   tokenExpiresAt: number | null;
@@ -82,14 +100,9 @@ export type ConnectorInstance = {
   updatedAt: number;
 };
 
-export type ConnectorInstanceSafe = Omit<
-  ConnectorInstance,
-  'clientSecret' | 'accessToken' | 'refreshToken' | 'apiKey'
-> & {
-  hasClientSecret: boolean;
+export type ConnectorInstanceSafe = Omit<ConnectorInstance, 'accessToken' | 'refreshToken'> & {
   hasAccessToken: boolean;
   hasRefreshToken: boolean;
-  hasApiKey: boolean;
   upgrade: {
     available: boolean;
     fromVersion: number;

--- a/packages/shared/src/id/index.ts
+++ b/packages/shared/src/id/index.ts
@@ -9,6 +9,7 @@ export const ID_PREFIXES = {
   permissionResponse: 'permres',
   permissionRule: 'perm',
   mcpServer: 'mcp',
+  connector: 'cnr',
   connectorInstance: 'conn',
   automation: 'auto',
   scheduledJob: 'schjob',
@@ -72,6 +73,7 @@ export const createQuestionId = createIdFactory(ID_PREFIXES.question);
 export const createPermissionResponseId = createIdFactory(ID_PREFIXES.permissionResponse);
 export const createPermissionRuleId = createIdFactory(ID_PREFIXES.permissionRule);
 export const createMcpServerId = createIdFactory(ID_PREFIXES.mcpServer);
+export const createConnectorId = createIdFactory(ID_PREFIXES.connector);
 export const createConnectorInstanceId = createIdFactory(ID_PREFIXES.connectorInstance);
 export const createAutomationId = createIdFactory(ID_PREFIXES.automation);
 export const createScheduledJobId = createIdFactory(ID_PREFIXES.scheduledJob);


### PR DESCRIPTION
## 🚀 Change Summary

Separates reusable connector credentials from connected account instances, allowing users to manage credential records independently while preserving account-specific labels, scopes, and auth state.

### ✨ New Features
- **Connector Credentials**: Adds a dedicated connector credential model with OAuth/API-key discriminated types and safe API responses.
- **Connected Accounts**: Links account instances to reusable connector credentials and supports deleting credentials with cascading connected accounts.

### 🛠 Improvements & Refactors
- Updates setup flow to create/select connector credentials before naming a connected account.
- Updates connector routes, services, SDK types, query helpers, and tests for the credential/account split.
- Adds a migration that preserves existing connector instance data while creating connector credential records.
