### PR TITLE
fix(realtime): recover stale SSE connections

### DIFF
--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -70,6 +70,9 @@ export async function createWindow(
       contextIsolation: true,
       nodeIntegration: false,
       webviewTag: true,
+      // The app lives in the tray with the window hidden; Chromium would
+      // otherwise throttle timers to 1/min, stalling the SSE reconnect watchdog.
+      backgroundThrottling: false,
     },
   });
 

--- a/apps/web/src/components/layout/server-status-state.test.ts
+++ b/apps/web/src/components/layout/server-status-state.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+
+import { formatEventBusSubtitle, toEventBusState, toServerState, worstState } from './server-status-state';
+
+describe('toServerState', () => {
+  it('stays pending before the first health result so launch does not flash red', () => {
+    expect(toServerState(undefined)).toBe('pending');
+  });
+
+  it('maps a known health result', () => {
+    expect(toServerState(true)).toBe('ok');
+    expect(toServerState(false)).toBe('down');
+  });
+});
+
+describe('toEventBusState', () => {
+  it('is only ok while connected', () => {
+    expect(toEventBusState('connected')).toBe('ok');
+    expect(toEventBusState('connecting')).toBe('pending');
+    expect(toEventBusState('reconnecting')).toBe('pending');
+  });
+});
+
+describe('worstState', () => {
+  it('prefers down over pending', () => {
+    expect(worstState('pending', 'down')).toBe('down');
+  });
+
+  it('prefers pending over ok', () => {
+    expect(worstState('ok', 'pending')).toBe('pending');
+  });
+
+  it('is ok only when every input is ok', () => {
+    expect(worstState('ok', 'ok')).toBe('ok');
+  });
+});
+
+describe('formatEventBusSubtitle', () => {
+  it('reports connecting before any heartbeat has arrived', () => {
+    expect(formatEventBusSubtitle('connecting', null)).toBe('Connecting');
+    expect(formatEventBusSubtitle('reconnecting', null)).toBe('Connecting');
+  });
+
+  it('distinguishes a healthy connection from a recovering one', () => {
+    const heartbeat = new Date(Date.now() - 30_000);
+    expect(formatEventBusSubtitle('connected', heartbeat)).toBe('Last heartbeat 30s ago');
+    expect(formatEventBusSubtitle('reconnecting', heartbeat)).toBe('Reconnecting; last heartbeat 30s ago');
+  });
+
+  it('flags a connected-but-silent stream', () => {
+    expect(formatEventBusSubtitle('connected', null)).toBe('Waiting for heartbeat');
+  });
+});

--- a/apps/web/src/components/layout/server-status-state.ts
+++ b/apps/web/src/components/layout/server-status-state.ts
@@ -1,0 +1,29 @@
+import type { SseConnectionStatus } from '@stitch/shared/realtime';
+
+import { formatTimeAgo } from '@/lib/format';
+
+/** `pending` covers "not yet known" and "recovering"; neither is a confirmed outage. */
+export type StatusState = 'ok' | 'pending' | 'down';
+
+export const STATE_COLOR = { ok: 'success', pending: 'warning', down: 'destructive' } as const;
+
+export function toServerState(isHealthy: boolean | undefined): StatusState {
+  if (isHealthy === undefined) return 'pending';
+  return isHealthy ? 'ok' : 'down';
+}
+
+export function toEventBusState(status: SseConnectionStatus): StatusState {
+  return status === 'connected' ? 'ok' : 'pending';
+}
+
+export function worstState(...states: StatusState[]): StatusState {
+  if (states.includes('down')) return 'down';
+  return states.includes('pending') ? 'pending' : 'ok';
+}
+
+export function formatEventBusSubtitle(status: SseConnectionStatus, lastHeartbeat: Date | null): string {
+  if (!lastHeartbeat) return status === 'connected' ? 'Waiting for heartbeat' : 'Connecting';
+
+  const age = formatTimeAgo(lastHeartbeat);
+  return status === 'connected' ? `Last heartbeat ${age}` : `Reconnecting; last heartbeat ${age}`;
+}

