### PR TITLE
refactor(server): consolidate z.templateLiteral usages into routeSchemas

### DIFF
--- a/packages/server/src/lib/route-schemas.ts
+++ b/packages/server/src/lib/route-schemas.ts
@@ -11,9 +11,7 @@ export function paginationQuerySchema(defaults: { pageSize?: number } = {}) {
 }
 
 function prefixedId<P extends IdPrefix>(prefix: P) {
-  return z.custom<PrefixedString<P>>((val) => {
-    return typeof val === 'string' && val.startsWith(`${prefix}_`);
-  }, `Invalid ID format. Expected prefix: ${prefix}_`);
+  return z.templateLiteral([z.literal(`${prefix}_`), z.string()]) as z.ZodType<PrefixedString<P>>;
 }
 
 export const routeSchemas = {
@@ -34,4 +32,11 @@ export const routeSchemas = {
   agendaListId: prefixedId(ID_PREFIXES.agendaList),
   agendaItemId: prefixedId(ID_PREFIXES.agendaItem),
   todoId: prefixedId(ID_PREFIXES.todo),
+  meetingNoteTemplateId: prefixedId(ID_PREFIXES.meetingNoteTemplate),
+  mailAccountId: prefixedId(ID_PREFIXES.mailAccount),
+  mailLabelId: prefixedId(ID_PREFIXES.mailLabel),
+  mailThreadId: prefixedId(ID_PREFIXES.mailThread),
+  mailMessageId: prefixedId(ID_PREFIXES.mailMessage),
+  mailAttachmentId: prefixedId(ID_PREFIXES.mailAttachment),
+  mailDraftId: prefixedId(ID_PREFIXES.mailDraft),
 } as const;

--- a/packages/server/src/routes/mail.ts
+++ b/packages/server/src/routes/mail.ts
@@ -9,23 +9,17 @@ import { mailAccounts } from '@stitch/mail/db/schema';
 
 import { getDb } from '@/db/client.js';
 import { connectorInstances } from '@/db/schema/connectors.js';
+import { routeSchemas } from '@/lib/route-schemas.js';
 import { assertCanEnrollMailAccount, filterEligibleMailAccounts } from '@/mail/eligibility.js';
 import { getAttachmentRecord, getDraftView, getMessageView } from '@/mail/read-model.js';
 import { getMailEngine, getMailSyncProgress, removeMailAccount } from '@/mail/wiring.js';
 import type { Context } from 'hono';
 
-const mailAccountIdSchema = z.templateLiteral([z.literal('macc_'), z.string().min(1)]);
-const mailLabelIdSchema = z.templateLiteral([z.literal('mlbl_'), z.string().min(1)]);
-const mailThreadIdSchema = z.templateLiteral([z.literal('mthr_'), z.string().min(1)]);
-const mailMessageIdSchema = z.templateLiteral([z.literal('mmsg_'), z.string().min(1)]);
-const mailAttachmentIdSchema = z.templateLiteral([z.literal('matt_'), z.string().min(1)]);
-const mailDraftIdSchema = z.templateLiteral([z.literal('mdrf_'), z.string().min(1)]);
-
-const accountIdParamSchema = z.object({ id: mailAccountIdSchema });
-const threadIdParamSchema = z.object({ id: mailThreadIdSchema });
-const messageIdParamSchema = z.object({ id: mailMessageIdSchema });
-const attachmentIdParamSchema = z.object({ id: mailAttachmentIdSchema });
-const draftIdParamSchema = z.object({ id: mailDraftIdSchema });
+const accountIdParamSchema = z.object({ id: routeSchemas.mailAccountId });
+const threadIdParamSchema = z.object({ id: routeSchemas.mailThreadId });
+const messageIdParamSchema = z.object({ id: routeSchemas.mailMessageId });
+const attachmentIdParamSchema = z.object({ id: routeSchemas.mailAttachmentId });
+const draftIdParamSchema = z.object({ id: routeSchemas.mailDraftId });
 
 const accountPatchSchema = z.object({
   enabled: z.boolean().optional(),
@@ -42,28 +36,28 @@ const enrollSchema = z.object({
 const resyncSchema = z.object({ mode: z.enum(['full', 'incremental']) });
 
 const threadsQuerySchema = z.object({
-  labelId: mailLabelIdSchema.optional(),
+  labelId: routeSchemas.mailLabelId.optional(),
   cursor: z.string().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(100).default(50),
 });
 
 const modifyMessageSchema = z.object({
-  addLabelIds: z.array(mailLabelIdSchema).optional(),
-  removeLabelIds: z.array(mailLabelIdSchema).optional(),
+  addLabelIds: z.array(routeSchemas.mailLabelId).optional(),
+  removeLabelIds: z.array(routeSchemas.mailLabelId).optional(),
   markRead: z.boolean().optional(),
 });
 
 const addressSchema = z.object({ name: z.string().nullable(), email: z.string().email() });
 
 const draftSchema = z.object({
-  accountId: mailAccountIdSchema,
+  accountId: routeSchemas.mailAccountId,
   to: z.array(addressSchema),
   cc: z.array(addressSchema).default([]),
   bcc: z.array(addressSchema).default([]),
   subject: z.string(),
   bodyText: z.string(),
   bodyHtml: z.string().nullable().default(null),
-  inReplyToMessageId: mailMessageIdSchema.nullable().default(null),
+  inReplyToMessageId: routeSchemas.mailMessageId.nullable().default(null),
 });
 
 const draftPatchSchema = draftSchema.partial().omit({ accountId: true });

--- a/packages/server/src/routes/permissions.ts
+++ b/packages/server/src/routes/permissions.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import { getSessionById } from '@/chat/session-crud.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
+import { routeSchemas } from '@/lib/route-schemas.js';
 import {
   allowPermissionResponse,
   alternativePermissionResponse,
@@ -11,11 +12,11 @@ import {
   rejectPermissionResponse,
 } from '@/permission/service.js';
 
-const sessionParamSchema = z.object({ id: z.templateLiteral(['ses_', z.string()]) });
+const sessionParamSchema = z.object({ id: routeSchemas.sessionId });
 
 const permissionResponseParamSchema = z.object({
-  sessionId: z.templateLiteral(['ses_', z.string()]),
-  permissionResponseId: z.templateLiteral(['permres_', z.string()]),
+  sessionId: routeSchemas.sessionId,
+  permissionResponseId: routeSchemas.permissionResponseId,
 });
 
 const setPermissionRuleSchema = z.object({

--- a/packages/server/src/routes/questions.ts
+++ b/packages/server/src/routes/questions.ts
@@ -4,14 +4,12 @@ import { z } from 'zod';
 
 import { getSessionById } from '@/chat/session-crud.js';
 import { unwrapResult } from '@/lib/route-helpers.js';
+import { routeSchemas } from '@/lib/route-schemas.js';
 import { createQuestion, getPendingQuestions, rejectQuestion, replyQuestion } from '@/question/service.js';
 
-const sessionParamSchema = z.object({ id: z.templateLiteral(['ses_', z.string()]) });
+const sessionParamSchema = z.object({ id: routeSchemas.sessionId });
 
-const questionParamSchema = z.object({
-  sessionId: z.templateLiteral(['ses_', z.string()]),
-  questionId: z.templateLiteral(['quest_', z.string()]),
-});
+const questionParamSchema = z.object({ sessionId: routeSchemas.sessionId, questionId: routeSchemas.questionId });
 
 const questionOptionSchema = z.object({ label: z.string(), description: z.string() });
 
@@ -26,7 +24,7 @@ const questionInfoSchema = z.object({
 const createQuestionsSchema = z.object({
   questions: z.array(questionInfoSchema).min(1),
   toolCallId: z.string().min(1),
-  messageId: z.templateLiteral(['msg_', z.string()]),
+  messageId: routeSchemas.messageId,
 });
 
 const replySchema = z.object({ answers: z.array(z.array(z.string())) });

--- a/packages/server/src/routes/recordings.ts
+++ b/packages/server/src/routes/recordings.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import type { StartRecordingInput, StopRecordingInput } from '@stitch/shared/recordings/types';
 
 import { unwrapResult } from '@/lib/route-helpers.js';
-import { paginationQuerySchema } from '@/lib/route-schemas.js';
+import { paginationQuerySchema, routeSchemas } from '@/lib/route-schemas.js';
 import { cancelRecordingAnalysis, startRecordingAnalysis } from '@/recordings/analysis-service.js';
 import {
   createMeetingNoteTemplate,
@@ -31,9 +31,9 @@ const startRecordingSchema = z.object({
 
 const stopRecordingSchema = z.object({ durationMs: z.number().int().nonnegative().nullable() });
 
-const recordingIdParamSchema = z.object({ id: z.templateLiteral([z.literal('rec'), z.string()]) });
+const recordingIdParamSchema = z.object({ id: routeSchemas.recordingId });
 
-const meetingNoteTemplateIdParamSchema = z.object({ id: z.templateLiteral([z.literal('mnt'), z.string()]) });
+const meetingNoteTemplateIdParamSchema = z.object({ id: routeSchemas.meetingNoteTemplateId });
 
 const meetingNoteTemplateSchema = z.object({
   name: z.string().trim().min(1).max(120),
@@ -42,7 +42,7 @@ const meetingNoteTemplateSchema = z.object({
 
 const analyzeQuerySchema = z.object({ force: z.enum(['1', 'true']).optional() });
 
-const analyzeBodySchema = z.object({ templateId: z.templateLiteral([z.literal('mnt'), z.string()]) });
+const analyzeBodySchema = z.object({ templateId: routeSchemas.meetingNoteTemplateId });
 
 export const recordingsRouter = new Hono();
 

--- a/packages/shared/src/id/index.ts
+++ b/packages/shared/src/id/index.ts
@@ -20,6 +20,12 @@ export const ID_PREFIXES = {
   agendaList: 'alist',
   agendaItem: 'aitm',
   todo: 'todo',
+  mailAccount: 'macc',
+  mailLabel: 'mlbl',
+  mailThread: 'mthr',
+  mailMessage: 'mmsg',
+  mailAttachment: 'matt',
+  mailDraft: 'mdrf',
 } as const;
 
 export type IdPrefix = (typeof ID_PREFIXES)[keyof typeof ID_PREFIXES];


### PR DESCRIPTION
## 🚀 Change Summary

Consolidates all z.templateLiteral usages into routeSchemas and migrates prefixedId from z.custom to z.templateLiteral for consistency and better type inference.

Closes #464

### ✨ New Features
- **Mail Prefixes**: Added mailAccount, mailLabel, mailThread, mailMessage, mailAttachment, mailDraft to ID_PREFIXES in shared id module

### 🛠 Improvements & Refactors
- **prefixedId**: Replaced z.custom<PrefixedString> with z.templateLiteral for cleaner validation
- **routeSchemas**: Added meetingNoteTemplateId and six mail ID schemas to centralize all prefixed ID validation
- **Route cleanup**: Removed all inline z.templateLiteral(...) calls from questions, permissions, recordings, and mail route files — they now import from routeSchemas
