### PR TITLE
refactor(web): render highlighted code from HAST instead of HTML strings

### DIFF
--- a/apps/desktop/src/main/browser/downloads.ts
+++ b/apps/desktop/src/main/browser/downloads.ts
@@ -10,7 +10,7 @@ export class DownloadTracker {
   constructor(private readonly broadcast: () => void) {}
 
   list(): ElectronBrowserDownload[] {
-    return Array.from(this.downloads.values()).sort((a, b) => b.createdAt - a.createdAt);
+    return Array.from(this.downloads.values()).toSorted((a, b) => b.createdAt - a.createdAt);
   }
 
   handleDownload(item: Electron.DownloadItem): void {

--- a/apps/desktop/src/main/browser/session-store.ts
+++ b/apps/desktop/src/main/browser/session-store.ts
@@ -147,10 +147,10 @@ export class SessionStore {
       return undefined;
     }
 
-    const remaining = Array.from(this.tabs.keys());
-    if (remaining.length > 0) {
-      this.activeTabId = remaining[remaining.length - 1]!;
-      const next = this.tabs.get(this.activeTabId)!;
+    const remaining = Array.from(this.tabs.values());
+    const next = remaining[remaining.length - 1];
+    if (next) {
+      this.activeTabId = next.id;
       this.broadcast();
       this.debouncedPersist();
       return next;

--- a/apps/desktop/src/main/ipc/server.ts
+++ b/apps/desktop/src/main/ipc/server.ts
@@ -37,9 +37,10 @@ export function registerServerHandlers(
 
   registerIpcHandler('server:set-config', async (_event, config): Promise<ServerConfigPayload> => {
     let nextConfig: ServerConnectionConfig;
+    let remoteUrl: string | null = null;
 
     if (config.mode === 'remote') {
-      const remoteUrl = normalizeRemoteUrl(config.remoteUrl ?? '');
+      remoteUrl = normalizeRemoteUrl(config.remoteUrl ?? '');
       if (!(await checkHealth(remoteUrl))) {
         throw new Error('Remote server health check failed');
       }
@@ -51,7 +52,7 @@ export function registerServerHandlers(
     await stopRecordingCapture().catch(() => null);
     await killServer();
 
-    const nextUrl = nextConfig.mode === 'remote' ? nextConfig.remoteUrl! : await startLocalServer();
+    const nextUrl = remoteUrl ?? (await startLocalServer());
 
     state.serverUrl = nextUrl;
     state.serverConnectionConfig = nextConfig;

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -183,8 +183,10 @@ async function spawnServerOnce(port: number, extraEnv: NodeJS.ProcessEnv): Promi
     console.error(`[sidecar:stderr] ${text.trim()}`);
   });
 
+  const proc = serverProcess;
+
   const exitPromise = new Promise<never>((_resolve, reject) => {
-    serverProcess!.on('exit', (code, signal) => {
+    proc.on('exit', (code, signal) => {
       const tail = logTail.trim();
       const details = tail ? `\n\nServer output:\n${tail}` : ' (no output captured)';
       const error = new Error(`Server exited before becoming healthy (code=${code}, signal=${signal})${details}`);
@@ -193,7 +195,7 @@ async function spawnServerOnce(port: number, extraEnv: NodeJS.ProcessEnv): Promi
       }
       reject(error);
     });
-    serverProcess!.on('error', (err) => {
+    proc.on('error', (err) => {
       reject(new Error(`Failed to spawn server: ${err.message}`));
     });
   });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "cmdk": "^1.1.1",
     "cnfast": "^0.0.7",
     "date-fns": "^4.1.0",
+    "hast-util-to-jsx-runtime": "^2.3.6",
     "katex": "^0.16.38",
     "lucide-react": "^0.577.0",
     "react": "19.2.4",

--- a/apps/web/src/components/chat/chat-markdown.tsx
+++ b/apps/web/src/components/chat/chat-markdown.tsx
@@ -1,3 +1,4 @@
+import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
 import { CheckIcon, CopyIcon } from 'lucide-react';
 import * as React from 'react';
 import {
@@ -13,12 +14,14 @@ import {
   memo,
 } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime';
 import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 
 import {
   getHighlighterPromise,
+  type HighlightedCodeHast,
   type SupportedLanguage,
   normalizeLanguage,
   highlightedCodeCache,
@@ -27,7 +30,11 @@ import {
 } from '@/lib/code-highlighting';
 import { normalizeInlineMath } from '@/lib/normalize-inline-math';
 import { cn } from '@/lib/utils';
-import type { Components } from 'react-markdown';
+import type { Components, ExtraProps } from 'react-markdown';
+
+const JSX_RUNTIME = { Fragment, jsx, jsxs };
+
+type MarkdownPreProps = React.ComponentProps<'pre'> & ExtraProps;
 
 interface ChatMarkdownProps {
   text: string;
@@ -129,22 +136,21 @@ interface SuspenseShikiCodeBlockProps {
 function SuspenseShikiCodeBlock({ className, code, isStreaming }: SuspenseShikiCodeBlockProps) {
   const language = extractFenceLanguage(className);
   const cacheKey = createHighlightCacheKey(code, language, 'dual');
-  const cachedHighlightedHtml = !isStreaming ? (highlightedCodeCache.get(cacheKey) ?? null) : null;
+  const cachedHighlightedHast = !isStreaming ? (highlightedCodeCache.get(cacheKey) ?? null) : null;
 
-  if (cachedHighlightedHtml !== null) {
+  if (cachedHighlightedHast !== null) {
     return (
-      <div
-        className="chat-markdown-shiki overflow-x-auto rounded-lg bg-muted/50 p-3 text-sm"
-        dangerouslySetInnerHTML={{ __html: cachedHighlightedHtml }}
-      />
+      <div className="chat-markdown-shiki overflow-x-auto rounded-lg bg-muted/50 p-3 text-sm">
+        {toJsxRuntime(cachedHighlightedHast, JSX_RUNTIME)}
+      </div>
     );
   }
 
   const highlighter = use(getHighlighterPromise(language));
 
-  let highlightedHtml: string;
+  let highlightedHast: HighlightedCodeHast;
   try {
-    highlightedHtml = highlighter.codeToHtml(code, {
+    highlightedHast = highlighter.codeToHast(code, {
       lang: language as SupportedLanguage,
       themes: { light: 'github-light', dark: 'github-dark' },
     });
@@ -153,21 +159,20 @@ function SuspenseShikiCodeBlock({ className, code, isStreaming }: SuspenseShikiC
       `Code highlighting failed for language "${language}", falling back to plain text.`,
       error instanceof Error ? error.message : error,
     );
-    highlightedHtml = highlighter.codeToHtml(code, {
+    highlightedHast = highlighter.codeToHast(code, {
       lang: 'text',
       themes: { light: 'github-light', dark: 'github-dark' },
     });
   }
 
   if (!isStreaming) {
-    highlightedCodeCache.set(cacheKey, highlightedHtml, estimateHighlightedSize(highlightedHtml, code));
+    highlightedCodeCache.set(cacheKey, highlightedHast, estimateHighlightedSize(highlightedHast, code));
   }
 
   return (
-    <div
-      className="chat-markdown-shiki overflow-x-auto rounded-lg bg-muted/50 p-3 text-sm"
-      dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-    />
+    <div className="chat-markdown-shiki overflow-x-auto rounded-lg bg-muted/50 p-3 text-sm">
+      {toJsxRuntime(highlightedHast, JSX_RUNTIME)}
+    </div>
   );
 }
 
@@ -278,7 +283,7 @@ function MarkdownAnchor({ href, children, ...props }: React.AnchorHTMLAttributes
   );
 }
 
-function MarkdownImage(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+function MarkdownImage({ alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) {
   const [broken, setBroken] = useState(false);
 
   if (broken) {
@@ -289,41 +294,45 @@ function MarkdownImage(props: React.ImgHTMLAttributes<HTMLImageElement>) {
     );
   }
 
-  return <img {...props} onError={() => setBroken(true)} />;
+  return <img {...props} alt={alt ?? ''} onError={() => setBroken(true)} />;
 }
 
+/** Plain `pre` used while streaming — Shiki highlighting is too expensive per token. */
+function StreamingMarkdownPre({ node: _node, children, ...props }: MarkdownPreProps) {
+  const codeBlock = extractCodeBlock(children);
+  if (!codeBlock) {
+    return <pre {...props}>{children}</pre>;
+  }
+
+  return (
+    <MarkdownCodeBlock code={codeBlock.code}>
+      <pre {...props}>{children}</pre>
+    </MarkdownCodeBlock>
+  );
+}
+
+function HighlightedMarkdownPre({ node: _node, children, ...props }: MarkdownPreProps) {
+  const codeBlock = extractCodeBlock(children);
+  if (!codeBlock) {
+    return <pre {...props}>{children}</pre>;
+  }
+
+  return (
+    <MarkdownCodeBlock code={codeBlock.code}>
+      <CodeBlockErrorBoundary fallback={<pre {...props}>{children}</pre>}>
+        <Suspense fallback={<pre {...props}>{children}</pre>}>
+          <SuspenseShikiCodeBlock className={codeBlock.className} code={codeBlock.code} isStreaming={false} />
+        </Suspense>
+      </CodeBlockErrorBoundary>
+    </MarkdownCodeBlock>
+  );
+}
+
+const STREAMING_COMPONENTS: Components = { img: MarkdownImage, a: MarkdownAnchor, pre: StreamingMarkdownPre };
+const HIGHLIGHTED_COMPONENTS: Components = { img: MarkdownImage, a: MarkdownAnchor, pre: HighlightedMarkdownPre };
+
 function ChatMarkdown({ text, className, isStreaming = false }: ChatMarkdownProps) {
-  const markdownComponents = useMemo<Components>(() => {
-    return {
-      img: MarkdownImage,
-      a: MarkdownAnchor,
-      pre({ node: _node, children, ...props }) {
-        const codeBlock = extractCodeBlock(children);
-        if (!codeBlock) {
-          return <pre {...props}>{children}</pre>;
-        }
-
-        // During streaming: skip Shiki (expensive async highlighting) — plain pre
-        if (isStreaming) {
-          return (
-            <MarkdownCodeBlock code={codeBlock.code}>
-              <pre {...props}>{children}</pre>
-            </MarkdownCodeBlock>
-          );
-        }
-
-        return (
-          <MarkdownCodeBlock code={codeBlock.code}>
-            <CodeBlockErrorBoundary fallback={<pre {...props}>{children}</pre>}>
-              <Suspense fallback={<pre {...props}>{children}</pre>}>
-                <SuspenseShikiCodeBlock className={codeBlock.className} code={codeBlock.code} isStreaming={false} />
-              </Suspense>
-            </CodeBlockErrorBoundary>
-          </MarkdownCodeBlock>
-        );
-      },
-    };
-  }, [isStreaming]);
+  const markdownComponents = isStreaming ? STREAMING_COMPONENTS : HIGHLIGHTED_COMPONENTS;
 
   // During streaming: use remarkGfm only — skip remark-math + rehype-katex (heavy)
   const remarkPlugins = useMemo(() => {

--- a/apps/web/src/lib/code-highlighting.ts
+++ b/apps/web/src/lib/code-highlighting.ts
@@ -1,4 +1,6 @@
-import type { BundledLanguage } from 'shiki';
+import type { BundledLanguage, Highlighter } from 'shiki';
+
+export type HighlightedCodeHast = ReturnType<Highlighter['codeToHast']>;
 
 interface LRUEntry<T> {
   value: T;
@@ -49,7 +51,10 @@ class LRUCache<T> {
 const MAX_HIGHLIGHT_CACHE_ENTRIES = 500;
 const MAX_HIGHLIGHT_CACHE_MEMORY_BYTES = 50 * 1024 * 1024;
 
-const _highlightedCodeCache = new LRUCache<string>(MAX_HIGHLIGHT_CACHE_ENTRIES, MAX_HIGHLIGHT_CACHE_MEMORY_BYTES);
+const _highlightedCodeCache = new LRUCache<HighlightedCodeHast>(
+  MAX_HIGHLIGHT_CACHE_ENTRIES,
+  MAX_HIGHLIGHT_CACHE_MEMORY_BYTES,
+);
 
 export const highlightedCodeCache = _highlightedCodeCache;
 
@@ -63,8 +68,8 @@ export function createHighlightCacheKey(code: string, language: string, themeNam
   return `${Math.abs(hash).toString(36)}:${code.length}:${language}:${themeName}`;
 }
 
-export function estimateHighlightedSize(html: string, code: string): number {
-  return Math.max(html.length * 2, code.length * 3);
+export function estimateHighlightedSize(hast: HighlightedCodeHast, code: string): number {
+  return Math.max(JSON.stringify(hast).length * 2, code.length * 3);
 }
 
 export type SupportedLanguage = BundledLanguage | 'text';

--- a/apps/website/src/main.ts
+++ b/apps/website/src/main.ts
@@ -39,7 +39,10 @@ document.addEventListener('click', (e: MouseEvent) => {
     document.documentElement.setAttribute('data-theme', stored);
   }
 
-  document.getElementById('theme-toggle')!.addEventListener('click', () => {
+  const themeToggle = document.getElementById('theme-toggle');
+  if (!themeToggle) throw new Error('Theme toggle element #theme-toggle not found');
+
+  themeToggle.addEventListener('click', () => {
     const current = document.documentElement.getAttribute('data-theme');
     let isLight: boolean;
 
@@ -58,10 +61,12 @@ document.addEventListener('click', (e: MouseEvent) => {
 // Waitlist dialog
 (() => {
   const dialog = document.getElementById('waitlist-dialog') as HTMLDialogElement;
-  const openBtn = document.getElementById('open-waitlist-dialog')!;
-  const closeBtn = document.getElementById('close-waitlist-dialog')!;
+  const openBtn = document.getElementById('open-waitlist-dialog');
+  const closeBtn = document.getElementById('close-waitlist-dialog');
   const form = document.getElementById('waitlist-form') as HTMLFormElement;
-  const successMsg = document.getElementById('waitlist-success')!;
+  const successMsg = document.getElementById('waitlist-success');
+
+  if (!openBtn || !closeBtn || !successMsg) throw new Error('Waitlist dialog elements not found');
 
   openBtn.addEventListener('click', () => {
     dialog.showModal();

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "@stitch/desktop",
-      "version": "0.7.1",
+      "version": "0.7.3",
       "dependencies": {
         "@stitch/audio-capture": "workspace:*",
         "@stitch/meeting-detection": "workspace:*",
@@ -38,7 +38,7 @@
     },
     "apps/web": {
       "name": "@stitch/web",
-      "version": "0.7.1",
+      "version": "0.7.3",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@stitch/scheduler": "workspace:*",
@@ -53,6 +53,7 @@
         "cmdk": "^1.1.1",
         "cnfast": "^0.0.7",
         "date-fns": "^4.1.0",
+        "hast-util-to-jsx-runtime": "^2.3.6",
         "katex": "^0.16.38",
         "lucide-react": "^0.577.0",
         "react": "19.2.4",

--- a/connectors/sdk/src/upgrade.ts
+++ b/connectors/sdk/src/upgrade.ts
@@ -3,7 +3,7 @@ import type { ConnectorUpgradeAction, ConnectorVersion } from '@stitch/shared/co
 import type { ConnectorDefinitionInput, ConnectorUpgradeState } from './types.js';
 
 function getSortedVersions(definition: ConnectorDefinitionInput): ConnectorVersion[] {
-  return [...definition.versionHistory].sort((a, b) => a.version - b.version);
+  return [...definition.versionHistory].toSorted((a, b) => a.version - b.version);
 }
 
 export function getCapabilitiesForVersion(definition: ConnectorDefinitionInput, appliedVersion: number): string[] {

--- a/packages/mail/src/db/queries.ts
+++ b/packages/mail/src/db/queries.ts
@@ -1,5 +1,16 @@
 import { and, asc, count, desc, eq, inArray, lt, or, sql } from 'drizzle-orm';
 
+import type {
+  MailAccountView,
+  MailAddressView,
+  MailAttachmentView,
+  MailDraftView,
+  MailLabelView,
+  MailMessageView,
+  MailThreadDetail,
+  MailThreadListItem,
+} from '@stitch/shared/mail/types';
+
 import { getMailDb, type MailDb } from './client.js';
 import {
   mailAccounts,
@@ -16,16 +27,6 @@ import {
   type MailMessageId,
   type MailThreadId,
 } from './schema.js';
-import type {
-  MailAccountView,
-  MailAddressView,
-  MailAttachmentView,
-  MailDraftView,
-  MailLabelView,
-  MailMessageView,
-  MailThreadDetail,
-  MailThreadListItem,
-} from '@stitch/shared/mail/types';
 
 type ListThreadsOptions = {
   accountId: MailAccountId;
@@ -116,7 +117,10 @@ async function labelsForThreads(db: MailDb, threadIds: MailThreadId[]): Promise<
   return labelsByThread;
 }
 
-async function sendersForThreads(db: MailDb, threadIds: MailThreadId[]): Promise<Map<MailThreadId, MailAddressView | null>> {
+async function sendersForThreads(
+  db: MailDb,
+  threadIds: MailThreadId[],
+): Promise<Map<MailThreadId, MailAddressView | null>> {
   const sendersByThread = new Map<MailThreadId, MailAddressView | null>();
   if (threadIds.length === 0) return sendersByThread;
 
@@ -139,12 +143,17 @@ export async function listThreads(options: ListThreadsOptions): Promise<ListThre
   const db = dbOrDefault(options.db);
   const limit = Math.min(Math.max(options.limit ?? 50, 1), 100);
   const cursor = parseThreadCursor(options.cursor);
-  const conditions = [eq(mailThreads.accountId, options.accountId), eq(mailThreads.isTrashed, options.isTrashed ?? false)];
+  const conditions = [
+    eq(mailThreads.accountId, options.accountId),
+    eq(mailThreads.isTrashed, options.isTrashed ?? false),
+  ];
 
   if (cursor) {
-    conditions.push(
-      or(lt(mailThreads.lastMessageAt, cursor.lastMessageAt), and(eq(mailThreads.lastMessageAt, cursor.lastMessageAt), lt(mailThreads.id, cursor.id)))!,
+    const cursorCondition = or(
+      lt(mailThreads.lastMessageAt, cursor.lastMessageAt),
+      and(eq(mailThreads.lastMessageAt, cursor.lastMessageAt), lt(mailThreads.id, cursor.id)),
     );
+    if (cursorCondition) conditions.push(cursorCondition);
   }
 
   if (options.labelId) {
@@ -170,7 +179,11 @@ export async function listThreads(options: ListThreadsOptions): Promise<ListThre
   ]);
 
   return {
-    threads: pageRows.map((thread) => ({ ...thread, from: sendersByThread.get(thread.id) ?? null, labels: labelsByThread.get(thread.id) ?? [] })),
+    threads: pageRows.map((thread) => ({
+      ...thread,
+      from: sendersByThread.get(thread.id) ?? null,
+      labels: labelsByThread.get(thread.id) ?? [],
+    })),
     nextCursor: rows.length > limit ? encodeThreadCursor(pageRows[pageRows.length - 1]) : null,
   };
 }
@@ -180,7 +193,11 @@ export async function getThread(threadId: MailThreadId, dbOption?: MailDb): Prom
   const [thread] = await db.select().from(mailThreads).where(eq(mailThreads.id, threadId)).limit(1);
   if (!thread) return null;
 
-  const messages = await db.select().from(mailMessages).where(eq(mailMessages.threadId, threadId)).orderBy(asc(mailMessages.internalDate));
+  const messages = await db
+    .select()
+    .from(mailMessages)
+    .where(eq(mailMessages.threadId, threadId))
+    .orderBy(asc(mailMessages.internalDate));
   const messageIds = messages.map((message) => message.id);
   const labelRows =
     messageIds.length === 0
@@ -190,14 +207,21 @@ export async function getThread(threadId: MailThreadId, dbOption?: MailDb): Prom
           .from(mailMessageLabels)
           .innerJoin(mailLabels, eq(mailLabels.id, mailMessageLabels.labelId))
           .where(inArray(mailMessageLabels.messageId, messageIds));
-  const attachmentRows = messageIds.length === 0 ? [] : await db.select().from(mailAttachments).where(inArray(mailAttachments.messageId, messageIds));
+  const attachmentRows =
+    messageIds.length === 0
+      ? []
+      : await db.select().from(mailAttachments).where(inArray(mailAttachments.messageId, messageIds));
 
   const labelsByMessage = new Map<MailMessageId, MailLabelView[]>();
-  for (const row of labelRows) labelsByMessage.set(row.messageId, [...(labelsByMessage.get(row.messageId) ?? []), toLabelView(row.label)]);
+  for (const row of labelRows)
+    labelsByMessage.set(row.messageId, [...(labelsByMessage.get(row.messageId) ?? []), toLabelView(row.label)]);
 
   const attachmentsByMessage = new Map<MailMessageId, MailAttachmentView[]>();
   for (const attachment of attachmentRows) {
-    attachmentsByMessage.set(attachment.messageId, [...(attachmentsByMessage.get(attachment.messageId) ?? []), toAttachmentView(attachment)]);
+    attachmentsByMessage.set(attachment.messageId, [
+      ...(attachmentsByMessage.get(attachment.messageId) ?? []),
+      toAttachmentView(attachment),
+    ]);
   }
 
   const messageViews: MailMessageView[] = messages.map((message) => ({
@@ -224,13 +248,25 @@ export async function getThread(threadId: MailThreadId, dbOption?: MailDb): Prom
     attachments: attachmentsByMessage.get(message.id) ?? [],
   }));
 
-  const [threadLabels, threadSenders] = await Promise.all([labelsForThreads(db, [thread.id]), sendersForThreads(db, [thread.id])]);
-  return { ...thread, from: threadSenders.get(thread.id) ?? null, labels: threadLabels.get(thread.id) ?? [], messages: messageViews };
+  const [threadLabels, threadSenders] = await Promise.all([
+    labelsForThreads(db, [thread.id]),
+    sendersForThreads(db, [thread.id]),
+  ]);
+  return {
+    ...thread,
+    from: threadSenders.get(thread.id) ?? null,
+    labels: threadLabels.get(thread.id) ?? [],
+    messages: messageViews,
+  };
 }
 
 export async function listLabels(accountId: MailAccountId, dbOption?: MailDb): Promise<MailLabelView[]> {
   const db = dbOrDefault(dbOption);
-  const labels = await db.select().from(mailLabels).where(eq(mailLabels.accountId, accountId)).orderBy(asc(mailLabels.kind), asc(mailLabels.name));
+  const labels = await db
+    .select()
+    .from(mailLabels)
+    .where(eq(mailLabels.accountId, accountId))
+    .orderBy(asc(mailLabels.kind), asc(mailLabels.name));
   return labels.map(toLabelView);
 }
 
@@ -248,19 +284,31 @@ export async function getAccount(accountId: MailAccountId, dbOption?: MailDb): P
 
 export async function listDrafts(accountId: MailAccountId, dbOption?: MailDb): Promise<MailDraftView[]> {
   const db = dbOrDefault(dbOption);
-  const drafts = await db.select().from(mailDrafts).where(eq(mailDrafts.accountId, accountId)).orderBy(desc(mailDrafts.updatedAt));
+  const drafts = await db
+    .select()
+    .from(mailDrafts)
+    .where(eq(mailDrafts.accountId, accountId))
+    .orderBy(desc(mailDrafts.updatedAt));
   return drafts.map(toDraftView);
 }
 
 async function getAccountView(db: MailDb, account: typeof mailAccounts.$inferSelect): Promise<MailAccountView> {
   const [[threadCount], [unreadThreadCount], [draftCount], [outboxPendingCount]] = await Promise.all([
     db.select({ value: count() }).from(mailThreads).where(eq(mailThreads.accountId, account.id)),
-    db.select({ value: count() }).from(mailThreads).where(and(eq(mailThreads.accountId, account.id), eq(mailThreads.hasUnread, true))),
+    db
+      .select({ value: count() })
+      .from(mailThreads)
+      .where(and(eq(mailThreads.accountId, account.id), eq(mailThreads.hasUnread, true))),
     db.select({ value: count() }).from(mailDrafts).where(eq(mailDrafts.accountId, account.id)),
     db
       .select({ value: count() })
       .from(mailOutbox)
-      .where(and(eq(mailOutbox.accountId, account.id), or(eq(mailOutbox.status, 'pending'), eq(mailOutbox.status, 'failed')))),
+      .where(
+        and(
+          eq(mailOutbox.accountId, account.id),
+          or(eq(mailOutbox.status, 'pending'), eq(mailOutbox.status, 'failed')),
+        ),
+      ),
   ]);
 
   return {

--- a/packages/mail/src/sync/engine.ts
+++ b/packages/mail/src/sync/engine.ts
@@ -155,7 +155,8 @@ export function createMailEngine(deps: MailEngineDeps): MailEngine {
   });
 
   async function runAccount(accountId: MailAccountId, forcedMode?: 'full' | 'incremental'): Promise<void> {
-    if (running.has(accountId)) return running.get(accountId)!.promise;
+    const inFlight = running.get(accountId);
+    if (inFlight) return inFlight.promise;
     const controller = new AbortController();
     const promise = (async () => {
       const db = getMailDb();
@@ -172,7 +173,9 @@ export function createMailEngine(deps: MailEngineDeps): MailEngine {
             updatedAt: Date.now(),
           })
           .where(eq(mailAccounts.id, account.id));
-        account = (await readAccount(accountId))!;
+        const refreshed = await readAccount(accountId);
+        if (!refreshed) return;
+        account = refreshed;
       }
 
       const provider = getMailProvider(account.provider).sync;

--- a/packages/scheduler/src/scheduler.test.ts
+++ b/packages/scheduler/src/scheduler.test.ts
@@ -206,8 +206,8 @@ describe('scheduler', () => {
     await scheduler.stop();
 
     const status = await store.getJob('concurrency-job');
-    expect(status!.totalRuns).toBeGreaterThanOrEqual(2);
-    expect(status!.runningCount).toBe(0);
+    expect(status?.totalRuns).toBeGreaterThanOrEqual(2);
+    expect(status?.runningCount).toBe(0);
   });
 
   test('catchup none drops backlog but runs the current due occurrence', async () => {

--- a/packages/server/scripts/new-lance-migration.ts
+++ b/packages/server/scripts/new-lance-migration.ts
@@ -61,7 +61,7 @@ function getConstName(versionTag: string, slug: string): string {
 async function getLastMigrationId(migrationsDir: string): Promise<string | null> {
   const files = (await fs.readdir(migrationsDir))
     .filter((file) => /^\d{4}-.+\.ts$/.test(file))
-    .sort((a, b) => a.localeCompare(b));
+    .toSorted((a, b) => a.localeCompare(b));
 
   const last = files.at(-1);
   if (!last) return null;
@@ -77,7 +77,7 @@ async function getLastMigrationId(migrationsDir: string): Promise<string | null>
 
 async function rewriteManifest(migrationsDir: string): Promise<void> {
   const allFiles = await fs.readdir(migrationsDir);
-  const migrationFiles = allFiles.filter((file) => /^\d{4}-.+\.ts$/.test(file)).sort((a, b) => a.localeCompare(b));
+  const migrationFiles = allFiles.filter((file) => /^\d{4}-.+\.ts$/.test(file)).toSorted((a, b) => a.localeCompare(b));
 
   const imports = migrationFiles
     .map((file) => {

--- a/packages/server/src/agenda/service.ts
+++ b/packages/server/src/agenda/service.ts
@@ -80,9 +80,11 @@ export function getAgendaLists(input?: { includeArchived?: boolean }): ServiceRe
 
   type Counts = AgendaListWithCounts['itemCounts'];
   const countMap = new Map<string, Counts>();
-  for (const list of lists) {
-    countMap.set(list.id, { open: 0, in_progress: 0, done: 0, cancelled: 0, total: 0, overdue: 0, dueSoon: 0 });
-  }
+  const listsWithCounts = lists.map((row) => {
+    const itemCounts: Counts = { open: 0, in_progress: 0, done: 0, cancelled: 0, total: 0, overdue: 0, dueSoon: 0 };
+    countMap.set(row.id, itemCounts);
+    return { ...toAgendaList(row), itemCounts };
+  });
 
   for (const item of allItems) {
     const counts = countMap.get(item.listId);
@@ -98,7 +100,7 @@ export function getAgendaLists(input?: { includeArchived?: boolean }): ServiceRe
     }
   }
 
-  return ok(lists.map((row) => ({ ...toAgendaList(row), itemCounts: countMap.get(row.id)! })));
+  return ok(listsWithCounts);
 }
 
 export function getAgendaListByName(name: string): ServiceResult<AgendaList | null> {

--- a/packages/server/src/automations/generation.ts
+++ b/packages/server/src/automations/generation.ts
@@ -64,7 +64,7 @@ function collectToolsetContext(messageList: GenerationMessageContext[]): {
   availableToolsets: string[];
 } {
   const available = listToolsets();
-  const availableToolsets = available.map((toolset) => toolset.id).sort();
+  const availableToolsets = available.map((toolset) => toolset.id).toSorted();
   const toolToToolset = new Map<string, string>();
 
   for (const toolset of available) {
@@ -85,7 +85,11 @@ function collectToolsetContext(messageList: GenerationMessageContext[]): {
     }
   }
 
-  return { usedToolNames: dedupeStrings(toolNames), inferredToolsets: [...inferredToolsets].sort(), availableToolsets };
+  return {
+    usedToolNames: dedupeStrings(toolNames),
+    inferredToolsets: [...inferredToolsets].toSorted(),
+    availableToolsets,
+  };
 }
 
 function buildAutomationPrompt(input: {

--- a/packages/server/src/chat/history-search-service.ts
+++ b/packages/server/src/chat/history-search-service.ts
@@ -244,7 +244,7 @@ export async function searchSessionHistory(
   }
 
   const sorted = hits
-    .sort((a, b) => {
+    .toSorted((a, b) => {
       if (b.score !== a.score) {
         return b.score - a.score;
       }

--- a/packages/server/src/chat/service.test.ts
+++ b/packages/server/src/chat/service.test.ts
@@ -74,8 +74,9 @@ describe('splitSession', () => {
     expect(result.error).toBeNull();
     expect(result.data?.prefillText).toBe('Continue from here');
     expect(result.data?.session.parentSessionId).toBeNull();
+    if (!result.data) throw new Error('expected split session data');
 
-    const clonedSessionId = result.data!.session.id;
+    const clonedSessionId = result.data.session.id;
     const [clonedSession] = await getDb().select().from(sessions).where(eq(sessions.id, clonedSessionId));
     expect(clonedSession.parentSessionId).toBeNull();
 
@@ -158,7 +159,9 @@ describe('splitSession', () => {
     const result = await splitSession(sessionId, splitMessageId);
 
     expect(result.error).toBeNull();
-    const clonedSessionId = result.data!.session.id;
+    if (!result.data) throw new Error('expected split session data');
+
+    const clonedSessionId = result.data.session.id;
     const clonedMessages = await getDb().select().from(messages).where(eq(messages.sessionId, clonedSessionId));
 
     expect(clonedMessages).toHaveLength(1);

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -529,12 +529,16 @@ export async function getSessionStats(sessionId: PrefixedString<'ses'>): Promise
 
   // Resolve provider/model labels and context limit
   // Find the latest real assistant message (skip background tasks like title generation, compaction, automation)
-  const BACKGROUND_PART_TYPES: StoredPart['type'][] = ['session-title', 'compaction', 'automation-generation'];
+  const BACKGROUND_PART_TYPES: Set<StoredPart['type']> = new Set([
+    'session-title',
+    'compaction',
+    'automation-generation',
+  ]);
   let latestRealMessage: (typeof sessionMessages)[number] | null = null;
   for (let i = sessionMessages.length - 1; i >= 0; i--) {
     const msg = sessionMessages[i];
     if (!msg || msg.role !== 'assistant') continue;
-    if (msg.parts?.some((p) => BACKGROUND_PART_TYPES.includes(p.type))) continue;
+    if (msg.parts?.some((p) => BACKGROUND_PART_TYPES.has(p.type))) continue;
     latestRealMessage = msg;
     break;
   }

--- a/packages/server/src/code-mode/bindings/tool-binding.ts
+++ b/packages/server/src/code-mode/bindings/tool-binding.ts
@@ -38,20 +38,21 @@ type ToolMeta = {
   bindingName: string;
   description: string;
   schema: Record<string, unknown>;
-  tool: Tool;
+  execute: NonNullable<Tool['execute']>;
 };
 
 function mapExecutableTools<T>(tools: Record<string, Tool>, mapper: (meta: ToolMeta) => T): Record<string, T> {
   const result: Record<string, T> = {};
 
   for (const [name, tool] of Object.entries(tools)) {
-    if (!tool.execute) continue;
+    const execute = tool.execute;
+    if (!execute) continue;
 
     const bindingName = `${EXTERNAL_PREFIX}${name}`;
     const description = tool.description ?? `Tool: ${name}`;
     const schema = getToolSchema(tool);
 
-    result[bindingName] = mapper({ originalName: name, bindingName, description, schema, tool });
+    result[bindingName] = mapper({ originalName: name, bindingName, description, schema, execute });
   }
 
   return result;
@@ -71,8 +72,7 @@ export function toolsToTypeInfo(tools: Record<string, Tool>): Record<string, Too
 }
 
 export function toolsToBindings(tools: Record<string, Tool>, abortSignal?: AbortSignal): Record<string, ToolBinding> {
-  return mapExecutableTools(tools, ({ bindingName, description, schema, tool }) => {
-    const execute = tool.execute!;
+  return mapExecutableTools(tools, ({ bindingName, description, schema, execute }) => {
     return {
       name: bindingName,
       description,

--- a/packages/server/src/db/lance-migrations.ts
+++ b/packages/server/src/db/lance-migrations.ts
@@ -109,7 +109,7 @@ function assertChecksumMatches(
 }
 
 export async function runPendingMigrations(db: Db, deps?: { getConnection?: typeof GetConnectionFn }): Promise<void> {
-  const orderedMigrations = [...MIGRATIONS].sort((a, b) => a.version - b.version);
+  const orderedMigrations = [...MIGRATIONS].toSorted((a, b) => a.version - b.version);
   ensureMigrationsAreValid(orderedMigrations);
 
   if (orderedMigrations.length === 0) return;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -40,11 +40,12 @@ function parseArgs() {
   let hostname = process.env['HOSTNAME'] || '127.0.0.1';
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--port' && args[i + 1]) {
-      port = Number(args[i + 1]);
+    const next = args[i + 1];
+    if (args[i] === '--port' && next) {
+      port = Number(next);
       i++;
-    } else if (args[i] === '--hostname' && args[i + 1]) {
-      hostname = args[i + 1]!;
+    } else if (args[i] === '--hostname' && next) {
+      hostname = next;
       i++;
     }
   }

--- a/packages/server/src/lib/log.ts
+++ b/packages/server/src/lib/log.ts
@@ -105,7 +105,7 @@ export async function cleanup(dir = PATHS.logDir): Promise<void> {
     return;
   }
 
-  const logFiles = entries.filter((f) => LOG_FILE_PATTERN.test(f)).sort();
+  const logFiles = entries.filter((f) => LOG_FILE_PATTERN.test(f)).toSorted();
 
   if (logFiles.length <= 10) return;
 

--- a/packages/server/src/llm/provider-schema.test.ts
+++ b/packages/server/src/llm/provider-schema.test.ts
@@ -14,6 +14,10 @@ function resolvedSchema(tool: Tool): JSONSchema7 {
   return (tool as { inputSchema: Schema }).inputSchema.jsonSchema as JSONSchema7;
 }
 
+function resolvedProperties(tool: Tool): Record<string, JSONSchema7> {
+  return resolvedSchema(tool).properties as Record<string, JSONSchema7>;
+}
+
 describe('sanitizeToolSchemasForProvider', () => {
   test('strips required from non-object anyOf branches for google (Apollo repro)', () => {
     const schema: JSONSchema7 = {
@@ -28,7 +32,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
     const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
-    const items = (resolvedSchema(out.t).properties!.tasks_attributes as JSONSchema7).items as JSONSchema7;
+    const items = resolvedProperties(out.t).tasks_attributes.items as JSONSchema7;
     const branches = items.anyOf as JSONSchema7[];
     expect(branches[0].required).toBeUndefined();
     expect(branches[1].required).toBeUndefined();
@@ -42,7 +46,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
     const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
-    const name = resolvedSchema(out.t).properties!.name as JSONSchema7;
+    const name = resolvedProperties(out.t).name;
     expect(name.required).toBeUndefined();
     expect(name.properties).toBeUndefined();
   });
@@ -60,7 +64,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
     const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
-    const level = resolvedSchema(out.t).properties!.level as JSONSchema7;
+    const level = resolvedProperties(out.t).level;
     expect(level.type).toBe('string');
     expect(level.enum).toEqual(['1', '2', '3']);
   });
@@ -73,7 +77,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
     const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
-    const value = resolvedSchema(out.t).properties!.value as Record<string, unknown>;
+    const value = resolvedProperties(out.t).value as Record<string, unknown>;
     expect(value.type).toBeUndefined();
     expect(value.anyOf).toEqual([{ type: 'string' }, { type: 'number' }]);
     expect(value.nullable).toBe(true);
@@ -84,7 +88,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
     const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
-    const tags = resolvedSchema(out.t).properties!.tags as JSONSchema7;
+    const tags = resolvedProperties(out.t).tags;
     expect(tags.items).toEqual({ type: 'string' });
   });
 
@@ -113,7 +117,7 @@ describe('sanitizeToolSchemasForProvider', () => {
       'google-vertex' as LlmProviderId,
       'gemini-2.5-pro',
     );
-    expect((resolvedSchema(geminiOut.t).properties!.p as JSONSchema7).required).toBeUndefined();
+    expect(resolvedProperties(geminiOut.t).p.required).toBeUndefined();
   });
 
   describe('openai sanitizer', () => {
@@ -124,7 +128,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
       const root = resolvedSchema(out.t);
       expect(root.type).toBe('object');
-      const mode = root.properties!.mode as JSONSchema7;
+      const mode = resolvedProperties(out.t).mode;
       expect(mode).toEqual({ enum: ['fast'], type: 'string' });
     });
 
@@ -133,7 +137,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
       const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
-      expect(resolvedSchema(out.t).properties!.anything).toEqual({ type: 'string' });
+      expect(resolvedProperties(out.t).anything).toEqual({ type: 'string' });
     });
 
     test('infers array type and defaults missing items to string', () => {
@@ -141,7 +145,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
       const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
-      const tags = resolvedSchema(out.t).properties!.tags as JSONSchema7;
+      const tags = resolvedProperties(out.t).tags;
       expect(tags.type).toBe('array');
     });
 
@@ -153,7 +157,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
       const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
-      const value = resolvedSchema(out.t).properties!.value as JSONSchema7;
+      const value = resolvedProperties(out.t).value;
       expect(value.type).toBeUndefined();
       expect(value.anyOf).toEqual([{ type: 'string' }, { type: 'number' }]);
     });
@@ -169,7 +173,7 @@ describe('sanitizeToolSchemasForProvider', () => {
         'google/gemini-2.5-pro',
       );
 
-      const level = resolvedSchema(out.t).properties!.level as JSONSchema7;
+      const level = resolvedProperties(out.t).level;
       expect(level.type).toBe('string');
       expect(level.enum).toEqual(['1', '2']);
     });
@@ -183,7 +187,7 @@ describe('sanitizeToolSchemasForProvider', () => {
         'openai/gpt-4o',
       );
 
-      expect((resolvedSchema(out.t).properties!.mode as JSONSchema7).enum).toEqual(['x']);
+      expect(resolvedProperties(out.t).mode.enum).toEqual(['x']);
     });
   });
 });

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -220,7 +220,7 @@ class StreamRunner {
   private getCurrentTools(): Record<string, Tool> {
     const dynamicTools = this.ctx.toolsetManager.getActiveTools();
     const all = { ...this.ctx.coreTools, ...dynamicTools };
-    return Object.fromEntries(Object.entries(all).sort(([a], [b]) => a.localeCompare(b)));
+    return Object.fromEntries(Object.entries(all).toSorted(([a], [b]) => a.localeCompare(b)));
   }
 
   private buildStepOptions(step: number, conversation = this.state.conversation): StepOptions {

--- a/packages/server/src/mail/eligibility.ts
+++ b/packages/server/src/mail/eligibility.ts
@@ -31,14 +31,14 @@ export function filterEligibleMailAccounts(
 ): EligibleMailAccount[] {
   return instances
     .filter(
-      (instance) =>
+      (instance): instance is EligibleConnectorInstance & { accountEmail: string } =>
         instance.connectorId === 'google' &&
         instance.status === 'connected' &&
         instance.accountEmail !== null &&
         !enrolledConnectorInstanceIds.has(instance.id) &&
         hasRequiredGmailScopes(instance.scopes),
     )
-    .map((instance) => ({ connectorInstanceId: instance.id, email: instance.accountEmail! }));
+    .map((instance) => ({ connectorInstanceId: instance.id, email: instance.accountEmail }));
 }
 
 export function assertCanEnrollMailAccount(

--- a/packages/server/src/mcp/icons.test.ts
+++ b/packages/server/src/mcp/icons.test.ts
@@ -31,7 +31,8 @@ describe('mcp icon cache', () => {
     });
 
     expect(cached).not.toBeNull();
-    const icon = await getMcpIconByKey(cached!.key, { cacheDir });
+    if (!cached) throw new Error('expected icon to be cached');
+    const icon = await getMcpIconByKey(cached.key, { cacheDir });
     expect(icon?.mimeType).toBe('image/png');
     expect(icon?.body.length).toBeGreaterThan(0);
   });

--- a/packages/server/src/memory/consolidation.ts
+++ b/packages/server/src/memory/consolidation.ts
@@ -127,7 +127,7 @@ async function findCandidateGroups(): Promise<ConsolidationMemory[][]> {
   const allResult = await getAllSemanticMemories({ page: 1, pageSize: 1000 });
   if (allResult.error || allResult.data.memories.length < MIN_GROUP_SIZE) return [];
 
-  const memories = [...allResult.data.memories].sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+  const memories = [...allResult.data.memories].toSorted((a, b) => a.updatedAt.localeCompare(b.updatedAt));
   const used = new Set<string>();
   const groups: ConsolidationMemory[][] = [];
 

--- a/packages/server/src/memory/processor.ts
+++ b/packages/server/src/memory/processor.ts
@@ -197,7 +197,7 @@ export async function processMemories(input: {
     // Apply per-turn cap
     if (facts.length > config.maxFactsPerTurn) {
       // Keep highest-importance facts when capping
-      facts = facts.sort((a, b) => b.importanceScore - a.importanceScore).slice(0, config.maxFactsPerTurn);
+      facts = facts.toSorted((a, b) => b.importanceScore - a.importanceScore).slice(0, config.maxFactsPerTurn);
     }
 
     // Apply remaining session budget

--- a/packages/server/src/memory/retriever.ts
+++ b/packages/server/src/memory/retriever.ts
@@ -5,7 +5,7 @@ import type { MemoryCategory } from '@/memory/types.js';
 import type { MemorySource } from '@/memory/types.js';
 
 const log = Log.create({ service: 'memory-retriever' });
-const CHAT_MEMORY_CATEGORIES: MemoryCategory[] = ['preference', 'fact', 'constraint'];
+const CHAT_MEMORY_CATEGORIES: Set<MemoryCategory> = new Set(['preference', 'fact', 'constraint']);
 
 function tokenize(value: string): Set<string> {
   return new Set(
@@ -71,7 +71,7 @@ export async function retrieveMemoryContext(query: string, sourceFilter?: Memory
 
   // Apply category and score filters before reranking.
   const candidates = semantic.memories.filter(
-    (m) => CHAT_MEMORY_CATEGORIES.includes(m.category) && m.score >= config.retrievalMinScore,
+    (m) => CHAT_MEMORY_CATEGORIES.has(m.category) && m.score >= config.retrievalMinScore,
   );
 
   const scoredCandidates = candidates.map((m) => {

--- a/packages/server/src/permission/default-permissions.test.ts
+++ b/packages/server/src/permission/default-permissions.test.ts
@@ -16,7 +16,7 @@ describe('syncDefaultPermissions', () => {
     const rows = await getDb().select().from(toolPermissions);
     const skillsRule = rows.find((r) => r.toolName === 'read' && r.pattern === `${PATHS.dirPaths.skills}${path.sep}*`);
 
-    expect(skillsRule!.permission).toBe('allow');
+    expect(skillsRule?.permission).toBe('allow');
   });
 
   test('creates file tool permissions for recordings directory', async () => {
@@ -30,7 +30,7 @@ describe('syncDefaultPermissions', () => {
         (r) => r.toolName === toolName && r.pattern === `${PATHS.dirPaths.recordings}${path.sep}*`,
       );
 
-      expect(rule!.permission).toBe('allow');
+      expect(rule?.permission).toBe('allow');
     }
   });
 

--- a/packages/server/src/permission/policy.ts
+++ b/packages/server/src/permission/policy.ts
@@ -29,7 +29,7 @@ export function resolvePermissionFromRules(
 
   const patternMatchesBySpecificity = patternRules
     .filter((row) => wildcardPatternMatches(row.pattern, patternTargets))
-    .sort((a, b) => b.pattern.length - a.pattern.length);
+    .toSorted((a, b) => b.pattern.length - a.pattern.length);
 
   const firstMatch = patternMatchesBySpecificity[0];
   if (!firstMatch) return 'ask';

--- a/packages/server/src/permission/service.test.ts
+++ b/packages/server/src/permission/service.test.ts
@@ -82,7 +82,7 @@ describe('permission service interactions', () => {
     await waitForEvents(1);
 
     const requestedEvent = emittedEvents.find(([name]) => name === 'permission.requested');
-    const requestedData = requestedEvent![1] as InternalEventMap['permission.requested'];
+    const requestedData = requestedEvent?.[1] as InternalEventMap['permission.requested'];
     expect(requestedData.permissionResponse).toMatchObject({
       sessionId,
       messageId,
@@ -96,7 +96,7 @@ describe('permission service interactions', () => {
     expect(promise).resolves.toEqual({ decision: 'allow' });
 
     const resolvedEvent = emittedEvents.find(([name]) => name === 'permission.resolved');
-    expect(resolvedEvent![1]).toEqual({ permissionResponseId, sessionId });
+    expect(resolvedEvent?.[1]).toEqual({ permissionResponseId, sessionId });
   });
 
   test('deduplicates concurrent permission requests with the same key', async () => {
@@ -186,7 +186,7 @@ describe('permission service interactions', () => {
     await waitForRequestedEvents(1);
     const firstRequested = emittedEvents.find(
       ([name]) => name === 'permission.requested',
-    )![1] as InternalEventMap['permission.requested'];
+    )?.[1] as InternalEventMap['permission.requested'];
 
     await allowPermissionResponse(firstRequested.permissionResponse.id);
     expect(first).resolves.toEqual({ decision: 'allow' });
@@ -268,7 +268,7 @@ describe('permission service interactions', () => {
 
     const requestedData = emittedEvents.find(
       ([name]) => name === 'permission.requested',
-    )![1] as InternalEventMap['permission.requested'];
+    )?.[1] as InternalEventMap['permission.requested'];
     const permissionResponseId = requestedData.permissionResponse.id;
 
     expect(alternativePermissionResponse(permissionResponseId, 'Use read instead')).resolves.toEqual({
@@ -322,7 +322,8 @@ describe('permission service interactions', () => {
     ).toBe(true);
 
     // Second permission (different session) is unaffected - still resolvable
-    await rejectPermissionResponse(secondId!);
+    if (!secondId) throw new Error('expected a permission request for the other session');
+    await rejectPermissionResponse(secondId);
     expect(second).resolves.toEqual({ decision: 'reject' });
   });
 });

--- a/packages/server/src/permission/service.ts
+++ b/packages/server/src/permission/service.ts
@@ -137,17 +137,18 @@ async function createPermissionResponse(opts: RequestPermissionResponseOptions):
 export async function requestPermissionResponse(
   opts: RequestPermissionResponseOptions,
 ): Promise<PermissionDecisionResult> {
-  if (!opts.dedupeKey) {
+  const dedupeKey = opts.dedupeKey;
+  if (!dedupeKey) {
     return createPermissionResponse(opts);
   }
 
-  const existing = pendingPermissionRequests.get(opts.dedupeKey);
+  const existing = pendingPermissionRequests.get(dedupeKey);
   if (existing) return existing;
 
   const promise = createPermissionResponse(opts).finally(() => {
-    pendingPermissionRequests.delete(opts.dedupeKey!);
+    pendingPermissionRequests.delete(dedupeKey);
   });
-  pendingPermissionRequests.set(opts.dedupeKey, promise);
+  pendingPermissionRequests.set(dedupeKey, promise);
   return promise;
 }
 

--- a/packages/server/src/provider/service.ts
+++ b/packages/server/src/provider/service.ts
@@ -33,8 +33,11 @@ export async function listProvidersWithCapabilities(): Promise<ServiceResult<Pro
   const capabilitiesMap = new Map<string, Set<ProviderCapability>>();
 
   function ensureEntry(id: string): Set<ProviderCapability> {
-    if (!capabilitiesMap.has(id)) capabilitiesMap.set(id, new Set());
-    return capabilitiesMap.get(id)!;
+    const existing = capabilitiesMap.get(id);
+    if (existing) return existing;
+    const created = new Set<ProviderCapability>();
+    capabilitiesMap.set(id, created);
+    return created;
   }
 
   for (const id of Object.keys(llmProviders)) {

--- a/packages/server/src/question/service.test.ts
+++ b/packages/server/src/question/service.test.ts
@@ -68,7 +68,7 @@ describe('question service interactions', () => {
     await waitForEvents(1);
 
     const askedEvent = emittedEvents.find(([name]) => name === 'question.asked');
-    const askedData = askedEvent![1] as InternalEventMap['question.asked'];
+    const askedData = askedEvent?.[1] as InternalEventMap['question.asked'];
     expect(askedData.question).toMatchObject({ sessionId, messageId, toolCallId: 'call_question', status: 'pending' });
 
     const questionId = askedData.question.id;
@@ -79,7 +79,7 @@ describe('question service interactions', () => {
     expect(promise).resolves.toEqual([['A']]);
 
     const repliedEvent = emittedEvents.find(([name]) => name === 'question.replied');
-    expect(repliedEvent![1]).toEqual({ questionId, sessionId, answers: [['A']] });
+    expect(repliedEvent?.[1]).toEqual({ questionId, sessionId, answers: [['A']] });
 
     const db = getDb();
     const [row] = await db.select().from(questions).where(eq(questions.id, questionId));
@@ -101,7 +101,7 @@ describe('question service interactions', () => {
 
     const askedData = emittedEvents.find(
       ([name]) => name === 'question.asked',
-    )![1] as InternalEventMap['question.asked'];
+    )?.[1] as InternalEventMap['question.asked'];
     const questionId = askedData.question.id;
 
     const rejectResult = await rejectQuestion(questionId);
@@ -110,7 +110,7 @@ describe('question service interactions', () => {
     expect(promise).rejects.toThrow('Question rejected by user');
 
     const rejectedEvent = emittedEvents.find(([name]) => name === 'question.rejected');
-    expect(rejectedEvent![1]).toEqual({ questionId, sessionId });
+    expect(rejectedEvent?.[1]).toEqual({ questionId, sessionId });
 
     const db = getDb();
     const [row] = await db.select().from(questions).where(eq(questions.id, questionId));
@@ -222,7 +222,8 @@ describe('question service interactions', () => {
     ).toBe(true);
 
     // Second question (different session) is unaffected - still resolvable
-    await replyQuestion(secondId!, [['ok']]);
+    if (!secondId) throw new Error('expected a question for the other session');
+    await replyQuestion(secondId, [['ok']]);
     expect(second).resolves.toEqual([['ok']]);
   });
 });

--- a/packages/server/src/recordings/meeting-note-templates.test.ts
+++ b/packages/server/src/recordings/meeting-note-templates.test.ts
@@ -18,8 +18,8 @@ describe('meeting note templates', () => {
 
     expect(result.error).toBeNull();
     if (result.error) return;
-    expect(result.data.templates.map((template) => template.id).sort()).toEqual(
-      PREBUILT_MEETING_NOTE_TEMPLATES.map((template) => template.id).sort(),
+    expect(result.data.templates.map((template) => template.id).toSorted()).toEqual(
+      PREBUILT_MEETING_NOTE_TEMPLATES.map((template) => template.id).toSorted(),
     );
   });
 

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -76,7 +76,7 @@ configRouter.get('/toolsets', async (c) => {
         tools: (view.tools ?? []).map((tool) => ({ toolName: tool.name, displayName: tool.displayName })),
       };
     })
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .toSorted((a, b) => a.name.localeCompare(b.name));
 
   return c.json({ toolsets });
 });

--- a/packages/server/src/skills/filesystem.test.ts
+++ b/packages/server/src/skills/filesystem.test.ts
@@ -218,7 +218,7 @@ describe('collectSkillDirFiles', () => {
     await fs.writeFile(path.join(skillDir, 'scripts', 'run.py'), 'print()', 'utf8');
 
     const files = await collectSkillDirFiles(skillDir, skillDir);
-    const paths = files.map((f) => f.relativePath).sort();
+    const paths = files.map((f) => f.relativePath).toSorted();
 
     expect(paths).toEqual(['agents/helper.md', 'scripts/run.py']);
   });

--- a/packages/server/src/skills/service.ts
+++ b/packages/server/src/skills/service.ts
@@ -208,7 +208,7 @@ export async function searchSkillsDirectory(query: string): Promise<ServiceResul
           },
         ];
       })
-      .sort((a, b) => b.installs - a.installs);
+      .toSorted((a, b) => b.installs - a.installs);
 
     return ok(results);
   } catch (error) {

--- a/packages/server/src/stt/base-adapter.ts
+++ b/packages/server/src/stt/base-adapter.ts
@@ -99,7 +99,7 @@ export async function createManagedConnection(config: ManagedConnectionConfig): 
     nextChunkStartMs = endMs;
 
     while (totalBufferedMs > bufferConfig.maxBufferedMs && ringBuffer.length > 1) {
-      const dropped = ringBuffer.shift()!;
+      const [dropped] = ringBuffer.splice(0, 1);
       totalBufferedMs -= dropped.durationMs;
       log.warn('buffer overflow, dropping oldest chunk');
     }
@@ -111,7 +111,7 @@ export async function createManagedConnection(config: ManagedConnectionConfig): 
 
   function trimBufferBefore(offsetMs: number): void {
     while (ringBuffer.length > 1 && ringBuffer[0].endMs <= offsetMs) {
-      const dropped = ringBuffer.shift()!;
+      const [dropped] = ringBuffer.splice(0, 1);
       totalBufferedMs -= dropped.durationMs;
     }
   }

--- a/packages/server/src/stt/ws-transport.test.ts
+++ b/packages/server/src/stt/ws-transport.test.ts
@@ -126,7 +126,8 @@ describe('createWsTransport', () => {
       () => 'commit',
     );
     FakeWebSocket.last?.open();
-    const socket = FakeWebSocket.last!;
+    const socket = FakeWebSocket.last;
+    if (!socket) throw new Error('expected a socket to have been created');
     const transport = await transportPromise;
 
     expect(socket.listenerCount).toBeGreaterThan(0);

--- a/packages/server/src/stt/ws-transport.ts
+++ b/packages/server/src/stt/ws-transport.ts
@@ -162,8 +162,8 @@ export function createWsTransport(
         },
         onError(cb) {
           errorListeners.push(cb);
-          while (pendingErrors.length > 0) {
-            cb(pendingErrors.shift()!);
+          for (const pending of pendingErrors.splice(0)) {
+            cb(pending);
           }
         },
         onClose(cb) {

--- a/packages/server/src/title-generation/generator.test.ts
+++ b/packages/server/src/title-generation/generator.test.ts
@@ -38,16 +38,16 @@ describe('generateTitleFromContent', () => {
       getModel: () => model,
     });
 
-    expect(result!.title).toBe('Project Setup');
-    expect(result!.providerId).toBe('openai');
-    expect(result!.modelId).toBe('gpt-5-nano');
-    expect(result!.usage!.inputTokens).toBe(10);
-    expect(result!.usage!.outputTokens).toBe(5);
+    expect(result?.title).toBe('Project Setup');
+    expect(result?.providerId).toBe('openai');
+    expect(result?.modelId).toBe('gpt-5-nano');
+    expect(result?.usage?.inputTokens).toBe(10);
+    expect(result?.usage?.outputTokens).toBe(5);
 
     expect(model.doGenerateCalls).toHaveLength(1);
     const messages = model.doGenerateCalls[0].prompt;
     const userMessage = messages.find((m) => m.role === 'user');
-    const textContent = userMessage!.content.find((c): c is { type: 'text'; text: string } => c.type === 'text');
+    const textContent = userMessage?.content.find((c): c is { type: 'text'; text: string } => c.type === 'text');
     expect(textContent?.text).toBe(content);
   });
 
@@ -58,7 +58,7 @@ describe('generateTitleFromContent', () => {
       getModel: () => model,
     });
 
-    expect(result!.title).toBe('Debug Auth Flow');
+    expect(result?.title).toBe('Debug Auth Flow');
   });
 
   test('returns null when model returns empty text', async () => {

--- a/packages/server/src/tools/core/glob.ts
+++ b/packages/server/src/tools/core/glob.ts
@@ -47,7 +47,7 @@ export async function globPaths(input: z.infer<typeof globInputSchema>): Promise
     }),
   );
 
-  const sorted = withMtime.sort((a, b) => b.mtime - a.mtime).map((entry) => entry.filePath);
+  const sorted = withMtime.toSorted((a, b) => b.mtime - a.mtime).map((entry) => entry.filePath);
   const truncated = sorted.length > MAX_RESULTS;
   const finalPaths = truncated ? sorted.slice(0, MAX_RESULTS) : sorted;
 

--- a/packages/server/src/tools/core/grep.ts
+++ b/packages/server/src/tools/core/grep.ts
@@ -62,7 +62,7 @@ export async function grepContent(input: z.infer<typeof grepInputSchema>): Promi
 
   const searchableFiles = filesWithMtime
     .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry))
-    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    .toSorted((a, b) => b.mtimeMs - a.mtimeMs);
 
   const matches: Match[] = [];
   let scannedFiles = 0;

--- a/packages/server/src/tools/core/read.ts
+++ b/packages/server/src/tools/core/read.ts
@@ -71,7 +71,7 @@ export async function readPathContent(input: z.infer<typeof readInputSchema>): P
     const entries = await fs.readdir(targetPath, { withFileTypes: true });
     const output = entries
       .map((entry) => (entry.isDirectory() ? `${entry.name}/` : entry.name))
-      .sort((a, b) => a.localeCompare(b))
+      .toSorted((a, b) => a.localeCompare(b))
       .join('\n');
 
     return { output, filePath: targetPath };

--- a/packages/server/src/tools/runtime/middleware.ts
+++ b/packages/server/src/tools/runtime/middleware.ts
@@ -15,7 +15,7 @@ function createPermissionDedupeKey(input: ToolExecutionInput, patternTargets: st
     input.context.messageId,
     input.context.streamRunId,
     input.toolName,
-    [...patternTargets].sort(),
+    [...patternTargets].toSorted(),
   ]);
 }
 

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -211,7 +211,7 @@ export class ToolsetManager {
     for (const [, entry] of this.getActiveEntries()) {
       Object.assign(merged, entry.tools);
     }
-    return Object.fromEntries(Object.entries(merged).sort(([a], [b]) => a.localeCompare(b)));
+    return Object.fromEntries(Object.entries(merged).toSorted(([a], [b]) => a.localeCompare(b)));
   }
 
   /**

--- a/packages/server/src/usage/service.ts
+++ b/packages/server/src/usage/service.ts
@@ -370,7 +370,7 @@ export async function getUsageDashboard(input: GetUsageDashboardInput): Promise<
   }
 
   const sourceOrder = new Map<string, number>(USAGE_SOURCES.map((source, index) => [source, index]));
-  const sources = Array.from(sourceSet).sort((a, b) => {
+  const sources = Array.from(sourceSet).toSorted((a, b) => {
     const aIndex = sourceOrder.get(a) ?? Number.MAX_SAFE_INTEGER;
     const bIndex = sourceOrder.get(b) ?? Number.MAX_SAFE_INTEGER;
     if (aIndex !== bIndex) return aIndex - bIndex;
@@ -386,13 +386,13 @@ export async function getUsageDashboard(input: GetUsageDashboardInput): Promise<
   return ok({
     range: { from: window.from, to: window.to, granularity, bucketCount: buckets.length },
     filters: { providerId: input.providerId ?? null, modelId: input.modelId ?? null },
-    usedProviders: Array.from(usedProviderIds).sort((a, b) => a.localeCompare(b)),
+    usedProviders: Array.from(usedProviderIds).toSorted((a, b) => a.localeCompare(b)),
     usedModels: Array.from(usedModelKeys)
       .map((key) => {
         const separator = key.indexOf('::');
         return { providerId: key.slice(0, separator), modelId: key.slice(separator + 2) };
       })
-      .sort((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
+      .toSorted((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
     sources,
     totals: { costUsd: totalCostUsd, tokenMetrics: totalTokenMetrics },
     buckets,
@@ -467,18 +467,18 @@ export async function getSttUsageDashboard(
     bucket.durationMsByService[service] = (bucket.durationMsByService[service] ?? 0) + durationMs;
   }
 
-  const services = Array.from(serviceSet).sort((a, b) => a.localeCompare(b));
+  const services = Array.from(serviceSet).toSorted((a, b) => a.localeCompare(b));
 
   return ok({
     range: { from: window.from, to: window.to, granularity, bucketCount: buckets.length },
     filters: { providerId: input.providerId ?? null, modelId: input.modelId ?? null },
-    usedProviders: Array.from(usedProviderIds).sort((a, b) => a.localeCompare(b)),
+    usedProviders: Array.from(usedProviderIds).toSorted((a, b) => a.localeCompare(b)),
     usedModels: Array.from(usedModelKeys)
       .map((key) => {
         const separator = key.indexOf('::');
         return { providerId: key.slice(0, separator), modelId: key.slice(separator + 2) };
       })
-      .sort((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
+      .toSorted((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
     services,
     totals: { costUsd: totalCostUsd, durationMs: totalDurationMs },
     buckets,
@@ -553,13 +553,13 @@ export async function getEmbeddingUsageDashboard(
   return ok({
     range: { from: window.from, to: window.to, granularity, bucketCount: buckets.length },
     filters: { providerId: input.providerId ?? null, modelId: input.modelId ?? null },
-    usedProviders: Array.from(usedProviderIds).sort((a, b) => a.localeCompare(b)),
+    usedProviders: Array.from(usedProviderIds).toSorted((a, b) => a.localeCompare(b)),
     usedModels: Array.from(usedModelKeys)
       .map((key) => {
         const separator = key.indexOf('::');
         return { providerId: key.slice(0, separator), modelId: key.slice(separator + 2) };
       })
-      .sort((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
+      .toSorted((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
     totals: { costUsd: totalCostUsd, totalTokens },
     buckets,
   });

--- a/packages/server/src/utils/stable-stringify.ts
+++ b/packages/server/src/utils/stable-stringify.ts
@@ -16,7 +16,7 @@ function sortKeys(value: unknown): unknown {
   }
 
   const sorted: Record<string, unknown> = {};
-  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+  for (const key of Object.keys(value as Record<string, unknown>).toSorted()) {
     sorted[key] = sortKeys((value as Record<string, unknown>)[key]);
   }
   return sorted;

--- a/packages/shared/src/tools/bash-families.ts
+++ b/packages/shared/src/tools/bash-families.ts
@@ -50,4 +50,4 @@ export const FAMILY_RULES: FamilyRule[] = [
   { tokens: ['grep'], arity: 1, description: 'search text in files', showAsPreset: true },
   { tokens: ['where'], arity: 1, description: 'find files or commands', showAsPreset: false },
   { tokens: ['which'], arity: 1, description: 'find files or commands', showAsPreset: false },
-].sort((a, b) => b.tokens.length - a.tokens.length);
+].toSorted((a, b) => b.tokens.length - a.tokens.length);

--- a/scripts/check-catalogs.ts
+++ b/scripts/check-catalogs.ts
@@ -72,9 +72,10 @@ for (const pkgPath of workspacePkgPaths) {
   for (const field of DEP_FIELDS) {
     const deps: Record<string, string> = pkg[field] ?? {};
     for (const [name, version] of Object.entries(deps)) {
-      if (!catalogPackages.has(name)) continue;
+      const expected = catalogPackages.get(name);
+      if (!expected) continue;
       if (version.startsWith('catalog:')) continue; // already using catalog
-      violations.push({ file: relPath, field, pkg: name, actual: version, expected: catalogPackages.get(name)! });
+      violations.push({ file: relPath, field, pkg: name, actual: version, expected });
     }
   }
 }


### PR DESCRIPTION
## 🚀 Change Summary

Chat markdown code blocks are now rendered from Shiki's HAST output through React elements instead of injecting highlighted HTML strings, eliminating the last `dangerouslySetInnerHTML` usage in the web app.

### 🛠 Improvements & Refactors

- **HAST-based highlighting**: new `apps/web/src/lib/code-highlighting.ts` converts Shiki HAST nodes into React nodes; `chat-markdown.tsx` consumes it directly.
- Removes the need for HTML sanitization on the highlight path.

### 📌 Stack

Stacked on `refactor/core-lint-safety`. Logically independent of it — only stacked so the `react/no-danger` rule added later in the stack lands green.
