### PR TITLE
refactor(server): decouple LLM usage recording from feature modules

### DIFF
--- a/packages/server/drizzle/0038_right_salo.sql
+++ b/packages/server/drizzle/0038_right_salo.sql
@@ -1,0 +1,24 @@
+-- Migrate existing rows: merge chat-specific columns into metadata JSON
+UPDATE `llm_usage_events`
+SET `metadata` = json_patch(
+  COALESCE(`metadata`, '{}'),
+  json_object(
+    'source', `source`,
+    'sessionId', `session_id`,
+    'messageId', `message_id`,
+    'stepIndex', `step_index`,
+    'attemptIndex', `attempt_index`
+  )
+)
+WHERE `session_id` IS NOT NULL OR `message_id` IS NOT NULL OR `step_index` IS NOT NULL OR `attempt_index` IS NOT NULL;--> statement-breakpoint
+-- Ensure all rows without metadata have at least a source field
+UPDATE `llm_usage_events`
+SET `metadata` = json_object('source', `source`)
+WHERE `metadata` IS NULL;--> statement-breakpoint
+DROP INDEX `llm_usage_events_run_id_idx`;--> statement-breakpoint
+ALTER TABLE `llm_usage_events` DROP COLUMN `run_id`;--> statement-breakpoint
+ALTER TABLE `llm_usage_events` DROP COLUMN `is_attributable`;--> statement-breakpoint
+ALTER TABLE `llm_usage_events` DROP COLUMN `session_id`;--> statement-breakpoint
+ALTER TABLE `llm_usage_events` DROP COLUMN `message_id`;--> statement-breakpoint
+ALTER TABLE `llm_usage_events` DROP COLUMN `step_index`;--> statement-breakpoint
+ALTER TABLE `llm_usage_events` DROP COLUMN `attempt_index`;