--- a/apps/web/src/components/layout/server-status.tsx
+++ b/apps/web/src/components/layout/server-status.tsx
@@ -4,12 +4,24 @@ import { useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 
+import {
+  formatEventBusSubtitle,
+  STATE_COLOR,
+  toEventBusState,
+  toServerState,
+  worstState,
+  type StatusState,
+} from './server-status-state';
+
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { StatusDot } from '@/components/ui/status-dot';
 import { useSSE } from '@/hooks/sse/sse-context';
 import { serverFetch, type ServerConnectionConfig } from '@/lib/api';
 
 type Tab = 'servers' | 'info';
+
+const HEALTH_POLL_INTERVAL_MS = 10_000;
+const HEALTH_TIMEOUT_MS = 5_000;
 
 function useServerConfig() {
   const [config, setConfig] = React.useState<ServerConnectionConfig | null>(null);
@@ -22,35 +34,54 @@ function useServerConfig() {
   return config;
 }
 
+/** Re-renders on an interval so relative timestamps keep counting up. */
+function useTicker(active: boolean) {
+  const [, setTick] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => setTick((tick) => tick + 1), 1_000);
+    return () => clearInterval(id);
+  }, [active]);
+}
+
 export function ServerStatus() {
   const [activeTab, setActiveTab] = useState<Tab>('servers');
+  const [isOpen, setIsOpen] = useState(false);
   const serverConfig = useServerConfig();
 
   const { data: isHealthy } = useQuery({
-    queryKey: ['health'],
+    queryKey: ['health', serverConfig?.url],
     queryFn: async () => {
-      const res = await serverFetch('/health');
-      return res.ok;
+      // Without a timeout a zombie server leaves this pending forever, and the
+      // poll never fires again because a request is still in flight.
+      const res = await serverFetch('/health', { signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS) }).catch(() => null);
+      return res?.ok ?? false;
     },
-    refetchInterval: 10_000,
+    refetchInterval: HEALTH_POLL_INTERVAL_MS,
+    refetchIntervalInBackground: true,
     retry: false,
   });
 
-  const { isConnected: isSseConnected, lastHeartbeat } = useSSE();
+  const { status: sseStatus, lastHeartbeat } = useSSE();
 
