### PR TITLE
chore: pin 'latest' dependency versions to resolved versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,11 +8,11 @@
         "dompurify": "^3.4.11",
       },
       "devDependencies": {
-        "knip": "latest",
-        "oxfmt": "latest",
-        "oxlint": "latest",
+        "knip": "^6.3.1",
+        "oxfmt": "^0.44.0",
+        "oxlint": "^1.59.0",
         "oxlint-tsgolint": "^0.16.0",
-        "turbo": "latest",
+        "turbo": "^2.9.5",
       },
     },
     "apps/desktop": {
@@ -255,8 +255,8 @@
     },
   },
   "catalog": {
-    "@types/bun": "latest",
-    "typescript": "latest",
+    "@types/bun": "1.3.14",
+    "typescript": "6.0.3",
     "zod": "4.3.6",
   },
   "catalogs": {

--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
     "dompurify": "^3.4.11"
   },
   "devDependencies": {
-    "knip": "latest",
-    "oxfmt": "latest",
-    "oxlint": "latest",
+    "knip": "^6.3.1",
+    "oxfmt": "^0.44.0",
+    "oxlint": "^1.59.0",
     "oxlint-tsgolint": "^0.16.0",
-    "turbo": "latest"
+    "turbo": "^2.9.5"
   },
   "packageManager": "bun@1.3.14",
   "catalog": {
-    "typescript": "latest",
-    "@types/bun": "latest",
+    "typescript": "6.0.3",
+    "@types/bun": "1.3.14",
     "zod": "4.3.6"
   },
   "catalogs": {


### PR DESCRIPTION
## Change Summary

Pinned all dependencies in root package.json that used "latest" as their version specifier to the actual resolved versions from un.lock.

### Changes
- knip: latest → ^6.3.1
- oxfmt: latest → ^0.44.0
- oxlint: latest → ^1.59.0
- 	urbo: latest → ^2.9.5
- 	ypescript (catalog): latest → 6.0.3
- @types/bun (catalog): latest → 1.3.14

DevDependencies use caret ranges to match existing conventions; catalog entries use exact versions.
