### PR TITLE
chore(ci): update paths-filter and wrangler-action to Node.js 24 runtime

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -37,7 +37,7 @@ jobs:
           VITE_POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/pr-master.yml
+++ b/.github/workflows/pr-master.yml
@@ -20,7 +20,7 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
       - uses: actions/checkout@v5
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           predicate-quantifier: 'every'


### PR DESCRIPTION
## Change Summary

Updates GitHub Actions that target the deprecated Node.js 20 runtime to versions that natively run on Node.js 24, eliminating the forced runtime fallback warnings.

### Changes

- `dorny/paths-filter@v3` -> `@v4` (Node 24 runtime, API unchanged)
- `cloudflare/wrangler-action@v3` -> `@v4` (Node 24 runtime, defaults to Wrangler v4)
