### PR TITLE
fix(web): replace allowlist with pre-parse normalizer for single-dollar inline math

### DIFF
--- a/apps/web/src/components/chat/chat-markdown.test.tsx
+++ b/apps/web/src/components/chat/chat-markdown.test.tsx
@@ -20,6 +20,33 @@ describe('ChatMarkdown', () => {
     expect(html).toContain('katex');
   });
 
+  test('renders single-dollar inline math', () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown text={'* $100,000 \\text{ LOC} \\approx 600,000 \\text{ tokens}$.'} />,
+    );
+
+    expect(html).toContain('katex');
+    expect(html).toContain('≈');
+    expect(html).not.toContain('$100,000 \\text{');
+    expect(html).not.toContain('katex-error');
+  });
+
+  test('renders escaped dollars inside single-dollar inline math', () => {
+    const html = renderToStaticMarkup(<ChatMarkdown text={'Cost: $\\$0.02 \\text{ per 1M tokens}$.'} />);
+
+    expect(html).toContain('katex');
+    expect(html).toContain('>$0.02<');
+    expect(html).not.toContain('katex-error');
+  });
+
+  test('renders math and currency in the same paragraph', () => {
+    const html = renderToStaticMarkup(<ChatMarkdown text={'Cursor charges $20/mo, we need $\\ge 95\\%$ margin.'} />);
+
+    expect(html).toContain('$20/mo');
+    expect(html).toContain('≥');
+    expect(html).not.toContain('katex-error');
+  });
+
   test('renders single-dollar LaTeX command spans', () => {
     const html = renderToStaticMarkup(<ChatMarkdown text={'Standard AI Routing Proxy $\\rightarrow$ NO-GO.'} />);
 
@@ -42,12 +69,5 @@ describe('ChatMarkdown', () => {
 
     expect(html).toContain('katex');
     expect(html).not.toContain('$\\rightarrow$');
-  });
-
-  test('leaves unsupported single-dollar LaTeX command spans as text', () => {
-    const html = renderToStaticMarkup(<ChatMarkdown text={'Unsupported $\\notarealcommand$ stays literal.'} />);
-
-    expect(html).toContain('$\\notarealcommand$');
-    expect(html).not.toContain('katex');
   });
 });

--- a/apps/web/src/components/chat/chat-markdown.tsx
+++ b/apps/web/src/components/chat/chat-markdown.tsx
@@ -25,6 +25,7 @@ import {
   createHighlightCacheKey,
   estimateHighlightedSize,
 } from '@/lib/code-highlighting';
+import { normalizeInlineMath } from '@/lib/normalize-inline-math';
 import { cn } from '@/lib/utils';
 import type { Components } from 'react-markdown';
 
