### PR TITLE
chore(ci): update GitHub Actions to Node.js 24 runtime

### DIFF
--- a/.github/actions/setup-git-committer/action.yml
+++ b/.github/actions/setup-git-committer/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: Create app token
       if: ${{ inputs.app-id != '' && inputs.app-private-key != '' }}
       id: app-token
-      uses: actions/create-github-app-token@v2
+      uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.app-private-key }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,7 @@ jobs:
         run: bun run ${{ matrix.package_script || 'package' }}
 
       - name: Upload desktop artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: desktop-${{ matrix.os }}-${{ matrix.arch || 'x64' }}
           if-no-files-found: error
@@ -301,7 +301,7 @@ jobs:
         run: bun run build
 
       - name: Upload Linux server artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: server-linux-x64
           if-no-files-found: error
@@ -330,14 +330,14 @@ jobs:
           bot-email: stitch[bot]@users.noreply.github.com
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: desktop-*
           path: release-assets
           merge-multiple: true
 
       - name: Download Linux server artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: server-linux-x64
           path: release-assets/server-linux-x64


### PR DESCRIPTION
## Change Summary

Updates GitHub Actions that target the deprecated Node.js 20 runtime to versions that natively run on Node.js 24, eliminating the forced runtime fallback warnings.

### Changes

- `actions/create-github-app-token@v2` -> `@v3` (Node 24 runtime)
- `actions/upload-artifact@v4` -> `@v7` (Node 24 runtime)
- `actions/download-artifact@v4` -> `@v7` (Node 24 runtime)

### Notes

- `download-artifact` pinned to v7 instead of v8 to avoid a breaking change where hash mismatches now error by default
- `create-github-app-token@v3` only breaking change is proxy handling (requires `NODE_USE_ENV_PROXY` env var) which does not affect this workflow
- All existing workflow parameters remain fully supported in the new versions
