### PR TITLE
fix(desktop): single persistent update toast with install action

### DIFF
--- a/apps/web/src/hooks/ui/use-updater-sync.tsx
+++ b/apps/web/src/hooks/ui/use-updater-sync.tsx
@@ -31,12 +31,13 @@ export function UpdaterSync() {
       setUpdaterState(payload);
       if (payload.status === previousStatus.current) return;
 
-      if (payload.status === 'available') {
-        toast.info(`Update available${payload.version ? `: v${payload.version}` : ''}`, { id: 'update-available' });
-      }
-
       if (payload.status === 'downloaded') {
-        toast.success('Update ready. Open Settings > General to restart and install.', { id: 'update-ready' });
+        toast.success(`Update ready${payload.version ? `: v${payload.version}` : ''}. Restart to install.`, {
+          id: 'update-ready',
+          duration: Infinity,
+          action: { label: 'Install & Restart', onClick: () => window.api?.updater?.install() },
+          cancel: { label: 'Not now', onClick: () => toast.dismiss('update-ready') },
+        });
       }
 
       if (payload.status === 'error') {


### PR DESCRIPTION
## 🚀 Change Summary

Updating the desktop app previously produced two toasts — an "Update available" notice followed by an "Update ready" notice that told you to go dig through Settings > General to actually install. This replaces both with a single persistent toast that appears once the update has downloaded and installs it directly from an action button.

### 🛠 Improvements & Refactors

- **Single update toast**: Removed the `available` status toast so only one notification fires, on `downloaded`.
- **Install from the toast**: The ready toast now has an "Install & Restart" action that calls the updater directly, plus a "Not now" dismiss, and persists (`duration: Infinity`) instead of auto-dismissing so it can't be missed.
- **Version in the message**: The downloaded toast now includes the version number.
