### PR TITLE
fix(memory): prevent off-topic memory contamination on low-signal turns

### DIFF
--- a/apps/web/src/components/settings/memory.tsx
+++ b/apps/web/src/components/settings/memory.tsx
@@ -241,6 +241,12 @@ function ExtractionSettings() {
         min={0}
         max={20}
       />
+      <SwitchSettingRow
+        settingKey="memory.extraction.fromAutomations"
+        label="Extract From Automations"
+        description="Allow automation sessions to extract and store new memories. When off, only chat sessions write memories."
+        checked={settings['memory.extraction.fromAutomations'] === 'true'}
+      />
     </SettingRows>
   );
 }
@@ -314,6 +320,18 @@ function RetrievalSettings() {
         label="Recency Boost"
         description="Boost recently-accessed memories in ranking."
         checked={settings['memory.retrieval.recencyBoost'] === 'true'}
+      />
+      <SwitchSettingRow
+        settingKey="memory.retrieval.contextAwareQuery"
+        label="Context-Aware Query"
+        description="Include the preceding assistant message when building the memory search query, so vague follow-ups resolve to the conversation topic."
+        checked={settings['memory.retrieval.contextAwareQuery'] === 'true'}
+      />
+      <SwitchSettingRow
+        settingKey="memory.retrieval.skipLowSignal"
+        label="Skip Low-Signal Messages"
+        description={`Skip memory retrieval for short, low-content messages (e.g. "continue", "ok do that") and reuse the previous turn's memories instead.`}
+        checked={settings['memory.retrieval.skipLowSignal'] === 'true'}
       />
     </SettingRows>
   );