--- a/packages/server/drizzle/meta/0038_snapshot.json
+++ b/packages/server/drizzle/meta/0038_snapshot.json
@@ -1,0 +1,2645 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d26d7804-9dc2-4a73-9791-f2921a7d17b4",
+  "prevId": "3fce8741-ec77-45b1-9d65-e4d5d0b30a2d",
+  "tables": {
+    "agenda_items": {
+      "name": "agenda_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'todo'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_items_list_id_idx": {
+          "name": "agenda_items_list_id_idx",
+          "columns": [
+            "list_id"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_status_idx": {
+          "name": "agenda_items_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_due_at_idx": {
+          "name": "agenda_items_due_at_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_created_at_idx": {
+          "name": "agenda_items_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_items_list_id_agenda_lists_id_fk": {
+          "name": "agenda_items_list_id_agenda_lists_id_fk",
+          "tableFrom": "agenda_items",
+          "tableTo": "agenda_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_items_type_check": {
+          "name": "agenda_items_type_check",
+          "value": "\"agenda_items\".\"type\" in ('todo', 'reminder', 'checkup')"
+        },
+        "agenda_items_status_check": {
+          "name": "agenda_items_status_check",
+          "value": "\"agenda_items\".\"status\" in ('open', 'in_progress', 'done', 'cancelled')"
+        },
+        "agenda_items_priority_check": {
+          "name": "agenda_items_priority_check",
+          "value": "\"agenda_items\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      }
+    },
+    "agenda_lists": {
+      "name": "agenda_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_lists_name_uidx": {
+          "name": "agenda_lists_name_uidx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "agenda_lists_created_at_idx": {
+          "name": "agenda_lists_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_ref_id": {
+          "name": "connector_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "auth_issue": {
+          "name": "auth_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instances_connector_ref_id_idx": {
+          "name": "connector_instances_connector_ref_id_idx",
+          "columns": [
+            "connector_ref_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connector_instances_connector_ref_id_connectors_id_fk": {
+          "name": "connector_instances_connector_ref_id_connectors_id_fk",
+          "tableFrom": "connector_instances",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "connectors": {
+      "name": "connectors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connectors_connector_id_idx": {
+          "name": "connectors_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connectors_auth_type_check": {
+          "name": "connectors_auth_type_check",
+          "value": "\"connectors\".\"auth_type\" in ('oauth2', 'api_key')"
+        }
+      }
+    },
+    "lance_migrations": {
+      "name": "lance_migrations",
+      "columns": {
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "prev_id": {
+          "name": "prev_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'applied'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_oauth_sessions": {
+      "name": "mcp_oauth_sessions",
+      "columns": {
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_information": {
+          "name": "client_information",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovery_state": {
+          "name": "discovery_state",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_oauth_sessions_server_id_mcp_servers_id_fk": {
+          "name": "mcp_oauth_sessions_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_oauth_sessions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_status": {
+          "name": "auth_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_enabled": {
+      "name": "tool_enabled",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_enabled_scope_identifier_uidx": {
+          "name": "tool_enabled_scope_identifier_uidx",
+          "columns": [
+            "scope",
+            "identifier"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": [
+            "tool_name",
+            "pattern"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ollama_models": {
+      "name": "ollama_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_limit": {
+          "name": "input_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_limit": {
+          "name": "output_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_cost_per_million": {
+          "name": "input_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_cost_per_million": {
+          "name": "output_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_cost_per_million": {
+          "name": "cache_read_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_per_million": {
+          "name": "cache_write_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_tool_calls": {
+          "name": "supports_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_vision": {
+          "name": "supports_vision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_reasoning": {
+          "name": "supports_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meeting_note_templates": {
+      "name": "meeting_note_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meeting_note_templates_updated_at_idx": {
+          "name": "meeting_note_templates_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_analyses": {
+      "name": "recording_analyses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_provider_id": {
+          "name": "transcription_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_model_id": {
+          "name": "transcription_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_provider_id": {
+          "name": "analysis_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_model_id": {
+          "name": "analysis_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recording_analyses_recording_id_uidx": {
+          "name": "recording_analyses_recording_id_uidx",
+          "columns": [
+            "recording_id"
+          ],
+          "isUnique": true
+        },
+        "recording_analyses_status_idx": {
+          "name": "recording_analyses_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recording_analyses_recording_id_recordings_id_fk": {
+          "name": "recording_analyses_recording_id_recordings_id_fk",
+          "tableFrom": "recording_analyses",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recording_analyses_status_check": {
+          "name": "recording_analyses_status_check",
+          "value": "\"recording_analyses\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "recordings": {
+      "name": "recordings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'recording'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recordings_created_at_idx": {
+          "name": "recordings_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "recordings_status_idx": {
+          "name": "recordings_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recordings_status_check": {
+          "name": "recordings_status_check",
+          "value": "\"recordings\".\"status\" in ('recording', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": [
+            "job_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": [
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_reason": {
+          "name": "archived_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_todos": {
+      "name": "session_todos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_todos_session_id_idx": {
+          "name": "session_todos_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "session_todos_order_idx": {
+          "name": "session_todos_order_idx",
+          "columns": [
+            "session_id",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_todos_session_id_sessions_id_fk": {
+          "name": "session_todos_session_id_sessions_id_fk",
+          "tableFrom": "session_todos",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "toolset_state": {
+          "name": "toolset_state",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_reason": {
+          "name": "archived_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_automation_id_automations_id_fk": {
+          "name": "sessions_automation_id_automations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_usage_events": {
+      "name": "embedding_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "embedding_usage_events_created_at_idx": {
+          "name": "embedding_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "embedding_usage_events_provider_model_idx": {
+          "name": "embedding_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stt_usage_events": {
+      "name": "stt_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stt_usage_events_service_idx": {
+          "name": "stt_usage_events_service_idx",
+          "columns": [
+            "service"
+          ],
+          "isUnique": false
+        },
+        "stt_usage_events_created_at_idx": {
+          "name": "stt_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "stt_usage_events_provider_model_idx": {
+          "name": "stt_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "stt_usage_events_service_check": {
+          "name": "stt_usage_events_service_check",
+          "value": "\"stt_usage_events\".\"service\" in ('chat-input', 'meeting-recording')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -45,6 +45,7 @@
     { "idx": 34, "version": "6", "when": 1781653056873, "tag": "0034_acoustic_eternity", "breakpoints": true },
     { "idx": 35, "version": "6", "when": 1782067742555, "tag": "0035_slim_sumo", "breakpoints": true },
     { "idx": 36, "version": "6", "when": 1783382634204, "tag": "0036_perfect_mauler", "breakpoints": true },
-    { "idx": 37, "version": "6", "when": 1783471267511, "tag": "0037_rich_maelstrom", "breakpoints": true }
+    { "idx": 37, "version": "6", "when": 1783471267511, "tag": "0037_rich_maelstrom", "breakpoints": true },
+    { "idx": 38, "version": "6", "when": 1783713767858, "tag": "0038_right_salo", "breakpoints": true }
   ]
 }

--- a/packages/server/src/adapters/title-generation.test.ts
+++ b/packages/server/src/adapters/title-generation.test.ts
@@ -112,7 +112,8 @@ describe('title generation adapter', () => {
     expect(titleMessages).toHaveLength(1);
     expect(titleMessages[0].parts[0]).toMatchObject({ type: 'session-title', title: 'Title: Chat Content' });
     expect(usageRows).toHaveLength(1);
-    expect(usageRows[0]).toMatchObject({ sessionId, providerId: 'openai', modelId: 'gpt-5' });
+    expect(usageRows[0]).toMatchObject({ providerId: 'openai', modelId: 'gpt-5' });
+    expect(usageRows[0].metadata).toMatchObject({ sessionId, target: 'chat' });
     expect(emitted).toEqual([{ sessionId, title: 'Title: Chat Content' }]);
   });
 
@@ -154,7 +155,12 @@ describe('title generation adapter', () => {
   test('increments recording analysis cost by generated title cost', async () => {
     await seedRecordingAnalysis();
     registerTitleGenerationAdapter({
-      generateTitle: async () => ({ title: 'Generated Recording Title', providerId: 'openai', modelId: 'gpt-5', usage: ZERO_USAGE }),
+      generateTitle: async () => ({
+        title: 'Generated Recording Title',
+        providerId: 'openai',
+        modelId: 'gpt-5',
+        usage: ZERO_USAGE,
+      }),
       recordTitleUsage: async () => ({ costUsd: 0.25 }),
     });
 

--- a/packages/server/src/adapters/title-generation.ts
+++ b/packages/server/src/adapters/title-generation.ts
@@ -1,12 +1,13 @@
 import { and, eq, sql } from 'drizzle-orm';
 
 import type { StoredPart } from '@stitch/shared/chat/messages';
+import { createMessageId, createPartId } from '@stitch/shared/id';
 
 import { saveTitleMessage } from '@/chat/message-store.js';
 import { getDb } from '@/db/client.js';
 import { recordingAnalyses } from '@/db/schema/recordings.js';
 import { sessions } from '@/db/schema/sessions.js';
-import { createMessageId, createPartId } from '@stitch/shared/id';
+import type { TitleGenerationLlmUsageMetadata } from '@/db/schema/usage.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { generateTitleFromContent } from '@/title-generation/generator.js';
@@ -21,22 +22,16 @@ type TitleGenerationAdapterDeps = {
 };
 
 async function recordTitleUsage(input: {
-  runId: string;
   providerId: string;
   modelId: string;
   usage: LanguageModelUsage | null;
-  metadata: Record<string, unknown>;
-  sessionId?: Parameters<typeof recordLlmUsage>[0]['sessionId'];
-  messageId?: Parameters<typeof recordLlmUsage>[0]['messageId'];
+  metadata: TitleGenerationLlmUsageMetadata;
 }): Promise<{ costUsd: number }> {
   const now = Date.now();
 
   return recordLlmUsage({
-    runId: input.runId,
     source: 'title_generation',
     status: 'succeeded',
-    sessionId: input.sessionId,
-    messageId: input.messageId,
     providerId: input.providerId,
     modelId: input.modelId,
     usage: input.usage,
@@ -68,13 +63,10 @@ export function registerTitleGenerationAdapter(deps: TitleGenerationAdapterDeps 
       };
 
       const { costUsd } = await recordUsage({
-        runId: titleMessageId,
         providerId: generatedTitle.providerId,
         modelId: generatedTitle.modelId,
         usage: generatedTitle.usage,
-        sessionId: event.sessionId,
-        messageId: titleMessageId,
-        metadata: { phase: 'title-generation', target: 'chat' },
+        metadata: { source: 'title_generation', target: 'chat', sessionId: event.sessionId, messageId: titleMessageId },
       });
 
       await saveTitleMessage({
@@ -88,7 +80,10 @@ export function registerTitleGenerationAdapter(deps: TitleGenerationAdapterDeps 
         createdAt: now,
       });
 
-      await db.update(sessions).set({ title: generatedTitle.title, updatedAt: Date.now() }).where(eq(sessions.id, event.sessionId));
+      await db
+        .update(sessions)
+        .set({ title: generatedTitle.title, updatedAt: Date.now() })
+        .where(eq(sessions.id, event.sessionId));
 
       internalBus.emit('session.title.updated', { sessionId: event.sessionId, title: generatedTitle.title });
     } catch (error) {
@@ -102,15 +97,14 @@ export function registerTitleGenerationAdapter(deps: TitleGenerationAdapterDeps 
       if (!generatedTitle) return;
 
       const { costUsd } = await recordUsage({
-        runId: `${event.analysisId}:title`,
         providerId: generatedTitle.providerId,
         modelId: generatedTitle.modelId,
         usage: generatedTitle.usage,
         metadata: {
+          source: 'title_generation',
+          target: 'recording-analysis',
           recordingId: event.recordingId,
           analysisId: event.analysisId,
-          phase: 'title-generation',
-          target: 'recording-analysis',
         },
       });
 
@@ -132,7 +126,10 @@ export function registerTitleGenerationAdapter(deps: TitleGenerationAdapterDeps 
         title: generatedTitle.title,
       });
     } catch (error) {
-      log.error({ recordingId: event.recordingId, analysisId: event.analysisId, error }, 'recording title generation failed');
+      log.error(
+        { recordingId: event.recordingId, analysisId: event.analysisId, error },
+        'recording title generation failed',
+      );
     }
   });
 }

--- a/packages/server/src/adapters/usage.ts
+++ b/packages/server/src/adapters/usage.ts
@@ -1,8 +1,10 @@
 import type {
   ChatFailedLlmUsageMetadata,
   ChatLlmUsageMetadata,
+  CompactionLlmUsageMetadata,
   DoomLoopFailedLlmUsageMetadata,
   DoomLoopSummaryLlmUsageMetadata,
+  MemoryExtractionLlmUsageMetadata,
 } from '@/db/schema/usage.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import { recordLlmUsage } from '@/usage/ledger.js';
@@ -96,6 +98,44 @@ export function registerUsageAdapter(): void {
       usage: event.usage,
       metadata,
       startedAt: Date.now(),
+    });
+  });
+
+  internalBus.on('usage.memory.completed', async (event) => {
+    const metadata: MemoryExtractionLlmUsageMetadata = { source: 'memory_extraction', phase: event.phase };
+
+    await recordLlmUsage({
+      source: 'memory_extraction',
+      status: 'succeeded',
+      providerId: event.providerId,
+      modelId: event.modelId,
+      usage: event.usage,
+      metadata,
+      startedAt: event.startedAt,
+      endedAt: event.endedAt,
+    });
+  });
+
+  internalBus.on('usage.compaction.failed', async (event) => {
+    const metadata: CompactionLlmUsageMetadata = {
+      source: 'compaction',
+      sessionId: event.sessionId,
+      messageId: event.messageId,
+      auto: event.auto,
+      overflow: event.overflow,
+    };
+
+    const now = Date.now();
+    await recordLlmUsage({
+      source: 'compaction',
+      status: 'failed',
+      providerId: event.providerId,
+      modelId: event.modelId,
+      errorCode: event.errorCode,
+      metadata,
+      startedAt: now,
+      endedAt: now,
+      durationMs: 0,
     });
   });
 }

--- a/packages/server/src/adapters/usage.ts
+++ b/packages/server/src/adapters/usage.ts
@@ -1,51 +1,11 @@
-import type { PrefixedString } from '@stitch/shared/id';
-
+import type {
+  ChatFailedLlmUsageMetadata,
+  ChatLlmUsageMetadata,
+  DoomLoopFailedLlmUsageMetadata,
+  DoomLoopSummaryLlmUsageMetadata,
+} from '@/db/schema/usage.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import { recordLlmUsage } from '@/usage/ledger.js';
-import type { LanguageModelUsage } from 'ai';
-
-type UsageBase = {
-  sessionId: PrefixedString<'ses'>;
-  messageId: PrefixedString<'msg'>;
-  streamRunId: string;
-  providerId: string;
-  modelId: string;
-};
-
-function recordUsage(
-  event: UsageBase,
-  opts: {
-    source: string;
-    status: 'succeeded' | 'failed';
-    metadata: Record<string, unknown>;
-    usage?: LanguageModelUsage;
-    errorCode?: string;
-    stepIndex?: number;
-    attemptIndex?: number;
-    startedAt?: number;
-    endedAt?: number;
-    durationMs?: number;
-  },
-): Promise<{ costUsd: number }> {
-  const now = Date.now();
-  return recordLlmUsage({
-    runId: event.streamRunId,
-    sessionId: event.sessionId,
-    messageId: event.messageId,
-    providerId: event.providerId,
-    modelId: event.modelId,
-    source: opts.source,
-    status: opts.status,
-    metadata: opts.metadata,
-    usage: opts.usage,
-    errorCode: opts.errorCode,
-    stepIndex: opts.stepIndex,
-    attemptIndex: opts.attemptIndex,
-    startedAt: opts.startedAt ?? now,
-    endedAt: opts.endedAt ?? now,
-    durationMs: opts.durationMs ?? 0,
-  });
-}
 
 /**
  * Registers usage tracking subscriptions on the internal bus.
@@ -53,13 +13,23 @@ function recordUsage(
  */
 export function registerUsageAdapter(): void {
   internalBus.on('stream.step.completed', async (event) => {
-    await recordUsage(event, {
+    const metadata: ChatLlmUsageMetadata = {
       source: 'chat',
-      status: 'succeeded',
-      usage: event.usage,
+      eventType: 'step-success',
+      sessionId: event.sessionId,
+      messageId: event.messageId,
       stepIndex: event.step,
       attemptIndex: event.attemptCount,
-      metadata: { phase: 'chat-step', eventType: 'step-success', finishReason: event.finishReason },
+      finishReason: event.finishReason,
+    };
+
+    await recordLlmUsage({
+      source: 'chat',
+      status: 'succeeded',
+      providerId: event.providerId,
+      modelId: event.modelId,
+      usage: event.usage,
+      metadata,
       startedAt: event.startedAt,
       endedAt: event.startedAt + event.durationMs,
       durationMs: event.durationMs,
@@ -67,42 +37,65 @@ export function registerUsageAdapter(): void {
   });
 
   internalBus.on('usage.step.failed', async (event) => {
-    await recordUsage(event, {
+    const metadata: ChatFailedLlmUsageMetadata = {
       source: 'chat',
-      status: 'failed',
-      errorCode: event.errorCode,
+      eventType: 'attempt-failure',
+      sessionId: event.sessionId,
+      messageId: event.messageId,
       stepIndex: event.step,
       attemptIndex: event.attempt,
-      metadata: {
-        phase: 'chat-step',
-        eventType: 'attempt-failure',
-        streamRunId: event.streamRunId,
-        isRetryable: event.isRetryable,
-      },
+      streamRunId: event.streamRunId,
+      isRetryable: event.isRetryable,
+    };
+
+    await recordLlmUsage({
+      source: 'chat',
+      status: 'failed',
+      providerId: event.providerId,
+      modelId: event.modelId,
+      errorCode: event.errorCode,
+      metadata,
+      startedAt: Date.now(),
     });
   });
 
   internalBus.on('usage.doom_loop.failed', async (event) => {
-    await recordUsage(event, {
+    const metadata: DoomLoopFailedLlmUsageMetadata = {
+      source: 'doom_loop_summary',
+      eventType: 'attempt-failure',
+      sessionId: event.sessionId,
+      messageId: event.messageId,
+      streamRunId: event.streamRunId,
+      isRetryable: event.isRetryable,
+    };
+
+    await recordLlmUsage({
       source: 'doom_loop_summary',
       status: 'failed',
+      providerId: event.providerId,
+      modelId: event.modelId,
       errorCode: event.errorCode,
-      attemptIndex: event.attempt,
-      metadata: {
-        phase: 'doom-loop',
-        eventType: 'attempt-failure',
-        streamRunId: event.streamRunId,
-        isRetryable: event.isRetryable,
-      },
+      metadata,
+      startedAt: Date.now(),
     });
   });
 
   internalBus.on('usage.doom_loop.summary', async (event) => {
-    await recordUsage(event, {
+    const metadata: DoomLoopSummaryLlmUsageMetadata = {
+      source: 'doom_loop_summary',
+      eventType: 'summary-after-stop',
+      sessionId: event.sessionId,
+      messageId: event.messageId,
+    };
+
+    await recordLlmUsage({
       source: 'doom_loop_summary',
       status: 'succeeded',
+      providerId: event.providerId,
+      modelId: event.modelId,
       usage: event.usage,
-      metadata: { phase: 'doom-loop', eventType: 'summary-after-stop' },
+      metadata,
+      startedAt: Date.now(),
     });
   });
 }

--- a/packages/server/src/automations/generation.ts
+++ b/packages/server/src/automations/generation.ts
@@ -211,15 +211,12 @@ export async function generateAutomationDraft(sessionId: string): Promise<Servic
   const usage = result.usage ?? null;
 
   const { costUsd } = await recordLlmUsage({
-    runId: generationMessageId,
     source: 'automation_generation',
     status: 'succeeded',
-    sessionId: session.id,
-    messageId: generationMessageId,
     providerId: resolved.providerId,
     modelId: resolved.modelId,
     usage,
-    metadata: { phase: 'automation-generation' },
+    metadata: { source: 'automation_generation', sessionId: session.id, messageId: generationMessageId },
     startedAt: start,
     endedAt: Date.now(),
     durationMs: Date.now() - start,

--- a/packages/server/src/db/schema/usage.ts
+++ b/packages/server/src/db/schema/usage.ts
@@ -25,22 +25,106 @@ export const embeddingUsageEvents = sqliteTable(
   ],
 );
 
+export type ChatLlmUsageMetadata = {
+  source: 'chat';
+  eventType: 'step-success';
+  sessionId: PrefixedString<'ses'>;
+  messageId: PrefixedString<'msg'>;
+  stepIndex: number;
+  attemptIndex: number;
+  finishReason: string;
+};
+
+export type ChatFailedLlmUsageMetadata = {
+  source: 'chat';
+  eventType: 'attempt-failure';
+  sessionId: PrefixedString<'ses'>;
+  messageId: PrefixedString<'msg'>;
+  stepIndex: number;
+  attemptIndex: number;
+  streamRunId: string;
+  isRetryable: boolean;
+};
+
+export type CompactionLlmUsageMetadata = {
+  source: 'compaction';
+  sessionId: PrefixedString<'ses'>;
+  messageId: PrefixedString<'msg'>;
+  auto: boolean;
+  overflow: boolean;
+};
+
+export type DoomLoopFailedLlmUsageMetadata = {
+  source: 'doom_loop_summary';
+  eventType: 'attempt-failure';
+  sessionId: PrefixedString<'ses'>;
+  messageId: PrefixedString<'msg'>;
+  streamRunId: string;
+  isRetryable: boolean;
+};
+
+export type DoomLoopSummaryLlmUsageMetadata = {
+  source: 'doom_loop_summary';
+  eventType: 'summary-after-stop';
+  sessionId: PrefixedString<'ses'>;
+  messageId: PrefixedString<'msg'>;
+};
+
+export type ChatTitleGenerationLlmUsageMetadata = {
+  source: 'title_generation';
+  target: 'chat';
+  sessionId: PrefixedString<'ses'>;
+  messageId: PrefixedString<'msg'>;
+};
+
+export type RecordingTitleGenerationLlmUsageMetadata = {
+  source: 'title_generation';
+  target: 'recording-analysis';
+  recordingId: string;
+  analysisId: string;
+};
+
+export type TitleGenerationLlmUsageMetadata =
+  | ChatTitleGenerationLlmUsageMetadata
+  | RecordingTitleGenerationLlmUsageMetadata;
+
+export type AutomationGenerationLlmUsageMetadata = {
+  source: 'automation_generation';
+  sessionId: PrefixedString<'ses'>;
+  messageId: PrefixedString<'msg'>;
+};
+
+export type RecordingAnalysisLlmUsageMetadata = {
+  source: 'recording_analysis';
+  recordingId: string;
+  analysisId: string;
+};
+
+export type MemoryExtractionPhase = 'extraction' | 'deduplication' | 'consolidation';
+
+export type MemoryExtractionLlmUsageMetadata = { source: 'memory_extraction'; phase: MemoryExtractionPhase };
+
+export type LlmUsageMetadata =
+  | ChatLlmUsageMetadata
+  | ChatFailedLlmUsageMetadata
+  | CompactionLlmUsageMetadata
+  | DoomLoopFailedLlmUsageMetadata
+  | DoomLoopSummaryLlmUsageMetadata
+  | TitleGenerationLlmUsageMetadata
+  | AutomationGenerationLlmUsageMetadata
+  | RecordingAnalysisLlmUsageMetadata
+  | MemoryExtractionLlmUsageMetadata;
+
 export const llmUsageEvents = sqliteTable(
   'llm_usage_events',
   {
     id: text('id').primaryKey(),
-    runId: text('run_id').notNull(),
     source: text('source').notNull(),
     status: text('status').notNull().default('succeeded'),
-    isAttributable: integer('is_attributable', { mode: 'boolean' }).notNull().default(true),
-    sessionId: text('session_id').$type<PrefixedString<'ses'> | null>(),
-    messageId: text('message_id').$type<PrefixedString<'msg'> | null>(),
-    stepIndex: integer('step_index'),
-    attemptIndex: integer('attempt_index'),
     providerId: text('provider_id').notNull(),
     modelId: text('model_id').notNull(),
     usage: blob('usage', { mode: 'json' }).$type<LanguageModelUsage>(),
-    metadata: blob('metadata', { mode: 'json' }).$type<Record<string, unknown>>(),
+    metadata: blob('metadata', { mode: 'json' }).$type<LlmUsageMetadata>(),
     inputTokens: integer('input_tokens').notNull().default(0),
     outputTokens: integer('output_tokens').notNull().default(0),
     reasoningTokens: integer('reasoning_tokens').notNull().default(0),
@@ -57,7 +141,6 @@ export const llmUsageEvents = sqliteTable(
       .$defaultFn(() => Date.now()),
   },
   (table) => [
-    index('llm_usage_events_run_id_idx').on(table.runId),
     index('llm_usage_events_source_idx').on(table.source),
     index('llm_usage_events_created_at_idx').on(table.createdAt),
     index('llm_usage_events_provider_model_idx').on(table.providerId, table.modelId),

--- a/packages/server/src/lib/internal-bus-events.ts
+++ b/packages/server/src/lib/internal-bus-events.ts
@@ -187,6 +187,25 @@ export type StreamPermissionRejectedEvent = {
 
 // ─── Usage (emitted by runner for adapter consumption) ───────────────────────
 
+export type UsageMemoryCompletedEvent = {
+  providerId: string;
+  modelId: string;
+  usage: LanguageModelUsage;
+  phase: 'extraction' | 'deduplication' | 'consolidation';
+  startedAt: number;
+  endedAt: number;
+};
+
+export type UsageCompactionFailedEvent = {
+  sessionId: PrefixedString<'ses'>;
+  messageId: PrefixedString<'msg'>;
+  providerId: string;
+  modelId: string;
+  errorCode: string | undefined;
+  auto: boolean;
+  overflow: boolean;
+};
+
 export type UsageStepFailedEvent = {
   sessionId: PrefixedString<'ses'>;
   messageId: PrefixedString<'msg'>;
@@ -355,6 +374,8 @@ export type InternalEventMap = {
   'stream.permission.rejected': StreamPermissionRejectedEvent;
 
   // Usage (emitted by runner for adapter consumption)
+  'usage.memory.completed': UsageMemoryCompletedEvent;
+  'usage.compaction.failed': UsageCompactionFailedEvent;
   'usage.step.failed': UsageStepFailedEvent;
   'usage.doom_loop.failed': UsageDoomLoopFailedEvent;
   'usage.doom_loop.summary': UsageDoomLoopSummaryEvent;

--- a/packages/server/src/llm/session-summary.ts
+++ b/packages/server/src/llm/session-summary.ts
@@ -426,23 +426,14 @@ export async function compact(input: {
       details: toStreamErrorDetails(mappedError),
     });
 
-    const failedAt = Date.now();
-    await recordLlmUsage({
-      source: 'compaction',
-      status: 'failed',
+    internalBus.emit('usage.compaction.failed', {
+      sessionId,
+      messageId: summaryMessageId,
       providerId: input.providerId,
       modelId: input.modelId,
       errorCode: mappedError.category,
-      metadata: {
-        source: 'compaction',
-        sessionId,
-        messageId: summaryMessageId,
-        auto: input.auto,
-        overflow: input.overflow ?? false,
-      },
-      startedAt: failedAt,
-      endedAt: failedAt,
-      durationMs: 0,
+      auto: input.auto,
+      overflow: input.overflow ?? false,
     });
 
     return 'error';

--- a/packages/server/src/llm/session-summary.ts
+++ b/packages/server/src/llm/session-summary.ts
@@ -350,15 +350,18 @@ export async function compact(input: {
     } as StoredPart;
 
     const { costUsd } = await recordLlmUsage({
-      runId: summaryMessageId,
       source: 'compaction',
       status: 'succeeded',
-      sessionId,
-      messageId: summaryMessageId,
       providerId: resolved.providerId,
       modelId: resolved.modelId,
       usage,
-      metadata: { phase: 'compaction', auto: input.auto, overflow: input.overflow ?? false },
+      metadata: {
+        source: 'compaction',
+        sessionId,
+        messageId: summaryMessageId,
+        auto: input.auto,
+        overflow: input.overflow ?? false,
+      },
       startedAt: now,
       endedAt: summaryNow,
       durationMs: summaryNow - now,
@@ -425,15 +428,18 @@ export async function compact(input: {
 
     const failedAt = Date.now();
     await recordLlmUsage({
-      runId: summaryMessageId,
       source: 'compaction',
       status: 'failed',
-      sessionId,
-      messageId: summaryMessageId,
       providerId: input.providerId,
       modelId: input.modelId,
       errorCode: mappedError.category,
-      metadata: { phase: 'compaction', auto: input.auto, overflow: input.overflow ?? false },
+      metadata: {
+        source: 'compaction',
+        sessionId,
+        messageId: summaryMessageId,
+        auto: input.auto,
+        overflow: input.overflow ?? false,
+      },
       startedAt: failedAt,
       endedAt: failedAt,
       durationMs: 0,

--- a/packages/server/src/memory/consolidation.ts
+++ b/packages/server/src/memory/consolidation.ts
@@ -1,7 +1,7 @@
 import { generateText, Output } from 'ai';
 import { z } from 'zod';
 
-import type { MemoryExtractionLlmUsageMetadata } from '@/db/schema/usage.js';
+import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
@@ -14,7 +14,6 @@ import {
   updateSemanticMemory,
 } from '@/memory/service.js';
 import type { MemorySource, SemanticMemory } from '@/memory/types.js';
-import { recordLlmUsage } from '@/usage/ledger.js';
 
 const log = Log.create({ service: 'memory-consolidation' });
 
@@ -124,26 +123,6 @@ function addCounts(result: ConsolidationResult, delta: ConsolidationResult): voi
   result.skipped += delta.skipped;
 }
 
-async function recordUsage(input: {
-  providerId: string;
-  modelId: string;
-  usage: NonNullable<Awaited<ReturnType<typeof generateText>>['usage']>;
-  startedAt: number;
-  endedAt: number;
-}): Promise<void> {
-  const metadata: MemoryExtractionLlmUsageMetadata = { source: 'memory_extraction', phase: 'consolidation' };
-  await recordLlmUsage({
-    source: 'memory_extraction',
-    status: 'succeeded',
-    providerId: input.providerId,
-    modelId: input.modelId,
-    usage: input.usage,
-    metadata,
-    startedAt: input.startedAt,
-    endedAt: input.endedAt,
-  }).catch((err) => log.warn({ error: err }, 'failed to record consolidation usage event'));
-}
-
 async function findCandidateGroups(): Promise<ConsolidationMemory[][]> {
   const allResult = await getAllSemanticMemories({ page: 1, pageSize: 1000 });
   if (allResult.error || allResult.data.memories.length < MIN_GROUP_SIZE) return [];
@@ -242,10 +221,11 @@ export async function consolidateMemories(): Promise<ConsolidationResult> {
       const endedAt = Date.now();
 
       if (output.usage) {
-        void recordUsage({
+        internalBus.emit('usage.memory.completed', {
           providerId: resolved.providerId,
           modelId: resolved.modelId,
           usage: output.usage,
+          phase: 'consolidation',
           startedAt,
           endedAt,
         });

--- a/packages/server/src/memory/consolidation.ts
+++ b/packages/server/src/memory/consolidation.ts
@@ -1,7 +1,7 @@
 import { generateText, Output } from 'ai';
-import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
+import type { MemoryExtractionLlmUsageMetadata } from '@/db/schema/usage.js';
 import * as Log from '@/lib/log.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
@@ -18,7 +18,6 @@ import { recordLlmUsage } from '@/usage/ledger.js';
 
 const log = Log.create({ service: 'memory-consolidation' });
 
-const MEMORY_SOURCE = 'memory_extraction' as const;
 const MAX_GROUPS = 5;
 const MAX_MEMORIES_PER_GROUP = 8;
 const SIMILARITY_THRESHOLD = 0.82;
@@ -126,21 +125,20 @@ function addCounts(result: ConsolidationResult, delta: ConsolidationResult): voi
 }
 
 async function recordUsage(input: {
-  runId: string;
   providerId: string;
   modelId: string;
   usage: NonNullable<Awaited<ReturnType<typeof generateText>>['usage']>;
   startedAt: number;
   endedAt: number;
 }): Promise<void> {
+  const metadata: MemoryExtractionLlmUsageMetadata = { source: 'memory_extraction', phase: 'consolidation' };
   await recordLlmUsage({
-    runId: input.runId,
-    source: MEMORY_SOURCE,
+    source: 'memory_extraction',
     status: 'succeeded',
     providerId: input.providerId,
     modelId: input.modelId,
     usage: input.usage,
-    metadata: { phase: 'consolidation' },
+    metadata,
     startedAt: input.startedAt,
     endedAt: input.endedAt,
   }).catch((err) => log.warn({ error: err }, 'failed to record consolidation usage event'));
@@ -230,7 +228,6 @@ export async function consolidateMemories(): Promise<ConsolidationResult> {
   }
 
   const model = createProvider(resolved.credentials)(resolved.modelId);
-  const runId = randomUUID();
   const totals = emptyResult();
 
   for (const group of groups) {
@@ -246,7 +243,6 @@ export async function consolidateMemories(): Promise<ConsolidationResult> {
 
       if (output.usage) {
         void recordUsage({
-          runId,
           providerId: resolved.providerId,
           modelId: resolved.modelId,
           usage: output.usage,

--- a/packages/server/src/memory/processor.ts
+++ b/packages/server/src/memory/processor.ts
@@ -1,11 +1,11 @@
 import { generateText, Output } from 'ai';
 import { eq } from 'drizzle-orm';
-import { randomUUID } from 'node:crypto';
 
 import type { PrefixedString } from '@stitch/shared/id';
 
 import { getDb } from '@/db/client.js';
 import { sessions } from '@/db/schema/sessions.js';
+import type { MemoryExtractionLlmUsageMetadata } from '@/db/schema/usage.js';
 import * as Log from '@/lib/log.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
@@ -61,16 +61,14 @@ function recordWrite(sessionId: string, count: number): void {
 }
 
 function recordUsageFireAndForget(params: {
-  runId: string;
   providerId: string;
   modelId: string;
   usage: NonNullable<Awaited<ReturnType<typeof generateText>>['usage']>;
-  metadata: Record<string, unknown>;
+  metadata: MemoryExtractionLlmUsageMetadata;
   startedAt: number;
   endedAt: number;
 }): void {
   recordLlmUsage({
-    runId: params.runId,
     source: MEMORY_SOURCE,
     status: 'succeeded',
     providerId: params.providerId,
@@ -153,7 +151,6 @@ export async function processMemories(input: {
     }
 
     const model = createProvider(resolved.credentials)(resolved.modelId);
-    const runId = randomUUID();
 
     const extractionPrompt = buildExtractionPrompt(input.userMessage, input.assistantMessage);
     const extractionStart = Date.now();
@@ -166,11 +163,10 @@ export async function processMemories(input: {
 
     if (extractionResult.usage) {
       recordUsageFireAndForget({
-        runId,
         providerId: resolved.providerId,
         modelId: resolved.modelId,
         usage: extractionResult.usage,
-        metadata: { phase: 'extraction' },
+        metadata: { source: 'memory_extraction', phase: 'extraction' },
         startedAt: extractionStart,
         endedAt: extractionEnd,
       });
@@ -278,11 +274,10 @@ export async function processMemories(input: {
 
       if (dedupResult.usage) {
         recordUsageFireAndForget({
-          runId,
           providerId: resolved.providerId,
           modelId: resolved.modelId,
           usage: dedupResult.usage,
-          metadata: { phase: 'deduplication', factContent: fact.content },
+          metadata: { source: 'memory_extraction', phase: 'deduplication' },
           startedAt: dedupStart,
           endedAt: dedupEnd,
         });

--- a/packages/server/src/memory/processor.ts
+++ b/packages/server/src/memory/processor.ts
@@ -5,7 +5,7 @@ import type { PrefixedString } from '@stitch/shared/id';
 
 import { getDb } from '@/db/client.js';
 import { sessions } from '@/db/schema/sessions.js';
-import type { MemoryExtractionLlmUsageMetadata } from '@/db/schema/usage.js';
+import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
@@ -24,11 +24,8 @@ import {
   pruneStaleMemories,
 } from '@/memory/service.js';
 import type { MemorySource } from '@/memory/types.js';
-import { recordLlmUsage } from '@/usage/ledger.js';
 
 const log = Log.create({ service: 'memory-processor' });
-
-const MEMORY_SOURCE = 'memory_extraction' as const;
 
 // ---------------------------------------------------------------------------
 // Per-session write budget tracking (in-process, resets on server restart).
@@ -58,26 +55,6 @@ function recordWrite(sessionId: string, count: number): void {
   const state = getSessionState(sessionId);
   state.factsWritten += count;
   state.lastWriteTurn = state.turnCount;
-}
-
-function recordUsageFireAndForget(params: {
-  providerId: string;
-  modelId: string;
-  usage: NonNullable<Awaited<ReturnType<typeof generateText>>['usage']>;
-  metadata: MemoryExtractionLlmUsageMetadata;
-  startedAt: number;
-  endedAt: number;
-}): void {
-  recordLlmUsage({
-    source: MEMORY_SOURCE,
-    status: 'succeeded',
-    providerId: params.providerId,
-    modelId: params.modelId,
-    usage: params.usage,
-    metadata: params.metadata,
-    startedAt: params.startedAt,
-    endedAt: params.endedAt,
-  }).catch((err) => log.warn({ error: err }, 'failed to record memory usage event'));
 }
 
 /**
@@ -162,11 +139,11 @@ export async function processMemories(input: {
     const extractionEnd = Date.now();
 
     if (extractionResult.usage) {
-      recordUsageFireAndForget({
+      internalBus.emit('usage.memory.completed', {
         providerId: resolved.providerId,
         modelId: resolved.modelId,
         usage: extractionResult.usage,
-        metadata: { source: 'memory_extraction', phase: 'extraction' },
+        phase: 'extraction',
         startedAt: extractionStart,
         endedAt: extractionEnd,
       });
@@ -273,11 +250,11 @@ export async function processMemories(input: {
       const dedupEnd = Date.now();
 
       if (dedupResult.usage) {
-        recordUsageFireAndForget({
+        internalBus.emit('usage.memory.completed', {
           providerId: resolved.providerId,
           modelId: resolved.modelId,
           usage: dedupResult.usage,
-          metadata: { source: 'memory_extraction', phase: 'deduplication' },
+          phase: 'deduplication',
           startedAt: dedupStart,
           endedAt: dedupEnd,
         });

--- a/packages/server/src/recordings/analysis-service.ts
+++ b/packages/server/src/recordings/analysis-service.ts
@@ -314,7 +314,6 @@ async function runRecordingAnalysis(
     broadcastRecordingAnalysisUpdated({ recordingId: input.recordingId, status: 'processing', title: null });
 
     const analysisModel = deps.createProvider(input.analysisCredentials)(input.analysisModelId);
-    const analysisRunId = `${analysisId}:analysis`;
     const analysisStart = Date.now();
     const analysisResult = await generateText({
       model: analysisModel,
@@ -333,12 +332,11 @@ async function runRecordingAnalysis(
     const analysisUsage = analysisResult.usage ?? ZERO_USAGE;
 
     const { costUsd: analysisCost } = await recordLlmUsage({
-      runId: analysisRunId,
       source: 'recording_analysis',
       providerId: input.analysisProviderId,
       modelId: input.analysisModelId,
       usage: analysisUsage,
-      metadata: { recordingId: input.recordingId, analysisId, phase: 'analysis' },
+      metadata: { source: 'recording_analysis', recordingId: input.recordingId, analysisId },
       startedAt: analysisStart,
       endedAt: Date.now(),
       durationMs: Date.now() - analysisStart,

--- a/packages/server/src/usage/ledger.test.ts
+++ b/packages/server/src/usage/ledger.test.ts
@@ -3,6 +3,7 @@ import { eq } from 'drizzle-orm';
 
 import { getDb } from '@/db/client.js';
 import { llmUsageEvents } from '@/db/schema/usage.js';
+import type { ChatLlmUsageMetadata, ChatTitleGenerationLlmUsageMetadata } from '@/db/schema/usage.js';
 import { setupTestDb } from '@/db/test-helpers.js';
 import { recordLlmUsage } from '@/usage/ledger.js';
 import type { LanguageModelUsage } from 'ai';
@@ -21,12 +22,22 @@ function buildUsage(inputTokens: number, outputTokens: number): LanguageModelUsa
 
 describe('recordLlmUsage', () => {
   test('returns 0 cost when usage is null', async () => {
+    const metadata: ChatLlmUsageMetadata = {
+      source: 'chat',
+      eventType: 'step-success',
+      sessionId: 'ses_test1',
+      messageId: 'msg_test1',
+      stepIndex: 0,
+      attemptIndex: 1,
+      finishReason: 'stop',
+    };
+
     const { costUsd } = await recordLlmUsage({
-      runId: 'run-null-usage',
       source: 'chat',
       providerId: 'any_provider',
       modelId: 'any_model',
       usage: null,
+      metadata,
       startedAt: Date.now(),
     });
 
@@ -34,12 +45,22 @@ describe('recordLlmUsage', () => {
   });
 
   test('returns 0 cost when model has no pricing info', async () => {
+    const metadata: ChatLlmUsageMetadata = {
+      source: 'chat',
+      eventType: 'step-success',
+      sessionId: 'ses_test2',
+      messageId: 'msg_test2',
+      stepIndex: 0,
+      attemptIndex: 1,
+      finishReason: 'stop',
+    };
+
     const { costUsd } = await recordLlmUsage({
-      runId: 'run-no-pricing',
       source: 'chat',
       providerId: 'unknown_provider',
       modelId: 'unknown_model',
       usage: buildUsage(1_000, 500),
+      metadata,
       startedAt: Date.now(),
     });
 
@@ -47,22 +68,21 @@ describe('recordLlmUsage', () => {
   });
 
   test('writes usage event to DB and returns computed costUsd', async () => {
-    const runId = 'run-db-write-test';
     const startedAt = Date.now();
 
     const { costUsd } = await recordLlmUsage({
-      runId,
       source: 'compaction',
       providerId: 'unknown_provider',
       modelId: 'unknown_model',
       usage: buildUsage(100, 50),
+      metadata: { source: 'compaction', sessionId: 'ses_test3', messageId: 'msg_test3', auto: true, overflow: false },
       startedAt,
     });
 
     expect(typeof costUsd).toBe('number');
 
     const db = getDb();
-    const events = await db.select().from(llmUsageEvents).where(eq(llmUsageEvents.runId, runId));
+    const events = await db.select().from(llmUsageEvents).where(eq(llmUsageEvents.source, 'compaction'));
 
     expect(events.length).toBe(1);
     expect(events[0]?.source).toBe('compaction');
@@ -71,24 +91,29 @@ describe('recordLlmUsage', () => {
   });
 
   test('writes correct status and metadata fields', async () => {
-    const runId = 'run-fields-test';
     const startedAt = Date.now();
 
+    const metadata: ChatTitleGenerationLlmUsageMetadata = {
+      source: 'title_generation',
+      target: 'chat',
+      sessionId: 'ses_test4',
+      messageId: 'msg_test4',
+    };
+
     await recordLlmUsage({
-      runId,
       source: 'title_generation',
       status: 'failed',
       providerId: 'unknown_provider',
       modelId: 'unknown_model',
       errorCode: 'rate_limit',
-      metadata: { phase: 'title' },
+      metadata,
       startedAt,
       endedAt: startedAt + 100,
       durationMs: 100,
     });
 
     const db = getDb();
-    const events = await db.select().from(llmUsageEvents).where(eq(llmUsageEvents.runId, runId));
+    const events = await db.select().from(llmUsageEvents).where(eq(llmUsageEvents.source, 'title_generation'));
 
     expect(events.length).toBe(1);
     expect(events[0]?.status).toBe('failed');

--- a/packages/server/src/usage/ledger.ts
+++ b/packages/server/src/usage/ledger.ts
@@ -1,9 +1,8 @@
 import { randomUUID } from 'node:crypto';
 
-import type { PrefixedString } from '@stitch/shared/id';
-
 import { getDb } from '@/db/client.js';
 import { embeddingUsageEvents, llmUsageEvents } from '@/db/schema/usage.js';
+import type { LlmUsageMetadata } from '@/db/schema/usage.js';
 import * as Log from '@/lib/log.js';
 import { calculateEmbeddingCostUsd, calculateMessageCostUsd } from '@/usage/cost.js';
 import { normalizeUsage } from '@/utils/usage.js';
@@ -14,18 +13,12 @@ const log = Log.create({ service: 'usage-ledger' });
 type UsageEventStatus = 'succeeded' | 'failed' | 'aborted';
 
 async function recordUsageEvent(input: {
-  runId: string;
   source: string;
   status?: UsageEventStatus;
-  isAttributable?: boolean;
-  sessionId?: PrefixedString<'ses'> | null;
-  messageId?: PrefixedString<'msg'> | null;
-  stepIndex?: number;
-  attemptIndex?: number;
   providerId: string;
   modelId: string;
   usage?: LanguageModelUsage | null;
-  metadata?: Record<string, unknown>;
+  metadata?: LlmUsageMetadata;
   costUsd?: number;
   errorCode?: string | null;
   startedAt: number;
@@ -42,14 +35,8 @@ async function recordUsageEvent(input: {
     .insert(llmUsageEvents)
     .values({
       id: randomUUID(),
-      runId: input.runId,
       source: input.source,
       status: input.status ?? 'succeeded',
-      isAttributable: input.isAttributable ?? true,
-      sessionId: input.sessionId ?? null,
-      messageId: input.messageId ?? null,
-      stepIndex: input.stepIndex,
-      attemptIndex: input.attemptIndex,
       providerId: input.providerId,
       modelId: input.modelId,
       usage: input.usage ?? undefined,
@@ -69,19 +56,13 @@ async function recordUsageEvent(input: {
 }
 
 export async function recordLlmUsage(input: {
-  runId: string;
   source: string;
   providerId: string;
   modelId: string;
   usage?: LanguageModelUsage | null;
   status?: UsageEventStatus;
-  isAttributable?: boolean;
-  sessionId?: PrefixedString<'ses'> | null;
-  messageId?: PrefixedString<'msg'> | null;
-  stepIndex?: number;
-  attemptIndex?: number;
   errorCode?: string | null;
-  metadata?: Record<string, unknown>;
+  metadata?: LlmUsageMetadata;
   startedAt: number;
   endedAt?: number;
   durationMs?: number;
@@ -93,7 +74,7 @@ export async function recordLlmUsage(input: {
   try {
     await recordUsageEvent({ ...input, costUsd });
   } catch (error) {
-    log.warn({ error, source: input.source, runId: input.runId }, 'usage event write failed');
+    log.warn({ error, source: input.source }, 'usage event write failed');
   }
 
   return { costUsd };

--- a/packages/server/src/usage/service.test.ts
+++ b/packages/server/src/usage/service.test.ts
@@ -55,26 +55,20 @@ describe('usageServiceInternals.buildBucketRanges', () => {
 });
 
 async function insertEvent(opts: {
-  runId?: string;
   source: string;
   providerId: string;
   modelId: string;
   costUsd: number;
   startedAt: number;
   status?: string;
-  isAttributable?: boolean;
 }): Promise<void> {
   const db = getDb();
   await db
     .insert(llmUsageEvents)
     .values({
       id: randomUUID(),
-      runId: opts.runId ?? randomUUID(),
       source: opts.source,
       status: opts.status ?? 'succeeded',
-      isAttributable: opts.isAttributable ?? true,
-      sessionId: null,
-      messageId: null,
       providerId: opts.providerId,
       modelId: opts.modelId,
       inputTokens: 100,
@@ -161,27 +155,6 @@ describe('getUsageDashboard', () => {
       modelId: 'gpt-4',
       costUsd: 5.0,
       startedAt: now - 60_000, // outside range
-    });
-
-    const result = await getUsageDashboard({ from, to: now });
-
-    expect(result.error).toBeNull();
-    if (result.error) return;
-
-    expect(result.data.totals.costUsd).toBe(0);
-  });
-
-  test('excludes non-attributable events from totals', async () => {
-    const now = Date.now();
-    const from = now - 10_000;
-
-    await insertEvent({
-      source: 'chat',
-      providerId: 'openai',
-      modelId: 'gpt-4',
-      costUsd: 9.99,
-      startedAt: from + 1_000,
-      isAttributable: false,
     });
 
     const result = await getUsageDashboard({ from, to: now });

--- a/packages/server/src/usage/service.ts
+++ b/packages/server/src/usage/service.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, gte, isNotNull, lt } from 'drizzle-orm';
+import { and, asc, eq, gte, isNotNull, lt, sql } from 'drizzle-orm';
 
 import {
   USAGE_SOURCES,
@@ -310,7 +310,6 @@ export async function getUsageDashboard(input: GetUsageDashboardInput): Promise<
   const eventConditions = [
     gte(llmUsageEvents.startedAt, window.from),
     lt(llmUsageEvents.startedAt, window.to),
-    eq(llmUsageEvents.isAttributable, true),
     eq(llmUsageEvents.status, 'succeeded'),
   ];
   if (input.providerId) {
@@ -332,7 +331,7 @@ export async function getUsageDashboard(input: GetUsageDashboardInput): Promise<
       sessionType: sessions.type,
     })
     .from(llmUsageEvents)
-    .leftJoin(sessions, eq(llmUsageEvents.sessionId, sessions.id))
+    .leftJoin(sessions, eq(sessions.id, sql`json_extract(${llmUsageEvents.metadata}, '$.sessionId')`))
     .where(and(...eventConditions));
 
   const usedProviderIds = new Set<string>();


### PR DESCRIPTION
## Change Summary

Decouples LLM usage recording from individual feature modules by routing all bare recordLlmUsage calls through the internal event bus, centralizing usage tracking in the usage adapter.

### Improvements & Refactors
- **Decoupled usage schema from chat-specific concerns**: The llm_usage_events table now uses generic source/status columns and a flexible JSON metadata blob instead of chat-centric fields (sessionId, messageId, finishReason, etc.)
- **Centralized usage recording in the usage adapter**: Memory extraction/deduplication/consolidation and compaction failure usage events now emit bus events (usage.memory.completed, usage.compaction.failed) handled by registerUsageAdapter() instead of calling recordLlmUsage directly
- **Simplified feature modules**: Removed thin wrapper functions (recordUsageFireAndForget, recordUsage) from memory processor and consolidation — replaced with inline internalBus.emit() calls
- **Migration**: Added 0038_right_salo.sql to restructure the usage events table
