### PR TITLE
fix(llm): preserve Gemini thought signatures

### DIFF
--- a/packages/server/src/llm/history-messages.ts
+++ b/packages/server/src/llm/history-messages.ts
@@ -11,6 +11,22 @@ const log = Log.create({ service: 'history-messages' });
 const PRESERVE_RECENT_ASSISTANT_TURNS = 3;
 const IMAGE_PRUNED_PLACEHOLDER = '[Image already processed by model]';
 
+type ProviderOptions = NonNullable<ModelMessage['providerOptions']>;
+type StoredPartWithProviderOptions = StoredPart & {
+  providerMetadata?: ProviderOptions;
+  providerOptions?: ProviderOptions;
+  callProviderMetadata?: ProviderOptions;
+};
+
+function getPartProviderOptions(part: StoredPart): ProviderOptions | undefined {
+  const withProviderOptions = part as StoredPartWithProviderOptions;
+  return (
+    withProviderOptions.providerOptions ??
+    withProviderOptions.providerMetadata ??
+    withProviderOptions.callProviderMetadata
+  );
+}
+
 export function buildHistoryMessages(
   msgs: Array<Pick<Message, 'role' | 'parts' | 'isSummary' | 'modelId'>>,
   promptConfig: PromptConfig,
@@ -138,7 +154,14 @@ export function buildHistoryMessages(
 
       if (textParts.length > 0 || matchedToolCalls.length > 0) {
         const assistantContent: Array<
-          { type: 'text'; text: string } | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown }
+          | { type: 'text'; text: string }
+          | {
+              type: 'tool-call';
+              toolCallId: string;
+              toolName: string;
+              input: unknown;
+              providerOptions?: ProviderOptions;
+            }
         > = [];
 
         const combinedText = textParts.map((p) => p.text).join('');
@@ -147,11 +170,13 @@ export function buildHistoryMessages(
         }
 
         for (const tc of matchedToolCalls) {
+          const providerOptions = getPartProviderOptions(tc);
           assistantContent.push({
             type: 'tool-call',
             toolCallId: tc.toolCallId,
             toolName: tc.toolName,
             input: tc.input,
+            ...(providerOptions ? { providerOptions } : {}),
           });
         }
 
@@ -165,6 +190,7 @@ export function buildHistoryMessages(
             .filter((tr) => matchedToolCallIds.has(tr.toolCallId))
             .map((tr) => {
               const compactedOutput = compactToolResultOutput(tr);
+              const providerOptions = getPartProviderOptions(tr);
 
               return {
                 type: 'tool-result' as const,
@@ -173,6 +199,7 @@ export function buildHistoryMessages(
                 output: isToolResultError(tr.output)
                   ? { type: 'error-json' as const, value: compactedOutput as never }
                   : { type: 'json' as const, value: compactedOutput as never },
+                ...(providerOptions ? { providerOptions } : {}),
               };
             }),
         });

--- a/packages/server/src/llm/session-summary.test.ts
+++ b/packages/server/src/llm/session-summary.test.ts
@@ -141,18 +141,24 @@ describe('buildHistoryMessages', () => {
     return { type: 'text-delta', id: 'prt_text' as StoredPart['id'], text, ...timing } as StoredPart;
   }
 
-  function toolCallPart(toolCallId: string, toolName = 'bash'): StoredPart {
+  function toolCallPart(toolCallId: string, toolName = 'bash', providerMetadata?: Record<string, unknown>): StoredPart {
     return {
       type: 'tool-call',
       id: `prt_call_${toolCallId}` as StoredPart['id'],
       toolCallId,
       toolName,
       input: { command: 'pwd' },
+      ...(providerMetadata ? { providerMetadata } : {}),
       ...timing,
     } as StoredPart;
   }
 
-  function toolResultPart(toolCallId: string, output: unknown, toolName = 'bash'): StoredPart {
+  function toolResultPart(
+    toolCallId: string,
+    output: unknown,
+    toolName = 'bash',
+    providerMetadata?: Record<string, unknown>,
+  ): StoredPart {
     return {
       type: 'tool-result',
       id: `prt_result_${toolCallId}` as StoredPart['id'],
@@ -160,6 +166,7 @@ describe('buildHistoryMessages', () => {
       toolName,
       output,
       truncated: false,
+      ...(providerMetadata ? { providerMetadata } : {}),
       ...timing,
     } as StoredPart;
   }
@@ -193,6 +200,41 @@ describe('buildHistoryMessages', () => {
     expect(nonSystem).toHaveLength(2);
     expect(nonSystem[0]).toMatchObject({ role: 'assistant', content: [{ type: 'tool-call', toolCallId: 'tc_1' }] });
     expect(nonSystem[1]).toMatchObject({ role: 'tool', content: [{ type: 'tool-result', toolCallId: 'tc_1' }] });
+  });
+
+  test('preserves provider metadata on replayed tool-call and tool-result parts', () => {
+    const providerMetadata = { google: { thoughtSignature: 'thought-sig-1' } };
+    const result = buildHistoryMessages(
+      [
+        {
+          role: 'assistant',
+          isSummary: false,
+          modelId: 'gemini-3.5-flash',
+          parts: [
+            toolCallPart('tc_1', 'gmail_search', providerMetadata),
+            toolResultPart('tc_1', { ok: true }, 'gmail_search', providerMetadata),
+          ],
+        },
+      ],
+      {
+        useBasePrompt: true,
+        systemPrompt: null,
+        userName: '',
+        userTimezone: '',
+        memoryContext: null,
+        todoContext: null,
+      },
+    );
+
+    const nonSystem = result.filter((m) => m.role !== 'system');
+    expect(nonSystem[0]).toMatchObject({
+      role: 'assistant',
+      content: [{ type: 'tool-call', toolCallId: 'tc_1', providerOptions: providerMetadata }],
+    });
+    expect(nonSystem[1]).toMatchObject({
+      role: 'tool',
+      content: [{ type: 'tool-result', toolCallId: 'tc_1', providerOptions: providerMetadata }],
+    });
   });
 
   test('drops unmatched tool-call parts from history', () => {


### PR DESCRIPTION
## 🚀 Change Summary

Preserves provider-specific metadata when replaying stored tool-call history so Gemini thought signatures survive across tool-call turns.

### 🐛 Bug Fixes
- Preserve stored `providerMetadata`/`providerOptions`/`callProviderMetadata` as AI SDK `providerOptions` when rebuilding assistant `tool-call` parts for replay.
- Preserve the same provider metadata on matching `tool-result` parts to avoid lossy history serialization.
- Add regression coverage for Gemini `thoughtSignature` replay through `buildHistoryMessages`.

Closes #462
