### PR TITLE
fix(web): render latex command spans in chat markdown

### DIFF
--- a/apps/web/src/components/chat/chat-markdown.test.tsx
+++ b/apps/web/src/components/chat/chat-markdown.test.tsx
@@ -19,4 +19,28 @@ describe('ChatMarkdown', () => {
 
     expect(html).toContain('katex');
   });
+
+  test('renders single-dollar LaTeX command spans', () => {
+    const html = renderToStaticMarkup(<ChatMarkdown text={'Standard AI Routing Proxy $\\rightarrow$ NO-GO.'} />);
+
+    expect(html).toContain('katex');
+    expect(html).not.toContain('$\\rightarrow$');
+  });
+
+  test('renders arrow command text while streaming', () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown text={'Standard AI Routing Proxy $\\rightarrow$ NO-GO.'} isStreaming />,
+    );
+
+    expect(html).toContain('→');
+    expect(html).not.toContain('$\\rightarrow$');
+    expect(html).not.toContain('katex');
+  });
+
+  test('renders double-escaped single-dollar LaTeX command spans', () => {
+    const html = renderToStaticMarkup(<ChatMarkdown text={'Standard AI Routing Proxy $\\\\rightarrow$ NO-GO.'} />);
+
+    expect(html).toContain('katex');
+    expect(html).not.toContain('$\\rightarrow$');
+  });
 });

--- a/apps/web/src/components/chat/chat-markdown.test.tsx
+++ b/apps/web/src/components/chat/chat-markdown.test.tsx
@@ -43,4 +43,11 @@ describe('ChatMarkdown', () => {
     expect(html).toContain('katex');
     expect(html).not.toContain('$\\rightarrow$');
   });
+
+  test('leaves unsupported single-dollar LaTeX command spans as text', () => {
+    const html = renderToStaticMarkup(<ChatMarkdown text={'Unsupported $\\notarealcommand$ stays literal.'} />);
+
+    expect(html).toContain('$\\notarealcommand$');
+    expect(html).not.toContain('katex');
+  });
 });

--- a/apps/web/src/components/chat/chat-markdown.tsx
+++ b/apps/web/src/components/chat/chat-markdown.tsx
@@ -46,14 +46,15 @@ interface MarkdownTextNode extends MarkdownNode {
   value: string;
 }
 