-  const overallHealthy = isHealthy && isSseConnected;
+  useTicker(isOpen);
+
+  const serverState = toServerState(isHealthy);
+  const eventBusState = toEventBusState(sseStatus);
+  const overallState = worstState(serverState, eventBusState);
 
   const serverLabel = serverConfig?.mode === 'remote' ? 'Remote Server' : 'Local Server';
   const serverSubtitle = serverConfig?.mode === 'remote' ? serverConfig.url : undefined;
 
   return (
-    <Popover>
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger
         className="relative flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-muted/50"
         aria-label="Server status">
         <HardDrive className="h-3.75 w-3.75 text-muted-foreground" />
         <StatusDot
-          color={overallHealthy ? 'success' : 'destructive'}
+          color={STATE_COLOR[overallState]}
           className="absolute top-1 right-1 border-[1.5px] border-background transition-colors"
         />
       </PopoverTrigger>
@@ -68,11 +99,11 @@ export function ServerStatus() {
         <div className="flex flex-col gap-4 bg-popover p-4">
           {activeTab === 'servers' ? (
             <>
-              <StatusItem active={!!isHealthy} label={serverLabel} subtitle={serverSubtitle} />
+              <StatusItem state={serverState} label={serverLabel} subtitle={serverSubtitle} />
               <StatusItem
-                active={isSseConnected}
+                state={eventBusState}
                 label="Event Bus"
-                subtitle={lastHeartbeat ? `Last heartbeat ${formatRelativeTime(lastHeartbeat)}` : undefined}
+                subtitle={formatEventBusSubtitle(sseStatus, lastHeartbeat)}
               />
             </>
           ) : (
@@ -84,28 +115,22 @@ export function ServerStatus() {
   );
 }
 
-type StatusItemProps = { active: boolean; label: string; subtitle?: string };
+type StatusItemProps = { state: StatusState; label: string; subtitle?: string };
 
-function StatusItem({ active, label, subtitle }: StatusItemProps) {
+function StatusItem({ state, label, subtitle }: StatusItemProps) {
+  const isOk = state === 'ok';
   return (
     <div className="flex cursor-default items-center justify-between">
       <div className="flex items-center gap-3">
-        <StatusDot color={active ? 'success' : 'destructive'} glow className="shrink-0" />
+        <StatusDot color={STATE_COLOR[state]} glow pulse={state === 'pending'} className="shrink-0" />
         <div className="flex flex-col gap-0.5">
-          <span className={`text-sm ${active ? 'font-medium text-foreground' : 'text-muted-foreground'}`}>{label}</span>
+          <span className={`text-sm ${isOk ? 'font-medium text-foreground' : 'text-muted-foreground'}`}>{label}</span>
           {subtitle && <span className="text-2xs text-muted-foreground">{subtitle}</span>}
         </div>
       </div>
-      {active && <Check className="h-3.5 w-3.5 text-muted-foreground" />}
+      {isOk && <Check className="h-3.5 w-3.5 text-muted-foreground" />}
     </div>
   );
-}
-
-function formatRelativeTime(date: Date): string {
-  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
-  if (seconds < 5) return 'just now';
-  if (seconds < 60) return `${seconds}s ago`;
-  return `${Math.floor(seconds / 60)}m ago`;
 }
 
 type TabButtonProps = { label: string; active: boolean; onClick: () => void };

--- a/apps/web/src/hooks/sse/sse-connection.test.ts
+++ b/apps/web/src/hooks/sse/sse-connection.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { createSseConnection, isIdle, retryDelay } from './sse-connection';
+
+class FakeEventSource {
+  static readonly CLOSED = 2;
+  static instances: FakeEventSource[] = [];
+
+  readonly listeners = new Map<string, (event: MessageEvent<string>) => void>();
+  readyState = 0;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(readonly url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(name: string, listener: EventListenerOrEventListenerObject): void {
+    this.listeners.set(name, listener as (event: MessageEvent<string>) => void);
+  }
+
+  close(): void {
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  emit(name: string, data: string): void {
+    this.listeners.get(name)?.({ data } as MessageEvent<string>);
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const OriginalEventSource = globalThis.EventSource;
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  globalThis.EventSource = FakeEventSource as unknown as typeof EventSource;
+});
+
+afterEach(() => {
+  globalThis.EventSource = OriginalEventSource;
+});
+
+describe('retryDelay', () => {
+  it('grows exponentially from the base delay', () => {
+    expect(retryDelay(0, () => 0)).toBe(500);
+    expect(retryDelay(1, () => 0)).toBe(1_000);
+    expect(retryDelay(2, () => 0)).toBe(2_000);
+  });
+
+  it('caps the delay so reconnects never stall indefinitely', () => {
+    expect(retryDelay(99, () => 1)).toBe(30_000);
+  });
+
+  it('applies jitter within the attempt window', () => {
+    expect(retryDelay(3, () => 0)).toBe(4_000);
+    expect(retryDelay(3, () => 1)).toBe(8_000);
+  });
+});
+
+describe('isIdle', () => {
+  it('tolerates a single dropped heartbeat', () => {
+    expect(isIdle(0, 30_000)).toBe(false);
+  });
+
+  it('reports idle once two heartbeat intervals have elapsed', () => {
+    expect(isIdle(0, 40_000)).toBe(true);
+  });
+});
+
+describe('createSseConnection', () => {
+  it('ignores an obsolete URL lookup after reconnecting', async () => {
+    const firstUrl = deferred<string>();
+    const secondUrl = deferred<string>();
+    let lookupCount = 0;
+    const connection = createSseConnection({
+      getUrl: () => (lookupCount++ === 0 ? firstUrl.promise : secondUrl.promise),
+      onEvent: () => {},
+      onStatus: () => {},
+    });
+
+    connection.reconnect();
+    secondUrl.resolve('http://current');
+    await flushPromises();
+    firstUrl.resolve('http://obsolete');
+    await flushPromises();
+
+    expect(FakeEventSource.instances.map(({ url }) => url)).toEqual(['http://current/events']);
+    connection.close();
+  });
+
+  it('ignores callbacks from a replaced EventSource', async () => {
+    const statuses: string[] = [];
+    const events: string[] = [];
+    const connection = createSseConnection({
+      getUrl: () => Promise.resolve('http://server'),
+      onEvent: (_name, raw) => events.push(raw),
+      onStatus: (status) => statuses.push(status),
+    });
+    await flushPromises();
+    const replaced = FakeEventSource.instances[0];
+
+    connection.reconnect();
+    await flushPromises();
+    replaced.onopen?.();
+    replaced.emit('heartbeat', '{"ts":1}');
+
+    expect(statuses).toEqual(['connecting']);
+    expect(events).toEqual([]);
+    connection.close();
+  });
+});

--- a/apps/web/src/hooks/sse/sse-connection.ts
+++ b/apps/web/src/hooks/sse/sse-connection.ts
@@ -1,0 +1,138 @@
+import { SSE_EVENT_NAMES, type SseConnectionStatus, type SseEventName } from '@stitch/shared/realtime';
+
+/** Slightly over two server heartbeat intervals (15s) to tolerate one dropped beat. */
+const IDLE_TIMEOUT_MS = 40_000;
+const WATCHDOG_INTERVAL_MS = 5_000;
+const BASE_RETRY_DELAY_MS = 1_000;
+const MAX_RETRY_DELAY_MS = 30_000;
+
+/** Exponential backoff with half jitter, capped. */
+export function retryDelay(attempt: number, random: () => number = Math.random): number {
+  const capped = Math.min(BASE_RETRY_DELAY_MS * 2 ** attempt, MAX_RETRY_DELAY_MS);
+  return Math.round(capped / 2 + random() * (capped / 2));
+}
+
+export function isIdle(lastMessageAt: number, now: number): boolean {
+  return now - lastMessageAt >= IDLE_TIMEOUT_MS;
+}
+
+type Options = {
+  getUrl: () => Promise<string>;
+  onEvent: (name: SseEventName, raw: string) => void;
+  onStatus: (status: SseConnectionStatus) => void;
+};
+
+export type SseConnection = {
+  /** Re-check liveness immediately instead of waiting for the next watchdog tick. */
+  poke: () => void;
+  /** Force a fresh connection, resetting backoff. */
+  reconnect: () => void;
+  close: () => void;
+};
+
+/**
+ * Owns the EventSource lifecycle.
+ *
+ * EventSource only auto-retries transient failures — it gives up permanently
+ * once `readyState` is CLOSED, and it never notices a half-open socket where
+ * the peer vanished without a TCP FIN. Both cases leave the app silently
+ * disconnected, so reconnection is driven explicitly here.
+ */
+export function createSseConnection({ getUrl, onEvent, onStatus }: Options): SseConnection {
+  let source: EventSource | null = null;
+  let attempt = 0;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastMessageAt = Date.now();
+  let generation = 0;
+  let closed = false;
+
+  const dropSource = () => {
+    source?.close();
+    source = null;
+  };
+
+  const scheduleRetry = () => {
+    if (closed || retryTimer) return;
+    generation += 1;
+    dropSource();
+    onStatus('reconnecting');
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      tryOpen();
+    }, retryDelay(attempt++));
+  };
+
+  const open = async (currentGeneration: number) => {
+    const baseUrl = await getUrl();
+    if (closed || currentGeneration !== generation) return;
+
+    const es = new EventSource(`${baseUrl}/events`);
+    source = es;
+
+    es.onopen = () => {
+      if (source !== es) return;
+      attempt = 0;
+      lastMessageAt = Date.now();
+      onStatus('connected');
+    };
+
+    es.onerror = () => {
+      // A stale source can still fire after it has been replaced; ignore it so
+      // it cannot mark a healthy connection as broken.
+      if (source !== es) return;
+
+      onStatus('reconnecting');
+      if (es.readyState !== EventSource.CLOSED) return;
+      scheduleRetry();
+    };
+
+    for (const name of SSE_EVENT_NAMES) {
+      es.addEventListener(name, (event) => {
+        if (source !== es) return;
+        lastMessageAt = Date.now();
+        onEvent(name, (event as MessageEvent<string>).data);
+      });
+    }
+  };
+
+  // A failed URL lookup must not leave the connection permanently dead.
+  const tryOpen = () => {
+    if (closed) return;
+    dropSource();
+    const currentGeneration = ++generation;
+    // Give the connect attempt itself a fresh idle window.
+    lastMessageAt = Date.now();
+    void open(currentGeneration).catch(() => {
+      if (currentGeneration === generation) scheduleRetry();
+    });
+  };
+
+  const poke = () => {
+    if (closed || retryTimer || !isIdle(lastMessageAt, Date.now())) return;
+    scheduleRetry();
+  };
+
+  const watchdog = setInterval(poke, WATCHDOG_INTERVAL_MS);
+
+  tryOpen();
+
+  return {
+    poke,
+    reconnect: () => {
+      if (closed) return;
+      attempt = 0;
+      if (retryTimer) clearTimeout(retryTimer);
+      retryTimer = null;
+      onStatus('connecting');
+      tryOpen();
+    },
+    close: () => {
+      closed = true;
+      generation += 1;
+      clearInterval(watchdog);
+      if (retryTimer) clearTimeout(retryTimer);
+      retryTimer = null;
+      dropSource();
+    },
+  };
+}

--- a/apps/web/src/hooks/sse/sse-context.tsx
+++ b/apps/web/src/hooks/sse/sse-context.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 
 import {
-  SSE_EVENT_NAMES,
+  type SseConnectionStatus,
   type SseEventName,
   type SseEventPayloadMap,
   type SseHandlers,
   type UseSseResult,
 } from '@stitch/shared/realtime';
+
+import { createSseConnection } from './sse-connection';
 
 type SessionScopedName = {
   [K in SseEventName]: SseEventPayloadMap[K] extends { sessionId: string }
@@ -23,7 +25,7 @@ type RecordingScopedName = {
 }[SseEventName];
 
 type SseContextValue = {
-  isConnected: boolean;
+  status: SseConnectionStatus;
   lastHeartbeat: Date | null;
   subscribe: (handlers: SseHandlers) => () => void;
 };
@@ -36,21 +38,6 @@ function parseJson(raw: string): unknown {
   } catch {
     return raw;
   }
-}
-
-// Heartbeat uses runtime fallback to Date.now() for connection health monitoring
-function parseEventData<K extends SseEventName>(eventName: K, raw: string): SseEventPayloadMap[K] {
-  if (eventName === 'heartbeat') {
-    const parsed = parseJson(raw);
-
-    if (typeof parsed === 'object' && parsed && 'ts' in parsed && typeof parsed.ts === 'number') {
-      return { ts: parsed.ts } as SseEventPayloadMap[K];
-    }
-
-    return { ts: Date.now() } as SseEventPayloadMap[K];
-  }
-
-  return parseJson(raw) as SseEventPayloadMap[K];
 }
 
 type AnyHandler = (data: never) => void;
@@ -98,68 +85,45 @@ function getRecordingIdFromPayload(eventName: SseEventName, payload: unknown): s
 }
 
 export function SseProvider({ children }: { children: React.ReactNode }) {
-  const [isConnected, setIsConnected] = React.useState(false);
+  const [status, setStatus] = React.useState<SseConnectionStatus>('connecting');
   const [lastHeartbeat, setLastHeartbeat] = React.useState<Date | null>(null);
-  const [connectionVersion, setConnectionVersion] = React.useState(0);
 
   // Map from event name → set of handlers so multiple subscribers can coexist per event.
   const handlersRef = React.useRef<Map<SseEventName, Set<AnyHandler>>>(new Map());
 
   React.useEffect(() => {
-    const reconnect = () => setConnectionVersion((version) => version + 1);
+    const connection = createSseConnection({
+      getUrl: async () => {
+        const { getServerUrl } = await import('@/lib/api');
+        return getServerUrl();
+      },
+      onStatus: setStatus,
+      onEvent: (eventName, raw) => {
+        // Stamped on arrival rather than from the server's `ts`, so the value stays
+        // meaningful for remote servers whose clock is skewed from the client's.
+        if (eventName === 'heartbeat') setLastHeartbeat(new Date());
+
+        const payload = parseJson(raw) as never;
+        handlersRef.current.get(eventName)?.forEach((handler) => handler(payload));
+      },
+    });
+
+    // On wake or network recovery, re-check liveness immediately instead of
+    // waiting for the next watchdog tick.
+    const poke = () => connection.poke();
+    const reconnect = () => connection.reconnect();
+
+    document.addEventListener('visibilitychange', poke);
+    window.addEventListener('online', poke);
     window.addEventListener('server-config-changed', reconnect);
-    return () => window.removeEventListener('server-config-changed', reconnect);
-  }, []);
-
-  React.useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        setConnectionVersion((version) => version + 1);
-      }
-    };
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
-  }, []);
-
-  React.useEffect(() => {
-    let eventSource: EventSource | null = null;
-    let cancelled = false;
-
-    const initEventSource = async () => {
-      const { getServerUrl } = await import('@/lib/api');
-      const baseUrl = await getServerUrl();
-
-      if (cancelled) return;
-
-      eventSource = new EventSource(`${baseUrl}/events`);
-
-      eventSource.onopen = () => setIsConnected(true);
-      eventSource.onerror = () => setIsConnected(false);
-
-      SSE_EVENT_NAMES.forEach((eventName) => {
-        eventSource!.addEventListener(eventName, (e) => {
-          if (eventName === 'heartbeat') {
-            const payload = parseEventData('heartbeat', e.data);
-            setLastHeartbeat(new Date(payload.ts));
-            handlersRef.current.get('heartbeat')?.forEach((h) => h(payload as never));
-            return;
-          }
-
-          const payload = parseEventData(eventName, e.data);
-          const castedPayload = payload as never;
-          handlersRef.current.get(eventName)?.forEach((h) => h(castedPayload));
-        });
-      });
-    };
-
-    void initEventSource();
 
     return () => {
-      cancelled = true;
-      eventSource?.close();
-      setIsConnected(false);
+      document.removeEventListener('visibilitychange', poke);
+      window.removeEventListener('online', poke);
+      window.removeEventListener('server-config-changed', reconnect);
+      connection.close();
     };
-  }, [connectionVersion]);
+  }, []);
 
   const subscribe = React.useCallback((handlers: SseHandlers) => {
     const entries = Object.entries(handlers) as [SseEventName, AnyHandler][];
@@ -178,7 +142,7 @@ export function SseProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  return <SseContext.Provider value={{ isConnected, lastHeartbeat, subscribe }}>{children}</SseContext.Provider>;
+  return <SseContext.Provider value={{ status, lastHeartbeat, subscribe }}>{children}</SseContext.Provider>;
 }
 
 function useSseContext(): SseContextValue {
@@ -190,7 +154,7 @@ function useSseContext(): SseContextValue {
 }
 
 export function useSSE(handlers: SseHandlers = {}): UseSseResult {
-  const { isConnected, lastHeartbeat, subscribe } = useSseContext();
+  const { status, lastHeartbeat, subscribe } = useSseContext();
 
   // Stable ref so the subscribe effect only runs once per mount, not on every render.
   const handlersRef = React.useRef(handlers);
@@ -215,7 +179,7 @@ export function useSSE(handlers: SseHandlers = {}): UseSseResult {
     return subscribe(stableHandlers);
   }, [subscribe, eventNames]);
 
-  return { isConnected, lastHeartbeat };
+  return { status, lastHeartbeat };
 }
 
 export function useSessionEvents(

--- a/apps/web/src/lib/format.test.ts
+++ b/apps/web/src/lib/format.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test';
+
+import { formatTimeAgo } from './format';
+
+describe('formatTimeAgo', () => {
+  const now = new Date('2026-01-01T12:00:00Z').getTime();
+  const ago = (ms: number) => formatTimeAgo(new Date(now - ms), now);
+
+  it('collapses the first few seconds', () => {
+    expect(ago(0)).toBe('just now');
+    expect(ago(4_400)).toBe('just now');
+  });
+
+  it('clamps future timestamps caused by server clock skew', () => {
+    expect(formatTimeAgo(new Date(now + 60_000), now)).toBe('just now');
+  });
+
+  it('scales through every unit', () => {
+    expect(ago(30_000)).toBe('30s ago');
+    expect(ago(90_000)).toBe('1m ago');
+    expect(ago(2 * 3_600_000)).toBe('2h ago');
+    expect(ago(3 * 86_400_000)).toBe('3d ago');
+  });
+});

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -5,3 +5,13 @@ export function formatDateTime(value: number): string {
 export function formatDate(value: number | string): string {
   return new Date(value).toLocaleDateString();
 }
+
+/** Clamps at zero so clock skew between a remote server and the client cannot render a negative age. */
+export function formatTimeAgo(value: Date, now: number = Date.now()): string {
+  const seconds = Math.max(0, Math.round((now - value.getTime()) / 1_000));
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3_600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3_600)}h ago`;
+  return `${Math.floor(seconds / 86_400)}d ago`;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,6 +2,7 @@ import { serve } from '@hono/node-server';
 import { createNodeWebSocket } from '@hono/node-ws';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
+import { Server as HttpServer } from 'node:http';
 
 import { init } from '@/init.js';
 import * as Log from '@/lib/log.js';
@@ -30,6 +31,8 @@ import { usageRouter } from '@/routes/usage.js';
 import { registerShutdownHandlers } from '@/shutdown.js';
 import { initSttAdapters } from '@/stt/init.js';
 import { createSttRouter } from '@/stt/route.js';
+
+const SOCKET_KEEPALIVE_DELAY_MS = 15_000;
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -87,4 +90,15 @@ await init();
 const server = serve({ fetch: app.fetch, port, hostname }, (info) => {
   log.info({ address: info.address, port: info.port }, 'server ready');
 });
+
+if (server instanceof HttpServer) {
+  // Long-lived SSE streams sit idle between events, so a peer that vanishes
+  // without a TCP FIN (sleep, network switch) would otherwise linger for the OS
+  // default (2h on Windows). Socket keepalive makes the kernel reap it, which
+  // closes the response and lets the SSE adapter drop the connection.
+  server.on('connection', (socket) => {
+    socket.setKeepAlive(true, SOCKET_KEEPALIVE_DELAY_MS);
+  });
+}
+
 nodeWebSocket.injectWebSocket(server);

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -4,8 +4,8 @@ import { streamSSE } from 'hono/streaming';
 import { registerSseConnection, unregisterSseConnection } from '@/adapters/sse.js';
 import * as Log from '@/lib/log.js';
 
-const HEARTBEAT_INTERVAL_MS = 30_000;
-const RECONNECT_DELAY_MS = 10_000;
+const HEARTBEAT_INTERVAL_MS = 15_000;
+const RECONNECT_DELAY_MS = 2_000;
 
 export const eventsRouter = new Hono();
 const log = Log.create({ service: 'events' });

--- a/packages/shared/src/realtime.ts
+++ b/packages/shared/src/realtime.ts
@@ -49,4 +49,5 @@ export type SseHandlers = {
   [K in SseEventName]?: (data: SseEventPayloadMap[K]) => void;
 };
 
-export type UseSseResult = { isConnected: boolean; lastHeartbeat: Date | null };
+export type SseConnectionStatus = 'connecting' | 'connected' | 'reconnecting';
+export type UseSseResult = { status: SseConnectionStatus; lastHeartbeat: Date | null };


### PR DESCRIPTION
## Change Summary

Improves realtime reliability by detecting silent SSE connections, recovering with bounded backoff, and exposing clear connection health throughout the desktop and web UI.

### Improvements

- Adds an explicit EventSource lifecycle with idle detection, jittered retries, stale-attempt protection, and wake/network recovery.
- Keeps desktop timers active while the window is hidden and configures server TCP keepalive for long-lived streams.
- Adds pending, connected, and reconnecting status presentation with continuously updated heartbeat age.

### Bug Fixes

- Prevents overlapping URL lookups and callbacks from replaced EventSource instances from corrupting connection state.
- Bounds health probes and treats failed probes as unhealthy instead of retaining stale healthy data.
- Handles client/server clock skew in relative heartbeat timestamps.