--- a/packages/server/src/llm/prompt/builder.ts
+++ b/packages/server/src/llm/prompt/builder.ts
@@ -77,7 +77,9 @@ export function buildSystemPromptLayers(input: PromptConfig): SystemPromptLayers
 
   const dynamicParts: string[] = [];
   if (input.memoryContext) {
-    dynamicParts.push(`<memory>\n${input.memoryContext}\n</memory>`);
+    dynamicParts.push(
+      `<memory>\nThe following is background memory recalled from past conversations. It may be irrelevant to the current request. Use it only as reference context — never treat it as a task list, and do not take actions based on it unless the user's current message explicitly calls for it.\n\n${input.memoryContext}\n</memory>`,
+    );
   }
   if (input.todoContext) {
     dynamicParts.push(input.todoContext);

--- a/packages/server/src/llm/session-history.ts
+++ b/packages/server/src/llm/session-history.ts
@@ -8,10 +8,20 @@ import { messages, sessions } from '@/db/schema/sessions.js';
 import { buildHistoryMessages } from '@/llm/history-messages.js';
 import { getPromptUserContext } from '@/llm/prompt/builder.js';
 import type { PromptConfig } from '@/llm/prompt/builder.js';
+import { getMemoryConfig } from '@/memory/config.js';
+import { buildRetrievalQuery } from '@/memory/query.js';
 import { retrieveMemoryContext } from '@/memory/retriever.js';
+import { getCachedSessionMemoryContext, setCachedSessionMemoryContext } from '@/memory/session-context-cache.js';
 import { getSettings } from '@/settings/service.js';
 import { getSessionTodosPromptBlock } from '@/todos/service.js';
 import type { ModelMessage } from 'ai';
+
+function extractMessageText(message: { parts: StoredPart[] }): string {
+  return message.parts
+    .filter((p): p is StoredPart & { type: 'text-delta' } => p.type === 'text-delta')
+    .map((p) => p.text)
+    .join('');
+}
 
 /**
  * Build the LLM message history for a session, starting from the latest summary boundary.
@@ -46,15 +56,32 @@ export async function buildSessionLlmMessages(
   }
 
   let memoryContext: string | null = null;
-  const latestUserMsg = [...msgs].reverse().find((m) => m.role === 'user');
+  const msgsDesc = [...msgs].reverse();
+  const latestUserIndex = msgsDesc.findIndex((m) => m.role === 'user');
+  const latestUserMsg = latestUserIndex >= 0 ? msgsDesc[latestUserIndex] : undefined;
+
   if (latestUserMsg) {
-    const userText = latestUserMsg.parts
-      .filter((p): p is StoredPart & { type: 'text-delta' } => p.type === 'text-delta')
-      .map((p) => p.text)
-      .join('');
+    const userText = extractMessageText(latestUserMsg);
 
     if (userText.length > 0) {
-      memoryContext = await retrieveMemoryContext(userText, memorySourceFilter).catch(() => null);
+      const previousAssistantMsg = msgsDesc.slice(latestUserIndex + 1).find((m) => m.role === 'assistant');
+      const previousAssistantText = previousAssistantMsg ? extractMessageText(previousAssistantMsg) : null;
+      const memoryConfig = await getMemoryConfig();
+      const query = buildRetrievalQuery({
+        userText,
+        previousAssistantText,
+        contextAwareQuery: memoryConfig.retrievalContextAwareQuery,
+        skipLowSignal: memoryConfig.retrievalSkipLowSignal,
+      });
+
+      if (query === null) {
+        memoryContext = getCachedSessionMemoryContext(sessionId);
+      } else {
+        memoryContext = await retrieveMemoryContext(query, memorySourceFilter).catch(() => null);
+        if (memoryContext !== null) {
+          setCachedSessionMemoryContext(sessionId, memoryContext);
+        }
+      }
     }
   }
 

--- a/packages/server/src/memory/config.ts
+++ b/packages/server/src/memory/config.ts
@@ -18,6 +18,9 @@ type MemoryConfig = {
   retrievalMaxResults: number;
   retrievalMinScore: number;
   retrievalRecencyBoost: boolean;
+  retrievalContextAwareQuery: boolean;
+  retrievalSkipLowSignal: boolean;
+  extractFromAutomations: boolean;
 };
 
 export function hasConfiguredEmbeddingModel(
@@ -55,6 +58,7 @@ export async function getMemoryConfig(): Promise<MemoryConfig> {
     'memory.extraction.importanceMinScore',
     'memory.extraction.maxFactsPerSession',
     'memory.extraction.minTurnsBetweenWrites',
+    'memory.extraction.fromAutomations',
     'memory.retention.maxMemories',
     'memory.retention.staleDays',
     'memory.retention.autoprune',
@@ -62,6 +66,8 @@ export async function getMemoryConfig(): Promise<MemoryConfig> {
     'memory.retrieval.maxResults',
     'memory.retrieval.minScore',
     'memory.retrieval.recencyBoost',
+    'memory.retrieval.contextAwareQuery',
+    'memory.retrieval.skipLowSignal',
   ] as const);
 
   cachedConfig = {
@@ -75,6 +81,7 @@ export async function getMemoryConfig(): Promise<MemoryConfig> {
     importanceMinScore: s['memory.extraction.importanceMinScore'],
     maxFactsPerSession: s['memory.extraction.maxFactsPerSession'],
     minTurnsBetweenWrites: s['memory.extraction.minTurnsBetweenWrites'],
+    extractFromAutomations: s['memory.extraction.fromAutomations'],
     maxMemories: s['memory.retention.maxMemories'],
     staleDays: s['memory.retention.staleDays'],
     autoprune: s['memory.retention.autoprune'],
@@ -82,6 +89,8 @@ export async function getMemoryConfig(): Promise<MemoryConfig> {
     retrievalMaxResults: s['memory.retrieval.maxResults'],
     retrievalMinScore: s['memory.retrieval.minScore'],
     retrievalRecencyBoost: s['memory.retrieval.recencyBoost'],
+    retrievalContextAwareQuery: s['memory.retrieval.contextAwareQuery'],
+    retrievalSkipLowSignal: s['memory.retrieval.skipLowSignal'],
   };
   cacheExpiresAt = now + CACHE_TTL_MS;
 

--- a/packages/server/src/memory/consolidation.test.ts
+++ b/packages/server/src/memory/consolidation.test.ts
@@ -85,4 +85,34 @@ describe('validateConsolidationActions', () => {
     ]);
     expect(result.skipped).toBe(0);
   });
+
+  test('collapses a paraphrase family to a single canonical memory', () => {
+    const group = [
+      memory({ id: 'mem-1', content: 'User currently has a job at Acme Corp.' }),
+      memory({ id: 'mem-2', content: 'User is employed by Acme Corp.' }),
+      memory({ id: 'mem-3', content: 'User works for Acme Corp.' }),
+      memory({ id: 'mem-4', content: 'User has a role at Acme Corp.' }),
+    ];
+
+    const result = validateConsolidationActions(group, [
+      { action: 'UPDATE', memoryId: 'mem-1', content: 'User works at Acme Corp.', category: null, confidence: null },
+      { action: 'DELETE', memoryId: 'mem-2', content: null, category: null, confidence: null },
+      { action: 'DELETE', memoryId: 'mem-3', content: null, category: null, confidence: null },
+      { action: 'DELETE', memoryId: 'mem-4', content: null, category: null, confidence: null },
+    ]);
+
+    expect(result.valid).toEqual([
+      { action: 'UPDATE', memoryId: 'mem-1', content: 'User works at Acme Corp.' },
+      { action: 'DELETE', memoryId: 'mem-2' },
+      { action: 'DELETE', memoryId: 'mem-3' },
+      { action: 'DELETE', memoryId: 'mem-4' },
+    ]);
+    expect(result.skipped).toBe(0);
+
+    const survivingIds = new Set(group.map((m) => m.id));
+    for (const action of result.valid) {
+      if (action.action === 'DELETE') survivingIds.delete(action.memoryId);
+    }
+    expect(survivingIds.size).toBe(1);
+  });
 });

--- a/packages/server/src/memory/maintenance.ts
+++ b/packages/server/src/memory/maintenance.ts
@@ -9,6 +9,9 @@ import type { MemoryStats } from '@/memory/service.js';
 
 const log = Log.create({ service: 'memory-maintenance' });
 
+// Manual "Maintainece" sweeps use a lower dedup threshold than the automatic
+const MANUAL_SWEEP_DEDUP_THRESHOLD = 0.8;
+
 type MaintenanceResult = {
   pruned: number;
   deduplicated: number;
@@ -16,7 +19,9 @@ type MaintenanceResult = {
   stats: MemoryStats | null;
 };
 
-export async function runMemoryMaintenance(): Promise<ServiceResult<MaintenanceResult>> {
+export async function runMemoryMaintenance(
+  options: { manual?: boolean } = {},
+): Promise<ServiceResult<MaintenanceResult>> {
   const config = await getMemoryConfig();
 
   if (!isMemoryActive(config)) {
@@ -44,8 +49,9 @@ export async function runMemoryMaintenance(): Promise<ServiceResult<MaintenanceR
   }
 
   // Phase 2: Dedup sweep — remove near-duplicate memories
-  const deduplicated = await deduplicateMemories(config.dedupThreshold);
-  log.info({ deduplicated }, 'memory maintenance: dedup sweep complete');
+  const dedupThreshold = options.manual ? MANUAL_SWEEP_DEDUP_THRESHOLD : config.dedupThreshold;
+  const deduplicated = await deduplicateMemories(dedupThreshold);
+  log.info({ deduplicated, dedupThreshold }, 'memory maintenance: dedup sweep complete');
 
   // Phase 3: Reflective consolidation of related semantic memories
   const consolidated = await consolidateMemories();

--- a/packages/server/src/memory/processor.ts
+++ b/packages/server/src/memory/processor.ts
@@ -122,6 +122,11 @@ export async function processMemories(input: {
       resolveMemorySource(input.sessionId, input.memorySource),
     ]);
 
+    if (memorySource === 'automation' && !config.extractFromAutomations) {
+      log.debug({ sessionId: input.sessionId }, 'skipping extraction: automation session extraction disabled');
+      return;
+    }
+
     if (!resolved) {
       log.warn('no model available for memory extraction');
       return;

--- a/packages/server/src/memory/query.test.ts
+++ b/packages/server/src/memory/query.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildRetrievalQuery } from '@/memory/query.js';
+
+describe('buildRetrievalQuery', () => {
+  test('returns null for low-signal messages when skipLowSignal is on', () => {
+    for (const userText of ['so prioritize that', 'continue', 'hello?', 'ok']) {
+      const result = buildRetrievalQuery({
+        userText,
+        previousAssistantText: null,
+        contextAwareQuery: false,
+        skipLowSignal: true,
+      });
+      expect(result).toBeNull();
+    }
+  });
+
+  test('returns the bare user text for messages with enough signal tokens', () => {
+    const result = buildRetrievalQuery({
+      userText: 'does obsidian support markdown export options',
+      previousAssistantText: null,
+      contextAwareQuery: false,
+      skipLowSignal: true,
+    });
+    expect(result).toBe('does obsidian support markdown export options');
+  });
+
+  test('does not skip low-signal messages when skipLowSignal is off', () => {
+    const result = buildRetrievalQuery({
+      userText: 'continue',
+      previousAssistantText: null,
+      contextAwareQuery: false,
+      skipLowSignal: false,
+    });
+    expect(result).toBe('continue');
+  });
+
+  test('concatenates previous assistant text and user text when contextAwareQuery is on', () => {
+    const result = buildRetrievalQuery({
+      userText: 'so prioritize that',
+      previousAssistantText: 'Obsidian is a note-taking app.',
+      contextAwareQuery: true,
+      skipLowSignal: false,
+    });
+    expect(result).toBe('Obsidian is a note-taking app.\nso prioritize that');
+  });
+
+  test('truncates previous assistant text to the last 500 characters', () => {
+    const longAssistantText = 'a'.repeat(600) + 'TAIL_MARKER';
+    const result = buildRetrievalQuery({
+      userText: 'continue building this',
+      previousAssistantText: longAssistantText,
+      contextAwareQuery: true,
+      skipLowSignal: false,
+    });
+    const expectedTail = longAssistantText.slice(-500);
+    expect(expectedTail.length).toBe(500);
+    expect(result).toBe(`${expectedTail}\ncontinue building this`);
+  });
+
+  test('returns bare user text when contextAwareQuery is on but there is no previous assistant text', () => {
+    const result = buildRetrievalQuery({
+      userText: 'is obsidian a task harness',
+      previousAssistantText: null,
+      contextAwareQuery: true,
+      skipLowSignal: false,
+    });
+    expect(result).toBe('is obsidian a task harness');
+  });
+
+  test('returns bare user text when contextAwareQuery is off, even with previous assistant text', () => {
+    const result = buildRetrievalQuery({
+      userText: 'does obsidian support markdown export',
+      previousAssistantText: 'Obsidian is a note-taking app.',
+      contextAwareQuery: false,
+      skipLowSignal: false,
+    });
+    expect(result).toBe('does obsidian support markdown export');
+  });
+});

--- a/packages/server/src/memory/query.ts
+++ b/packages/server/src/memory/query.ts
@@ -1,0 +1,33 @@
+const MIN_SIGNAL_TOKENS = 4;
+const MIN_TOKEN_LENGTH = 3;
+const CONTEXT_TAIL_CHARS = 500;
+
+function countSignalTokens(text: string): number {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length >= MIN_TOKEN_LENGTH).length;
+}
+
+/**
+ * Build the memory retrieval query for a turn, or return null when the turn is
+ * low-signal and should reuse the previous turn's cached memory context instead.
+ */
+export function buildRetrievalQuery(input: {
+  userText: string;
+  previousAssistantText: string | null;
+  contextAwareQuery: boolean;
+  skipLowSignal: boolean;
+}): string | null {
+  const { userText, previousAssistantText, contextAwareQuery, skipLowSignal } = input;
+
+  if (skipLowSignal && countSignalTokens(userText) < MIN_SIGNAL_TOKENS) {
+    return null;
+  }
+
+  if (contextAwareQuery && previousAssistantText) {
+    return `${previousAssistantText.slice(-CONTEXT_TAIL_CHARS)}\n${userText}`;
+  }
+
+  return userText;
+}

--- a/packages/server/src/memory/retriever.ts
+++ b/packages/server/src/memory/retriever.ts
@@ -76,9 +76,9 @@ export async function retrieveMemoryContext(query: string, sourceFilter?: Memory
 
   const scoredCandidates = candidates.map((m) => {
     const lexicalFactor = getLexicalFactor(query, m.content);
-    const recencyFactor = config.retrievalRecencyBoost ? getRecencyFactor(m.lastAccessedAt) : 0;
+    const recencyFactor = config.retrievalRecencyBoost ? getRecencyFactor(m.updatedAt) : 0;
     const confidenceFactor = getConfidenceFactor(m.confidence);
-    const blendedScore = m.score * 0.6 + lexicalFactor * 0.25 + recencyFactor * 0.1 + confidenceFactor * 0.05;
+    const blendedScore = m.score * 0.75 + lexicalFactor * 0.15 + recencyFactor * 0.05 + confidenceFactor * 0.05;
     return { ...m, blendedScore };
   });
 
@@ -94,7 +94,10 @@ export async function retrieveMemoryContext(query: string, sourceFilter?: Memory
 
   const entries = relevant.map((m) => `- [${m.category}] ${m.content} (confidence: ${m.confidence})`);
 
-  log.debug({ semanticCount: relevant.length }, 'retrieved memory context');
+  log.debug(
+    { query, memories: relevant.map((m) => ({ id: m.id, score: m.score, blendedScore: m.blendedScore })) },
+    'retrieved memory context',
+  );
 
-  return `Known facts about the user:\n${entries.join('\n')}`;
+  return `Background memory recalled from past conversations:\n${entries.join('\n')}`;
 }

--- a/packages/server/src/memory/session-context-cache.ts
+++ b/packages/server/src/memory/session-context-cache.ts
@@ -1,0 +1,21 @@
+import type { PrefixedString } from '@stitch/shared/id';
+
+const MAX_ENTRIES = 100;
+
+const cache = new Map<PrefixedString<'ses'>, string>();
+
+/** Returns the cached memory context for a session, or null if none is cached. */
+export function getCachedSessionMemoryContext(sessionId: PrefixedString<'ses'>): string | null {
+  return cache.get(sessionId) ?? null;
+}
+
+/** Caches the memory context for a session, evicting the oldest entry once the cap is exceeded. */
+export function setCachedSessionMemoryContext(sessionId: PrefixedString<'ses'>, memoryContext: string): void {
+  cache.delete(sessionId);
+  cache.set(sessionId, memoryContext);
+
+  if (cache.size > MAX_ENTRIES) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey !== undefined) cache.delete(oldestKey);
+  }
+}