-interface MarkdownInlineMathNode extends MarkdownNode {
-  type: 'inlineMath';
-  value: string;
-  data: { hName: 'code'; hProperties: { className: string[] }; hChildren: [{ type: 'text'; value: string }] };
+interface SingleDollarLatexCommand {
+  math: string;
+  streamingText: string;
 }
 
-const LATEX_COMMAND_SPAN_REGEX = /\$\\{1,2}[a-zA-Z]+(?:\s*[-+*/=<>()[\]{}.,:;|\\\w]+)*\$/g;
-const STREAMING_LATEX_COMMAND_TEXT: Record<string, string> = { '\\rightarrow': '\u2192' };
+const SINGLE_DOLLAR_LATEX_COMMANDS: Record<string, SingleDollarLatexCommand> = {
+  rightarrow: { math: '\\rightarrow', streamingText: '\u2192' },
+};
+const LATEX_COMMAND_SPAN_REGEX = /\$\\{1,2}([a-zA-Z]+)\$/g;
 
 interface CodeBlockErrorBoundaryProps {
   fallback: React.ReactNode;
@@ -209,7 +210,22 @@ function extractCodeBlock(children: React.ReactNode): { className: string | unde
   return { className: onlyChild.props.className, code: nodeToPlainText(onlyChild.props.children) };
 }
 
-function splitLatexCommandSpans(node: MarkdownTextNode, renderAsText: boolean): MarkdownNode[] {
+function createInlineMathNode(value: string): MarkdownNode {
+  return {
+    type: 'inlineMath',
+    value,
+    data: {
+      hName: 'code',
+      hProperties: { className: ['language-math', 'math-inline'] },
+      hChildren: [{ type: 'text', value }],
+    },
+  };
+}
+
+function splitLatexCommandSpans(
+  node: MarkdownTextNode,
+  createCommandNode: (command: SingleDollarLatexCommand) => MarkdownNode,
+): MarkdownNode[] {
   const nodes: MarkdownNode[] = [];
   let lastIndex = 0;
 
@@ -217,26 +233,14 @@ function splitLatexCommandSpans(node: MarkdownTextNode, renderAsText: boolean): 
     const index = match.index;
     if (index === undefined) continue;
 
+    const command = SINGLE_DOLLAR_LATEX_COMMANDS[match[1] ?? ''];
+    if (!command) continue;
+
     if (index > lastIndex) {
       nodes.push({ type: 'text', value: node.value.slice(lastIndex, index) });
     }
 
-    const value = match[0].slice(1, -1).replace(/^\\\\/, '\\');
-    if (renderAsText) {
-      nodes.push({ type: 'text', value: STREAMING_LATEX_COMMAND_TEXT[value] ?? match[0] });
-      lastIndex = index + match[0].length;
-      continue;
-    }
-
-    nodes.push({
-      type: 'inlineMath',
-      value,
-      data: {
-        hName: 'code',
-        hProperties: { className: ['language-math', 'math-inline'] },
-        hChildren: [{ type: 'text', value }],
-      },
-    } satisfies MarkdownInlineMathNode);
+    nodes.push(createCommandNode(command));
     lastIndex = index + match[0].length;
   }
 
@@ -251,29 +255,38 @@ function splitLatexCommandSpans(node: MarkdownTextNode, renderAsText: boolean): 
   return nodes;
 }
 
+function createSingleDollarLatexCommandTransformer(renderAsText: boolean) {
+  const createCommandNode = renderAsText
+    ? (command: SingleDollarLatexCommand): MarkdownNode => ({ type: 'text', value: command.streamingText })
+    : (command: SingleDollarLatexCommand): MarkdownNode => createInlineMathNode(command.math);
+
+  return function transform(tree: MarkdownNode) {
+    transformLatexCommandTextNodes(tree, createCommandNode);
+  };
+}
+
 function remarkSingleDollarLatexCommands() {
-  return function transform(tree: MarkdownNode) {
-    transformLatexCommandTextNodes(tree, false);
-  };
+  return createSingleDollarLatexCommandTransformer(false);
 }
 
-function remarkStreamingLatexCommandText() {
-  return function transform(tree: MarkdownNode) {
-    transformLatexCommandTextNodes(tree, true);
-  };
+function remarkStreamingSingleDollarLatexCommands() {
+  return createSingleDollarLatexCommandTransformer(true);
 }
 
-function transformLatexCommandTextNodes(node: MarkdownNode, renderAsText: boolean) {
+function transformLatexCommandTextNodes(
+  node: MarkdownNode,
+  createCommandNode: (command: SingleDollarLatexCommand) => MarkdownNode,
+) {
   if (!node.children) return;
 
   const transformedChildren: MarkdownNode[] = [];
   for (const child of node.children) {
     if (child.type === 'text' && typeof child.value === 'string') {
-      transformedChildren.push(...splitLatexCommandSpans(child as MarkdownTextNode, renderAsText));
+      transformedChildren.push(...splitLatexCommandSpans(child as MarkdownTextNode, createCommandNode));
       continue;
     }
 
-    transformLatexCommandTextNodes(child, renderAsText);
+    transformLatexCommandTextNodes(child, createCommandNode);
     transformedChildren.push(child);
   }
 
@@ -352,7 +365,7 @@ function ChatMarkdown({ text, className, isStreaming = false }: ChatMarkdownProp
 
   // During streaming: use remarkGfm only — skip remark-math + rehype-katex (heavy)
   const remarkPlugins = useMemo(() => {
-    if (isStreaming) return [remarkGfm, remarkStreamingLatexCommandText];
+    if (isStreaming) return [remarkGfm, remarkStreamingSingleDollarLatexCommands];
 
     const remarkMathWithoutSingleDollar = [remarkMath, { singleDollarTextMath: false }] as [
       typeof remarkMath,

--- a/apps/web/src/components/chat/chat-markdown.tsx
+++ b/apps/web/src/components/chat/chat-markdown.tsx
@@ -34,6 +34,27 @@ interface ChatMarkdownProps {
   isStreaming?: boolean;
 }
 
+interface MarkdownNode {
+  type: string;
+  value?: string;
+  children?: MarkdownNode[];
+  data?: unknown;
+}
+
+interface MarkdownTextNode extends MarkdownNode {
+  type: 'text';
+  value: string;
+}
+
+interface MarkdownInlineMathNode extends MarkdownNode {
+  type: 'inlineMath';
+  value: string;
+  data: { hName: 'code'; hProperties: { className: string[] }; hChildren: [{ type: 'text'; value: string }] };
+}
+
+const LATEX_COMMAND_SPAN_REGEX = /\$\\{1,2}[a-zA-Z]+(?:\s*[-+*/=<>()[\]{}.,:;|\\\w]+)*\$/g;
+const STREAMING_LATEX_COMMAND_TEXT: Record<string, string> = { '\\rightarrow': '\u2192' };
+
 interface CodeBlockErrorBoundaryProps {
   fallback: React.ReactNode;
   children: React.ReactNode;
@@ -188,6 +209,77 @@ function extractCodeBlock(children: React.ReactNode): { className: string | unde
   return { className: onlyChild.props.className, code: nodeToPlainText(onlyChild.props.children) };
 }
 
+function splitLatexCommandSpans(node: MarkdownTextNode, renderAsText: boolean): MarkdownNode[] {
+  const nodes: MarkdownNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of node.value.matchAll(LATEX_COMMAND_SPAN_REGEX)) {
+    const index = match.index;
+    if (index === undefined) continue;
+
+    if (index > lastIndex) {
+      nodes.push({ type: 'text', value: node.value.slice(lastIndex, index) });
+    }
+
+    const value = match[0].slice(1, -1).replace(/^\\\\/, '\\');
+    if (renderAsText) {
+      nodes.push({ type: 'text', value: STREAMING_LATEX_COMMAND_TEXT[value] ?? match[0] });
+      lastIndex = index + match[0].length;
+      continue;
+    }
+
+    nodes.push({
+      type: 'inlineMath',
+      value,
+      data: {
+        hName: 'code',
+        hProperties: { className: ['language-math', 'math-inline'] },
+        hChildren: [{ type: 'text', value }],
+      },
+    } satisfies MarkdownInlineMathNode);
+    lastIndex = index + match[0].length;
+  }
+
+  if (nodes.length === 0) {
+    return [node];
+  }
+
+  if (lastIndex < node.value.length) {
+    nodes.push({ type: 'text', value: node.value.slice(lastIndex) });
+  }
+
+  return nodes;
+}
+
+function remarkSingleDollarLatexCommands() {
+  return function transform(tree: MarkdownNode) {
+    transformLatexCommandTextNodes(tree, false);
+  };
+}
+
+function remarkStreamingLatexCommandText() {
+  return function transform(tree: MarkdownNode) {
+    transformLatexCommandTextNodes(tree, true);
+  };
+}
+
+function transformLatexCommandTextNodes(node: MarkdownNode, renderAsText: boolean) {
+  if (!node.children) return;
+
+  const transformedChildren: MarkdownNode[] = [];
+  for (const child of node.children) {
+    if (child.type === 'text' && typeof child.value === 'string') {
+      transformedChildren.push(...splitLatexCommandSpans(child as MarkdownTextNode, renderAsText));
+      continue;
+    }
+
+    transformLatexCommandTextNodes(child, renderAsText);
+    transformedChildren.push(child);
+  }
+
+  node.children = transformedChildren;
+}
+
 function MarkdownAnchor({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -260,13 +352,13 @@ function ChatMarkdown({ text, className, isStreaming = false }: ChatMarkdownProp
 
   // During streaming: use remarkGfm only — skip remark-math + rehype-katex (heavy)
   const remarkPlugins = useMemo(() => {
-    if (isStreaming) return [remarkGfm];
+    if (isStreaming) return [remarkGfm, remarkStreamingLatexCommandText];
 
     const remarkMathWithoutSingleDollar = [remarkMath, { singleDollarTextMath: false }] as [
       typeof remarkMath,
       { singleDollarTextMath: false },
     ];
-    return [remarkGfm, remarkMathWithoutSingleDollar];
+    return [remarkGfm, remarkSingleDollarLatexCommands, remarkMathWithoutSingleDollar];
   }, [isStreaming]);
   const rehypePlugins = useMemo(() => (isStreaming ? [] : [rehypeKatex]), [isStreaming]);
 


### PR DESCRIPTION
## 🚀 Change Summary

Fixes chat markdown rendering for model output that includes safe single-dollar LaTeX command spans like `$\rightarrow$`, while preserving the existing protection against parsing dollar amounts like `$10` as math.

### 🐛 Bug Fixes
- **Chat Markdown Rendering**: Renders supported single-dollar LaTeX command spans through KaTeX once messages are finalized.
- **Streaming Output**: Displays supported command spans as lightweight text replacements during streaming without enabling full KaTeX rendering.

### 🛠 Improvements & Refactors
- Restricts single-dollar command handling to an explicit allowlist instead of using broad pseudo-LaTeX parsing.
- Adds regression coverage for dollar amounts, finalized arrow rendering, streaming arrow rendering, double-escaped command input, and unsupported command spans.
