### PR TITLE
chore: remove stale knip issue ignore

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -47,7 +47,6 @@ const config: KnipConfig = {
     'tailwindcss',
     '@tailwindcss/typography',
   ],
-  ignoreIssues: { 'apps/web/src/routes/mail/**': ['exports'], 'apps/web/src/routes/settings/mail.tsx': ['exports'] },
   ignoreBinaries: [],
 };
 


### PR DESCRIPTION
## 🚀 Change Summary

Remove stale `ignoreIssues` entry for mail route exports — the underlying unused exports have since been resolved.