--- a/packages/server/src/routes/memory.ts
+++ b/packages/server/src/routes/memory.ts
@@ -139,7 +139,7 @@ memoryRouter.post('/maintenance', async (c) => {
   const inactiveResponse = await ensureMemoryActive(c);
   if (inactiveResponse) return inactiveResponse;
 
-  const result = await runMemoryMaintenance();
+  const result = await runMemoryMaintenance({ manual: true });
   return unwrapResult(c, result);
 });
 

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -162,6 +162,12 @@ const SETTINGS_REGISTRY = {
     default: '3',
     description: 'Minimum user turns between consecutive auto-memory writes for the same session. Acts as a cooldown.',
   },
+  'memory.extraction.fromAutomations': {
+    schema: booleanSetting,
+    default: 'false',
+    description:
+      'Allow automation sessions to extract and store new memories. When off, only chat sessions write memories.',
+  },
   'memory.retention.maxMemories': {
     schema: z.coerce.number().int().min(10),
     default: '150',
@@ -196,6 +202,18 @@ const SETTINGS_REGISTRY = {
     schema: booleanSetting,
     default: 'true',
     description: 'Boost recently-accessed memories in ranking.',
+  },
+  'memory.retrieval.contextAwareQuery': {
+    schema: booleanSetting,
+    default: 'true',
+    description:
+      'Include the preceding assistant message when building the memory search query, so vague follow-ups resolve to the conversation topic.',
+  },
+  'memory.retrieval.skipLowSignal': {
+    schema: booleanSetting,
+    default: 'true',
+    description:
+      'Skip memory retrieval for short, low-content messages (e.g. "continue", "ok do that") and reuse the previous turn\'s memories instead.',
   },
   'agents.customInstructions': {
     schema: z.string().max(20_000),


### PR DESCRIPTION
## 🚀 Change Summary

Fixes memory contamination where semantic-memory retrieval on vague follow-up turns (e.g. "so prioritize that") injected off-topic memories framed as "Known facts about the user", which the model then executed as a task backlog. Retrieval is now conversation-aware, recalled memory is framed as non-directive background context, and the self-reinforcing recency loop in ranking is broken.

### ✨ New Features

- **Conversation-aware retrieval query**: the memory search query now includes the preceding assistant message, so vague follow-ups resolve to the conversation topic instead of matching on bare pronouns (`memory.retrieval.contextAwareQuery`, default on)
- **Low-signal turn skip**: short, low-content messages ("continue", "ok do that") skip retrieval entirely and reuse the previous turn's memory context via a per-session cache (`memory.retrieval.skipLowSignal`, default on)
- **Automation extraction gating**: automation sessions no longer extract and store new memories unless explicitly enabled (`memory.extraction.fromAutomations`, default off)
- All three settings are exposed as toggles in the Memory settings page

### 🛠 Improvements & Refactors

- **Non-directive memory framing**: recalled memories are now presented as "Background memory recalled from past conversations" with an explicit caveat that they are reference context, never a task list
- **Retrieval scoring**: recency factor now uses `updatedAt` instead of `lastAccessedAt`, so being retrieved no longer boosts future ranking; blend re-weighted to favor semantic similarity (0.75/0.15/0.05/0.05)
- **Manual maintenance sweep**: the manual "Run Maintenance" action deduplicates at a lower 0.80 threshold to collapse paraphrase families; the automatic autoprune path keeps its existing threshold
- Retrieval debug logging now includes the query and injected memory IDs/scores for observability

### ⚠️ Behavior Change

`memory.extraction.fromAutomations` defaults to `false` — automation sessions currently extract memories and will stop doing so by default. Existing automation-sourced memories are untouched (read path unchanged).