@@ -38,7 +39,6 @@ interface MarkdownNode {
   type: string;
   value?: string;
   children?: MarkdownNode[];
-  data?: unknown;
 }
 
 interface MarkdownTextNode extends MarkdownNode {
@@ -46,14 +46,8 @@ interface MarkdownTextNode extends MarkdownNode {
   value: string;
 }
 
-interface SingleDollarLatexCommand {
-  math: string;
-  streamingText: string;
-}
-
-const SINGLE_DOLLAR_LATEX_COMMANDS: Record<string, SingleDollarLatexCommand> = {
-  rightarrow: { math: '\\rightarrow', streamingText: '\u2192' },
-};
+/** Plain-text stand-ins used while streaming, when KaTeX is skipped for performance. */
+const STREAMING_LATEX_TEXT: Record<string, string> = { rightarrow: '\u2192' };
 const LATEX_COMMAND_SPAN_REGEX = /\$\\{1,2}([a-zA-Z]+)\$/g;
 
 interface CodeBlockErrorBoundaryProps {
@@ -210,22 +204,7 @@ function extractCodeBlock(children: React.ReactNode): { className: string | unde
   return { className: onlyChild.props.className, code: nodeToPlainText(onlyChild.props.children) };
 }
 
-function createInlineMathNode(value: string): MarkdownNode {
-  return {
-    type: 'inlineMath',
-    value,
-    data: {
-      hName: 'code',
-      hProperties: { className: ['language-math', 'math-inline'] },
-      hChildren: [{ type: 'text', value }],
-    },
-  };
-}
-
-function splitLatexCommandSpans(
-  node: MarkdownTextNode,
-  createCommandNode: (command: SingleDollarLatexCommand) => MarkdownNode,
-): MarkdownNode[] {
+function splitLatexCommandSpans(node: MarkdownTextNode): MarkdownNode[] {
   const nodes: MarkdownNode[] = [];
   let lastIndex = 0;
 
@@ -233,14 +212,14 @@ function splitLatexCommandSpans(
     const index = match.index;
     if (index === undefined) continue;
 
-    const command = SINGLE_DOLLAR_LATEX_COMMANDS[match[1] ?? ''];
-    if (!command) continue;
+    const streamingText = STREAMING_LATEX_TEXT[match[1] ?? ''];
+    if (streamingText === undefined) continue;
 
     if (index > lastIndex) {
       nodes.push({ type: 'text', value: node.value.slice(lastIndex, index) });
     }
 
-    nodes.push(createCommandNode(command));
+    nodes.push({ type: 'text', value: streamingText });
     lastIndex = index + match[0].length;
   }
 
@@ -255,38 +234,21 @@ function splitLatexCommandSpans(
   return nodes;
 }
 
-function createSingleDollarLatexCommandTransformer(renderAsText: boolean) {
-  const createCommandNode = renderAsText
-    ? (command: SingleDollarLatexCommand): MarkdownNode => ({ type: 'text', value: command.streamingText })
-    : (command: SingleDollarLatexCommand): MarkdownNode => createInlineMathNode(command.math);
-
-  return function transform(tree: MarkdownNode) {
-    transformLatexCommandTextNodes(tree, createCommandNode);
-  };
-}
-
-function remarkSingleDollarLatexCommands() {
-  return createSingleDollarLatexCommandTransformer(false);
-}
-
 function remarkStreamingSingleDollarLatexCommands() {
-  return createSingleDollarLatexCommandTransformer(true);
+  return transformLatexCommandTextNodes;
 }
 
-function transformLatexCommandTextNodes(
-  node: MarkdownNode,
-  createCommandNode: (command: SingleDollarLatexCommand) => MarkdownNode,
-) {
+function transformLatexCommandTextNodes(node: MarkdownNode) {
   if (!node.children) return;
 
   const transformedChildren: MarkdownNode[] = [];
   for (const child of node.children) {
     if (child.type === 'text' && typeof child.value === 'string') {
-      transformedChildren.push(...splitLatexCommandSpans(child as MarkdownTextNode, createCommandNode));
+      transformedChildren.push(...splitLatexCommandSpans(child as MarkdownTextNode));
       continue;
     }
 
-    transformLatexCommandTextNodes(child, createCommandNode);
+    transformLatexCommandTextNodes(child);
     transformedChildren.push(child);
   }
 
@@ -371,14 +333,15 @@ function ChatMarkdown({ text, className, isStreaming = false }: ChatMarkdownProp
       typeof remarkMath,
       { singleDollarTextMath: false },
     ];
-    return [remarkGfm, remarkSingleDollarLatexCommands, remarkMathWithoutSingleDollar];
+    return [remarkGfm, remarkMathWithoutSingleDollar];
   }, [isStreaming]);
   const rehypePlugins = useMemo(() => (isStreaming ? [] : [rehypeKatex]), [isStreaming]);
+  const source = useMemo(() => (isStreaming ? text : normalizeInlineMath(text)), [text, isStreaming]);
 
   return (
     <div className={cn('prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed', className)}>
       <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins} components={markdownComponents}>
-        {text}
+        {source}
       </ReactMarkdown>
     </div>
   );

--- a/apps/web/src/lib/normalize-inline-math.test.ts
+++ b/apps/web/src/lib/normalize-inline-math.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+
+import { normalizeInlineMath } from './normalize-inline-math.js';
+
+describe('normalizeInlineMath', () => {
+  test('returns text without dollars untouched', () => {
+    expect(normalizeInlineMath('Plain **markdown** with `code`.')).toBe('Plain **markdown** with `code`.');
+  });
+
+  test('promotes spans containing LaTeX commands to double-dollar math', () => {
+    expect(normalizeInlineMath('$100,000 \\text{ LOC} \\approx 600,000 \\text{ tokens}$.')).toBe(
+      '$$100,000 \\text{ LOC} \\approx 600,000 \\text{ tokens}$$.',
+    );
+  });
+
+  test('keeps escaped dollars inside promoted math spans', () => {
+    expect(normalizeInlineMath('Cost: $\\$0.02 \\text{ per 1M tokens}$.')).toBe(
+      'Cost: $$\\$0.02 \\text{ per 1M tokens}$$.',
+    );
+  });
+
+  test('promotes spans whose only LaTeX signal is an escaped punctuation command', () => {
+    expect(normalizeInlineMath('Only $<2\\%$ of files change.')).toBe('Only $$<2\\%$$ of files change.');
+  });
+
+  test('promotes short bare formulas containing an operator', () => {
+    expect(normalizeInlineMath('where $k=60$ and $>1.5$ seconds')).toBe('where $$k=60$$ and $$>1.5$$ seconds');
+  });
+
+  test('escapes currency pairs that would otherwise look like a span', () => {
+    expect(normalizeInlineMath('Cursor charges $20/mo (Pro) or $40/mo.')).toBe(
+      'Cursor charges \\$20/mo (Pro) or \\$40/mo.',
+    );
+  });
+
+  test('escapes a lone dollar with no closing delimiter', () => {
+    expect(normalizeInlineMath('Total of $3.23 per user')).toBe('Total of \\$3.23 per user');
+  });
+
+  test('escapes spans padded with whitespace', () => {
+    expect(normalizeInlineMath('from $10 to $20 total')).toBe('from \\$10 to \\$20 total');
+  });
+
+  test('rejects spans that cross a line boundary', () => {
+    expect(normalizeInlineMath('| **$0 / month** |\n| **$29 / month** |')).toBe(
+      '| **\\$0 / month** |\n| **\\$29 / month** |',
+    );
+  });
+
+  test('rejects bare formulas longer than the short-span limit', () => {
+    const long = 'a=1 and the rest of this sentence is far too long to be a formula';
+    expect(normalizeInlineMath(`$${long}$`)).toBe(`\\$${long}\\$`);
+  });
+
+  test('leaves already-escaped dollars alone', () => {
+    expect(normalizeInlineMath('Costs \\$20 per seat.')).toBe('Costs \\$20 per seat.');
+  });
+
+  test('passes existing double-dollar math through unchanged', () => {
+    expect(normalizeInlineMath('Inline $$x + y$$ and block\n\n$$\na = b\n$$\n')).toBe(
+      'Inline $$x + y$$ and block\n\n$$\na = b\n$$\n',
+    );
+  });
+
+  test('escapes an unpaired double dollar', () => {
+    expect(normalizeInlineMath('Price is $$20')).toBe('Price is \\$\\$20');
+  });
+
+  test('ignores dollars inside inline code', () => {
+    expect(normalizeInlineMath('Run `echo $HOME` then $x=1$.')).toBe('Run `echo $HOME` then $$x=1$$.');
+  });
+
+  test('ignores dollars inside fenced code blocks', () => {
+    const input = '```sh\nexport A=$1\necho $PATH\n```\n\nCost $20.';
+    expect(normalizeInlineMath(input)).toBe('```sh\nexport A=$1\necho $PATH\n```\n\nCost \\$20.');
+  });
+
+  test('ignores dollars after an unterminated fence', () => {
+    expect(normalizeInlineMath('```sh\nexport A=$1 $2')).toBe('```sh\nexport A=$1 $2');
+  });
+
+  test('does not swallow the document on an unmatched single backtick', () => {
+    expect(normalizeInlineMath('a ` b $20 c')).toBe('a ` b \\$20 c');
+  });
+});

--- a/apps/web/src/lib/normalize-inline-math.ts
+++ b/apps/web/src/lib/normalize-inline-math.ts
@@ -1,0 +1,106 @@
+/**
+ * remark-math cannot tell `$...$` inline math from currency, and its single-dollar
+ * tokenizer treats `\$` as a delimiter instead of an escape — so `$\$0.02 \text{x}$`
+ * shatters. Deciding this after parsing is also impossible: markdown resolves escapes
+ * first, turning `RRF\_Score` into `RRF_Score` and destroying the LaTeX.
+ *
+ * So this pass runs on the raw markdown. Math-like spans become `$$...$$`, which
+ * remark-math parses as inline math (with `singleDollarTextMath: false`) and where
+ * `\$` survives. Every other dollar is escaped so it renders as literal text.
+ */
+
+const LATEX_COMMAND = /\\[a-zA-Z]{2,}|\\[%$&#_{}]|[\^_]\{/;
+const BARE_FORMULA_SHAPED = /^[A-Za-z0-9\s+\-*/=<>^_(){}[\].,;:!'"\\]+$/;
+const BARE_FORMULA_OPERATOR = /[=<>^_\\]|\d\s*[+*/]\s*\d/;
+const PADDED_CONTENT = /^\s|\s$/;
+
+const MAX_SPAN_LENGTH = 400;
+const MAX_BARE_FORMULA_LENGTH = 40;
+
+function isMathLike(content: string): boolean {
+  if (content === '' || content.includes('\n') || PADDED_CONTENT.test(content)) return false;
+  if (LATEX_COMMAND.test(content)) return true;
+  if (content.length > MAX_BARE_FORMULA_LENGTH) return false;
+  return BARE_FORMULA_SHAPED.test(content) && BARE_FORMULA_OPERATOR.test(content);
+}
+
+/** Index of the closing `$`, honouring `\$` escapes, or -1. */
+function findSpanEnd(markdown: string, openIndex: number): number {
+  const limit = Math.min(markdown.length, openIndex + MAX_SPAN_LENGTH + 2);
+  for (let i = openIndex + 1; i < limit; i++) {
+    const char = markdown[i];
+    if (char === '\\') {
+      i++;
+      continue;
+    }
+    if (char === '$') return i;
+  }
+  return -1;
+}
+
+/**
+ * A run of 3+ backticks is a code fence: skip to its close, or to the end of the
+ * document when it is still open (a streaming fence). Shorter unmatched runs are
+ * literal text in markdown, so they are left alone.
+ */
+function findCodeSpanEnd(markdown: string, startIndex: number): number {
+  let tickCount = 0;
+  while (markdown[startIndex + tickCount] === '`') tickCount++;
+
+  const fence = '`'.repeat(tickCount);
+  const closeIndex = markdown.indexOf(fence, startIndex + tickCount);
+  if (closeIndex !== -1) return closeIndex + tickCount;
+  return tickCount >= 3 ? markdown.length : startIndex + tickCount;
+}
+
+export function normalizeInlineMath(markdown: string): string {
+  if (!markdown.includes('$')) return markdown;
+
+  let out = '';
+  let index = 0;
+
+  while (index < markdown.length) {
+    const char = markdown[index];
+
+    if (char === '`') {
+      const end = findCodeSpanEnd(markdown, index);
+      out += markdown.slice(index, end);
+      index = end;
+      continue;
+    }
+
+    if (char === '\\' && markdown[index + 1] === '$') {
+      out += '\\$';
+      index += 2;
+      continue;
+    }
+
+    if (char !== '$') {
+      out += char;
+      index++;
+      continue;
+    }
+
+    if (markdown[index + 1] === '$') {
+      const closeIndex = markdown.indexOf('$$', index + 2);
+      if (closeIndex !== -1) {
+        out += markdown.slice(index, closeIndex + 2);
+        index = closeIndex + 2;
+        continue;
+      }
+    }
+
+    const spanEnd = findSpanEnd(markdown, index);
+    const content = spanEnd === -1 ? '' : markdown.slice(index + 1, spanEnd);
+    if (isMathLike(content)) {
+      out += `$$${content}$$`;
+      index = spanEnd + 1;
+      continue;
+    }
+
+    out += '\\$';
+    index++;
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Change Summary

Single-dollar inline math (`$...$`) from the LLM was rendering as literal text because the old approach ran after markdown escape resolution (destroying `\$`, `\_`, etc.) and allowlisted exactly one command (`\rightarrow`).

### What changed

- **New pre-parse normalizer** (`apps/web/src/lib/normalize-inline-math.ts`): runs on raw markdown before remark-math. Promotes math-like `$...$` to `$$...$$` (which parses as inlineMath with `singleDollarTextMath: false`) and escapes currency `$` to `\$` so it renders literally.
- **Classification heuristic**: LaTeX commands → math; short bare formulas with operators (`$k=60$`, `$>1.5$`) → math; everything else → currency. Skips inline code and fenced code blocks.
- Removed the `$\\rightarrow$` allowlist, `createInlineMathNode`, and the dual-mode transformer factory — no longer needed.

### Verification

- All 55 math spans from `ses_f95bb15020015si6W4qA73Gkli` render through KaTeX with zero errors
- 125 currency amounts (`$20/mo`, `$0.03`, etc.) preserved as text — zero false positives
- 17 unit tests + 3 new integration tests covering the full surface