### PR TITLE
fix(memory): maintenance never cleaning up stale/duplicate memories

### DIFF
--- a/apps/web/src/components/settings/memory.tsx
+++ b/apps/web/src/components/settings/memory.tsx
@@ -272,6 +272,15 @@ function RetentionSettings() {
         description="Run automatic pruning after extraction to stay within limits."
         checked={settings['memory.retention.autoprune'] === 'true'}
       />
+      <SliderSettingRow
+        settingKey="memory.retention.dedupThreshold"
+        label="Dedup Similarity Threshold"
+        description="How similar two memories must be to count as duplicates. Lower = more aggressive dedup."
+        currentValue={Number(settings['memory.retention.dedupThreshold'])}
+        min={0.5}
+        max={1}
+        step={0.01}
+      />
     </SettingRows>
   );
 }

--- a/apps/web/src/lib/queries/memories.ts
+++ b/apps/web/src/lib/queries/memories.ts
@@ -150,7 +150,14 @@ export function bulkDeleteMemoriesMutationOptions(queryClient: QueryClient): Mut
   };
 }
 
-type MaintenanceResult = { pruned: number; deduplicated: number; stats: MemoryHealthStats | null };
+type ConsolidationResult = { groupsReviewed: number; added: number; updated: number; deleted: number; skipped: number };
+
+type MaintenanceResult = {
+  pruned: number;
+  deduplicated: number;
+  consolidated: ConsolidationResult;
+  stats: MemoryHealthStats | null;
+};
 
 export function runMaintenanceMutationOptions(
   queryClient: QueryClient,
@@ -162,6 +169,9 @@ export function runMaintenanceMutationOptions(
       const parts: string[] = [];
       if (result.pruned > 0) parts.push(`${result.pruned} pruned`);
       if (result.deduplicated > 0) parts.push(`${result.deduplicated} deduplicated`);
+      const consolidated = result.consolidated;
+      const consolidatedTotal = consolidated.added + consolidated.updated + consolidated.deleted;
+      if (consolidatedTotal > 0) parts.push(`${consolidatedTotal} consolidated`);
       toast.success(
         parts.length > 0 ? `Maintenance complete: ${parts.join(', ')}` : 'Maintenance complete — nothing to clean up',
         { id: 'memory-maintenance' },

--- a/packages/server/src/memory/config.ts
+++ b/packages/server/src/memory/config.ts
@@ -14,6 +14,7 @@ type MemoryConfig = {
   maxMemories: number;
   staleDays: number;
   autoprune: boolean;
+  dedupThreshold: number;
   retrievalMaxResults: number;
   retrievalMinScore: number;
   retrievalRecencyBoost: boolean;
@@ -57,6 +58,7 @@ export async function getMemoryConfig(): Promise<MemoryConfig> {
     'memory.retention.maxMemories',
     'memory.retention.staleDays',
     'memory.retention.autoprune',
+    'memory.retention.dedupThreshold',
     'memory.retrieval.maxResults',
     'memory.retrieval.minScore',
     'memory.retrieval.recencyBoost',
@@ -76,6 +78,7 @@ export async function getMemoryConfig(): Promise<MemoryConfig> {
     maxMemories: s['memory.retention.maxMemories'],
     staleDays: s['memory.retention.staleDays'],
     autoprune: s['memory.retention.autoprune'],
+    dedupThreshold: s['memory.retention.dedupThreshold'],
     retrievalMaxResults: s['memory.retrieval.maxResults'],
     retrievalMinScore: s['memory.retrieval.minScore'],
     retrievalRecencyBoost: s['memory.retrieval.recencyBoost'],

--- a/packages/server/src/memory/maintenance.ts
+++ b/packages/server/src/memory/maintenance.ts
@@ -44,7 +44,7 @@ export async function runMemoryMaintenance(): Promise<ServiceResult<MaintenanceR
   }
 
   // Phase 2: Dedup sweep — remove near-duplicate memories
-  const deduplicated = await deduplicateMemories();
+  const deduplicated = await deduplicateMemories(config.dedupThreshold);
   log.info({ deduplicated }, 'memory maintenance: dedup sweep complete');
 
   // Phase 3: Reflective consolidation of related semantic memories

--- a/packages/server/src/memory/service.ts
+++ b/packages/server/src/memory/service.ts
@@ -316,10 +316,9 @@ export async function pruneStaleMemories(config: {
   const embedder = await getEmbedder();
   const table = await getSemanticTable(embedder.dimensions);
 
-  const count = await table.countRows();
-  if (count <= config.maxMemories) return ok(undefined);
-
   const rows = await table.query().toArray();
+  const count = rows.length;
+  if (count === 0) return ok(undefined);
 
   // Calculate value score for each memory
   const scored = rows.map((r) => {
@@ -344,20 +343,22 @@ export async function pruneStaleMemories(config: {
 
   const toDelete = new Set<string>();
 
-  // First, delete lowest value memories until we are under the cap
-  let currentTotal = count;
+  // First, delete any unpinned memory that is stale AND never accessed
   for (const item of scored) {
-    if (currentTotal <= config.maxMemories) break;
-    if (!item.pinned) {
+    if (!item.pinned && item.daysSince > config.staleDays && item.accessCount === 0) {
       toDelete.add(item.id);
-      currentTotal--;
     }
   }
 
-  // Second, delete any unpinned memory that is stale AND never accessed
-  for (const item of scored) {
-    if (!item.pinned && !toDelete.has(item.id) && item.daysSince > config.staleDays && item.accessCount === 0) {
-      toDelete.add(item.id);
+  // Second, if still over the cap, delete lowest value memories until under
+  let currentTotal = count - toDelete.size;
+  if (currentTotal > config.maxMemories) {
+    for (const item of scored) {
+      if (currentTotal <= config.maxMemories) break;
+      if (!item.pinned && !toDelete.has(item.id)) {
+        toDelete.add(item.id);
+        currentTotal--;
+      }
     }
   }
 
@@ -372,7 +373,7 @@ export async function pruneStaleMemories(config: {
   return ok(undefined);
 }
 
-export async function deduplicateMemories(similarityThreshold = 0.92): Promise<number> {
+export async function deduplicateMemories(similarityThreshold = 0.85): Promise<number> {
   const embedder = await getEmbedder();
   const table = await getSemanticTable(embedder.dimensions);
 

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -35,6 +35,7 @@ export const SETTINGS_KEYS = [
   'memory.retention.maxMemories',
   'memory.retention.staleDays',
   'memory.retention.autoprune',
+  'memory.retention.dedupThreshold',
   'memory.retrieval.maxResults',
   'memory.retrieval.minScore',
   'memory.retrieval.recencyBoost',
@@ -92,6 +93,7 @@ export const SETTINGS_SCHEMAS = {
   'memory.retention.maxMemories': z.coerce.number().int().min(10),
   'memory.retention.staleDays': z.coerce.number().int().min(1),
   'memory.retention.autoprune': booleanSetting,
+  'memory.retention.dedupThreshold': z.coerce.number().min(0.5).max(1),
   'memory.retrieval.maxResults': z.coerce.number().int().min(1),
   'memory.retrieval.minScore': z.coerce.number().min(0).max(1),
   'memory.retrieval.recencyBoost': booleanSetting,
@@ -232,7 +234,7 @@ export const SETTINGS_DEFAULTS: SettingDefault[] = [
   {
     key: 'memory.extraction.importanceMinScore',
     value: '0.7',
-    description: 'Minimum importance score (0–1) a fact must have to be persisted. Lower scores are discarded.',
+    description: 'Minimum importance score (0-1) a fact must have to be persisted. Lower scores are discarded.',
   },
   {
     key: 'memory.extraction.maxFactsPerSession',
@@ -258,6 +260,11 @@ export const SETTINGS_DEFAULTS: SettingDefault[] = [
     key: 'memory.retention.autoprune',
     value: 'true',
     description: 'Run automatic pruning after extraction to stay within limits.',
+  },
+  {
+    key: 'memory.retention.dedupThreshold',
+    value: '0.85',
+    description: 'Cosine similarity threshold (0.5-1.0) for deduplication. Lower catches more duplicates.',
   },
   { key: 'memory.retrieval.maxResults', value: '3', description: 'Max memories injected into context per turn.' },
   {


### PR DESCRIPTION
## Bug Fix

Memory maintenance always reported "nothing to clean up" even as memories piled up. Three bugs caused this:

### Root Causes

1. **Stale memories never pruned** — `pruneStaleMemories` had an early return when total count was under `maxMemories` (default 150). The stale cleanup logic ran *after* this return, so stale never-accessed memories were never removed unless the cap was already hit.

2. **Dedup threshold too strict** — Hardcoded at 0.92 cosine similarity, too strict for most embedding models to catch real duplicates.

3. **Toast ignored consolidation results** — The frontend `MaintenanceResult` type was missing the `consolidated` field, so even when consolidation merged/deleted memories the UI reported "nothing to clean up".

### Fixes

- Removed the early return in `pruneStaleMemories` — stale never-accessed memories are now always cleaned regardless of total count, then the cap is enforced separately.
- Lowered default dedup threshold to 0.85 and made it a user-configurable setting (`memory.retention.dedupThreshold`) with a slider in Settings > Memory > Retention.
- Added `consolidated` to the frontend type and included consolidation stats in the success toast.
