### PR TITLE
feat(events): add domain realtime events

### DIFF
--- a/apps/web/src/hooks/sse/server-event-sync.ts
+++ b/apps/web/src/hooks/sse/server-event-sync.ts
@@ -9,11 +9,13 @@ import type { PartDelta } from '@stitch/shared/chat/stream-events';
 
 import { useSSE } from '@/hooks/sse/sse-context';
 import { sessionKeys } from '@/lib/queries/chat';
+import { connectorKeys } from '@/lib/queries/connectors';
 import { mcpKeys } from '@/lib/queries/mcp';
 import { permissionResponseKeys } from '@/lib/queries/permissions';
 import { questionKeys } from '@/lib/queries/questions';
 import { recordingsKeys } from '@/lib/queries/recordings';
 import { settingsQueryOptions } from '@/lib/queries/settings';
+import { skillKeys } from '@/lib/queries/skills';
 import { todoKeys } from '@/lib/queries/todos';
 import { toolKeys } from '@/lib/queries/tools';
 import { playNotificationSound } from '@/lib/sounds';
@@ -156,6 +158,53 @@ function useServerEventSync(): void {
     },
     'recording-analysis-updated': ({ recordingId }) => {
       void queryClient.invalidateQueries({ queryKey: recordingsKeys.detail(recordingId) });
+    },
+    'recording-analysis-completed': ({ recordingId }) => {
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.detail(recordingId) });
+    },
+    'recording-analysis-failed': ({ recordingId }) => {
+      void queryClient.invalidateQueries({ queryKey: recordingsKeys.detail(recordingId) });
+    },
+
+    // Skill Events
+    'skill-created': () => {
+      void queryClient.invalidateQueries({ queryKey: skillKeys.all });
+    },
+    'skill-updated': () => {
+      void queryClient.invalidateQueries({ queryKey: skillKeys.all });
+    },
+    'skill-deleted': () => {
+      void queryClient.invalidateQueries({ queryKey: skillKeys.all });
+    },
+
+    // Connector Events
+    'connector-token-refreshed': ({ instanceId }) => {
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: connectorKeys.instances() }),
+        queryClient.invalidateQueries({ queryKey: connectorKeys.instance(instanceId) }),
+      ]);
+    },
+    'connector-auth-failed': ({ instanceId }) => {
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: connectorKeys.instances() }),
+        queryClient.invalidateQueries({ queryKey: connectorKeys.instance(instanceId) }),
+      ]);
+    },
+    'connector-authorized': ({ instanceId }) => {
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: connectorKeys.instances() }),
+        queryClient.invalidateQueries({ queryKey: connectorKeys.instance(instanceId) }),
+        queryClient.invalidateQueries({ queryKey: toolKeys.knownTools() }),
+        queryClient.invalidateQueries({ queryKey: toolKeys.knownToolsets() }),
+      ]);
+    },
+    'connector-removed': ({ instanceId }) => {
+      void Promise.all([
+        queryClient.invalidateQueries({ queryKey: connectorKeys.all }),
+        ...(instanceId ? [queryClient.invalidateQueries({ queryKey: connectorKeys.instance(instanceId) })] : []),
+        queryClient.invalidateQueries({ queryKey: toolKeys.knownTools() }),
+        queryClient.invalidateQueries({ queryKey: toolKeys.knownToolsets() }),
+      ]);
     },
 
     // Session Events

--- a/apps/web/src/lib/queries/connectors.ts
+++ b/apps/web/src/lib/queries/connectors.ts
@@ -4,7 +4,7 @@ import type { ConnectorDefinition, ConnectorInstanceSafe, ConnectorSafe } from '
 
 import { serverRequest } from '@/lib/api';
 
-const connectorKeys = {
+export const connectorKeys = {
   all: ['connectors'] as const,
   configured: () => [...connectorKeys.all, 'configured'] as const,
   definitions: () => [...connectorKeys.all, 'definitions'] as const,

--- a/apps/web/src/lib/queries/skills.ts
+++ b/apps/web/src/lib/queries/skills.ts
@@ -13,7 +13,7 @@ import type {
 
 import { serverRequest } from '@/lib/api';
 
-const skillKeys = {
+export const skillKeys = {
   all: ['skills'] as const,
   list: () => [...skillKeys.all, 'list'] as const,
   search: (query: string) => [...skillKeys.all, 'search', query] as const,

--- a/packages/server/src/adapters/automations.ts
+++ b/packages/server/src/adapters/automations.ts
@@ -1,0 +1,10 @@
+import { syncAllAutomationSchedules } from '@/automations/scheduler.js';
+import { internalBus } from '@/lib/internal-bus.js';
+
+export function registerAutomationsAdapter(): void {
+  internalBus.on('settings.changed', async (event) => {
+    if (event.key !== 'profile.timezone') return;
+
+    await syncAllAutomationSchedules();
+  });
+}

--- a/packages/server/src/adapters/connectors.ts
+++ b/packages/server/src/adapters/connectors.ts
@@ -1,0 +1,16 @@
+import { refreshConnectorToolsetsFor } from '@/connectors/runtime.js';
+import { internalBus } from '@/lib/internal-bus.js';
+import * as Log from '@/lib/log.js';
+
+const log = Log.create({ service: 'connector-events-adapter' });
+
+function refreshToolsets(connectorId: string): void {
+  void refreshConnectorToolsetsFor(connectorId).catch((error) => {
+    log.error({ connectorId, error }, 'failed to refresh connector toolsets after connector event');
+  });
+}
+
+export function registerConnectorEventsAdapter(): void {
+  internalBus.onSync('connector.authorized', (event) => refreshToolsets(event.connectorId));
+  internalBus.onSync('connector.removed', (event) => refreshToolsets(event.connectorId));
+}

--- a/packages/server/src/adapters/index.ts
+++ b/packages/server/src/adapters/index.ts
@@ -1,3 +1,4 @@
+import { registerAutomationsAdapter } from './automations.js';
 import { registerConnectorEventsAdapter } from './connectors.js';
 import { registerMemoryAdapter } from './memory.js';
 import { registerSseAdapter } from './sse.js';
@@ -9,6 +10,7 @@ import { registerUsageAdapter } from './usage.js';
  */
 export function registerAdapters(): void {
   registerSseAdapter();
+  registerAutomationsAdapter();
   registerConnectorEventsAdapter();
   registerUsageAdapter();
   registerMemoryAdapter();

--- a/packages/server/src/adapters/index.ts
+++ b/packages/server/src/adapters/index.ts
@@ -1,3 +1,4 @@
+import { registerConnectorEventsAdapter } from './connectors.js';
 import { registerMemoryAdapter } from './memory.js';
 import { registerSseAdapter } from './sse.js';
 import { registerUsageAdapter } from './usage.js';
@@ -8,6 +9,7 @@ import { registerUsageAdapter } from './usage.js';
  */
 export function registerAdapters(): void {
   registerSseAdapter();
+  registerConnectorEventsAdapter();
   registerUsageAdapter();
   registerMemoryAdapter();
 }

--- a/packages/server/src/adapters/memory.ts
+++ b/packages/server/src/adapters/memory.ts
@@ -1,6 +1,7 @@
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { processMemories } from '@/memory/processor.js';
+import { resetEmbedder } from '@/models/embedding/factory.js';
 
 const log = Log.create({ service: 'memory-adapter' });
 
@@ -9,6 +10,12 @@ const log = Log.create({ service: 'memory-adapter' });
  * Reacts to stream completion and triggers fire-and-forget memory processing.
  */
 export function registerMemoryAdapter(): void {
+  internalBus.onSync('settings.changed', (event) => {
+    if (event.key === 'memory.embedding.providerId' || event.key === 'memory.embedding.modelId') {
+      resetEmbedder();
+    }
+  });
+
   internalBus.on('stream.completed', async (event) => {
     if (!event.userMessage || !event.assistantMessage) return;
 

--- a/packages/server/src/adapters/sse.ts
+++ b/packages/server/src/adapters/sse.ts
@@ -225,6 +225,14 @@ export function registerSseAdapter(): void {
     });
   });
 
+  internalBus.onSync('recording.analysis.completed', (event) => {
+    broadcast('recording-analysis-completed', { recordingId: event.recordingId, title: event.title });
+  });
+
+  internalBus.onSync('recording.analysis.failed', (event) => {
+    broadcast('recording-analysis-failed', { recordingId: event.recordingId });
+  });
+
   internalBus.onSync('recording.transcript.entry', (event) => {
     broadcast('recording-transcript-entry', {
       recordingId: event.recordingId,
@@ -234,6 +242,38 @@ export function registerSseAdapter(): void {
       content: event.content,
       offsetMs: event.offsetMs,
     });
+  });
+
+  // ─── Skills ────────────────────────────────────────────────────────────────
+
+  internalBus.onSync('skill.created', (event) => {
+    broadcast('skill-created', { name: event.name });
+  });
+
+  internalBus.onSync('skill.updated', (event) => {
+    broadcast('skill-updated', { name: event.name, previousName: event.previousName });
+  });
+
+  internalBus.onSync('skill.deleted', (event) => {
+    broadcast('skill-deleted', { name: event.name });
+  });
+
+  // ─── Connectors ────────────────────────────────────────────────────────────
+
+  internalBus.onSync('connector.token.refreshed', (event) => {
+    broadcast('connector-token-refreshed', { instanceId: event.instanceId });
+  });
+
+  internalBus.onSync('connector.auth.failed', (event) => {
+    broadcast('connector-auth-failed', { instanceId: event.instanceId });
+  });
+
+  internalBus.onSync('connector.authorized', (event) => {
+    broadcast('connector-authorized', { instanceId: event.instanceId, connectorId: event.connectorId });
+  });
+
+  internalBus.onSync('connector.removed', (event) => {
+    broadcast('connector-removed', { instanceId: event.instanceId, connectorId: event.connectorId });
   });
 
   // ─── Mail ───────────────────────────────────────────────────────────────────

--- a/packages/server/src/automations/scheduler.ts
+++ b/packages/server/src/automations/scheduler.ts
@@ -3,6 +3,7 @@ import type { Automation, AutomationSchedule } from '@stitch/shared/automations/
 
 import { listAutomations, runAutomation } from './service.js';
 
+import { internalBus } from '@/lib/internal-bus.js';
 import { registerSchedulerJob, unregisterSchedulerJob } from '@/scheduler/runtime.js';
 import { getSettings } from '@/settings/service.js';
 
@@ -41,10 +42,14 @@ async function registerAutomationJob(automation: Automation, timezone: string): 
     key: getAutomationJobKey(automation.id),
     schedule: toSchedulerSchedule(automation.schedule, timezone),
     callback: async () => {
+      const key = getAutomationJobKey(automation.id);
+      internalBus.emit('schedule.job.fired', { key, automationId: automation.id });
       const result = await runAutomation(automation.id);
       if (result.error) {
+        internalBus.emit('schedule.job.failed', { key, automationId: automation.id, error: result.error.message });
         throw new Error(result.error.message);
       }
+      internalBus.emit('schedule.job.succeeded', { key, automationId: automation.id });
     },
     maxConcurrency: 1,
     catchup: 'one',

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -21,6 +21,7 @@ import { createSession } from '@/chat/session-crud.js';
 import { getDb } from '@/db/client.js';
 import { automations } from '@/db/schema/automations.js';
 import { sessions } from '@/db/schema/sessions.js';
+import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { paginatedQuery } from '@/lib/paginated-query.js';
 import { err, ok } from '@/lib/service-result.js';
@@ -319,6 +320,7 @@ export async function runAutomation(automationId: string): Promise<ServiceResult
   const sessionResult = await createSession({ title, type: 'automation', automationId: automation.id });
   if (sessionResult.error) return sessionResult;
   const session = sessionResult.data;
+  internalBus.emit('automation.run.started', { automationId: automation.id, sessionId: session.id });
 
   const assistantMessageId = createMessageId();
   const sendResult = await sendMessage({
@@ -328,7 +330,10 @@ export async function runAutomation(automationId: string): Promise<ServiceResult
     modelId: automation.modelId,
     assistantMessageId,
   });
-  if (sendResult.error) return sendResult;
+  if (sendResult.error) {
+    internalBus.emit('automation.run.failed', { automationId: automation.id, error: sendResult.error.message });
+    return sendResult;
+  }
 
   const [updatedAutomation] = await db.transaction(async (tx) => {
     const [updated] = await tx
@@ -348,8 +353,11 @@ export async function runAutomation(automationId: string): Promise<ServiceResult
   });
 
   if (!updatedAutomation) {
+    internalBus.emit('automation.run.failed', { automationId: automation.id, error: 'Automation not found' });
     return err('Automation not found', 404);
   }
+
+  internalBus.emit('automation.run.completed', { automationId: automation.id, sessionId: session.id });
 
   return ok({
     sessionId: session.id,

--- a/packages/server/src/connectors/auth/token-refresh.ts
+++ b/packages/server/src/connectors/auth/token-refresh.ts
@@ -9,6 +9,7 @@ import { withRefreshLock } from '@/connectors/auth/refresh-lock.js';
 import { getConnectorDefinition } from '@/connectors/registry.js';
 import { getDb } from '@/db/client.js';
 import { connectorInstances } from '@/db/schema/connectors.js';
+import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 
 const log = Log.create({ service: 'token-refresh' });
@@ -105,6 +106,7 @@ export async function refreshExpiringTokens(deps?: {
         .where(eq(connectorInstances.id, instance.id));
 
       log.info({ event: 'token-refresh.success', instanceId: instance.id }, `Token refreshed for ${instance.label}`);
+      internalBus.emit('connector.token.refreshed', { instanceId: instance.id });
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       const requiresReauth = requiresOAuthReauth(e);
@@ -126,6 +128,7 @@ export async function refreshExpiringTokens(deps?: {
           .update(connectorInstances)
           .set({ status: 'error', authIssue: 'reauthorization_required', updatedAt: Date.now() })
           .where(eq(connectorInstances.id, instance.id));
+        internalBus.emit('connector.auth.failed', { instanceId: instance.id });
       }
     }
   }

--- a/packages/server/src/connectors/google-toolsets.ts
+++ b/packages/server/src/connectors/google-toolsets.ts
@@ -22,6 +22,7 @@ import { withRefreshLock } from '@/connectors/auth/refresh-lock.js';
 import { getConnectorDefinition } from '@/connectors/registry.js';
 import { getDb } from '@/db/client.js';
 import { connectorInstances } from '@/db/schema/connectors.js';
+import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { PATHS } from '@/lib/paths.js';
 import { registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
@@ -145,6 +146,8 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
                       })
                       .where(eq(connectorInstances.id, chosen.id));
 
+                    internalBus.emit('connector.token.refreshed', { instanceId: chosen.id });
+
                     return refreshed.accessToken;
                   } catch (error) {
                     const message = error instanceof Error ? error.message : String(error);
@@ -167,6 +170,7 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
                         .update(connectorInstances)
                         .set({ status: 'error', authIssue: 'reauthorization_required', updatedAt: Date.now() })
                         .where(eq(connectorInstances.id, chosen.id));
+                      internalBus.emit('connector.auth.failed', { instanceId: chosen.id });
                     }
                     throw error;
                   }

--- a/packages/server/src/connectors/service.ts
+++ b/packages/server/src/connectors/service.ts
@@ -23,9 +23,10 @@ import {
 import type { startOAuthFlow as StartOAuthFlowFn } from '@/connectors/auth/oauth2.js';
 import { withRefreshLock } from '@/connectors/auth/refresh-lock.js';
 import { getConnectorDefinition } from '@/connectors/registry.js';
-import { getConnectorModule, refreshConnectorToolsetsFor } from '@/connectors/runtime.js';
+import { getConnectorModule } from '@/connectors/runtime.js';
 import { getDb } from '@/db/client.js';
 import { connectorInstances, connectors } from '@/db/schema/connectors.js';
+import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
@@ -148,7 +149,7 @@ export async function deleteConnector(connectorRefId: string): Promise<ServiceRe
   if (!existing) return err('Connector not found', 404);
 
   await db.delete(connectors).where(eq(connectors.id, typedConnectorRefId));
-  await refreshConnectorToolsetsFor(existing.connectorId);
+  internalBus.emit('connector.removed', { instanceId: null, connectorId: existing.connectorId });
 
   log.info(
     { event: 'connector.credentials.deleted', connectorRefId, connectorId: existing.connectorId },
@@ -360,8 +361,7 @@ export async function authorizeOAuthInstance(
         .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
 
       log.info({ event: 'connector.authorized', instanceId, accountEmail }, `Connector authorized: ${instance.label}`);
-
-      await refreshConnectorToolsetsFor(instance.connectorId);
+      internalBus.emit('connector.authorized', { instanceId, connectorId: instance.connectorId });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       await db
@@ -369,6 +369,7 @@ export async function authorizeOAuthInstance(
         .set({ status: 'error' as ConnectorStatus, authIssue: 'temporary_failure', updatedAt: Date.now() })
         .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
       log.warn({ event: 'connector.authorize.failed', instanceId, error: message }, 'connector authorization failed');
+      internalBus.emit('connector.auth.failed', { instanceId });
       throw error;
     }
   };
@@ -440,6 +441,7 @@ export async function upgradeConnectorInstance(
         updatedAt: now,
       })
       .where(eq(connectorInstances.id, typedInstanceId));
+    internalBus.emit('connector.authorized', { instanceId, connectorId: instance.connectorId });
     return ok({ type: 'updated' });
   }
 
@@ -466,6 +468,8 @@ export async function upgradeConnectorInstance(
         updatedAt: now,
       })
       .where(eq(connectorInstances.id, typedInstanceId));
+
+    internalBus.emit('connector.authorized', { instanceId, connectorId: instance.connectorId });
 
     return ok({ type: 'updated' });
   }
@@ -534,7 +538,7 @@ export async function deleteConnectorInstance(instanceId: string): Promise<Servi
   if (module?.hooks?.onDeleted) {
     await module.hooks.onDeleted({ instance: existing, logger: log });
   }
-  await refreshConnectorToolsetsFor(existing.connectorId);
+  internalBus.emit('connector.removed', { instanceId, connectorId: existing.connectorId });
 
   log.info({ event: 'connector.deleted', instanceId }, `Connector instance deleted: ${existing.label}`);
 
@@ -582,6 +586,7 @@ export async function testConnectorInstance(instanceId: string): Promise<Service
             updatedAt: now,
           })
           .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+        internalBus.emit('connector.token.refreshed', { instanceId });
         testedInstance = {
           ...instance,
           accessToken: refreshed.accessToken,
@@ -616,6 +621,7 @@ export async function testConnectorInstance(instanceId: string): Promise<Service
         .update(connectorInstances)
         .set({ status: 'error' as ConnectorStatus, authIssue: 'reauthorization_required', updatedAt: Date.now() })
         .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+      internalBus.emit('connector.auth.failed', { instanceId });
     }
 
     return err(

--- a/packages/server/src/lib/internal-bus-events.ts
+++ b/packages/server/src/lib/internal-bus-events.ts
@@ -242,6 +242,10 @@ export type RecordingAnalysisUpdatedEvent = {
   title: string | null;
 };
 
+export type RecordingAnalysisCompletedEvent = { recordingId: PrefixedString<'rec'>; title: string };
+
+export type RecordingAnalysisFailedEvent = { recordingId: PrefixedString<'rec'> };
+
 export type RecordingTranscriptEntryEvent = {
   recordingId: string;
   kind: 'partial' | 'final';
@@ -256,6 +260,38 @@ export type RecordingTranscriptEntryEvent = {
 export type McpToolsChangedEvent = { serverId: PrefixedString<'mcp'>; serverName: string; toolCount: number | null };
 
 export type McpAuthStatusChangedEvent = { serverId: PrefixedString<'mcp'>; authStatus: McpAuthStatus };
+
+// ─── Skills ──────────────────────────────────────────────────────────────────
+
+export type SkillCreatedEvent = { name: string };
+
+export type SkillUpdatedEvent = { name: string; previousName: string };
+
+export type SkillDeletedEvent = { name: string };
+
+// ─── Connectors ──────────────────────────────────────────────────────────────
+
+export type ConnectorTokenRefreshedEvent = { instanceId: string };
+
+export type ConnectorAuthFailedEvent = { instanceId: string };
+
+export type ConnectorAuthorizedEvent = { instanceId: string; connectorId: string };
+
+export type ConnectorRemovedEvent = { instanceId: string | null; connectorId: string };
+
+// ─── Automations / Schedules ─────────────────────────────────────────────────
+
+export type AutomationRunStartedEvent = { automationId: PrefixedString<'auto'>; sessionId: PrefixedString<'ses'> };
+
+export type AutomationRunCompletedEvent = { automationId: PrefixedString<'auto'>; sessionId: PrefixedString<'ses'> };
+
+export type AutomationRunFailedEvent = { automationId: PrefixedString<'auto'>; error: string };
+
+export type ScheduleJobFiredEvent = { key: string; automationId: PrefixedString<'auto'> };
+
+export type ScheduleJobSucceededEvent = { key: string; automationId: PrefixedString<'auto'> };
+
+export type ScheduleJobFailedEvent = { key: string; automationId: PrefixedString<'auto'>; error: string };
 
 // ─── Mail ────────────────────────────────────────────────────────────────────
 
@@ -317,12 +353,33 @@ export type InternalEventMap = {
   'recording.stopped': RecordingStoppedEvent;
   'recording.unrecoverable': RecordingUnrecoverableEvent;
   'recording.analysis.updated': RecordingAnalysisUpdatedEvent;
+  'recording.analysis.completed': RecordingAnalysisCompletedEvent;
+  'recording.analysis.failed': RecordingAnalysisFailedEvent;
   'recording.transcript.entry': RecordingTranscriptEntryEvent;
 
   // MCP
   'mcp.tools.list_changed': McpToolsChangedEvent;
   'mcp.tools.changed': McpToolsChangedEvent;
   'mcp.auth.status_changed': McpAuthStatusChangedEvent;
+
+  // Skills
+  'skill.created': SkillCreatedEvent;
+  'skill.updated': SkillUpdatedEvent;
+  'skill.deleted': SkillDeletedEvent;
+
+  // Connectors
+  'connector.token.refreshed': ConnectorTokenRefreshedEvent;
+  'connector.auth.failed': ConnectorAuthFailedEvent;
+  'connector.authorized': ConnectorAuthorizedEvent;
+  'connector.removed': ConnectorRemovedEvent;
+
+  // Automations / Schedules
+  'automation.run.started': AutomationRunStartedEvent;
+  'automation.run.completed': AutomationRunCompletedEvent;
+  'automation.run.failed': AutomationRunFailedEvent;
+  'schedule.job.fired': ScheduleJobFiredEvent;
+  'schedule.job.succeeded': ScheduleJobSucceededEvent;
+  'schedule.job.failed': ScheduleJobFailedEvent;
 
   // Mail
   'mail.sync.progress': MailSyncProgressEvent;

--- a/packages/server/src/lib/internal-bus-events.ts
+++ b/packages/server/src/lib/internal-bus-events.ts
@@ -7,6 +7,7 @@ import type { McpAuthStatus } from '@stitch/shared/mcp/types';
 import type { PermissionResponse } from '@stitch/shared/permissions/types';
 import type { QuestionRequest } from '@stitch/shared/questions/types';
 import type { RecordingAnalysisStatus } from '@stitch/shared/recordings/types';
+import type { SettingsKey } from '@stitch/shared/settings/types';
 
 import type { LanguageModelUsage } from 'ai';
 
@@ -279,6 +280,10 @@ export type ConnectorAuthorizedEvent = { instanceId: string; connectorId: string
 
 export type ConnectorRemovedEvent = { instanceId: string | null; connectorId: string };
 
+// ─── Settings ────────────────────────────────────────────────────────────────
+
+export type SettingsChangedEvent = { key: SettingsKey };
+
 // ─── Automations / Schedules ─────────────────────────────────────────────────
 
 export type AutomationRunStartedEvent = { automationId: PrefixedString<'auto'>; sessionId: PrefixedString<'ses'> };
@@ -372,6 +377,9 @@ export type InternalEventMap = {
   'connector.auth.failed': ConnectorAuthFailedEvent;
   'connector.authorized': ConnectorAuthorizedEvent;
   'connector.removed': ConnectorRemovedEvent;
+
+  // Settings
+  'settings.changed': SettingsChangedEvent;
 
   // Automations / Schedules
   'automation.run.started': AutomationRunStartedEvent;

--- a/packages/server/src/mail/wiring.ts
+++ b/packages/server/src/mail/wiring.ts
@@ -150,6 +150,8 @@ async function getGoogleAccessToken(connectorInstanceId: string, forceRefresh: b
             })
             .where(eq(connectorInstances.id, connectorInstanceId as ConnectorInstanceId));
 
+          internalBus.emit('connector.token.refreshed', { instanceId: connectorInstanceId });
+
           return refreshed.accessToken;
         } catch (error) {
           const requiresReauth = requiresOAuthReauth(error);
@@ -169,6 +171,7 @@ async function getGoogleAccessToken(connectorInstanceId: string, forceRefresh: b
               .update(connectorInstances)
               .set({ status: 'error', authIssue: 'reauthorization_required', updatedAt: Date.now() })
               .where(eq(connectorInstances.id, connectorInstanceId as ConnectorInstanceId));
+            internalBus.emit('connector.auth.failed', { instanceId: connectorInstanceId });
           }
           throw error;
         }

--- a/packages/server/src/recordings/analysis-service.ts
+++ b/packages/server/src/recordings/analysis-service.ts
@@ -261,7 +261,7 @@ export async function cancelRecordingAnalysis(recordingId: PrefixedString<'rec'>
     .where(eq(recordingAnalyses.id, existing.id))
     .returning();
 
-  broadcastRecordingAnalysisUpdated({ recordingId, status: 'failed', title: null });
+  internalBus.emit('recording.analysis.failed', { recordingId });
 
   if (!updated) {
     return err('Failed to cancel recording analysis', 400);
@@ -384,7 +384,7 @@ async function runRecordingAnalysis(
       })
       .where(eq(recordingAnalyses.id, analysisId));
 
-    broadcastRecordingAnalysisUpdated({ recordingId: input.recordingId, status: 'completed', title });
+    internalBus.emit('recording.analysis.completed', { recordingId: input.recordingId, title });
 
     log.info({ analysisId, recordingId: input.recordingId }, 'recording analysis completed');
   } catch (error) {
@@ -406,7 +406,7 @@ async function runRecordingAnalysis(
       .set({ status: 'failed', error: message, endedAt, durationMs: endedAt - startedAt, updatedAt: endedAt })
       .where(eq(recordingAnalyses.id, analysisId));
 
-    broadcastRecordingAnalysisUpdated({ recordingId: input.recordingId, status: 'failed', title: null });
+    internalBus.emit('recording.analysis.failed', { recordingId: input.recordingId });
 
     log.error({ analysisId, recordingId: input.recordingId, error: message }, 'recording analysis failed');
   } finally {

--- a/packages/server/src/settings/service.ts
+++ b/packages/server/src/settings/service.ts
@@ -3,14 +3,13 @@ import { eq, inArray } from 'drizzle-orm';
 import { SETTINGS_DEFAULTS, SETTINGS_SCHEMAS } from '@stitch/shared/settings/types';
 import type { SettingsKey } from '@stitch/shared/settings/types';
 
-import { syncAllAutomationSchedules } from '@/automations/scheduler.js';
 import { getDb } from '@/db/client.js';
 import { userSettings } from '@/db/schema/settings.js';
+import { internalBus } from '@/lib/internal-bus.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { listEnabledProviderEmbeddingModels } from '@/llm/provider/service.js';
 import { getMemoryConfig, hasConfiguredEmbeddingModel } from '@/memory/config.js';
-import { resetEmbedder } from '@/models/embedding/factory.js';
 import type { z } from 'zod';
 
 type SettingValue<K extends SettingsKey> = z.infer<(typeof SETTINGS_SCHEMAS)[K]>;
@@ -80,24 +79,6 @@ async function checkMemoryEnablePrerequisites(): Promise<ServiceResult<null>> {
   return ok(null);
 }
 
-function isTimezoneKey(key: string): boolean {
-  return key === 'profile.timezone';
-}
-
-function isEmbeddingKey(key: string): boolean {
-  return key === 'memory.embedding.providerId' || key === 'memory.embedding.modelId';
-}
-
-async function runSettingSideEffects(key: string): Promise<void> {
-  if (isTimezoneKey(key)) {
-    await syncAllAutomationSchedules();
-  }
-
-  if (isEmbeddingKey(key)) {
-    resetEmbedder();
-  }
-}
-
 export async function saveSetting(key: string, value: string): Promise<ServiceResult<null>> {
   const schema = SETTINGS_SCHEMAS[key as SettingsKey];
   if (!schema) {
@@ -121,7 +102,7 @@ export async function saveSetting(key: string, value: string): Promise<ServiceRe
     .values({ key: key as SettingsKey, value })
     .onConflictDoUpdate({ target: userSettings.key, set: { value, updatedAt: Date.now() } });
 
-  await runSettingSideEffects(key);
+  internalBus.emit('settings.changed', { key: key as SettingsKey });
 
   return ok(null);
 }
@@ -140,7 +121,7 @@ export async function deleteSetting(key: string): Promise<ServiceResult<null>> {
     return err('Setting not found', 404);
   }
 
-  await runSettingSideEffects(key);
+  internalBus.emit('settings.changed', { key: key as SettingsKey });
 
   return ok(null);
 }

--- a/packages/server/src/skills/service.ts
+++ b/packages/server/src/skills/service.ts
@@ -12,6 +12,7 @@ import type {
 } from '@stitch/shared/skills/types';
 
 import { getDisabledAppSkillNames } from '@/apps/service.js';
+import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
@@ -100,13 +101,17 @@ export async function createSkill(input: SkillCreateInput): Promise<ServiceResul
 
   await writeSkillMdFile(value.name, buildSkillMd(value));
 
-  return ok({
+  const skill = {
     name: value.name,
     description: value.description.trim(),
     content: value.content.trim(),
     location: getSkillMdPath(value.name),
     files: [],
-  });
+  };
+
+  internalBus.emit('skill.created', { name: skill.name });
+
+  return ok(skill);
 }
 
 export async function syncBuiltInSkills(builtInSkills: BuiltInSkill[]): Promise<void> {
@@ -147,13 +152,17 @@ export async function updateSkill(name: string, input: SkillUpdateInput): Promis
   const targetDir = getSkillDir(value.name);
   const files = await listSkillFiles(targetDir);
 
-  return ok({
+  const skill = {
     name: value.name,
     description: value.description.trim(),
     content: value.content.trim(),
     location: getSkillMdPath(value.name),
     files,
-  });
+  };
+
+  internalBus.emit('skill.updated', { name: skill.name, previousName: name });
+
+  return ok(skill);
 }
 
 export async function deleteSkill(name: string): Promise<ServiceResult<null>> {
@@ -165,6 +174,7 @@ export async function deleteSkill(name: string): Promise<ServiceResult<null>> {
   }
 
   await rm(skillDir, { recursive: true, force: true });
+  internalBus.emit('skill.deleted', { name });
   return ok(null);
 }
 
@@ -276,13 +286,17 @@ export async function importSkillFromDirectory(input: SkillImportInput): Promise
 
     const skillFiles = await listSkillFiles(skillDir);
 
-    return ok({
+    const skill = {
       name: value.name,
       description: value.description.trim(),
       content: value.content.trim(),
       location: getSkillMdPath(value.name),
       files: skillFiles,
-    });
+    };
+
+    internalBus.emit('skill.created', { name: skill.name });
+
+    return ok(skill);
   } catch (error) {
     if (error instanceof SkillNameCollisionError) {
       return err(error.message, 409);

--- a/packages/shared/src/connectors/events.ts
+++ b/packages/shared/src/connectors/events.ts
@@ -1,0 +1,13 @@
+export const CONNECTOR_EVENT_NAMES = [
+  'connector-token-refreshed',
+  'connector-auth-failed',
+  'connector-authorized',
+  'connector-removed',
+] as const;
+
+export type ConnectorEvents = {
+  'connector-token-refreshed': { instanceId: string };
+  'connector-auth-failed': { instanceId: string };
+  'connector-authorized': { instanceId: string; connectorId: string };
+  'connector-removed': { instanceId: string | null; connectorId: string };
+};

--- a/packages/shared/src/realtime.ts
+++ b/packages/shared/src/realtime.ts
@@ -1,10 +1,12 @@
 import { SESSION_EVENT_NAMES, type SessionEvents } from './chat/session-events.js';
 import { STREAM_EVENT_NAMES, type StreamEvents } from './chat/stream-events.js';
+import { CONNECTOR_EVENT_NAMES, type ConnectorEvents } from './connectors/events.js';
 import { MAIL_EVENT_NAMES, type MailEvents } from './mail/events.js';
 import { MCP_EVENT_NAMES, type McpEvents } from './mcp/events.js';
 import { PERMISSION_EVENT_NAMES, type PermissionEvents } from './permissions/events.js';
 import { QUESTION_EVENT_NAMES, type QuestionEvents } from './questions/events.js';
 import { RECORDING_EVENT_NAMES, type RecordingEvents } from './recordings/events.js';
+import { SKILL_EVENT_NAMES, type SkillEvents } from './skills/events.js';
 
 const CONNECTION_EVENT_NAMES = ['heartbeat', 'connected'] as const;
 
@@ -14,6 +16,8 @@ export type SseEventPayloadMap = ConnectionEvents &
   StreamEvents &
   SessionEvents &
   RecordingEvents &
+  SkillEvents &
+  ConnectorEvents &
   QuestionEvents &
   PermissionEvents &
   McpEvents &
@@ -24,6 +28,8 @@ export const SSE_EVENT_NAMES = [
   ...STREAM_EVENT_NAMES,
   ...SESSION_EVENT_NAMES,
   ...RECORDING_EVENT_NAMES,
+  ...SKILL_EVENT_NAMES,
+  ...CONNECTOR_EVENT_NAMES,
   ...QUESTION_EVENT_NAMES,
   ...PERMISSION_EVENT_NAMES,
   ...MCP_EVENT_NAMES,

--- a/packages/shared/src/recordings/events.ts
+++ b/packages/shared/src/recordings/events.ts
@@ -7,6 +7,10 @@ export type RecordingAnalysisUpdatedPayload = {
   title: string | null;
 };
 
+export type RecordingAnalysisCompletedPayload = { recordingId: PrefixedString<'rec'>; title: string };
+
+export type RecordingAnalysisFailedPayload = { recordingId: PrefixedString<'rec'> };
+
 export type RecordingWarningPayload = { code: string; message: string };
 
 export type RecordingDeviceChangedPayload = { kind: 'input' | 'output' | 'list'; deviceName: string | null };
@@ -29,6 +33,8 @@ export type RecordingTranscriptEntryPayload = {
 
 export const RECORDING_EVENT_NAMES = [
   'recording-analysis-updated',
+  'recording-analysis-completed',
+  'recording-analysis-failed',
   'recording-transcript-entry',
   'recording-started',
   'recording-stopped',
@@ -37,6 +43,8 @@ export const RECORDING_EVENT_NAMES = [
 
 export type RecordingEvents = {
   'recording-analysis-updated': RecordingAnalysisUpdatedPayload;
+  'recording-analysis-completed': RecordingAnalysisCompletedPayload;
+  'recording-analysis-failed': RecordingAnalysisFailedPayload;
   'recording-transcript-entry': RecordingTranscriptEntryPayload;
   'recording-started': RecordingStartedPayload;
   'recording-stopped': RecordingStoppedPayload;

--- a/packages/shared/src/skills/events.ts
+++ b/packages/shared/src/skills/events.ts
@@ -1,0 +1,7 @@
+export const SKILL_EVENT_NAMES = ['skill-created', 'skill-updated', 'skill-deleted'] as const;
+
+export type SkillEvents = {
+  'skill-created': { name: string };
+  'skill-updated': { name: string; previousName: string };
+  'skill-deleted': { name: string };
+};


### PR DESCRIPTION
## 🚀 Change Summary

Adds domain-level realtime events so the app reacts consistently to server-side lifecycle changes across skills, connectors, automations, schedules, recordings, and settings.

### ✨ New Features
- **Domain Realtime Events**: Adds shared and internal event contracts for skills, connectors, automation runs, schedule jobs, recording analysis, and settings changes.
- **Reactive UI Sync**: Invalidates relevant skill, connector, and tool queries when matching SSE events arrive.

### 🛠 Improvements & Refactors
- Moves connector toolset refresh and settings side effects behind internal bus adapters to reduce direct service coupling.
- Emits explicit recording analysis completion/failure events instead of relying only on generic status updates.
- Keeps backend event broadcasting centralized through the SSE adapter.