### PR TITLE
chore(lint): enable stricter safety rules and align web components

### DIFF
--- a/apps/desktop/src/main/browser/downloads.ts
+++ b/apps/desktop/src/main/browser/downloads.ts
@@ -10,7 +10,7 @@ export class DownloadTracker {
   constructor(private readonly broadcast: () => void) {}
 
   list(): ElectronBrowserDownload[] {
-    return Array.from(this.downloads.values()).sort((a, b) => b.createdAt - a.createdAt);
+    return Array.from(this.downloads.values()).toSorted((a, b) => b.createdAt - a.createdAt);
   }
 
   handleDownload(item: Electron.DownloadItem): void {

--- a/apps/desktop/src/main/browser/session-store.ts
+++ b/apps/desktop/src/main/browser/session-store.ts
@@ -147,10 +147,10 @@ export class SessionStore {
       return undefined;
     }
 
-    const remaining = Array.from(this.tabs.keys());
-    if (remaining.length > 0) {
-      this.activeTabId = remaining[remaining.length - 1]!;
-      const next = this.tabs.get(this.activeTabId)!;
+    const remaining = Array.from(this.tabs.values());
+    const next = remaining[remaining.length - 1];
+    if (next) {
+      this.activeTabId = next.id;
       this.broadcast();
       this.debouncedPersist();
       return next;

--- a/apps/desktop/src/main/ipc/server.ts
+++ b/apps/desktop/src/main/ipc/server.ts
@@ -37,9 +37,10 @@ export function registerServerHandlers(
 
   registerIpcHandler('server:set-config', async (_event, config): Promise<ServerConfigPayload> => {
     let nextConfig: ServerConnectionConfig;
+    let remoteUrl: string | null = null;
 
     if (config.mode === 'remote') {
-      const remoteUrl = normalizeRemoteUrl(config.remoteUrl ?? '');
+      remoteUrl = normalizeRemoteUrl(config.remoteUrl ?? '');
       if (!(await checkHealth(remoteUrl))) {
         throw new Error('Remote server health check failed');
       }
@@ -51,7 +52,7 @@ export function registerServerHandlers(
     await stopRecordingCapture().catch(() => null);
     await killServer();
 
-    const nextUrl = nextConfig.mode === 'remote' ? nextConfig.remoteUrl! : await startLocalServer();
+    const nextUrl = remoteUrl ?? (await startLocalServer());
 
     state.serverUrl = nextUrl;
     state.serverConnectionConfig = nextConfig;

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -183,8 +183,10 @@ async function spawnServerOnce(port: number, extraEnv: NodeJS.ProcessEnv): Promi
     console.error(`[sidecar:stderr] ${text.trim()}`);
   });
 
+  const proc = serverProcess;
+
   const exitPromise = new Promise<never>((_resolve, reject) => {
-    serverProcess!.on('exit', (code, signal) => {
+    proc.on('exit', (code, signal) => {
       const tail = logTail.trim();
       const details = tail ? `\n\nServer output:\n${tail}` : ' (no output captured)';
       const error = new Error(`Server exited before becoming healthy (code=${code}, signal=${signal})${details}`);
@@ -193,7 +195,7 @@ async function spawnServerOnce(port: number, extraEnv: NodeJS.ProcessEnv): Promi
       }
       reject(error);
     });
-    serverProcess!.on('error', (err) => {
+    proc.on('error', (err) => {
       reject(new Error(`Failed to spawn server: ${err.message}`));
     });
   });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "cmdk": "^1.1.1",
     "cnfast": "^0.0.7",
     "date-fns": "^4.1.0",
+    "hast-util-to-jsx-runtime": "^2.3.6",
     "katex": "^0.16.38",
     "lucide-react": "^0.577.0",
     "react": "19.2.4",

--- a/apps/web/src/components/agenda/agenda-item-detail.tsx
+++ b/apps/web/src/components/agenda/agenda-item-detail.tsx
@@ -24,30 +24,18 @@ type Props = { item: AgendaItem | null; open: boolean; onOpenChange: (open: bool
 
 export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
   const timeZone = useUserTimezone();
-  const [title, setTitle] = React.useState('');
-  const [description, setDescription] = React.useState('');
-  const [status, setStatus] = React.useState<AgendaItemStatus>('open');
-  const [priority, setPriority] = React.useState<AgendaItemPriority>('medium');
-  const [dueDate, setDueDate] = React.useState<Date | undefined>(undefined);
+  const [title, setTitle] = React.useState(item?.title ?? '');
+  const [description, setDescription] = React.useState(item?.description ?? '');
+  const [status, setStatus] = React.useState<AgendaItemStatus>(item?.status ?? 'open');
+  const [priority, setPriority] = React.useState<AgendaItemPriority>(item?.priority ?? 'medium');
+  const [dueDate, setDueDate] = React.useState<Date | undefined>(() =>
+    item?.dueAt ? new Date(item.dueAt) : undefined,
+  );
   const [confirmDeleteOpen, setConfirmDeleteOpen] = React.useState(false);
   const [datePickerOpen, setDatePickerOpen] = React.useState(false);
 
   const updateMutation = useUpdateAgendaItem();
   const deleteMutation = useDeleteAgendaItem();
-
-  // Keep a stable ref to the item so callbacks can access it without stale closures
-  const itemRef = React.useRef(item);
-  itemRef.current = item;
-
-  React.useEffect(() => {
-    if (item) {
-      setTitle(item.title);
-      setDescription(item.description);
-      setStatus(item.status);
-      setPriority(item.priority);
-      setDueDate(item.dueAt ? new Date(item.dueAt) : undefined);
-    }
-  }, [item]);
 
   function dateToMs(date: Date): number {
     const y = date.getFullYear();
@@ -63,8 +51,8 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
     priority?: AgendaItemPriority;
     dueAt?: number | null;
   }) {
-    if (!itemRef.current) return;
-    updateMutation.mutate({ id: itemRef.current.id, updates });
+    if (!item) return;
+    updateMutation.mutate({ id: item.id, updates });
   }
 
   // Debounced save for text fields
@@ -80,10 +68,9 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
     if (!nextOpen && debounceRef.current) {
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
-      const current = itemRef.current;
-      if (current) {
-        const pendingTitle = title !== current.title ? title : undefined;
-        const pendingDescription = description !== current.description ? description : undefined;
+      if (item) {
+        const pendingTitle = title !== item.title ? title : undefined;
+        const pendingDescription = description !== item.description ? description : undefined;
         if (pendingTitle !== undefined || pendingDescription !== undefined) {
           save({ title: pendingTitle, description: pendingDescription });
         }
@@ -95,7 +82,7 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
   function handleTitleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const next = e.target.value;
     setTitle(next);
-    if (itemRef.current && next !== itemRef.current.title) {
+    if (item && next !== item.title) {
       saveDebounced({ title: next, description: undefined });
     }
   }
@@ -103,7 +90,7 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
   function handleDescriptionChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
     const next = e.target.value;
     setDescription(next);
-    if (itemRef.current && next !== itemRef.current.description) {
+    if (item && next !== item.description) {
       saveDebounced({ title: undefined, description: next });
     }
   }
@@ -112,7 +99,7 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
     if (!v) return;
     const next = v as AgendaItemStatus;
     setStatus(next);
-    if (itemRef.current && next !== itemRef.current.status) {
+    if (item && next !== item.status) {
       save({ status: next });
     }
   }
@@ -121,7 +108,7 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
     if (!v) return;
     const next = v as AgendaItemPriority;
     setPriority(next);
-    if (itemRef.current && next !== itemRef.current.priority) {
+    if (item && next !== item.priority) {
       save({ priority: next });
     }
   }
@@ -129,16 +116,16 @@ export function AgendaItemDetailSheet({ item, open, onOpenChange }: Props) {
   function handleDateSelect(date: Date | undefined) {
     setDueDate(date);
     setDatePickerOpen(false);
-    if (!itemRef.current) return;
+    if (!item) return;
     const newDueMs = date ? dateToMs(date) : null;
-    if (newDueMs !== itemRef.current.dueAt) {
+    if (newDueMs !== item.dueAt) {
       save({ dueAt: newDueMs });
     }
   }
 
   function handleClearDate() {
     setDueDate(undefined);
-    if (itemRef.current && itemRef.current.dueAt !== null) {
+    if (item && item.dueAt !== null) {
       save({ dueAt: null });
     }
   }

--- a/apps/web/src/components/agenda/agenda-page.tsx
+++ b/apps/web/src/components/agenda/agenda-page.tsx
@@ -93,13 +93,19 @@ export function AgendaPage({ listId }: { listId?: string }) {
   const totalPages = itemsData?.totalPages ?? 0;
   const total = itemsData?.total ?? 0;
 
-  React.useEffect(() => {
+  // Adjust paging/selection during render when the filters or the loaded page change
+  const viewKey = `${listId ?? ''}|${filterStatus}|${filterPriority}`;
+  const resultKey = `${viewKey}|${itemsData?.page ?? 0}|${itemsData?.total ?? 0}`;
+  const [prevViewKey, setPrevViewKey] = React.useState(viewKey);
+  const [prevResultKey, setPrevResultKey] = React.useState(resultKey);
+  if (prevViewKey !== viewKey) {
+    setPrevViewKey(viewKey);
     setPage(1);
-  }, [filterStatus, filterPriority, listId]);
-
-  React.useEffect(() => {
+  }
+  if (prevResultKey !== resultKey) {
+    setPrevResultKey(resultKey);
     setSelectedIds(new Set());
-  }, [itemsData?.page, itemsData?.total, filterStatus, filterPriority]);
+  }
 
   const createMutation = useCreateAgendaItem();
   const deleteMutation = useDeleteAgendaItem();
@@ -257,7 +263,7 @@ export function AgendaPage({ listId }: { listId?: string }) {
     for (let index = start; index <= end; index += 1) {
       pages.add(index);
     }
-    return [...pages].sort((a, b) => a - b);
+    return [...pages].toSorted((a, b) => a - b);
   }, [currentPage, totalPages]);
 
   const allSelected = items.length > 0 && selectedIds.size === items.length;
@@ -448,9 +454,9 @@ export function AgendaPage({ listId }: { listId?: string }) {
                       <React.Fragment key={item.id}>
                         {dropIndex === index && dragItemId && dragItemId !== item.id && (
                           <tr aria-hidden="true">
-                            <td colSpan={listId ? 6 : 7} className="p-0">
+                            <Table.Cell colSpan={listId ? 6 : 7} className="p-0">
                               <div className="h-0.5 bg-primary" />
-                            </td>
+                            </Table.Cell>
                           </tr>
                         )}
                         <AgendaItemRow
@@ -469,9 +475,9 @@ export function AgendaPage({ listId }: { listId?: string }) {
                     ))}
                     {dropIndex === items.length && dragItemId && (
                       <tr aria-hidden="true">
-                        <td colSpan={listId ? 6 : 7} className="p-0">
+                        <Table.Cell colSpan={listId ? 6 : 7} className="p-0">
                           <div className="h-0.5 bg-primary" />
-                        </td>
+                        </Table.Cell>
                       </tr>
                     )}
                   </>
@@ -536,7 +542,12 @@ export function AgendaPage({ listId }: { listId?: string }) {
       </PageContent>
 
       {/* Detail sheet */}
-      <AgendaItemDetailSheet item={sheetItem} open={sheetOpen} onOpenChange={setSheetOpen} />
+      <AgendaItemDetailSheet
+        key={sheetItem ? `${sheetItem.id}:${sheetItem.updatedAt}` : 'none'}
+        item={sheetItem}
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+      />
 
       {/* Create dialog */}
       <Dialog open={createOpen} onOpenChange={setCreateOpen}>
@@ -551,7 +562,6 @@ export function AgendaPage({ listId }: { listId?: string }) {
             onKeyDown={(e) => {
               if (e.key === 'Enter') handleCreate();
             }}
-            autoFocus
           />
           <DialogFooter>
             <Button variant="outline" onClick={() => setCreateOpen(false)}>
@@ -614,8 +624,9 @@ function AgendaItemRow({
   onDateChange,
 }: AgendaItemRowProps) {
   const [dateOpen, setDateOpen] = React.useState(false);
+  const [nowMs] = React.useState(() => Date.now());
   const isDone = item.status === 'done' || item.status === 'cancelled';
-  const isOverdue = item.dueAt && item.dueAt < Date.now() && item.status !== 'done' && item.status !== 'cancelled';
+  const isOverdue = item.dueAt && item.dueAt < nowMs && item.status !== 'done' && item.status !== 'cancelled';
 
   function handleDragStart(e: React.DragEvent) {
     e.stopPropagation();
@@ -647,13 +658,15 @@ function AgendaItemRow({
       onClick={onClick}
       onDragOver={onDragOver}>
       <Table.Cell className="w-8">
-        <div
+        <button
+          type="button"
           draggable
+          aria-label={`Reorder ${item.title}`}
           onDragStart={handleDragStart}
           className="flex w-4 cursor-grab items-center justify-center opacity-0 transition-opacity group-hover:opacity-60 active:cursor-grabbing"
           onClick={(e) => e.stopPropagation()}>
           <GripVerticalIcon className="size-3.5 text-muted-foreground" />
-        </div>
+        </button>
       </Table.Cell>
 
       <Table.Cell

--- a/apps/web/src/components/agenda/agenda-sidebar.tsx
+++ b/apps/web/src/components/agenda/agenda-sidebar.tsx
@@ -302,7 +302,6 @@ export function AgendaSidebarContent() {
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && newListName.trim()) handleCreateList();
                 }}
-                autoFocus
               />
             </div>
             <div className="flex flex-col gap-1.5">

--- a/apps/web/src/components/agenda/utils.ts
+++ b/apps/web/src/components/agenda/utils.ts
@@ -2,9 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 
 import { settingsQueryOptions } from '@/lib/queries/settings';
 
+const LOCAL_TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 export function useUserTimezone(): string {
   const { data: settings } = useQuery(settingsQueryOptions);
-  return settings?.['profile.timezone'] || Intl.DateTimeFormat().resolvedOptions().timeZone;
+  return settings?.['profile.timezone'] || LOCAL_TIME_ZONE;
 }
 
 export function formatDateInTz(ts: number, timeZone: string): string {

--- a/apps/web/src/components/automations/automation-dialog.tsx
+++ b/apps/web/src/components/automations/automation-dialog.tsx
@@ -13,6 +13,10 @@ import { Textarea } from '@/components/ui/textarea';
 import { getAutomationScheduleLabel } from '@/lib/automations/schedule-label';
 import type { ProviderModels } from '@/lib/queries/providers';
 
+const DEFAULT_CRON_EXPRESSION = '0 9 * * *';
+
+type EditorView = 'prompt' | 'preview' | 'schedule';
+
 type AutomationDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -34,6 +38,18 @@ type AutomationDialogProps = {
   timezone: string;
 };
 
+type AutomationFormProps = Omit<AutomationDialogProps, 'open'>;
+
+type InitialFormState = {
+  title: string;
+  initialMessage: string;
+  providerId: string;
+  modelId: string;
+  isScheduled: boolean;
+  editorView: EditorView;
+  cronExpression: string;
+};
+
 function getInitialSelection(providerModels: ProviderModels[]): { providerId: string; modelId: string } | null {
   const provider = providerModels[0];
   const model = provider?.models[0];
@@ -41,8 +57,51 @@ function getInitialSelection(providerModels: ProviderModels[]): { providerId: st
   return { providerId: provider.providerId, modelId: model.id };
 }
 
-export function AutomationDialog({
-  open,
+function getInitialFormState(
+  mode: 'create' | 'edit',
+  automation: Automation | undefined,
+  prefill: GeneratedAutomationDraft | null | undefined,
+  providerModels: ProviderModels[],
+): InitialFormState {
+  if (mode === 'edit' && automation) {
+    const schedule = automation.schedule;
+    return {
+      title: automation.title,
+      initialMessage: automation.initialMessage,
+      providerId: automation.providerId,
+      modelId: automation.modelId,
+      isScheduled: schedule !== null,
+      editorView: schedule ? 'schedule' : 'prompt',
+      cronExpression: schedule?.expression ?? DEFAULT_CRON_EXPRESSION,
+    };
+  }
+
+  const initialSelection = getInitialSelection(providerModels);
+  return {
+    title: prefill?.title ?? '',
+    initialMessage: prefill?.prompt ?? '',
+    providerId: prefill?.providerId ?? initialSelection?.providerId ?? '',
+    modelId: prefill?.modelId ?? initialSelection?.modelId ?? '',
+    isScheduled: false,
+    editorView: 'prompt',
+    cronExpression: DEFAULT_CRON_EXPRESSION,
+  };
+}
+
+export function AutomationDialog({ open, ...formProps }: AutomationDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={formProps.onOpenChange}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{formProps.mode === 'create' ? 'Create automation' : 'Edit automation'}</DialogTitle>
+      </DialogHeader>
+      <DialogContent className="flex max-h-[calc(100vh-2rem)] w-[min(1080px,calc(100vw-2rem))] max-w-none flex-col overflow-hidden p-0 sm:max-w-none">
+        <AutomationForm {...formProps} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AutomationForm({
   onOpenChange,
   mode,
   automation,
@@ -51,61 +110,27 @@ export function AutomationDialog({
   onSubmit,
   isPending,
   timezone,
-}: AutomationDialogProps) {
-  const [title, setTitle] = React.useState('');
-  const [initialMessage, setInitialMessage] = React.useState('');
-  const [providerId, setProviderId] = React.useState('');
-  const [modelId, setModelId] = React.useState('');
-  const [isScheduled, setIsScheduled] = React.useState(false);
-  const [editorView, setEditorView] = React.useState<'prompt' | 'preview' | 'schedule'>('prompt');
-  const [cronExpression, setCronExpression] = React.useState('0 9 * * *');
-
-  React.useEffect(() => {
-    if (!open) return;
-
-    if (mode === 'edit' && automation) {
-      setTitle(automation.title);
-      setInitialMessage(automation.initialMessage);
-      setProviderId(automation.providerId);
-      setModelId(automation.modelId);
-      const schedule = automation.schedule;
-      if (!schedule) {
-        setIsScheduled(false);
-        setEditorView('prompt');
-        setCronExpression('0 9 * * *');
-      } else {
-        setIsScheduled(true);
-        setEditorView('schedule');
-        setCronExpression(schedule.expression);
-      }
-      return;
-    }
-
-    const initialSelection = getInitialSelection(providerModels);
-    setTitle(prefill?.title ?? '');
-    setInitialMessage(prefill?.prompt ?? '');
-    setProviderId(prefill?.providerId ?? initialSelection?.providerId ?? '');
-    setModelId(prefill?.modelId ?? initialSelection?.modelId ?? '');
-    setIsScheduled(false);
-    setEditorView('prompt');
-    setCronExpression('0 9 * * *');
-  }, [open, mode, automation, providerModels, prefill]);
+}: AutomationFormProps) {
+  const [initial] = React.useState(() => getInitialFormState(mode, automation, prefill, providerModels));
+  const [title, setTitle] = React.useState(initial.title);
+  const [initialMessage, setInitialMessage] = React.useState(initial.initialMessage);
+  const [providerId, setProviderId] = React.useState(initial.providerId);
+  const [modelId, setModelId] = React.useState(initial.modelId);
+  const [isScheduled, setIsScheduled] = React.useState(initial.isScheduled);
+  const [editorView, setEditorView] = React.useState<EditorView>(initial.editorView);
+  const [cronExpression, setCronExpression] = React.useState(initial.cronExpression);
 
   const selectedProvider = providerModels.find((provider) => provider.providerId === providerId) ?? null;
-  const availableModels = React.useMemo(() => selectedProvider?.models ?? [], [selectedProvider]);
+  const availableModels = selectedProvider?.models ?? [];
   const selectedProviderLabel = selectedProvider?.providerName ?? null;
+  const resolvedModelId =
+    !selectedProvider || availableModels.some((model) => model.id === modelId)
+      ? modelId
+      : (availableModels[0]?.id ?? '');
   const selectedModelLabel =
-    availableModels.find((model) => model.id === modelId)?.name ??
-    providerModels.flatMap((provider) => provider.models).find((model) => model.id === modelId)?.name ??
+    availableModels.find((model) => model.id === resolvedModelId)?.name ??
+    providerModels.flatMap((provider) => provider.models).find((model) => model.id === resolvedModelId)?.name ??
     null;
-
-  React.useEffect(() => {
-    if (!selectedProvider) return;
-    const hasCurrentModel = availableModels.some((model) => model.id === modelId);
-    if (!hasCurrentModel) {
-      setModelId(availableModels[0]?.id ?? '');
-    }
-  }, [selectedProvider, availableModels, modelId]);
 
   const isCronValid = cronExpression.trim().length > 0;
   const triggerLabel = isScheduled ? 'Scheduled' : 'Manual';
@@ -117,7 +142,7 @@ export function AutomationDialog({
     title.trim().length > 0 &&
     initialMessage.trim().length > 0 &&
     providerId.length > 0 &&
-    modelId.length > 0 &&
+    resolvedModelId.length > 0 &&
     (!isScheduled || isCronValid) &&
     !isPending;
 
@@ -129,200 +154,190 @@ export function AutomationDialog({
       : { type: 'cron', expression: cronExpression.trim() };
 
     await onSubmit(
-      { title: title.trim(), initialMessage: initialMessage.trim(), providerId, modelId, schedule },
+      { title: title.trim(), initialMessage: initialMessage.trim(), providerId, modelId: resolvedModelId, schedule },
       action,
     );
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogHeader className="sr-only">
-        <DialogTitle>{mode === 'create' ? 'Create automation' : 'Edit automation'}</DialogTitle>
-      </DialogHeader>
-      <DialogContent className="flex max-h-[calc(100vh-2rem)] w-[min(1080px,calc(100vw-2rem))] max-w-none flex-col overflow-hidden p-0 sm:max-w-none">
-        <div className="border-b border-border/60 px-6 py-5">
-          <h2 className="text-xl font-semibold tracking-tight">
-            {mode === 'create' ? 'Create automation' : 'Edit automation'}
-          </h2>
-          <p className="mt-1 text-sm text-muted-foreground">Save a reusable model + prompt pair for recurring tasks.</p>
-        </div>
+    <>
+      <div className="border-b border-border/60 px-6 py-5">
+        <h2 className="text-xl font-semibold tracking-tight">
+          {mode === 'create' ? 'Create automation' : 'Edit automation'}
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">Save a reusable model + prompt pair for recurring tasks.</p>
+      </div>
 
-        <div className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[minmax(280px,1fr)_minmax(0,2fr)]">
-          <div className="space-y-5 overflow-y-auto border-b border-border/50 bg-muted/10 px-6 py-5 lg:border-r lg:border-b-0">
-            <div className="space-y-1.5">
-              <Label htmlFor="automation-title">Title</Label>
-              <Input
-                id="automation-title"
-                value={title}
-                onChange={(event) => setTitle(event.target.value)}
-                placeholder="e.g. Daily standup prep"
-                autoFocus
-              />
-            </div>
-
-            <div className="space-y-1.5">
-              <Label>Provider</Label>
-              <Select value={providerId} onValueChange={(value) => setProviderId(value ?? '')}>
-                <SelectTrigger className="w-full">
-                  <SelectValue>{selectedProviderLabel ?? 'Select provider'}</SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  {providerModels.map((provider) => (
-                    <SelectItem key={provider.providerId} value={provider.providerId}>
-                      {provider.providerName}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label>Model</Label>
-              <Select value={modelId} onValueChange={(value) => setModelId(value ?? '')}>
-                <SelectTrigger className="w-full">
-                  <SelectValue>{selectedModelLabel ?? 'Select model'}</SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  {availableModels.map((model) => (
-                    <SelectItem key={model.id} value={model.id}>
-                      {model.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="space-y-1.5">
-              <Label>Trigger</Label>
-              <Select
-                value={isScheduled ? 'scheduled' : 'manual'}
-                onValueChange={(value) => {
-                  const scheduled = value === 'scheduled';
-                  setIsScheduled(scheduled);
-                  if (scheduled) {
-                    setEditorView('schedule');
-                  } else {
-                    setEditorView('prompt');
-                  }
-                }}>
-                <SelectTrigger className="w-full">
-                  <SelectValue>{triggerLabel}</SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="manual">Manual</SelectItem>
-                  <SelectItem value="scheduled">Scheduled</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="rounded-lg border border-border/60 bg-card/70 px-3 py-2.5">
-              <p className="text-2xs font-semibold tracking-wide text-muted-foreground uppercase">Current schedule</p>
-              <p className="mt-1 text-sm text-foreground">{scheduleSummary}</p>
-            </div>
+      <div className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden lg:grid-cols-[minmax(280px,1fr)_minmax(0,2fr)]">
+        <div className="space-y-5 overflow-y-auto border-b border-border/50 bg-muted/10 px-6 py-5 lg:border-r lg:border-b-0">
+          <div className="space-y-1.5">
+            <Label htmlFor="automation-title">Title</Label>
+            <Input
+              id="automation-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="e.g. Daily standup prep"
+            />
           </div>
 
-          <div className="flex min-h-0 flex-col px-6 py-5">
-            <div className="mb-3 inline-flex w-fit gap-1 rounded-[min(var(--radius-md),10px)] border border-border/60 bg-muted/30 p-1">
-              <Button
-                type="button"
-                size="sm"
-                variant={editorView === 'prompt' ? 'default' : 'ghost'}
-                onClick={() => setEditorView('prompt')}
-                className={
-                  editorView === 'prompt' ? 'bg-background text-foreground shadow-sm hover:bg-background' : ''
-                }>
-                Prompt
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant={editorView === 'preview' ? 'default' : 'ghost'}
-                onClick={() => setEditorView('preview')}
-                className={
-                  editorView === 'preview' ? 'bg-background text-foreground shadow-sm hover:bg-background' : ''
-                }>
-                Preview
-              </Button>
-              {isScheduled && (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant={editorView === 'schedule' ? 'default' : 'ghost'}
-                  onClick={() => {
-                    if (!isScheduled) return;
-                    setEditorView('schedule');
-                  }}
-                  className={
-                    editorView === 'schedule' ? 'bg-background text-foreground shadow-sm hover:bg-background' : ''
-                  }>
-                  Schedule
-                </Button>
-              )}
-            </div>
+          <div className="space-y-1.5">
+            <Label>Provider</Label>
+            <Select value={providerId} onValueChange={(value) => setProviderId(value ?? '')}>
+              <SelectTrigger className="w-full">
+                <SelectValue>{selectedProviderLabel ?? 'Select provider'}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {providerModels.map((provider) => (
+                  <SelectItem key={provider.providerId} value={provider.providerId}>
+                    {provider.providerName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
 
-            {editorView === 'preview' ? (
-              <div className="flex min-h-0 flex-1 flex-col space-y-2">
-                <div className="flex items-center justify-between">
-                  <Label>Prompt preview</Label>
-                  <span className="text-xs text-muted-foreground">Markdown</span>
-                </div>
-                <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-border/60 bg-muted/10 p-3">
-                  {initialMessage.trim() ? (
-                    <ChatMarkdown text={initialMessage} />
-                  ) : (
-                    <p className="text-sm text-muted-foreground">Prompt preview appears here.</p>
-                  )}
-                </div>
-              </div>
-            ) : editorView === 'prompt' || !isScheduled ? (
-              <div className="flex min-h-0 flex-1 flex-col space-y-2">
-                <div className="flex items-center justify-between">
-                  <Label htmlFor="automation-message">Initial prompt</Label>
-                  <span className="text-xs text-muted-foreground">{initialMessage.length} chars</span>
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  This message is used to kick off the session when the automation runs.
-                </p>
-                <div className="flex min-h-0 flex-1 rounded-xl border border-border/60 bg-muted/15 p-3">
-                  <Textarea
-                    id="automation-message"
-                    value={initialMessage}
-                    onChange={(event) => setInitialMessage(event.target.value)}
-                    placeholder="Write the prompt that should be sent when this automation starts..."
-                    className="min-h-55 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-1.5 py-1 text-sm leading-6 shadow-none focus-visible:ring-0"
-                  />
-                </div>
-              </div>
-            ) : (
-              <div className="flex min-h-0 flex-1 flex-col space-y-2">
-                <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-border/60 bg-muted/15 p-3">
-                  <CronExpressionBuilder value={cronExpression} onChange={setCronExpression} timezone={timezone} />
-                </div>
-              </div>
+          <div className="space-y-1.5">
+            <Label>Model</Label>
+            <Select value={resolvedModelId} onValueChange={(value) => setModelId(value ?? '')}>
+              <SelectTrigger className="w-full">
+                <SelectValue>{selectedModelLabel ?? 'Select model'}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                {availableModels.map((model) => (
+                  <SelectItem key={model.id} value={model.id}>
+                    {model.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Trigger</Label>
+            <Select
+              value={isScheduled ? 'scheduled' : 'manual'}
+              onValueChange={(value) => {
+                const scheduled = value === 'scheduled';
+                setIsScheduled(scheduled);
+                if (scheduled) {
+                  setEditorView('schedule');
+                } else {
+                  setEditorView('prompt');
+                }
+              }}>
+              <SelectTrigger className="w-full">
+                <SelectValue>{triggerLabel}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="manual">Manual</SelectItem>
+                <SelectItem value="scheduled">Scheduled</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="rounded-lg border border-border/60 bg-card/70 px-3 py-2.5">
+            <p className="text-2xs font-semibold tracking-wide text-muted-foreground uppercase">Current schedule</p>
+            <p className="mt-1 text-sm text-foreground">{scheduleSummary}</p>
+          </div>
+        </div>
+
+        <div className="flex min-h-0 flex-col px-6 py-5">
+          <div className="mb-3 inline-flex w-fit gap-1 rounded-[min(var(--radius-md),10px)] border border-border/60 bg-muted/30 p-1">
+            <Button
+              type="button"
+              size="sm"
+              variant={editorView === 'prompt' ? 'default' : 'ghost'}
+              onClick={() => setEditorView('prompt')}
+              className={editorView === 'prompt' ? 'bg-background text-foreground shadow-sm hover:bg-background' : ''}>
+              Prompt
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={editorView === 'preview' ? 'default' : 'ghost'}
+              onClick={() => setEditorView('preview')}
+              className={editorView === 'preview' ? 'bg-background text-foreground shadow-sm hover:bg-background' : ''}>
+              Preview
+            </Button>
+            {isScheduled && (
+              <Button
+                type="button"
+                size="sm"
+                variant={editorView === 'schedule' ? 'default' : 'ghost'}
+                onClick={() => {
+                  if (!isScheduled) return;
+                  setEditorView('schedule');
+                }}
+                className={
+                  editorView === 'schedule' ? 'bg-background text-foreground shadow-sm hover:bg-background' : ''
+                }>
+                Schedule
+              </Button>
             )}
           </div>
-        </div>
 
-        <div className="flex justify-end gap-2 border-t border-border/60 px-6 py-4">
-          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
-            Cancel
-          </Button>
-          {mode === 'create' ? (
-            <>
-              <Button variant="outline" onClick={() => void handleSubmit('create')} disabled={!canSubmit}>
-                {isPending ? 'Creating...' : 'Create'}
-              </Button>
-              <Button onClick={() => void handleSubmit('create-view')} disabled={!canSubmit}>
-                {isPending ? 'Creating...' : 'Create and View'}
-              </Button>
-            </>
+          {editorView === 'preview' ? (
+            <div className="flex min-h-0 flex-1 flex-col space-y-2">
+              <div className="flex items-center justify-between">
+                <Label>Prompt preview</Label>
+                <span className="text-xs text-muted-foreground">Markdown</span>
+              </div>
+              <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-border/60 bg-muted/10 p-3">
+                {initialMessage.trim() ? (
+                  <ChatMarkdown text={initialMessage} />
+                ) : (
+                  <p className="text-sm text-muted-foreground">Prompt preview appears here.</p>
+                )}
+              </div>
+            </div>
+          ) : editorView === 'prompt' || !isScheduled ? (
+            <div className="flex min-h-0 flex-1 flex-col space-y-2">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="automation-message">Initial prompt</Label>
+                <span className="text-xs text-muted-foreground">{initialMessage.length} chars</span>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                This message is used to kick off the session when the automation runs.
+              </p>
+              <div className="flex min-h-0 flex-1 rounded-xl border border-border/60 bg-muted/15 p-3">
+                <Textarea
+                  id="automation-message"
+                  value={initialMessage}
+                  onChange={(event) => setInitialMessage(event.target.value)}
+                  placeholder="Write the prompt that should be sent when this automation starts..."
+                  className="min-h-55 flex-1 resize-none overflow-y-auto border-0 bg-transparent px-1.5 py-1 text-sm leading-6 shadow-none focus-visible:ring-0"
+                />
+              </div>
+            </div>
           ) : (
-            <Button onClick={() => void handleSubmit('save')} disabled={!canSubmit}>
-              {isPending ? 'Saving...' : 'Save'}
-            </Button>
+            <div className="flex min-h-0 flex-1 flex-col space-y-2">
+              <div className="min-h-0 flex-1 overflow-y-auto rounded-xl border border-border/60 bg-muted/15 p-3">
+                <CronExpressionBuilder value={cronExpression} onChange={setCronExpression} timezone={timezone} />
+              </div>
+            </div>
           )}
         </div>
-      </DialogContent>
-    </Dialog>
+      </div>
+
+      <div className="flex justify-end gap-2 border-t border-border/60 px-6 py-4">
+        <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+          Cancel
+        </Button>
+        {mode === 'create' ? (
+          <>
+            <Button variant="outline" onClick={() => void handleSubmit('create')} disabled={!canSubmit}>
+              {isPending ? 'Creating...' : 'Create'}
+            </Button>
+            <Button onClick={() => void handleSubmit('create-view')} disabled={!canSubmit}>
+              {isPending ? 'Creating...' : 'Create and View'}
+            </Button>
+          </>
+        ) : (
+          <Button onClick={() => void handleSubmit('save')} disabled={!canSubmit}>
+            {isPending ? 'Saving...' : 'Save'}
+          </Button>
+        )}
+      </div>
+    </>
   );
 }

--- a/apps/web/src/components/automations/automation-runs-table.tsx
+++ b/apps/web/src/components/automations/automation-runs-table.tsx
@@ -2,6 +2,7 @@ import { ArrowUpRightIcon } from 'lucide-react';
 import * as React from 'react';
 
 import {
+  type CellContext,
   createColumnHelper,
   flexRender,
   getCoreRowModel,
@@ -19,44 +20,45 @@ type AutomationRunsTableProps = { sessions: Session[]; onOpen: (sessionId: strin
 
 const columnHelper = createColumnHelper<Session>();
 
+type AutomationRunsTableMeta = { onOpen: (sessionId: string) => void };
+
+function TitleCell({ row }: CellContext<Session, Session['title']>) {
+  return <Table.Title>{row.original.title ?? 'Untitled run'}</Table.Title>;
+}
+
+function TimeCell({ getValue }: CellContext<Session, number>) {
+  return <Table.Time value={getValue()} />;
+}
+
+function ActionsCell({ row, table }: CellContext<Session, unknown>) {
+  const { onOpen } = table.options.meta as AutomationRunsTableMeta;
+
+  return (
+    <Table.Actions>
+      <Button variant="outline" size="sm" onClick={() => onOpen(row.original.id)}>
+        <ArrowUpRightIcon data-icon="inline-start" className="size-4" />
+        View
+      </Button>
+    </Table.Actions>
+  );
+}
+
+const columns = [
+  columnHelper.accessor('title', { header: 'Run', cell: TitleCell }),
+  columnHelper.accessor('createdAt', { header: 'Started', cell: TimeCell }),
+  columnHelper.accessor('updatedAt', { header: 'Updated', cell: TimeCell }),
+  columnHelper.display({ id: 'actions', header: '', cell: ActionsCell }),
+];
+
 export function AutomationRunsTable({ sessions, onOpen }: AutomationRunsTableProps) {
   const [sorting, setSorting] = React.useState<SortingState>([{ id: 'updatedAt', desc: true }]);
-
-  const columns = React.useMemo(
-    () => [
-      columnHelper.accessor('title', {
-        header: 'Run',
-        cell: ({ row }) => <Table.Title>{row.original.title ?? 'Untitled run'}</Table.Title>,
-      }),
-      columnHelper.accessor('createdAt', {
-        header: 'Started',
-        cell: ({ getValue }) => <Table.Time value={getValue()} />,
-      }),
-      columnHelper.accessor('updatedAt', {
-        header: 'Updated',
-        cell: ({ getValue }) => <Table.Time value={getValue()} />,
-      }),
-      columnHelper.display({
-        id: 'actions',
-        header: '',
-        cell: ({ row }) => (
-          <Table.Actions>
-            <Button variant="outline" size="sm" onClick={() => onOpen(row.original.id)}>
-              <ArrowUpRightIcon data-icon="inline-start" className="size-4" />
-              View
-            </Button>
-          </Table.Actions>
-        ),
-      }),
-    ],
-    [onOpen],
-  );
 
   const table = useReactTable({
     data: sessions,
     columns,
     state: { sorting },
     onSortingChange: setSorting,
+    meta: { onOpen } satisfies AutomationRunsTableMeta,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });

--- a/apps/web/src/components/automations/automations-page.tsx
+++ b/apps/web/src/components/automations/automations-page.tsx
@@ -1,5 +1,5 @@
 import { BotIcon, PencilIcon, PlayIcon, PlusIcon, Trash2Icon } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { toast } from 'sonner';
 
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
@@ -42,6 +42,8 @@ import { useAutomationStore } from '@/stores/automation-store';
 
 type AutomationsPageProps = { automationId?: string };
 
+const LOCAL_TIME_ZONE = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
 export function AutomationsPage({ automationId }: AutomationsPageProps) {
   const navigate = useNavigate();
   const { data: sidebarAutomations } = useSuspenseQuery(automationsSidebarListQueryOptions);
@@ -83,15 +85,12 @@ export function AutomationsPage({ automationId }: AutomationsPageProps) {
   const [automationToDelete, setAutomationToDelete] = useState<Automation | null>(null);
   const [archiveDeletedAutomationSessions, setArchiveDeletedAutomationSessions] = useState(false);
 
-  useEffect(() => {
-    if (automationsPage.totalPages === 0 && page !== 1) {
-      setPage(1);
-      return;
-    }
-    if (automationsPage.totalPages > 0 && page > automationsPage.totalPages) {
-      setPage(automationsPage.totalPages);
-    }
-  }, [automationsPage.totalPages, page]);
+  // Clamp the requested page during render when the result set shrinks
+  if (automationsPage.totalPages === 0 && page !== 1) {
+    setPage(1);
+  } else if (automationsPage.totalPages > 0 && page > automationsPage.totalPages) {
+    setPage(automationsPage.totalPages);
+  }
 
   const handleDelete = (automation: Automation) => {
     setArchiveDeletedAutomationSessions(false);
@@ -138,7 +137,7 @@ export function AutomationsPage({ automationId }: AutomationsPageProps) {
   const pageDescription = selectedAutomation
     ? 'Automation details and run history.'
     : 'Manage reusable prompts and model presets for recurring tasks.';
-  const timezone = settings?.['profile.timezone']?.trim() || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+  const timezone = settings?.['profile.timezone']?.trim() || LOCAL_TIME_ZONE || 'UTC';
   const selectedScheduleLabel = selectedAutomation ? getAutomationScheduleLabel(selectedAutomation.schedule) : 'Manual';
   const upcomingRuns = selectedAutomation ? getUpcomingRuns(selectedAutomation.schedule, 3, timezone) : [];
 
@@ -309,8 +308,11 @@ export function AutomationsPage({ automationId }: AutomationsPageProps) {
         pendingLabel="Delete"
         isPending={deleteAutomation.isPending}
         contentClassName="max-w-sm">
-        <label className="flex items-start gap-3 rounded-lg border border-border/60 bg-muted/40 p-3 text-sm">
+        <label
+          htmlFor="archive-automation-sessions"
+          className="flex items-start gap-3 rounded-lg border border-border/60 bg-muted/40 p-3 text-sm">
           <Checkbox
+            id="archive-automation-sessions"
             checked={archiveDeletedAutomationSessions}
             onCheckedChange={(checked) => setArchiveDeletedAutomationSessions(Boolean(checked))}
             disabled={deleteAutomation.isPending}

--- a/apps/web/src/components/automations/automations-table.tsx
+++ b/apps/web/src/components/automations/automations-table.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { Link } from '@tanstack/react-router';
 import {
+  type CellContext,
   createColumnHelper,
   flexRender,
   getCoreRowModel,
@@ -43,6 +44,88 @@ type AutomationsTableProps = {
 
 const columnHelper = createColumnHelper<Automation>();
 
+type AutomationsTableMeta = {
+  modelLabelByKey: Map<string, string>;
+  runPending: boolean;
+  deletePending: boolean;
+  onRun: (automation: Automation) => void;
+  onEdit: (automationId: string) => void;
+  onDelete: (automation: Automation) => void;
+};
+
+function TitleCell({ row }: CellContext<Automation, Automation['title']>) {
+  return (
+    <Table.Title className="block">
+      <Link
+        to="/automations/$automationId"
+        params={{ automationId: row.original.id }}
+        className="text-foreground hover:underline">
+        {row.original.title}
+      </Link>
+    </Table.Title>
+  );
+}
+
+function ModelCell({ row, table }: CellContext<Automation, unknown>) {
+  const { modelLabelByKey } = table.options.meta as AutomationsTableMeta;
+  const automation = row.original;
+  const label = modelLabelByKey.get(`${automation.providerId}:${automation.modelId}`) ?? automation.modelId;
+  return <Table.Badge>{label}</Table.Badge>;
+}
+
+function RunCountCell({ getValue }: CellContext<Automation, Automation['runCount']>) {
+  return <Table.Number value={getValue()} />;
+}
+
+function ScheduleCell({ row }: CellContext<Automation, unknown>) {
+  return <Table.Text>{getAutomationScheduleLabel(row.original.schedule)}</Table.Text>;
+}
+
+function UpdatedAtCell({ getValue }: CellContext<Automation, Automation['updatedAt']>) {
+  return <Table.Time value={getValue()} />;
+}
+
+function ActionsCell({ row, table }: CellContext<Automation, unknown>) {
+  const { runPending, deletePending, onRun, onEdit, onDelete } = table.options.meta as AutomationsTableMeta;
+
+  return (
+    <Table.Actions>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={() => onRun(row.original)}
+        disabled={runPending}
+        aria-label={`Run ${row.original.title}`}>
+        <PlayIcon className="size-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={() => onEdit(row.original.id)}
+        aria-label={`Edit ${row.original.title}`}>
+        <PencilIcon className="size-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={() => onDelete(row.original)}
+        disabled={deletePending}
+        aria-label={`Delete ${row.original.title}`}>
+        <Trash2Icon className="size-3.5 text-destructive" />
+      </Button>
+    </Table.Actions>
+  );
+}
+
+const columns = [
+  columnHelper.accessor('title', { header: 'Title', cell: TitleCell }),
+  columnHelper.display({ id: 'model', header: 'Model', cell: ModelCell }),
+  columnHelper.accessor('runCount', { header: 'Runs', cell: RunCountCell }),
+  columnHelper.display({ id: 'schedule', header: 'Schedule', cell: ScheduleCell }),
+  columnHelper.accessor('updatedAt', { header: 'Updated', cell: UpdatedAtCell }),
+  columnHelper.display({ id: 'actions', header: '', cell: ActionsCell }),
+];
+
 export function AutomationsTable({
   automations,
   providerModels,
@@ -67,83 +150,12 @@ export function AutomationsTable({
     return map;
   }, [providerModels]);
 
-  const columns = React.useMemo(
-    () => [
-      columnHelper.accessor('title', {
-        header: 'Title',
-        cell: ({ row }) => (
-          <Table.Title className="block">
-            <Link
-              to="/automations/$automationId"
-              params={{ automationId: row.original.id }}
-              className="text-foreground hover:underline">
-              {row.original.title}
-            </Link>
-          </Table.Title>
-        ),
-      }),
-      columnHelper.display({
-        id: 'model',
-        header: 'Model',
-        cell: ({ row }) => {
-          const automation = row.original;
-          const label = modelLabelByKey.get(`${automation.providerId}:${automation.modelId}`) ?? automation.modelId;
-          return <Table.Badge>{label}</Table.Badge>;
-        },
-      }),
-      columnHelper.accessor('runCount', {
-        header: 'Runs',
-        cell: ({ getValue }) => <Table.Number value={getValue()} />,
-      }),
-      columnHelper.display({
-        id: 'schedule',
-        header: 'Schedule',
-        cell: ({ row }) => <Table.Text>{getAutomationScheduleLabel(row.original.schedule)}</Table.Text>,
-      }),
-      columnHelper.accessor('updatedAt', {
-        header: 'Updated',
-        cell: ({ getValue }) => <Table.Time value={getValue()} />,
-      }),
-      columnHelper.display({
-        id: 'actions',
-        header: '',
-        cell: ({ row }) => (
-          <Table.Actions>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => onRun(row.original)}
-              disabled={runPending}
-              aria-label={`Run ${row.original.title}`}>
-              <PlayIcon className="size-3.5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => onEdit(row.original.id)}
-              aria-label={`Edit ${row.original.title}`}>
-              <PencilIcon className="size-3.5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => onDelete(row.original)}
-              disabled={deletePending}
-              aria-label={`Delete ${row.original.title}`}>
-              <Trash2Icon className="size-3.5 text-destructive" />
-            </Button>
-          </Table.Actions>
-        ),
-      }),
-    ],
-    [deletePending, modelLabelByKey, onDelete, onEdit, onRun, runPending],
-  );
-
   const table = useReactTable({
     data: automations,
     columns,
     state: { sorting },
     onSortingChange: setSorting,
+    meta: { modelLabelByKey, runPending, deletePending, onRun, onEdit, onDelete } satisfies AutomationsTableMeta,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
@@ -164,7 +176,7 @@ export function AutomationsTable({
       pages.add(index);
     }
 
-    return [...pages].sort((a, b) => a - b);
+    return [...pages].toSorted((a, b) => a - b);
   }, [currentPage, totalPages]);
 
   return (

--- a/apps/web/src/components/chat/chat-input-parts/mic-level-meter.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/mic-level-meter.tsx
@@ -8,7 +8,13 @@ type MicLevelMeterProps = {
 
 // Fixed per-bar weights so the meter reads as a centered, organic spread
 // rather than a flat block. Multiplied by the live level.
-const BAR_WEIGHTS = [0.45, 0.75, 1, 0.75, 0.45];
+const BARS = [
+  { id: 'bar-1', weight: 0.45 },
+  { id: 'bar-2', weight: 0.75 },
+  { id: 'bar-3', weight: 1 },
+  { id: 'bar-4', weight: 0.75 },
+  { id: 'bar-5', weight: 0.45 },
+];
 
 /**
  * Live microphone level meter. Bars scale with the incoming audio level.
@@ -16,20 +22,20 @@ const BAR_WEIGHTS = [0.45, 0.75, 1, 0.75, 0.45];
  */
 export function MicLevelMeter({ level, className }: MicLevelMeterProps) {
   return (
-    <div className={cn('flex items-center', className)} aria-hidden="true">
-      <div className="flex h-4 items-center gap-0.5 motion-reduce:hidden">
-        {BAR_WEIGHTS.map((weight, i) => {
+    <span className={cn('flex items-center', className)} aria-hidden="true">
+      <span className="flex h-4 items-center gap-0.5 motion-reduce:hidden">
+        {BARS.map(({ id, weight }) => {
           const height = Math.max(3, Math.min(16, level * weight * 16 + 3));
           return (
             <span
-              key={i}
+              key={id}
               className="w-0.5 rounded-full bg-destructive transition-[height] duration-75 ease-out"
               style={{ height: `${height}px` }}
             />
           );
         })}
-      </div>
+      </span>
       <span className="hidden text-xs font-medium text-destructive motion-reduce:inline">Listening</span>
-    </div>
+    </span>
   );
 }

--- a/apps/web/src/components/chat/chat-input-parts/model-selector-popover.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/model-selector-popover.tsx
@@ -54,7 +54,6 @@ export function ModelSelectorPopover({ selectedValue, onSelect, providerModels }
             <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2">
               <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
               <input
-                autoFocus
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
                 placeholder="Search models"

--- a/apps/web/src/components/chat/chat-input-parts/recording-bar.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/recording-bar.tsx
@@ -26,7 +26,6 @@ function useElapsed(startedAt: number | null): number {
 
   React.useEffect(() => {
     if (startedAt === null) return;
-    setNow(Date.now());
     const id = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(id);
   }, [startedAt]);
@@ -43,7 +42,7 @@ export function RecordingBar({ audioLevel, startedAt, isStopping, onCancel, onSt
   const elapsedMs = useElapsed(startedAt);
 
   return (
-    <div className="flex w-full items-center gap-2" role="status" aria-live="polite">
+    <output className="flex w-full items-center gap-2" aria-live="polite">
       <StatusDot color="destructive" pulse={!isStopping} />
       <span className="text-xs font-medium text-destructive">{isStopping ? 'Transcribing…' : 'Recording'}</span>
       <MicLevelMeter level={isStopping ? 0 : audioLevel} />
@@ -67,6 +66,6 @@ export function RecordingBar({ audioLevel, startedAt, isStopping, onCancel, onSt
         title="Stop and insert transcript">
         <CheckIcon className="size-3.5" />
       </Button>
-    </div>
+    </output>
   );
 }

--- a/apps/web/src/components/chat/chat-input-parts/use-attachments.ts
+++ b/apps/web/src/components/chat/chat-input-parts/use-attachments.ts
@@ -80,12 +80,19 @@ type UseAttachmentsOptions = { pendingAttachments?: Attachment[]; onPendingAttac
 
 export function useAttachments(options: UseAttachmentsOptions) {
   const { pendingAttachments, onPendingAttachmentsConsumed } = options;
-  const [attachments, setAttachments] = React.useState<Attachment[]>([]);
+  const [attachments, setAttachments] = React.useState<Attachment[]>(pendingAttachments ?? []);
   const [isDragging, setIsDragging] = React.useState(false);
+  const [appliedPending, setAppliedPending] = React.useState(pendingAttachments);
+
+  if (appliedPending !== pendingAttachments) {
+    setAppliedPending(pendingAttachments);
+    if (pendingAttachments && pendingAttachments.length > 0) {
+      setAttachments(pendingAttachments);
+    }
+  }
 
   React.useEffect(() => {
     if (pendingAttachments && pendingAttachments.length > 0) {
-      setAttachments(pendingAttachments);
       onPendingAttachmentsConsumed?.();
     }
   }, [pendingAttachments, onPendingAttachmentsConsumed]);

--- a/apps/web/src/components/chat/chat-input-parts/use-dictation.ts
+++ b/apps/web/src/components/chat/chat-input-parts/use-dictation.ts
@@ -49,8 +49,6 @@ export function useDictation({
 }: UseDictationArgs): UseDictationReturn {
   const stt = useStt();
   const baseOffsetRef = React.useRef(0);
-  const valueRef = React.useRef(value);
-  valueRef.current = value;
   // Set when stop is requested before recording has actually started (fast
   // push-to-talk taps). Finalizes as soon as the session reaches 'recording'.
   const pendingStopRef = React.useRef(false);
@@ -82,10 +80,10 @@ export function useDictation({
       const resolved = resolveModel(model);
       if (!resolved) return;
       pendingStopRef.current = false;
-      baseOffsetRef.current = valueRef.current.length;
+      baseOffsetRef.current = value.length;
       void stt.start(resolved.providerId, resolved.modelId, resolved.sampleRateHz);
     },
-    [stt, resolveModel],
+    [stt, resolveModel, value],
   );
 
   const stopAndCommit = React.useCallback(async () => {
@@ -96,9 +94,9 @@ export function useDictation({
       return;
     }
     const transcript = await stt.stop();
-    const base = valueRef.current.slice(0, baseOffsetRef.current);
+    const base = value.slice(0, baseOffsetRef.current);
     onChange(spliceTranscript(base, transcript));
-  }, [stt, onChange]);
+  }, [stt, onChange, value]);
 
   // Honor a stop requested during the startup window.
   React.useEffect(() => {

--- a/apps/web/src/components/chat/chat-markdown.tsx
+++ b/apps/web/src/components/chat/chat-markdown.tsx
@@ -1,3 +1,4 @@
+import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
 import { CheckIcon, CopyIcon } from 'lucide-react';
 import * as React from 'react';
 import {
@@ -13,12 +14,14 @@ import {
   memo,
 } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { Fragment, jsx, jsxs } from 'react/jsx-runtime';
 import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 
 import {
   getHighlighterPromise,
+  type HighlightedCodeHast,
   type SupportedLanguage,
   normalizeLanguage,
   highlightedCodeCache,
@@ -27,7 +30,11 @@ import {
 } from '@/lib/code-highlighting';
 import { normalizeInlineMath } from '@/lib/normalize-inline-math';
 import { cn } from '@/lib/utils';
-import type { Components } from 'react-markdown';
+import type { Components, ExtraProps } from 'react-markdown';
+
+const JSX_RUNTIME = { Fragment, jsx, jsxs };
+
+type MarkdownPreProps = React.ComponentProps<'pre'> & ExtraProps;
 
 interface ChatMarkdownProps {
   text: string;
@@ -129,22 +136,21 @@ interface SuspenseShikiCodeBlockProps {
 function SuspenseShikiCodeBlock({ className, code, isStreaming }: SuspenseShikiCodeBlockProps) {
   const language = extractFenceLanguage(className);
   const cacheKey = createHighlightCacheKey(code, language, 'dual');
-  const cachedHighlightedHtml = !isStreaming ? (highlightedCodeCache.get(cacheKey) ?? null) : null;
+  const cachedHighlightedHast = !isStreaming ? (highlightedCodeCache.get(cacheKey) ?? null) : null;
 
-  if (cachedHighlightedHtml !== null) {
+  if (cachedHighlightedHast !== null) {
     return (
-      <div
-        className="chat-markdown-shiki overflow-x-auto rounded-lg bg-muted/50 p-3 text-sm"
-        dangerouslySetInnerHTML={{ __html: cachedHighlightedHtml }}
-      />
+      <div className="chat-markdown-shiki overflow-x-auto rounded-lg bg-muted/50 p-3 text-sm">
+        {toJsxRuntime(cachedHighlightedHast, JSX_RUNTIME)}
+      </div>
     );
   }
 
   const highlighter = use(getHighlighterPromise(language));
 
-  let highlightedHtml: string;
+  let highlightedHast: HighlightedCodeHast;
   try {
-    highlightedHtml = highlighter.codeToHtml(code, {
+    highlightedHast = highlighter.codeToHast(code, {
       lang: language as SupportedLanguage,
       themes: { light: 'github-light', dark: 'github-dark' },
     });
@@ -153,21 +159,20 @@ function SuspenseShikiCodeBlock({ className, code, isStreaming }: SuspenseShikiC
       `Code highlighting failed for language "${language}", falling back to plain text.`,
       error instanceof Error ? error.message : error,
     );
-    highlightedHtml = highlighter.codeToHtml(code, {
+    highlightedHast = highlighter.codeToHast(code, {
       lang: 'text',
       themes: { light: 'github-light', dark: 'github-dark' },
     });
   }
 
   if (!isStreaming) {
-    highlightedCodeCache.set(cacheKey, highlightedHtml, estimateHighlightedSize(highlightedHtml, code));
+    highlightedCodeCache.set(cacheKey, highlightedHast, estimateHighlightedSize(highlightedHast, code));
   }
 
   return (
-    <div
-      className="chat-markdown-shiki overflow-x-auto rounded-lg bg-muted/50 p-3 text-sm"
-      dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-    />
+    <div className="chat-markdown-shiki overflow-x-auto rounded-lg bg-muted/50 p-3 text-sm">
+      {toJsxRuntime(highlightedHast, JSX_RUNTIME)}
+    </div>
   );
 }
 
@@ -278,7 +283,7 @@ function MarkdownAnchor({ href, children, ...props }: React.AnchorHTMLAttributes
   );
 }
 
-function MarkdownImage(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+function MarkdownImage({ alt, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) {
   const [broken, setBroken] = useState(false);
 
   if (broken) {
@@ -289,41 +294,45 @@ function MarkdownImage(props: React.ImgHTMLAttributes<HTMLImageElement>) {
     );
   }
 
-  return <img {...props} onError={() => setBroken(true)} />;
+  return <img {...props} alt={alt ?? ''} onError={() => setBroken(true)} />;
 }
 
+/** Plain `pre` used while streaming — Shiki highlighting is too expensive per token. */
+function StreamingMarkdownPre({ node: _node, children, ...props }: MarkdownPreProps) {
+  const codeBlock = extractCodeBlock(children);
+  if (!codeBlock) {
+    return <pre {...props}>{children}</pre>;
+  }
+
+  return (
+    <MarkdownCodeBlock code={codeBlock.code}>
+      <pre {...props}>{children}</pre>
+    </MarkdownCodeBlock>
+  );
+}
+
+function HighlightedMarkdownPre({ node: _node, children, ...props }: MarkdownPreProps) {
+  const codeBlock = extractCodeBlock(children);
+  if (!codeBlock) {
+    return <pre {...props}>{children}</pre>;
+  }
+
+  return (
+    <MarkdownCodeBlock code={codeBlock.code}>
+      <CodeBlockErrorBoundary fallback={<pre {...props}>{children}</pre>}>
+        <Suspense fallback={<pre {...props}>{children}</pre>}>
+          <SuspenseShikiCodeBlock className={codeBlock.className} code={codeBlock.code} isStreaming={false} />
+        </Suspense>
+      </CodeBlockErrorBoundary>
+    </MarkdownCodeBlock>
+  );
+}
+
+const STREAMING_COMPONENTS: Components = { img: MarkdownImage, a: MarkdownAnchor, pre: StreamingMarkdownPre };
+const HIGHLIGHTED_COMPONENTS: Components = { img: MarkdownImage, a: MarkdownAnchor, pre: HighlightedMarkdownPre };
+
 function ChatMarkdown({ text, className, isStreaming = false }: ChatMarkdownProps) {
-  const markdownComponents = useMemo<Components>(() => {
-    return {
-      img: MarkdownImage,
-      a: MarkdownAnchor,
-      pre({ node: _node, children, ...props }) {
-        const codeBlock = extractCodeBlock(children);
-        if (!codeBlock) {
-          return <pre {...props}>{children}</pre>;
-        }
-
-        // During streaming: skip Shiki (expensive async highlighting) — plain pre
-        if (isStreaming) {
-          return (
-            <MarkdownCodeBlock code={codeBlock.code}>
-              <pre {...props}>{children}</pre>
-            </MarkdownCodeBlock>
-          );
-        }
-
-        return (
-          <MarkdownCodeBlock code={codeBlock.code}>
-            <CodeBlockErrorBoundary fallback={<pre {...props}>{children}</pre>}>
-              <Suspense fallback={<pre {...props}>{children}</pre>}>
-                <SuspenseShikiCodeBlock className={codeBlock.className} code={codeBlock.code} isStreaming={false} />
-              </Suspense>
-            </CodeBlockErrorBoundary>
-          </MarkdownCodeBlock>
-        );
-      },
-    };
-  }, [isStreaming]);
+  const markdownComponents = isStreaming ? STREAMING_COMPONENTS : HIGHLIGHTED_COMPONENTS;
 
   // During streaming: use remarkGfm only — skip remark-math + rehype-katex (heavy)
   const remarkPlugins = useMemo(() => {

--- a/apps/web/src/components/chat/docks/dock.tsx
+++ b/apps/web/src/components/chat/docks/dock.tsx
@@ -165,15 +165,15 @@ export function DockContainer({ docks, className }: DockContainerProps) {
   const [isOpen, setIsOpen] = React.useState(false);
   const hasDocks = docks.length > 0;
 
-  React.useEffect(() => {
-    if (hasDocks) {
-      setRenderedDocks(docks);
-      const frame = requestAnimationFrame(() => setIsOpen(true));
-      return () => cancelAnimationFrame(frame);
-    }
+  // Keep the last non-empty docks mounted so the collapse transition can play out.
+  if (hasDocks && renderedDocks !== docks) setRenderedDocks(docks);
+  if (!hasDocks && isOpen) setIsOpen(false);
 
-    setIsOpen(false);
-  }, [docks, hasDocks]);
+  React.useEffect(() => {
+    if (!hasDocks) return;
+    const frame = requestAnimationFrame(() => setIsOpen(true));
+    return () => cancelAnimationFrame(frame);
+  }, [hasDocks]);
 
   const handleTransitionEnd = React.useCallback(
     (event: React.TransitionEvent<HTMLDivElement>) => {

--- a/apps/web/src/components/chat/docks/permission-response-dock.tsx
+++ b/apps/web/src/components/chat/docks/permission-response-dock.tsx
@@ -30,10 +30,12 @@ export function PermissionResponseDock({
 }: PermissionResponseDockProps) {
   const suggestion = permissionResponse.suggestion;
   const [entry, setEntry] = React.useState('');
+  const [entryFor, setEntryFor] = React.useState(permissionResponse.id);
 
-  React.useEffect(() => {
+  if (entryFor !== permissionResponse.id) {
+    setEntryFor(permissionResponse.id);
     setEntry('');
-  }, [permissionResponse.id]);
+  }
 
   const canSubmitAlternative = entry.trim().length > 0 && !isPending;
   const isDirectorySuggestion = suggestion?.message.startsWith(DIR_PREFIX) ?? false;

--- a/apps/web/src/components/chat/docks/question-dock.tsx
+++ b/apps/web/src/components/chat/docks/question-dock.tsx
@@ -28,12 +28,14 @@ export function QuestionDock({ request, onReply, onReject }: QuestionDockProps) 
   const [tab, setTab] = React.useState(0);
   const [answers, setAnswers] = React.useState<string[][]>(() => emptyAnswers(items));
   const [customAnswers, setCustomAnswers] = React.useState<string[]>(() => emptyText(items));
+  const [answeredRequest, setAnsweredRequest] = React.useState({ id: request.id, items });
 
-  React.useEffect(() => {
+  if (answeredRequest.id !== request.id || answeredRequest.items !== items) {
+    setAnsweredRequest({ id: request.id, items });
     setTab(0);
     setAnswers(emptyAnswers(items));
     setCustomAnswers(emptyText(items));
-  }, [request.id, items]);
+  }
 
   function handleSelect(idx: number, optionLabel: string) {
     const newAnswers = [...answers];
@@ -84,7 +86,7 @@ export function QuestionDock({ request, onReply, onReject }: QuestionDockProps) 
         {total > 1 && (
           <TabsList variant="line" className="w-full justify-start">
             {items.map((item, idx) => (
-              <TabsTrigger key={idx} value={String(idx)} className="gap-1.5 text-xs">
+              <TabsTrigger key={item.question} value={String(idx)} className="gap-1.5 text-xs">
                 {item.header}
                 {isAnswered(idx) && <CheckIcon className="size-3 text-primary" />}
               </TabsTrigger>
@@ -97,7 +99,7 @@ export function QuestionDock({ request, onReply, onReject }: QuestionDockProps) 
           const isTabSelected = (label: string) => answers[idx]?.includes(label) ?? false;
 
           return (
-            <TabsContent key={idx} value={String(idx)} className="mt-0">
+            <TabsContent key={item.question} value={String(idx)} className="mt-0">
               <div className="mb-1 text-sm text-foreground">{item.question}</div>
               <div className="mb-2 text-2xs text-muted-foreground">
                 {isMultiQ ? 'Select all that apply' : 'Select one option'}

--- a/apps/web/src/components/chat/message-bubble/assistant-message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble/assistant-message-bubble.tsx
@@ -17,18 +17,34 @@ import { ToolCallGroup } from '@/components/chat/message-bubble/tool-call-group.
 
 type AssistantMessageBubbleProps = { parts: StoredPart[]; finishReason?: string | null; onAbortTool?: () => void };
 
+type InlineSegments = NonNullable<ReturnType<typeof parseInlineLiquidUiText>>;
+
+/**
+ * Segments come from a linear scan of the message text, so each segment's start
+ * offset is a stable identity even while the message is still streaming in.
+ */
+function keyInlineSegments(segments: InlineSegments) {
+  let offset = 0;
+
+  return segments.map((segment) => {
+    const key = `${segment.type}-${offset}`;
+    offset += segment.type === 'text' ? segment.text.length : 1;
+    return { key, segment };
+  });
+}
+
 function AssistantTextSegment({ text }: { text: string }) {
   const inlineSegments = parseInlineLiquidUiText(text);
   if (!inlineSegments) return <ChatMarkdown text={text} />;
 
   return (
     <>
-      {inlineSegments.map((segment, index) => {
+      {keyInlineSegments(inlineSegments).map(({ key, segment }) => {
         if (segment.type === 'text') {
-          return segment.text ? <ChatMarkdown key={index} text={segment.text} /> : null;
+          return segment.text ? <ChatMarkdown key={key} text={segment.text} /> : null;
         }
 
-        return <LiquidUi key={index} spec={segment.spec} />;
+        return <LiquidUi key={key} spec={segment.spec} />;
       })}
     </>
   );

--- a/apps/web/src/components/chat/message-bubble/source-chip.tsx
+++ b/apps/web/src/components/chat/message-bubble/source-chip.tsx
@@ -6,7 +6,10 @@ type SourceChipProps = { url: string; title?: string };
 
 export function SourceChip({ url, title }: SourceChipProps) {
   return (
-    <Badge variant="soft" className="mr-1 mb-2" render={<a href={url} target="_blank" rel="noopener noreferrer" />}>
+    <Badge
+      variant="soft"
+      className="mr-1 mb-2"
+      render={<a href={url} target="_blank" rel="noopener noreferrer" aria-label={title ?? url} />}>
       <LinkIcon className="size-2.5 shrink-0" />
       <span className="max-w-45 truncate">{title ?? url}</span>
     </Badge>

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -57,8 +57,9 @@ export function ToolCallGroup({ calls, onAbort }: ToolCallGroupProps) {
   const [errorDetails, setErrorDetails] = React.useState<ToolErrorDetails | null>(null);
   const hiddenCount = Math.max(0, calls.length - VISIBLE_TOOL_COUNT);
   const visibleCalls = expanded ? calls : calls.slice(hiddenCount);
-  const previousHiddenCount = usePrevious(hiddenCount);
-  const hiddenCountIncreased = previousHiddenCount !== undefined && hiddenCount > previousHiddenCount;
+  // Only animate counts that grew after mount, so restored history stays static.
+  const [mountedHiddenCount] = React.useState(hiddenCount);
+  const hiddenCountIncreased = hiddenCount > mountedHiddenCount;
 
   if (calls.length === 0) return null;
 
@@ -159,8 +160,13 @@ function ToolCallRowRoot({
   animateIn: boolean;
   children: React.ReactNode;
 }) {
+  const contextValue = React.useMemo(
+    () => ({ call, summary, errorDetails, onViewErrorDetails }),
+    [call, summary, errorDetails, onViewErrorDetails],
+  );
+
   return (
-    <ToolCallRowContext.Provider value={{ call, summary, errorDetails, onViewErrorDetails }}>
+    <ToolCallRowContext.Provider value={contextValue}>
       <div
         className={cn(
           'group flex min-h-7 min-w-0 items-center gap-2 rounded-md px-1.5 text-xs transition-colors hover:bg-muted/40',
@@ -332,14 +338,4 @@ function ToolStatusIcon({ status, summary }: { status: ToolCallStatus; summary: 
       className={cn('size-3.5 shrink-0', status === 'error' ? 'text-destructive' : 'text-success')}
     />
   );
-}
-
-function usePrevious(value: number) {
-  const ref = React.useRef<number>(undefined);
-
-  React.useEffect(() => {
-    ref.current = value;
-  }, [value]);
-
-  return ref.current;
 }

--- a/apps/web/src/components/connectors/setup-wizard.tsx
+++ b/apps/web/src/components/connectors/setup-wizard.tsx
@@ -63,16 +63,18 @@ export function SetupWizard({ definition, connectors, onClose }: Props) {
   const apiKeyConfig = !isOAuth ? (definition.authConfig as ApiKeyConfig) : null;
   const isCreatingConnector = selectedConnectorRefId === 'new';
 
+  const serviceAccessOptions = oauthConfig?.serviceAccessOptions;
+
   const initialServiceAccess = useMemo(() => {
-    if (!oauthConfig?.serviceAccessOptions) return {} as Record<string, 'none' | 'read' | 'write'>;
+    if (!serviceAccessOptions) return {} as Record<string, 'none' | 'read' | 'write'>;
     return Object.fromEntries(
-      oauthConfig.serviceAccessOptions.map((option) => {
+      serviceAccessOptions.map((option) => {
         const hasWrite = (option.writeScopes ?? []).some((scope) => selectedScopes.includes(scope));
         const hasRead = option.readScopes.some((scope) => selectedScopes.includes(scope));
         return [option.id, hasWrite ? 'write' : hasRead ? 'read' : 'none'];
       }),
     ) as Record<string, 'none' | 'read' | 'write'>;
-  }, [oauthConfig?.serviceAccessOptions, selectedScopes]);
+  }, [serviceAccessOptions, selectedScopes]);
   const [serviceAccess, setServiceAccess] = useState<Record<string, 'none' | 'read' | 'write'>>(initialServiceAccess);
 
   function toggleScope(scope: string) {
@@ -264,24 +266,25 @@ function InstructionsStep({ instructions, onNext }: { instructions: ConnectorSet
     <div className="flex h-full min-h-0 flex-col gap-3">
       <ScrollArea className="max-h-[45vh] min-h-0 flex-1 rounded-lg border border-border/60 bg-muted/30 p-3">
         <ol className="list-inside list-decimal space-y-2 text-sm text-foreground/85">
-          {instructions.map((instruction, i) => (
-            <li key={i} className="leading-relaxed">
-              <span>{instruction.text}</span>
-              {instruction.href ? (
-                <button
-                  type="button"
-                  className="ml-1 inline-flex items-center gap-1 text-primary hover:underline"
-                  onClick={() => {
-                    void (
-                      window.api?.shell?.openExternal(instruction.href!) ?? window.open(instruction.href, '_blank')
-                    );
-                  }}>
-                  {instruction.hrefLabel ?? 'Open'}
-                  <ExternalLinkIcon className="size-3" />
-                </button>
-              ) : null}
-            </li>
-          ))}
+          {instructions.map((instruction) => {
+            const href = instruction.href;
+            return (
+              <li key={instruction.text} className="leading-relaxed">
+                <span>{instruction.text}</span>
+                {href ? (
+                  <button
+                    type="button"
+                    className="ml-1 inline-flex items-center gap-1 text-primary hover:underline"
+                    onClick={() => {
+                      void (window.api?.shell?.openExternal(href) ?? window.open(href, '_blank'));
+                    }}>
+                    {instruction.hrefLabel ?? 'Open'}
+                    <ExternalLinkIcon className="size-3" />
+                  </button>
+                ) : null}
+              </li>
+            );
+          })}
         </ol>
       </ScrollArea>
       <DialogFooter className="shrink-0">
@@ -325,6 +328,8 @@ function ConnectorCredentialsStep({
   onBack: () => void;
   onNext: () => void;
 }) {
+  const helpUrl = apiKeyConfig?.helpUrl;
+
   return (
     <div className="flex h-full min-h-0 flex-col gap-3">
       <div className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
@@ -386,18 +391,15 @@ function ConnectorCredentialsStep({
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
             />
-            {apiKeyConfig?.helpUrl && (
+            {helpUrl && (
               <a
-                href={apiKeyConfig.helpUrl}
+                href={helpUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
                 onClick={(e) => {
                   e.preventDefault();
-                  void (
-                    window.api?.shell?.openExternal(apiKeyConfig.helpUrl!) ??
-                    window.open(apiKeyConfig.helpUrl, '_blank')
-                  );
+                  void (window.api?.shell?.openExternal(helpUrl) ?? window.open(helpUrl, '_blank'));
                 }}>
                 <ExternalLinkIcon className="size-3" />
                 Get your API key
@@ -572,8 +574,10 @@ function ScopesStep({
               {Object.entries(config.scopeDescriptions).map(([scope, description]) => (
                 <label
                   key={scope}
+                  htmlFor={scope}
                   className="flex cursor-pointer items-start gap-2.5 rounded-lg p-2 text-sm hover:bg-muted/50">
                   <Checkbox
+                    id={scope}
                     checked={selectedScopes.includes(scope)}
                     onCheckedChange={() => toggleScope(scope)}
                     className="mt-0.5"

--- a/apps/web/src/components/cron-expression-builder.tsx
+++ b/apps/web/src/components/cron-expression-builder.tsx
@@ -43,130 +43,90 @@ const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const MINUTES = Array.from({ length: 12 }, (_, i) => i * 5); // 0, 5, 10...
 const DAYS_OF_MONTH = Array.from({ length: 31 }, (_, i) => i + 1);
 
+type CronConfig = {
+  frequency: Frequency;
+  minutes: number[];
+  hours: number[];
+  daysOfMonth: number[];
+  months: number[];
+  daysOfWeek: number[];
+};
+
+const DEFAULT_CONFIG: CronConfig = {
+  frequency: 'daily',
+  minutes: [0],
+  hours: [9],
+  daysOfMonth: [1],
+  months: [],
+  daysOfWeek: [1],
+};
+
+function parsePart(part: string): number[] {
+  if (part === '*' || part === '?') return [];
+  return part
+    .split(',')
+    .map((v) => Number.parseInt(v, 10))
+    .filter((v) => !Number.isNaN(v));
+}
+
+// Simple parser: the builder only ever writes numeric lists, so ranges/steps fall back to the closest match
+function parseFrequency(hour: string, dayOfMonth: string, month: string, dayOfWeek: string): Frequency {
+  if (hour === '*' && dayOfMonth === '*' && month === '*' && dayOfWeek === '*') return 'hourly';
+  if (dayOfMonth === '*' && month === '*' && dayOfWeek === '*') return 'daily';
+  if (dayOfMonth === '*' && month === '*') return 'weekly';
+  if (dayOfMonth !== '*' && dayOfWeek === '*') return 'monthly';
+  if (dayOfWeek !== '*') return 'weekly';
+  return 'daily';
+}
+
+function parseCron(value: string): CronConfig {
+  const parts = value.trim().split(' ');
+  if (!value || parts.length < 5) return DEFAULT_CONFIG;
+
+  const [m, h, dom, mon, dow] = parts;
+  const parsedMinutes = parsePart(m);
+
+  return {
+    frequency: parseFrequency(h, dom, mon, dow),
+    minutes: parsedMinutes.length > 0 ? [parsedMinutes[0]] : DEFAULT_CONFIG.minutes,
+    hours: parsePart(h),
+    daysOfMonth: parsePart(dom),
+    months: parsePart(mon),
+    daysOfWeek: parsePart(dow),
+  };
+}
+
+function formatPart(values: number[]): string {
+  if (values.length === 0) return '*';
+  return values.join(',');
+}
+
+function buildCron(config: CronConfig): string {
+  const minute = config.minutes.length > 0 ? config.minutes[0].toString() : '0';
+  const hour = formatPart(config.hours);
+
+  switch (config.frequency) {
+    case 'hourly':
+      return `${minute} * * * *`;
+    case 'weekly':
+      return `${minute} ${hour} * * ${formatPart(config.daysOfWeek)}`;
+    case 'monthly':
+      return `${minute} ${hour} ${formatPart(config.daysOfMonth)} ${formatPart(config.months)} *`;
+    default:
+      return `${minute} ${hour} * * *`;
+  }
+}
+
 export function CronExpressionBuilder({ value, onChange, timezone = 'UTC', className }: CronExpressionBuilderProps) {
-  // State
-  const [frequency, setFrequency] = React.useState<Frequency>('daily');
-  const [minutes, setMinutes] = React.useState<number[]>([0]); // Single minute for > hourly
-  const [hours, setHours] = React.useState<number[]>([9]);
-  const [daysOfMonth, setDaysOfMonth] = React.useState<number[]>([1]);
-  const [months, setMonths] = React.useState<number[]>([]); // Empty means *
-  const [daysOfWeek, setDaysOfWeek] = React.useState<number[]>([1]); // Default Mon
+  // The cron parts are derived from `value`; only the frequency is a user choice that `value` cannot always express
+  const parsed = parseCron(value);
+  const [frequency, setFrequency] = React.useState(parsed.frequency);
+  const { minutes, hours, daysOfMonth, months, daysOfWeek } = parsed;
 
-  // Track when we're syncing from an external value change to avoid
-  // the construct effect firing with stale state before parse completes.
-  const isSyncingRef = React.useRef(true);
-
-  // Parse incoming cron expression
-  React.useEffect(() => {
-    if (!value) return;
-
-    isSyncingRef.current = true;
-
-    const parts = value.trim().split(' ');
-    if (parts.length < 5) return;
-
-    const [m, h, dom, mon, dow] = parts;
-
-    const parsePart = (part: string, _max: number): number[] => {
-      if (part === '*' || part === '?') return [];
-      return part
-        .split(',')
-        .map((v) => Number.parseInt(v, 10))
-        .filter((v) => !Number.isNaN(v));
-    };
-
-    // Minutes
-    const parsedMinutes = parsePart(m, 59);
-    if (parsedMinutes.length > 0) setMinutes([parsedMinutes[0]]); // Enforce single minute
-
-    // Hours
-    const parsedHours = parsePart(h, 23);
-    setHours(parsedHours.length > 0 ? parsedHours : []);
-
-    // Days of Month
-    const parsedDom = parsePart(dom, 31);
-    setDaysOfMonth(parsedDom.length > 0 ? parsedDom : []);
-
-    // Months
-    const parsedMon = parsePart(mon, 12);
-    setMonths(parsedMon.length > 0 ? parsedMon : []);
-
-    // Days of Week
-    // Handle MON-FRI etc if necessary, but we mostly write numbers
-    // This is a simple parser, might need more robust parsing for complex expressions
-    // For now assuming the builder generates standard numeric lists
-    const parsedDow = parsePart(dow, 7);
-    setDaysOfWeek(parsedDow.length > 0 ? parsedDow : []);
-
-    // Determine Frequency
-    if (h === '*' && dom === '*' && mon === '*' && dow === '*') {
-      setFrequency('hourly');
-    } else if (dom === '*' && mon === '*' && dow === '*') {
-      setFrequency('daily');
-    } else if (dom === '*' && mon === '*' && dow !== '*') {
-      setFrequency('weekly');
-    } else if (dom !== '*' && mon === '*' && dow === '*') {
-      setFrequency('monthly');
-    } else {
-      // Default to daily if it doesn't match perfectly or custom
-      // If it's a specific day of month AND day of week, it's complex, maybe monthly?
-      if (dom !== '*' && dow === '*') setFrequency('monthly');
-      else if (dow !== '*') setFrequency('weekly');
-      else setFrequency('daily');
-    }
-  }, [value]);
-
-  // Construct cron expression
-  const constructCron = React.useCallback(() => {
-    // Helper to format part
-    const formatPart = (vals: number[], allChar = '*') => {
-      if (vals.length === 0) return allChar;
-      return vals.join(',');
-    };
-
-    const mStr = minutes.length > 0 ? minutes[0].toString() : '0';
-
-    let cron = '';
-    switch (frequency) {
-      case 'hourly':
-        cron = `${mStr} * * * *`;
-        break;
-      case 'daily': {
-        const hStr = formatPart(hours);
-        cron = `${mStr} ${hStr} * * *`;
-        break;
-      }
-      case 'weekly': {
-        const hStr = formatPart(hours);
-        const dowStr = formatPart(daysOfWeek);
-        cron = `${mStr} ${hStr} * * ${dowStr}`;
-        break;
-      }
-      case 'monthly': {
-        const hStr = formatPart(hours);
-        const domStr = formatPart(daysOfMonth);
-        const monStr = formatPart(months);
-        cron = `${mStr} ${hStr} ${domStr} ${monStr} *`;
-        break;
-      }
-      default:
-        cron = value; // Fallback
-    }
-
-    // Only update if changed
-    if (cron !== value) {
-      onChange(cron);
-    }
-  }, [frequency, minutes, hours, daysOfWeek, daysOfMonth, months, onChange, value]);
-
-  // Update on state change
-  React.useEffect(() => {
-    if (isSyncingRef.current) {
-      isSyncingRef.current = false;
-      return;
-    }
-    constructCron();
-  }, [constructCron]);
+  function emit(changes: Partial<CronConfig>) {
+    const next = buildCron({ ...parsed, frequency, ...changes });
+    if (next !== value) onChange(next);
+  }
 
   // Calculate upcoming executions
   const upcomingExecutions = React.useMemo(() => {
@@ -202,7 +162,7 @@ export function CronExpressionBuilder({ value, onChange, timezone = 'UTC', class
         value={[minutes[0]?.toString() ?? '0']}
         onValueChange={(vals) => {
           const val = vals[0];
-          if (val) setMinutes([Number.parseInt(val)]);
+          if (val) emit({ minutes: [Number.parseInt(val)] });
         }}
         className="flex flex-wrap justify-start gap-1">
         {MINUTES.map((m) => (
@@ -224,7 +184,7 @@ export function CronExpressionBuilder({ value, onChange, timezone = 'UTC', class
         multiple
         value={hours.map((h) => h.toString())}
         onValueChange={(vals) => {
-          if (vals.length > 0) setHours(vals.map((v) => Number.parseInt(v)).sort((a, b) => a - b));
+          if (vals.length > 0) emit({ hours: vals.map((v) => Number.parseInt(v)).toSorted((a, b) => a - b) });
         }}
         className="flex flex-wrap justify-start gap-1">
         {HOURS.map((h) => (
@@ -246,7 +206,7 @@ export function CronExpressionBuilder({ value, onChange, timezone = 'UTC', class
         multiple
         value={daysOfWeek.map((d) => d.toString())}
         onValueChange={(vals) => {
-          if (vals.length > 0) setDaysOfWeek(vals.map((v) => Number.parseInt(v)));
+          if (vals.length > 0) emit({ daysOfWeek: vals.map((v) => Number.parseInt(v)) });
         }}
         className="flex flex-wrap justify-start gap-1">
         {DAYS_OF_WEEK.map((day) => (
@@ -268,7 +228,7 @@ export function CronExpressionBuilder({ value, onChange, timezone = 'UTC', class
         multiple
         value={daysOfMonth.map((d) => d.toString())}
         onValueChange={(vals) => {
-          if (vals.length > 0) setDaysOfMonth(vals.map((v) => Number.parseInt(v)).sort((a, b) => a - b));
+          if (vals.length > 0) emit({ daysOfMonth: vals.map((v) => Number.parseInt(v)).toSorted((a, b) => a - b) });
         }}
         className="flex flex-wrap justify-start gap-1">
         {DAYS_OF_MONTH.map((d) => (
@@ -291,7 +251,7 @@ export function CronExpressionBuilder({ value, onChange, timezone = 'UTC', class
         value={months.map((m) => m.toString())}
         onValueChange={(vals) => {
           // If empty, it means all months (cron *)
-          setMonths(vals.map((v) => Number.parseInt(v)).sort((a, b) => a - b));
+          emit({ months: vals.map((v) => Number.parseInt(v)).toSorted((a, b) => a - b) });
         }}
         className="flex flex-wrap justify-start gap-1">
         {MONTHS_SHORT.map((m, i) => (
@@ -320,12 +280,11 @@ export function CronExpressionBuilder({ value, onChange, timezone = 'UTC', class
               setFrequency(newFreq);
 
               // Ensure required fields are populated when switching
-              if (newFreq === 'monthly' && daysOfMonth.length === 0) {
-                setDaysOfMonth([1]);
-              }
-              if (newFreq === 'weekly' && daysOfWeek.length === 0) {
-                setDaysOfWeek([1]); // Monday
-              }
+              emit({
+                frequency: newFreq,
+                daysOfMonth: newFreq === 'monthly' && daysOfMonth.length === 0 ? [1] : daysOfMonth,
+                daysOfWeek: newFreq === 'weekly' && daysOfWeek.length === 0 ? [1] : daysOfWeek, // Monday
+              });
             }
           }}
           className="w-fit justify-start rounded-md border bg-muted/30 p-1">

--- a/apps/web/src/components/icons/masked-icon.tsx
+++ b/apps/web/src/components/icons/masked-icon.tsx
@@ -5,10 +5,9 @@ type MaskedIconProps = { src: string; label: string; className?: string };
 export function MaskedIcon({ src, label, className }: MaskedIconProps) {
   return (
     <div
-      role="img"
-      aria-label={label}
       className={cn('bg-foreground', className)}
-      style={{ WebkitMask: `url(${src}) no-repeat center / contain`, mask: `url(${src}) no-repeat center / contain` }}
-    />
+      style={{ WebkitMask: `url(${src}) no-repeat center / contain`, mask: `url(${src}) no-repeat center / contain` }}>
+      <span className="sr-only">{label}</span>
+    </div>
   );
 }

--- a/apps/web/src/components/icons/remote-icon.tsx
+++ b/apps/web/src/components/icons/remote-icon.tsx
@@ -5,51 +5,35 @@ import { useServerAssetUrl } from '@/components/icons/use-server-asset-url';
 import { cn } from '@/lib/utils';
 
 const resolvedImageCache = new Map<string, boolean>();
+const resolvedImageListeners = new Set<() => void>();
+
+function subscribeToResolvedImages(listener: () => void) {
+  resolvedImageListeners.add(listener);
+  return () => {
+    resolvedImageListeners.delete(listener);
+  };
+}
+
+function cacheResolvedImage(url: string, resolved: boolean) {
+  resolvedImageCache.set(url, resolved);
+  for (const listener of resolvedImageListeners) listener();
+}
 
 function useResolvedImageUrl(url: string | null): string | null {
-  const [resolvedUrl, setResolvedUrl] = React.useState<string | null>(() => {
-    if (!url) return null;
-    return resolvedImageCache.get(url) === true ? url : null;
-  });
-  const [failed, setFailed] = React.useState(() => (url ? resolvedImageCache.get(url) === false : false));
+  const resolved = React.useSyncExternalStore(subscribeToResolvedImages, () =>
+    url ? resolvedImageCache.get(url) === true : false,
+  );
 
   React.useEffect(() => {
-    if (!url) {
-      setResolvedUrl(null);
-      setFailed(false);
-      return;
-    }
+    if (!url || resolvedImageCache.has(url)) return;
 
-    const cached = resolvedImageCache.get(url);
-    if (cached !== undefined) {
-      setResolvedUrl(cached ? url : null);
-      setFailed(!cached);
-      return;
-    }
-
-    let active = true;
     const image = new Image();
-    image.onload = () => {
-      if (!active) return;
-      resolvedImageCache.set(url, true);
-      setResolvedUrl(url);
-      setFailed(false);
-    };
-    image.onerror = () => {
-      if (!active) return;
-      resolvedImageCache.set(url, false);
-      setResolvedUrl(null);
-      setFailed(true);
-    };
+    image.onload = () => cacheResolvedImage(url, true);
+    image.onerror = () => cacheResolvedImage(url, false);
     image.src = url;
-
-    return () => {
-      active = false;
-    };
   }, [url]);
 
-  if (failed) return null;
-  return resolvedUrl;
+  return resolved ? url : null;
 }
 
 type RemoteMaskedIconProps = {
@@ -76,13 +60,9 @@ type RemoteImageIconProps = {
 
 export function RemoteImageIcon({ path, label, className, fallback }: RemoteImageIconProps) {
   const url = useServerAssetUrl(path);
-  const [failed, setFailed] = React.useState(false);
+  const [failedUrl, setFailedUrl] = React.useState<string | null>(null);
 
-  React.useEffect(() => {
-    setFailed(false);
-  }, [url]);
-
-  if (!url || failed) return <>{fallback}</>;
+  if (!url || failedUrl === url) return <>{fallback}</>;
 
   return (
     <img
@@ -91,7 +71,7 @@ export function RemoteImageIcon({ path, label, className, fallback }: RemoteImag
       aria-label={label}
       className={cn('shrink-0 rounded-sm object-contain', className)}
       loading="lazy"
-      onError={() => setFailed(true)}
+      onError={() => setFailedUrl(url)}
     />
   );
 }

--- a/apps/web/src/components/mail/mail-page.tsx
+++ b/apps/web/src/components/mail/mail-page.tsx
@@ -51,9 +51,12 @@ function MailPageContent({
   const [selectedThreadId, setSelectedThreadId] = React.useState<MailThreadId | null>(null);
   const [composerOpen, setComposerOpen] = React.useState(false);
 
-  React.useEffect(() => {
+  const scope = `${accountId}:${labelId}`;
+  const [previousScope, setPreviousScope] = React.useState(scope);
+  if (previousScope !== scope) {
+    setPreviousScope(scope);
     setSelectedThreadId(null);
-  }, [accountId, labelId]);
+  }
 
   return (
     <div className="flex h-full min-h-0 bg-background">

--- a/apps/web/src/components/mail/mail-sidebar.tsx
+++ b/apps/web/src/components/mail/mail-sidebar.tsx
@@ -49,22 +49,27 @@ function getSystemLabelGroup(label: MailLabelView): 'primary' | 'category' | 'ma
   return null;
 }
 
-function getSystemIcon(label: MailLabelView) {
-  const normalized = label.providerLabelId.toUpperCase();
-  if (normalized === 'INBOX') return InboxIcon;
-  if (normalized === 'SENT') return SendIcon;
-  if (normalized === 'TRASH') return TrashIcon;
-  if (normalized.startsWith('CATEGORY_')) return ArchiveIcon;
-  if (normalized === 'IMPORTANT' || normalized === 'YELLOW_STAR' || normalized === 'STARRED') return StarIcon;
-  return MailIcon;
-}
-
 function getLabelIconClassName(label: MailLabelView): string {
   const normalized = label.providerLabelId.toUpperCase();
   if (normalized === 'IMPORTANT' || normalized === 'YELLOW_STAR' || normalized === 'STARRED') {
     return 'size-3.5 text-warning fill-warning';
   }
   return 'size-3.5 text-muted-foreground';
+}
+
+function LabelIcon({ label }: { label: MailLabelView }) {
+  const className = getLabelIconClassName(label);
+  if (label.kind !== 'system') return <TagIcon className={className} />;
+
+  const normalized = label.providerLabelId.toUpperCase();
+  if (normalized === 'INBOX') return <InboxIcon className={className} />;
+  if (normalized === 'SENT') return <SendIcon className={className} />;
+  if (normalized === 'TRASH') return <TrashIcon className={className} />;
+  if (normalized.startsWith('CATEGORY_')) return <ArchiveIcon className={className} />;
+  if (normalized === 'IMPORTANT' || normalized === 'YELLOW_STAR' || normalized === 'STARRED') {
+    return <StarIcon className={className} />;
+  }
+  return <MailIcon className={className} />;
 }
 
 function getLabelDepthClassName(depth: number): string | undefined {
@@ -109,7 +114,7 @@ function buildUserLabelTree(labels: MailLabelView[]): UserLabelNode[] {
 }
 
 function sortLabels(labels: MailLabelView[]): MailLabelView[] {
-  return [...labels].sort((a, b) => {
+  return [...labels].toSorted((a, b) => {
     const aIndex = SYSTEM_LABEL_ORDER.findIndex((id) => id === a.providerLabelId.toUpperCase());
     const bIndex = SYSTEM_LABEL_ORDER.findIndex((id) => id === b.providerLabelId.toUpperCase());
     if (aIndex !== -1 || bIndex !== -1) return (aIndex === -1 ? 999 : aIndex) - (bIndex === -1 ? 999 : bIndex);
@@ -167,8 +172,6 @@ function LabelItem({
   onSelect: () => void;
   onToggle?: () => void;
 }) {
-  const Icon = label.kind === 'system' ? getSystemIcon(label) : TagIcon;
-
   return (
     <SidebarMenuItem>
       <SidebarMenuButton
@@ -180,7 +183,7 @@ function LabelItem({
           depth > 0 && 'text-muted-foreground',
           label.unreadCount > 0 && 'font-medium',
         )}>
-        <Icon className={getLabelIconClassName(label)} />
+        <LabelIcon label={label} />
         <span className="min-w-0 flex-1 truncate">{getLabelDisplayName(label)}</span>
         {!hasChildren ? <LabelBadge count={label.unreadCount} /> : null}
       </SidebarMenuButton>

--- a/apps/web/src/components/memories/memories-page.tsx
+++ b/apps/web/src/components/memories/memories-page.tsx
@@ -82,6 +82,7 @@ export function MemoriesPage() {
   }, [searchInput]);
 
   const isSearching = debouncedSearch.length > 0;
+  const filterKey = `${debouncedSearch}|${filterSource}|${filterCategory}`;
 
   const listQuery = useQuery(
     semanticMemoriesQueryOptions({
@@ -101,12 +102,21 @@ export function MemoriesPage() {
     }),
   );
 
-  React.useEffect(() => {
+  const [previousFilterKey, setPreviousFilterKey] = React.useState(filterKey);
+  if (previousFilterKey !== filterKey) {
+    setPreviousFilterKey(filterKey);
     setPage(1);
-  }, [debouncedSearch, filterSource, filterCategory]);
+  }
 
   const pageData = isSearching ? searchQuery.data : listQuery.data;
   const memories = pageData?.memories ?? [];
+
+  const selectionKey = `${pageData?.page}|${pageData?.total}|${filterKey}`;
+  const [previousSelectionKey, setPreviousSelectionKey] = React.useState(selectionKey);
+  if (previousSelectionKey !== selectionKey) {
+    setPreviousSelectionKey(selectionKey);
+    setSelectedIds(new Set());
+  }
 
   const bulkDeleteMutation = useMutation(bulkDeleteMemoriesMutationOptions(queryClient));
 
@@ -141,10 +151,6 @@ export function MemoriesPage() {
     });
   }
 
-  React.useEffect(() => {
-    setSelectedIds(new Set());
-  }, [pageData?.page, pageData?.total, debouncedSearch, filterSource, filterCategory]);
-
   const isLoading = isSearching ? searchQuery.isLoading : listQuery.isLoading;
   const totalPages = pageData?.totalPages ?? 0;
   const currentPage = (pageData?.page ?? page) - 1;
@@ -163,7 +169,7 @@ export function MemoriesPage() {
       pages.add(index);
     }
 
-    return [...pages].sort((a, b) => a - b);
+    return [...pages].toSorted((a, b) => a - b);
   }, [currentPage, totalPages]);
 
   const allSelected = memories.length > 0 && selectedIds.size === memories.length;

--- a/apps/web/src/components/memories/memory-detail-sheet.tsx
+++ b/apps/web/src/components/memories/memory-detail-sheet.tsx
@@ -29,15 +29,17 @@ export function MemoryDetailSheet({ memory, open, onOpenChange }: Props) {
   const deleteMutation = useMutation(deleteMemoryMutationOptions(queryClient));
 
   const memoryRef = React.useRef(memory);
-  memoryRef.current = memory;
-
   React.useEffect(() => {
-    if (memory) {
-      setContent(memory.content);
-      setCategory(memory.category);
-      setConfidence(memory.confidence);
-    }
+    memoryRef.current = memory;
   }, [memory]);
+
+  const [syncedMemory, setSyncedMemory] = React.useState<SemanticMemory | null>(null);
+  if (memory && syncedMemory !== memory) {
+    setSyncedMemory(memory);
+    setContent(memory.content);
+    setCategory(memory.category);
+    setConfidence(memory.confidence);
+  }
 
   function save(updates: { content?: string; category?: MemoryCategory; confidence?: MemoryConfidence }) {
     if (!memoryRef.current) return;

--- a/apps/web/src/components/model-selectors/stt-model-selector-popover.tsx
+++ b/apps/web/src/components/model-selectors/stt-model-selector-popover.tsx
@@ -76,7 +76,6 @@ export function SttModelSelectorPopover({
             <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2">
               <SearchIcon className="size-3.5 shrink-0 text-muted-foreground" />
               <input
-                autoFocus
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
                 placeholder="Search models"

--- a/apps/web/src/components/navigation/command-palette.tsx
+++ b/apps/web/src/components/navigation/command-palette.tsx
@@ -9,6 +9,15 @@ import { useShortcuts } from '@/lib/shortcuts';
 
 type CommandPaletteProps = { actions: Action[] };
 
+function toKeyItems(labels: string[]): Array<{ id: string; label: string }> {
+  const occurrences = new Map<string, number>();
+  return labels.map((label) => {
+    const occurrence = (occurrences.get(label) ?? 0) + 1;
+    occurrences.set(label, occurrence);
+    return { id: `${label}-${occurrence}`, label };
+  });
+}
+
 export function CommandPalette({ actions }: CommandPaletteProps) {
   const { commandPaletteOpen, setCommandPaletteOpen } = useDialogContext();
   const shortcuts = useShortcuts();
@@ -39,37 +48,30 @@ export function CommandPalette({ actions }: CommandPaletteProps) {
                   const hotkey = info?.hotkey ?? null;
                   const isLeaderShortcut = typeof hotkey === 'string' && hotkey.startsWith('LEADER+');
                   const leaderSuffix = isLeaderShortcut ? hotkey.slice('LEADER+'.length) : null;
+                  const keyItems = toKeyItems(
+                    hotkey === null
+                      ? []
+                      : isLeaderShortcut
+                        ? [
+                            'Leader',
+                            ...formatForDisplay(leaderSuffix ?? '')
+                              .split('+')
+                              .filter(Boolean),
+                          ]
+                        : info?.isSequence
+                          ? [...formatForDisplay(hotkey).split('+'), ...formatForDisplay(hotkey).split('+')]
+                          : formatForDisplay(hotkey).split('+'),
+                  );
                   return (
                     <CommandItem key={action.id} onSelect={() => handleSelect(action)}>
                       <span className="flex-1">{action.label}</span>
                       {hotkey && (
                         <span className="ml-auto flex items-center gap-1.5">
-                          {isLeaderShortcut
-                            ? [
-                                'Leader',
-                                ...formatForDisplay(leaderSuffix ?? '')
-                                  .split('+')
-                                  .filter(Boolean),
-                              ].map((key, i) => (
-                                <Kbd key={i} size="sm">
-                                  {key}
-                                </Kbd>
-                              ))
-                            : info?.isSequence
-                              ? [...formatForDisplay(hotkey).split('+'), ...formatForDisplay(hotkey).split('+')].map(
-                                  (key, i) => (
-                                    <Kbd key={i} size="sm">
-                                      {key}
-                                    </Kbd>
-                                  ),
-                                )
-                              : formatForDisplay(hotkey)
-                                  .split('+')
-                                  .map((key, i) => (
-                                    <Kbd key={i} size="sm">
-                                      {key}
-                                    </Kbd>
-                                  ))}
+                          {keyItems.map((item) => (
+                            <Kbd key={item.id} size="sm">
+                              {item.label}
+                            </Kbd>
+                          ))}
                         </span>
                       )}
                     </CommandItem>

--- a/apps/web/src/components/navigation/right-click-menu.tsx
+++ b/apps/web/src/components/navigation/right-click-menu.tsx
@@ -173,12 +173,14 @@ export function RightClickMenu({ children }: RightClickMenuProps) {
     [close],
   );
 
+  const misspelledWord = params?.misspelledWord ?? null;
+
   const handleAddToDictionary = useCallback(() => {
-    if (params?.misspelledWord) {
-      void window.api?.spellcheck?.addToDictionary(params.misspelledWord);
+    if (misspelledWord) {
+      void window.api?.spellcheck?.addToDictionary(misspelledWord);
     }
     close();
-  }, [params?.misspelledWord, close]);
+  }, [misspelledWord, close]);
 
   const handleCut = useCallback(() => {
     document.execCommand('cut');
@@ -197,7 +199,7 @@ export function RightClickMenu({ children }: RightClickMenuProps) {
     close();
   }, [close]);
 
-  const isMisspelled = !!params?.misspelledWord;
+  const isMisspelled = !!misspelledWord;
   const isEditable = params?.isEditable ?? false;
   const { canCut, canCopy, canPaste } = params?.editFlags ?? { canCut: false, canCopy: false, canPaste: false };
 

--- a/apps/web/src/components/onboarding/steps/memory-step.tsx
+++ b/apps/web/src/components/onboarding/steps/memory-step.tsx
@@ -43,15 +43,15 @@ export function MemoryStep({ onComplete, onBackToProviders }: Props) {
 
   const modelOptions = React.useMemo(() => buildModelOptions(providerModels), [providerModels]);
 
-  const [selectedValue, setSelectedValue] = React.useState<string>('');
+  const [chosenValue, setChosenValue] = React.useState<string | null>(null);
 
-  React.useEffect(() => {
-    if (!settings || modelOptions.length === 0) return;
-
-    const existingValue = `${settings['memory.embedding.providerId']}:${settings['memory.embedding.modelId']}`;
-    const hasExisting = modelOptions.some((option) => option.value === existingValue);
-    setSelectedValue(hasExisting ? existingValue : modelOptions[0].value);
-  }, [modelOptions, settings]);
+  const existingValue = settings
+    ? `${settings['memory.embedding.providerId']}:${settings['memory.embedding.modelId']}`
+    : '';
+  const defaultValue = modelOptions.some((option) => option.value === existingValue)
+    ? existingValue
+    : (modelOptions[0]?.value ?? '');
+  const selectedValue = chosenValue ?? defaultValue;
 
   if (!settings || !providerModels) {
     return <div className="text-sm text-muted-foreground">Loading memory settings...</div>;
@@ -91,7 +91,7 @@ export function MemoryStep({ onComplete, onBackToProviders }: Props) {
       {hasModels ? (
         <div className="space-y-2">
           <Label htmlFor="onboarding-memory-model">Embedding model</Label>
-          <Select value={selectedValue} onValueChange={(value) => setSelectedValue(value ?? '')}>
+          <Select value={selectedValue} onValueChange={(value) => setChosenValue(value ?? '')}>
             <SelectTrigger id="onboarding-memory-model" className="w-full">
               <SelectValue placeholder="Select an embedding model">{selectedOption?.label}</SelectValue>
             </SelectTrigger>

--- a/apps/web/src/components/onboarding/steps/profile-step.tsx
+++ b/apps/web/src/components/onboarding/steps/profile-step.tsx
@@ -69,7 +69,6 @@ export function ProfileStep({ initialName, initialTimezone, isSaving, onContinue
           onBlur={() => setTouched(true)}
           placeholder="Jane"
           maxLength={80}
-          autoFocus
         />
         {hasError && <p className="text-xs text-destructive">Please enter your name.</p>}
       </div>

--- a/apps/web/src/components/recordings/list/recordings-pagination.tsx
+++ b/apps/web/src/components/recordings/list/recordings-pagination.tsx
@@ -25,7 +25,7 @@ function getPageNumbers(currentPage: number, pageCount: number): number[] {
     pages.add(index);
   }
 
-  return [...pages].sort((a, b) => a - b);
+  return [...pages].toSorted((a, b) => a - b);
 }
 
 export function RecordingsPagination({

--- a/apps/web/src/components/recordings/list/recordings-table.tsx
+++ b/apps/web/src/components/recordings/list/recordings-table.tsx
@@ -2,6 +2,7 @@ import { Trash2Icon, MicIcon } from 'lucide-react';
 import * as React from 'react';
 
 import {
+  type CellContext,
   createColumnHelper,
   flexRender,
   getCoreRowModel,
@@ -22,6 +23,78 @@ import { Table } from '@/components/ui/table';
 
 const columnHelper = createColumnHelper<Recording>();
 
+type RecordingsTableMeta = { activeRecordingId: string | null; onDelete: (recording: Recording) => void };
+
+function TitleCell({ row }: CellContext<Recording, string>) {
+  return (
+    <div className="flex min-w-0 flex-col">
+      <Table.Title>{getRecordingDisplayTitle(row.original)}</Table.Title>
+    </div>
+  );
+}
+
+function PlatformCell({ getValue }: CellContext<Recording, Recording['platform']>) {
+  return <PlatformBadge platform={getValue()} />;
+}
+
+function StatusCell({ getValue }: CellContext<Recording, Recording['status']>) {
+  return <Table.Badge variant={STATUS_VARIANTS[getValue()]}>{STATUS_LABELS[getValue()]}</Table.Badge>;
+}
+
+function StartedAtCell({ getValue }: CellContext<Recording, Recording['startedAt']>) {
+  return <Table.Time value={getValue()} />;
+}
+
+function DurationCell({ row, table }: CellContext<Recording, unknown>) {
+  const { activeRecordingId } = table.options.meta as RecordingsTableMeta;
+  const recording = row.original;
+  if (recording.id === activeRecordingId) {
+    return <LiveDuration startedAt={recording.startedAt} />;
+  }
+  return <Table.Duration>{formatClockDuration(recording.durationMs)}</Table.Duration>;
+}
+
+function CostCell({ getValue }: CellContext<Recording, Recording['costUsd']>) {
+  return <Table.Money value={getValue()} />;
+}
+
+function ActionsHeader() {
+  return <div className="pr-1 text-right">Actions</div>;
+}
+
+function ActionsCell({ row, table }: CellContext<Recording, unknown>) {
+  const { activeRecordingId, onDelete } = table.options.meta as RecordingsTableMeta;
+
+  return (
+    <Table.Actions className="-mr-1.5">
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete(row.original);
+        }}
+        title="Delete recording"
+        aria-label="Delete recording"
+        disabled={row.original.id === activeRecordingId}
+        className="text-destructive hover:text-destructive">
+        <Trash2Icon className="size-4" />
+      </Button>
+    </Table.Actions>
+  );
+}
+
+const columns = [
+  columnHelper.accessor('title', { header: 'Title', cell: TitleCell }),
+  columnHelper.accessor('platform', { header: 'Platform', cell: PlatformCell }),
+  columnHelper.accessor('status', { header: 'Capturing', cell: StatusCell }),
+  columnHelper.accessor('startedAt', { header: 'Date', cell: StartedAtCell }),
+  columnHelper.display({ id: 'duration', header: 'Duration', cell: DurationCell }),
+  columnHelper.accessor('costUsd', { header: 'Cost', cell: CostCell }),
+  columnHelper.display({ id: 'actions', header: ActionsHeader, cell: ActionsCell }),
+];
+
 interface RecordingsTableProps {
   recordings: Recording[];
   activeRecordingId: string | null;
@@ -39,71 +112,13 @@ export function RecordingsTable({
   onDelete,
   onNavigate,
 }: RecordingsTableProps) {
-  const columns = React.useMemo(
-    () => [
-      columnHelper.accessor('title', {
-        header: 'Title',
-        cell: ({ row }) => (
-          <div className="flex min-w-0 flex-col">
-            <Table.Title>{getRecordingDisplayTitle(row.original)}</Table.Title>
-          </div>
-        ),
-      }),
-      columnHelper.accessor('platform', {
-        header: 'Platform',
-        cell: ({ getValue }) => <PlatformBadge platform={getValue()} />,
-      }),
-      columnHelper.accessor('status', {
-        header: 'Capturing',
-        cell: ({ getValue }) => (
-          <Table.Badge variant={STATUS_VARIANTS[getValue()]}>{STATUS_LABELS[getValue()]}</Table.Badge>
-        ),
-      }),
-      columnHelper.accessor('startedAt', { header: 'Date', cell: ({ getValue }) => <Table.Time value={getValue()} /> }),
-      columnHelper.display({
-        id: 'duration',
-        header: 'Duration',
-        cell: ({ row }) => {
-          const recording = row.original;
-          if (recording.id === activeRecordingId) {
-            return <LiveDuration startedAt={recording.startedAt} />;
-          }
-          return <Table.Duration>{formatClockDuration(recording.durationMs)}</Table.Duration>;
-        },
-      }),
-      columnHelper.accessor('costUsd', { header: 'Cost', cell: ({ getValue }) => <Table.Money value={getValue()} /> }),
-      columnHelper.display({
-        id: 'actions',
-        header: () => <div className="pr-1 text-right">Actions</div>,
-        cell: ({ row }) => (
-          <Table.Actions className="-mr-1.5">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(row.original);
-              }}
-              title="Delete recording"
-              aria-label="Delete recording"
-              disabled={row.original.id === activeRecordingId}
-              className="text-destructive hover:text-destructive">
-              <Trash2Icon className="size-4" />
-            </Button>
-          </Table.Actions>
-        ),
-      }),
-    ],
-    [activeRecordingId, onDelete],
-  );
-
   const table = useReactTable({
     data: recordings,
     columns,
     getRowId: (row) => row.id,
     state: { sorting },
     onSortingChange,
+    meta: { activeRecordingId, onDelete } satisfies RecordingsTableMeta,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });

--- a/apps/web/src/components/recordings/meeting-recording-banner.tsx
+++ b/apps/web/src/components/recordings/meeting-recording-banner.tsx
@@ -37,7 +37,9 @@ export function RecordingEventListener() {
   const stopRecording = useStopRecording();
 
   const stopRecordingRef = React.useRef(stopRecording);
-  stopRecordingRef.current = stopRecording;
+  React.useEffect(() => {
+    stopRecordingRef.current = stopRecording;
+  }, [stopRecording]);
 
   React.useEffect(() => {
     const unsubscribeWarning = window.api?.recording?.onWarning((payload) => {
@@ -95,10 +97,11 @@ export function MeetingRecordingBanner() {
       : null;
 
   const activeRecordingIdRef = React.useRef(activeRecordingId);
-  activeRecordingIdRef.current = activeRecordingId;
-
   const dismissedKeysRef = React.useRef(dismissedKeys);
-  dismissedKeysRef.current = dismissedKeys;
+  React.useEffect(() => {
+    activeRecordingIdRef.current = activeRecordingId;
+    dismissedKeysRef.current = dismissedKeys;
+  }, [activeRecordingId, dismissedKeys]);
 
   function dismissMeeting(key: string): void {
     setDismissedKeys((current) => {
@@ -167,11 +170,13 @@ export function MeetingRecordingBanner() {
     };
   }, []);
 
-  React.useEffect(() => {
+  const [previousActiveRecordingId, setPreviousActiveRecordingId] = React.useState(activeRecordingId);
+  if (previousActiveRecordingId !== activeRecordingId) {
+    setPreviousActiveRecordingId(activeRecordingId);
     if (activeRecordingId) {
       setDetection(null);
     }
-  }, [activeRecordingId]);
+  }
 
   if (data === undefined || !detection || activeRecordingId) {
     return null;

--- a/apps/web/src/components/recordings/shared/live-duration.tsx
+++ b/apps/web/src/components/recordings/shared/live-duration.tsx
@@ -5,7 +5,7 @@ import { formatClockDuration } from './formatting';
 import { Table } from '@/components/ui/table';
 
 function useDurationTick(): number {
-  const [tick, setTick] = React.useState(Date.now());
+  const [tick, setTick] = React.useState(() => Date.now());
 
   React.useEffect(() => {
     const id = setInterval(() => setTick(Date.now()), 1_000);

--- a/apps/web/src/components/rename-session-dialog.tsx
+++ b/apps/web/src/components/rename-session-dialog.tsx
@@ -13,21 +13,29 @@ import { useRenameSession } from '@/lib/queries/chat';
 export function RenameSessionDialog() {
   const { renameSessionOpen, setRenameSessionOpen } = useDialogContext();
   const params = useParams({ strict: false });
-  const renameMutation = useRenameSession();
-  const [title, setTitle] = React.useState('');
 
   const sessionId = params.id;
 
-  React.useEffect(() => {
-    if (renameSessionOpen && sessionId) {
-      setTitle('');
-    }
-  }, [renameSessionOpen, sessionId]);
+  return (
+    <Dialog open={renameSessionOpen} onOpenChange={setRenameSessionOpen}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Rename Session</DialogTitle>
+        </DialogHeader>
+        <RenameSessionForm key={sessionId} sessionId={sessionId} onClose={() => setRenameSessionOpen(false)} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function RenameSessionForm({ sessionId, onClose }: { sessionId: string | undefined; onClose: () => void }) {
+  const renameMutation = useRenameSession();
+  const [title, setTitle] = React.useState('');
 
   const handleRename = async () => {
     if (!title.trim() || !sessionId) return;
     await renameMutation.mutateAsync({ sessionId: sessionId as PrefixedString<'ses'>, title: title.trim() });
-    setRenameSessionOpen(false);
+    onClose();
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -37,27 +45,21 @@ export function RenameSessionDialog() {
   };
 
   return (
-    <Dialog open={renameSessionOpen} onOpenChange={setRenameSessionOpen}>
-      <DialogContent className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle>Rename Session</DialogTitle>
-        </DialogHeader>
-        <Input
-          placeholder="Session name"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          onKeyDown={handleKeyDown}
-          autoFocus
-        />
-        <DialogFooter>
-          <Button variant="outline" onClick={() => setRenameSessionOpen(false)}>
-            Cancel
-          </Button>
-          <Button onClick={handleRename} disabled={!title.trim() || renameMutation.isPending}>
-            Rename
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <>
+      <Input
+        placeholder="Session name"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button onClick={handleRename} disabled={!title.trim() || renameMutation.isPending}>
+          Rename
+        </Button>
+      </DialogFooter>
+    </>
   );
 }

--- a/apps/web/src/components/session/session-chat-pane/use-seeded-input.ts
+++ b/apps/web/src/components/session/session-chat-pane/use-seeded-input.ts
@@ -3,8 +3,8 @@ import * as React from 'react';
 import { consumeNextSessionInputSeed, getTransitionSeedClearDelayMs } from '@/lib/chat-input-transition-seed';
 
 export function useSeededInput() {
-  const seedTextRef = React.useRef(consumeNextSessionInputSeed());
-  const [value, setValue] = React.useState(seedTextRef.current);
+  const [value, setValue] = React.useState(consumeNextSessionInputSeed);
+  const seedTextRef = React.useRef(value);
 
   React.useEffect(() => {
     const seedText = seedTextRef.current;

--- a/apps/web/src/components/session/session-page-header.tsx
+++ b/apps/web/src/components/session/session-page-header.tsx
@@ -48,7 +48,8 @@ export function SessionPageHeader({
   const { setRenameSessionOpen } = useDialogContext();
   const { data: session } = useSuspenseQuery(sessionQueryOptions(sessionId));
 
-  const isChildSession = session.parentSessionId !== null;
+  const parentSessionId = session.parentSessionId;
+  const isChildSession = parentSessionId !== null;
 
   return (
     <header className="border-b border-border/60 bg-muted/40">
@@ -57,7 +58,7 @@ export function SessionPageHeader({
           {isChildSession ? (
             <Link
               to="/session/$id"
-              params={{ id: session.parentSessionId! }}
+              params={{ id: parentSessionId }}
               className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground">
               <ArrowLeftIcon className="size-4" />
               <span className="hidden sm:inline">Back to parent</span>

--- a/apps/web/src/components/session/session-page.tsx
+++ b/apps/web/src/components/session/session-page.tsx
@@ -24,6 +24,8 @@ import { settingsQueryOptions } from '@/lib/queries/settings';
 
 type SessionPageProps = { sessionId: string };
 
+const LOCAL_TIMEZONE = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+
 export function SessionPage({ sessionId }: SessionPageProps) {
   const navigate = useNavigate();
   const { mutate: markReadMutate } = useMarkSessionRead();
@@ -34,37 +36,32 @@ export function SessionPage({ sessionId }: SessionPageProps) {
   const generateAutomation = useGenerateAutomationDraft();
   const details = useSessionDetailsStats(sessionId);
   const streamState = useSessionStreamState(sessionId);
-  const [rightPanel, setRightPanel] = React.useState<SessionPageHeaderProps['rightPanel']>('closed');
+  const [requestedRightPanel, setRequestedRightPanel] = React.useState<SessionPageHeaderProps['rightPanel']>('closed');
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
   const [automationDialogOpen, setAutomationDialogOpen] = React.useState(false);
   const [generatedDraft, setGeneratedDraft] = React.useState<GeneratedAutomationDraft | null>(null);
   const lastReadCompletedMessageIdRef = React.useRef<string | null>(null);
-  const timezone = settings?.['profile.timezone']?.trim() || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-
-  const rightPanelOpen = rightPanel !== 'closed';
+  const timezone = settings?.['profile.timezone']?.trim() || LOCAL_TIMEZONE;
 
   const browserAppEnabled = appEnabledStates?.find((state) => state.appId === 'browser')?.enabled ?? true;
   const hasBrowser = typeof window !== 'undefined' && Boolean(window.api?.browser) && browserAppEnabled;
 
+  const rightPanel = requestedRightPanel === 'browser' && !hasBrowser ? 'closed' : requestedRightPanel;
+  const rightPanelOpen = rightPanel !== 'closed';
+
   const toggleDetails = React.useCallback(() => {
-    setRightPanel((previous) => (previous === 'details' ? 'closed' : 'details'));
+    setRequestedRightPanel((previous) => (previous === 'details' ? 'closed' : 'details'));
   }, []);
 
   const toggleBrowser = React.useCallback(() => {
-    setRightPanel((previous) => (previous === 'browser' ? 'closed' : 'browser'));
+    setRequestedRightPanel((previous) => (previous === 'browser' ? 'closed' : 'browser'));
   }, []);
 
   React.useEffect(() => {
     return window.api?.browser.onShowRequested(() => {
-      if (browserAppEnabled) setRightPanel('browser');
+      if (browserAppEnabled) setRequestedRightPanel('browser');
     });
   }, [browserAppEnabled]);
-
-  React.useEffect(() => {
-    if (!hasBrowser && rightPanel === 'browser') {
-      setRightPanel('closed');
-    }
-  }, [hasBrowser, rightPanel]);
 
   React.useEffect(() => {
     lastReadCompletedMessageIdRef.current = null;
@@ -133,7 +130,7 @@ export function SessionPage({ sessionId }: SessionPageProps) {
 
               <ResizablePanel defaultSize="30%" minSize="24%" maxSize="55%">
                 {rightPanel === 'browser' ? (
-                  <BrowserPanel sessionId={sessionId} onClose={() => setRightPanel('closed')} />
+                  <BrowserPanel sessionId={sessionId} onClose={() => setRequestedRightPanel('closed')} />
                 ) : (
                   <SessionDetailsSheet {...details} sessionId={sessionId} className="hidden lg:block" />
                 )}
@@ -147,7 +144,7 @@ export function SessionPage({ sessionId }: SessionPageProps) {
         sessionId={sessionId}
         open={deleteDialogOpen}
         onOpenChange={setDeleteDialogOpen}
-        onDeleted={() => setRightPanel('closed')}
+        onDeleted={() => setRequestedRightPanel('closed')}
       />
 
       <AutomationDialog

--- a/apps/web/src/components/settings/agents.tsx
+++ b/apps/web/src/components/settings/agents.tsx
@@ -19,10 +19,12 @@ export function AgentsSettings() {
   );
   const savedInstructions = settings[SETTING_KEY] ?? '';
   const [instructions, setInstructions] = React.useState(savedInstructions);
+  const [syncedInstructions, setSyncedInstructions] = React.useState(savedInstructions);
 
-  React.useEffect(() => {
+  if (syncedInstructions !== savedInstructions) {
+    setSyncedInstructions(savedInstructions);
     setInstructions(savedInstructions);
-  }, [savedInstructions]);
+  }
 
   const saveInstructions = () => {
     if (instructions !== savedInstructions) {

--- a/apps/web/src/components/settings/appearance.tsx
+++ b/apps/web/src/components/settings/appearance.tsx
@@ -34,6 +34,7 @@ export function AppearanceSelector() {
           {APPEARANCE_MODES.map((m) => (
             <button
               key={m}
+              type="button"
               onClick={() => setMode(m)}
               className={cn(
                 'flex-1 rounded-xl border px-3 py-3 text-sm font-medium transition-all text-center',
@@ -52,6 +53,7 @@ export function AppearanceSelector() {
           {THEMES.map((t) => (
             <button
               key={t.name}
+              type="button"
               onClick={() => setTheme(t.name)}
               className={cn(
                 'rounded-xl border p-3 text-left transition-all space-y-2',

--- a/apps/web/src/components/settings/connection.tsx
+++ b/apps/web/src/components/settings/connection.tsx
@@ -33,11 +33,13 @@ function ConnectionContent() {
   const [mode, setMode] = React.useState<ServerMode>(config.mode);
   const [remoteUrl, setRemoteUrl] = React.useState(config.remoteUrl ?? '');
   const [testState, setTestState] = React.useState<TestState>({ status: 'idle' });
+  const [syncedConfig, setSyncedConfig] = React.useState(config);
 
-  React.useEffect(() => {
+  if (syncedConfig !== config) {
+    setSyncedConfig(config);
     setMode(config.mode);
     setRemoteUrl(config.remoteUrl ?? '');
-  }, [config]);
+  }
 
   const hasChanges = mode !== config.mode || remoteUrl.trim() !== (config.remoteUrl ?? '');
   const remoteSelected = mode === 'remote';

--- a/apps/web/src/components/settings/mail/mail-account-card.tsx
+++ b/apps/web/src/components/settings/mail/mail-account-card.tsx
@@ -51,10 +51,12 @@ function MailNumberInput({
   onSave: (value: number) => void;
 }) {
   const [localValue, setLocalValue] = React.useState(String(value));
+  const [syncedValue, setSyncedValue] = React.useState(value);
 
-  React.useEffect(() => {
+  if (syncedValue !== value) {
+    setSyncedValue(value);
     setLocalValue(String(value));
-  }, [value]);
+  }
 
   function handleBlur() {
     const nextValue = Math.max(min, Number.parseInt(localValue, 10));

--- a/apps/web/src/components/settings/mcp-servers/header-rows.tsx
+++ b/apps/web/src/components/settings/mcp-servers/header-rows.tsx
@@ -15,13 +15,13 @@ export function HeaderRows({ rows, onChange }: { rows: HeaderEntry[]; onChange: 
   };
 
   const add = () => {
-    onChange([...rows, { key: '', value: '' }]);
+    onChange([...rows, { id: crypto.randomUUID(), key: '', value: '' }]);
   };
 
   return (
     <div className="space-y-2">
       {rows.map((row, i) => (
-        <div key={`${row.key}-${i}`} className="flex items-center gap-2">
+        <div key={row.id} className="flex items-center gap-2">
           <Input
             placeholder="Header name"
             value={row.key}

--- a/apps/web/src/components/settings/mcp-servers/shared.ts
+++ b/apps/web/src/components/settings/mcp-servers/shared.ts
@@ -7,7 +7,7 @@ export const AUTH_TYPE_LABELS: Record<McpAuthType, { label: string; description:
   oauth: { label: 'OAuth', description: 'Authorize in your browser (PKCE, auto-registration)' },
 };
 
-export type HeaderEntry = { key: string; value: string };
+export type HeaderEntry = { id: string; key: string; value: string };
 
 export type AddFormState = {
   name: string;
@@ -81,7 +81,7 @@ export function applyAuthConfigToForm(form: AddFormState, authConfig: McpAuthCon
       ...form,
       authType: 'headers',
       apiKey: '',
-      headers: Object.entries(authConfig.headers).map(([key, value]) => ({ key, value })),
+      headers: Object.entries(authConfig.headers).map(([key, value]) => ({ id: crypto.randomUUID(), key, value })),
     };
   }
 

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -151,7 +151,7 @@ function ToolsContent() {
   const connectorToolsets = filteredToolsets.filter((toolset) => toolset.source === 'connector');
 
   const mcpToolsetGroups = useMcpToolsetGroups(knownTools, mcpToolMetaByName);
-  const filteredMcpGroups = React.useMemo(() => filterMcpGroups(mcpToolsetGroups, query), [mcpToolsetGroups, query]);
+  const filteredMcpGroups = filterMcpGroups(mcpToolsetGroups, query);
 
   if (editingTarget) {
     return (

--- a/apps/web/src/components/settings/permissions/mcp-tools-tab.tsx
+++ b/apps/web/src/components/settings/permissions/mcp-tools-tab.tsx
@@ -47,8 +47,8 @@ export function useMcpToolsetGroups(
     }
 
     return Array.from(groups.values())
-      .map((group) => ({ ...group, tools: group.tools.sort((a, b) => a.displayName.localeCompare(b.displayName)) }))
-      .sort((a, b) => a.serverName.localeCompare(b.serverName));
+      .map((group) => ({ ...group, tools: group.tools.toSorted((a, b) => a.displayName.localeCompare(b.displayName)) }))
+      .toSorted((a, b) => a.serverName.localeCompare(b.serverName));
   }, [knownTools, mcpToolMetaByName]);
 }
 

--- a/apps/web/src/components/settings/providers/provider-config.tsx
+++ b/apps/web/src/components/settings/providers/provider-config.tsx
@@ -67,9 +67,9 @@ export function ProviderConfig({ provider, onBack, saveLabel = 'Save', onSaved, 
   const [fieldsByMethod, setFieldsByMethod] = React.useState<Record<string, FieldValues>>({});
   const [extraFields, setExtraFields] = React.useState<FieldValues>({});
   const [fieldErrors, setFieldErrors] = React.useState<Record<string, string>>({});
+  const [hydratedConfig, setHydratedConfig] = React.useState<typeof existingConfig>(undefined);
 
-  React.useEffect(() => {
-    if (!existingConfig || !meta) return;
+  if (existingConfig && meta && hydratedConfig !== existingConfig) {
     const hydrated = hydrateProviderConfigState(existingConfig as Record<string, unknown>, enabledAuthMethods);
     const activeMethod = hydrated.activeMethod;
     if (activeMethod) {
@@ -79,7 +79,8 @@ export function ProviderConfig({ provider, onBack, saveLabel = 'Save', onSaved, 
       setActiveTab(enabledAuthMethods[0].method);
     }
     setExtraFields(hydrated.extraFields);
-  }, [enabledAuthMethods, existingConfig, meta]);
+    setHydratedConfig(existingConfig);
+  }
 
   const saveMutation = useSaveProviderConfigMutation({
     providerId: provider.id,

--- a/apps/web/src/components/settings/recordings.tsx
+++ b/apps/web/src/components/settings/recordings.tsx
@@ -354,23 +354,17 @@ function MeetingNoteTemplatesSettings() {
   const selectedTemplate = data.templates.find((template) => template.id === selectedId) ?? null;
   const [name, setName] = React.useState(selectedTemplate?.name ?? '');
   const [content, setContent] = React.useState(selectedTemplate?.content ?? EMPTY_TEMPLATE_CONTENT);
+  const [syncedTemplate, setSyncedTemplate] = React.useState(selectedTemplate);
 
-  React.useEffect(() => {
-    if (!selectedTemplate) {
-      setName('');
-      setContent(EMPTY_TEMPLATE_CONTENT);
-      return;
-    }
+  if (!selectedId && data.templates[0]) {
+    setSelectedId(data.templates[0].id);
+  }
 
-    setName(selectedTemplate.name);
-    setContent(selectedTemplate.content);
-  }, [selectedTemplate]);
-
-  React.useEffect(() => {
-    if (!selectedId && data.templates[0]) {
-      setSelectedId(data.templates[0].id);
-    }
-  }, [data.templates, selectedId]);
+  if (syncedTemplate !== selectedTemplate) {
+    setSyncedTemplate(selectedTemplate);
+    setName(selectedTemplate?.name ?? '');
+    setContent(selectedTemplate?.content ?? EMPTY_TEMPLATE_CONTENT);
+  }
 
   const canSave = name.trim().length > 0 && selectedTemplate !== null;
   const isSaving = createMutation.isPending || updateMutation.isPending;

--- a/apps/web/src/components/settings/settings-ui.tsx
+++ b/apps/web/src/components/settings/settings-ui.tsx
@@ -233,10 +233,12 @@ export function SliderSettingRow({
 }: SliderSettingRowProps) {
   const queryClient = useQueryClient();
   const [localValue, setLocalValue] = React.useState(currentValue);
+  const [syncedValue, setSyncedValue] = React.useState(currentValue);
 
-  React.useEffect(() => {
+  if (syncedValue !== currentValue) {
+    setSyncedValue(currentValue);
     setLocalValue(currentValue);
-  }, [currentValue]);
+  }
 
   const saveMutation = useMutation(saveSettingMutationOptions(settingKey, queryClient, { silent: true }));
 

--- a/apps/web/src/components/settings/shortcuts.tsx
+++ b/apps/web/src/components/settings/shortcuts.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/lib/queries/shortcuts';
 import { cn } from '@/lib/utils';
 
-const BLOCKED_HOTKEYS = ['Mod+C', 'Mod+V', 'Mod+R', 'Mod+M'];
+const BLOCKED_HOTKEYS = new Set(['Mod+C', 'Mod+V', 'Mod+R', 'Mod+M']);
 const LEADER_KEY_RECORDING_ID = '__leader-key__';
 
 const defaultsByActionId = new Map<string, (typeof SHORTCUT_DEFAULTS)[number]>(
@@ -47,7 +47,7 @@ function groupByCategory(entries: ShortcutEntry[]): Map<string, ShortcutEntry[]>
   return groups;
 }
 
-const defaultLeaderKey = SETTINGS_DEFAULTS.find((s) => s.key === 'shortcuts.leaderKey')!.value;
+const defaultLeaderKey = SETTINGS_DEFAULTS.find((s) => s.key === 'shortcuts.leaderKey')?.value ?? 'Mod+X';
 
 function HotkeyBadge({ hotkey, isSequence }: { hotkey: string | null; isSequence: boolean }) {
   if (!hotkey) {
@@ -63,8 +63,8 @@ function HotkeyBadge({ hotkey, isSequence }: { hotkey: string | null; isSequence
       <span className="inline-flex items-center gap-1.5">
         <Kbd>Leader</Kbd>
         <span className="text-2xs font-semibold tracking-widest text-muted-foreground uppercase">then</span>
-        {suffixDisplayKeys.map((key, i) => (
-          <Kbd key={`suffix-${i}`}>{key}</Kbd>
+        {suffixDisplayKeys.map((key) => (
+          <Kbd key={`suffix-${key}`}>{key}</Kbd>
         ))}
       </span>
     );
@@ -75,11 +75,11 @@ function HotkeyBadge({ hotkey, isSequence }: { hotkey: string | null; isSequence
   if (isSequence) {
     return (
       <span className="inline-flex gap-1.5">
-        {displayKeys.map((key, i) => (
-          <Kbd key={`first-${i}`}>{key}</Kbd>
+        {displayKeys.map((key) => (
+          <Kbd key={`first-${key}`}>{key}</Kbd>
         ))}
-        {displayKeys.map((key, i) => (
-          <Kbd key={`second-${i}`}>{key}</Kbd>
+        {displayKeys.map((key) => (
+          <Kbd key={`second-${key}`}>{key}</Kbd>
         ))}
       </span>
     );
@@ -87,8 +87,8 @@ function HotkeyBadge({ hotkey, isSequence }: { hotkey: string | null; isSequence
 
   return (
     <span className="inline-flex gap-1.5">
-      {displayKeys.map((key, i) => (
-        <Kbd key={i}>{key}</Kbd>
+      {displayKeys.map((key) => (
+        <Kbd key={key}>{key}</Kbd>
       ))}
     </span>
   );
@@ -121,6 +121,7 @@ function ShortcutRow({
         )}
       </div>
       <button
+        type="button"
         onClick={() => !isLeaderShortcut && onStartRecording(entry.actionId)}
         className={cn(
           'text-sm rounded-md px-2 py-1.5 transition-colors',
@@ -162,7 +163,7 @@ function ShortcutsContent() {
     onRecord: (hotkey) => {
       if (!recordingId) return;
 
-      if (BLOCKED_HOTKEYS.includes(hotkey)) {
+      if (BLOCKED_HOTKEYS.has(hotkey)) {
         toast.error(`${formatForDisplay(hotkey)} is reserved and cannot be used`, { id: 'shortcut-reserved' });
         setRecordingId(null);
         return;
@@ -253,9 +254,10 @@ function ShortcutsContent() {
       if (!entry.hotkey) continue;
       // Use hotkey + isSequence as the conflict key so single-press and double-press don't clash
       const conflictKey = `${entry.hotkey}:${entry.isSequence}`;
-      if (hotkeyToDef.has(conflictKey)) {
-        map.set(entry.actionId, hotkeyToDef.get(conflictKey)!.label);
-        map.set(hotkeyToDef.get(conflictKey)!.actionId, entry.label);
+      const existing = hotkeyToDef.get(conflictKey);
+      if (existing) {
+        map.set(entry.actionId, existing.label);
+        map.set(existing.actionId, entry.label);
       } else {
         hotkeyToDef.set(conflictKey, entry);
       }
@@ -286,6 +288,7 @@ function ShortcutsContent() {
         <SettingRows>
           <SettingRow label="Leader key" description="Used as the prefix for LEADER+ shortcuts">
             <button
+              type="button"
               onClick={handleStartLeaderKeyRecording}
               className={cn(
                 'text-sm rounded-md px-2 py-1.5 transition-colors hover:bg-accent/60 cursor-pointer',

--- a/apps/web/src/components/settings/skills.tsx
+++ b/apps/web/src/components/settings/skills.tsx
@@ -62,7 +62,6 @@ function ImportSkillView({ onBack }: { onBack: () => void }) {
       backLabel="Back to skills">
       <div className="flex min-h-0 flex-1 flex-col gap-4">
         <Input
-          autoFocus
           value={search}
           placeholder="Search skills, e.g. frontend design"
           onChange={(event) => setSearch(event.target.value)}
@@ -107,10 +106,6 @@ function SkillEditor({ skill, onBack }: { skill: Skill | null; onBack: () => voi
   const createSkill = useCreateSkill();
   const updateSkill = useUpdateSkill();
   const [draft, setDraft] = React.useState<SkillDraft>(() => toDraft(skill));
-
-  React.useEffect(() => {
-    setDraft(toDraft(skill));
-  }, [skill]);
 
   const isEditing = !!skill;
   const isSaving = createSkill.isPending || updateSkill.isPending;

--- a/apps/web/src/components/ui/calendar.tsx
+++ b/apps/web/src/components/ui/calendar.tsx
@@ -1,6 +1,15 @@
 import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import * as React from 'react';
-import { DayPicker, getDefaultClassNames, type DayButton, type Locale } from 'react-day-picker';
+import {
+  DayPicker,
+  getDefaultClassNames,
+  useDayPicker,
+  type ChevronProps,
+  type DayButton,
+  type Locale,
+  type RootProps,
+  type WeekNumberProps,
+} from 'react-day-picker';
 
 import { Button, buttonVariants } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
@@ -103,33 +112,45 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        Root: ({ className, rootRef, ...props }) => {
-          return <div data-slot="calendar" ref={rootRef} className={cn(className)} {...props} />;
-        },
-        Chevron: ({ className, orientation, ...props }) => {
-          if (orientation === 'left') {
-            return <ChevronLeftIcon className={cn('cn-rtl-flip size-4', className)} {...props} />;
-          }
-
-          if (orientation === 'right') {
-            return <ChevronRightIcon className={cn('cn-rtl-flip size-4', className)} {...props} />;
-          }
-
-          return <ChevronDownIcon className={cn('size-4', className)} {...props} />;
-        },
-        DayButton: ({ ...props }) => <CalendarDayButton locale={locale} {...props} />,
-        WeekNumber: ({ children, ...props }) => {
-          return (
-            <td {...props}>
-              <div className="flex size-(--cell-size) items-center justify-center text-center">{children}</div>
-            </td>
-          );
-        },
+        Root: CalendarRoot,
+        Chevron: CalendarChevron,
+        DayButton: CalendarDayButtonWithLocale,
+        WeekNumber: CalendarWeekNumber,
         ...components,
       }}
       {...props}
     />
   );
+}
+
+function CalendarRoot({ className, rootRef, ...props }: RootProps) {
+  return <div data-slot="calendar" ref={rootRef} className={cn(className)} {...props} />;
+}
+
+function CalendarChevron({ className, orientation, ...props }: ChevronProps) {
+  if (orientation === 'left') {
+    return <ChevronLeftIcon className={cn('cn-rtl-flip size-4', className)} {...props} />;
+  }
+
+  if (orientation === 'right') {
+    return <ChevronRightIcon className={cn('cn-rtl-flip size-4', className)} {...props} />;
+  }
+
+  return <ChevronDownIcon className={cn('size-4', className)} {...props} />;
+}
+
+function CalendarWeekNumber({ children, ...props }: WeekNumberProps) {
+  return (
+    <td {...props}>
+      <div className="flex size-(--cell-size) items-center justify-center text-center">{children}</div>
+    </td>
+  );
+}
+
+function CalendarDayButtonWithLocale(props: React.ComponentProps<typeof DayButton>) {
+  const { dayPickerProps } = useDayPicker();
+
+  return <CalendarDayButton locale={dayPickerProps.locale} {...props} />;
 }
 
 function CalendarDayButton({

--- a/apps/web/src/components/ui/page.tsx
+++ b/apps/web/src/components/ui/page.tsx
@@ -42,8 +42,12 @@ function PageIcon({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
-function PageTitle({ className, ...props }: React.ComponentProps<'h1'>) {
-  return <h1 data-slot="page-title" className={cn('text-xl font-semibold', className)} {...props} />;
+function PageTitle({ className, children, ...props }: React.ComponentProps<'h1'>) {
+  return (
+    <h1 data-slot="page-title" className={cn('text-xl font-semibold', className)} {...props}>
+      {children}
+    </h1>
+  );
 }
 
 function PageDescription({ className, ...props }: React.ComponentProps<'p'>) {

--- a/apps/web/src/components/ui/pagination.tsx
+++ b/apps/web/src/components/ui/pagination.tsx
@@ -27,7 +27,7 @@ function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
 type PaginationLinkProps = { isActive?: boolean } & Pick<React.ComponentProps<typeof Button>, 'size'> &
   React.ComponentProps<'a'>;
 
-function PaginationLink({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) {
+function PaginationLink({ className, isActive, size = 'icon', children, ...props }: PaginationLinkProps) {
   return (
     <Button
       variant={isActive ? 'outline' : 'ghost'}
@@ -35,7 +35,9 @@ function PaginationLink({ className, isActive, size = 'icon', ...props }: Pagina
       className={cn(className)}
       nativeButton={false}
       render={
-        <a aria-current={isActive ? 'page' : undefined} data-slot="pagination-link" data-active={isActive} {...props} />
+        <a aria-current={isActive ? 'page' : undefined} data-slot="pagination-link" data-active={isActive} {...props}>
+          {children}
+        </a>
       }
     />
   );

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -228,6 +228,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<'button'>) {
 
   return (
     <button
+      type="button"
       data-sidebar="rail"
       data-slot="sidebar-rail"
       aria-label="Toggle Sidebar"

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -89,12 +89,15 @@ function TableEmptyRow({ colSpan, children }: { colSpan: number; children: React
 type TableSkeletonColumn = { className?: string; skeletonClassName?: string };
 
 function TableSkeletonRows({ rows = 5, columns }: { rows?: number; columns: TableSkeletonColumn[] }) {
+  const rowKeys = Array.from({ length: rows }, (_, index) => `skeleton-row-${index}`);
+  const cells = columns.map((column, index) => ({ column, key: `skeleton-cell-${index}` }));
+
   return (
     <>
-      {Array.from({ length: rows }).map((_, rowIndex) => (
-        <TableRow key={rowIndex} className="hover:bg-transparent">
-          {columns.map((column, columnIndex) => (
-            <TableCell key={columnIndex} className={column.className}>
+      {rowKeys.map((rowKey) => (
+        <TableRow key={rowKey} className="hover:bg-transparent">
+          {cells.map(({ column, key }) => (
+            <TableCell key={key} className={column.className}>
               {column.skeletonClassName ? <Skeleton className={column.skeletonClassName} /> : null}
             </TableCell>
           ))}

--- a/apps/web/src/components/ui/textarea-completions.tsx
+++ b/apps/web/src/components/ui/textarea-completions.tsx
@@ -176,16 +176,16 @@ export function TextareaCompletions({
     };
   }, [completionState, textareaRef]);
 
-  const updateCompletionState = React.useCallback(() => {
-    const textarea = textareaRef.current;
-    const nextState = textarea ? getCompletionState(textarea, groups) : null;
-    setCompletionState(nextState);
-    setActiveIndex(0);
-  }, [groups, textareaRef]);
+  const updateCompletionState = React.useCallback(
+    (textarea: HTMLTextAreaElement) => {
+      setCompletionState(getCompletionState(textarea, groups));
+      setActiveIndex(0);
+    },
+    [groups],
+  );
 
-  function applyCompletion(option: TextareaCompletionOption) {
-    const textarea = textareaRef.current;
-    if (!textarea || !completionState) return;
+  function applyCompletion(textarea: HTMLTextAreaElement, option: TextareaCompletionOption) {
+    if (!completionState) return;
 
     const replacement = `${completionState.group.prefix}${option.value} `;
     const prefix = value.slice(0, completionState.anchorIndex) + replacement;
@@ -222,7 +222,7 @@ export function TextareaCompletions({
 
       if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
         event.preventDefault();
-        applyCompletion(completionOptions[activeIndex]);
+        applyCompletion(event.currentTarget, completionOptions[activeIndex]);
         return;
       }
     }
@@ -236,13 +236,14 @@ export function TextareaCompletions({
     'aria-controls': isOpen ? listId : undefined,
     'aria-expanded': isOpen,
     onChange: (event) => {
-      onChange(event.target.value);
-      requestAnimationFrame(updateCompletionState);
+      const textarea = event.currentTarget;
+      onChange(textarea.value);
+      requestAnimationFrame(() => updateCompletionState(textarea));
     },
     onKeyDown: handleKeyDown,
-    onSelect: updateCompletionState,
+    onSelect: (event) => updateCompletionState(event.currentTarget),
     onBlur: () => setCompletionState(null),
-    onFocus: updateCompletionState,
+    onFocus: (event) => updateCompletionState(event.currentTarget),
   };
 
   return (
@@ -273,7 +274,10 @@ export function TextareaCompletions({
                 )}
                 onMouseDown={(event) => event.preventDefault()}
                 onMouseEnter={() => setActiveIndex(index)}
-                onClick={() => applyCompletion(option)}>
+                onClick={() => {
+                  const textarea = textareaRef.current;
+                  if (textarea) applyCompletion(textarea, option);
+                }}>
                 <span className="font-medium">
                   {completionState?.group.prefix}
                   {option.value}

--- a/apps/web/src/components/ui/toggle-group.tsx
+++ b/apps/web/src/components/ui/toggle-group.tsx
@@ -20,6 +20,8 @@ function ToggleGroup({
   ...props
 }: ToggleGroupPrimitive.Props &
   VariantProps<typeof toggleVariants> & { spacing?: number; orientation?: 'horizontal' | 'vertical' }) {
+  const context = React.useMemo(() => ({ variant, size, spacing, orientation }), [variant, size, spacing, orientation]);
+
   return (
     <ToggleGroupPrimitive
       data-slot="toggle-group"
@@ -33,9 +35,7 @@ function ToggleGroup({
         className,
       )}
       {...props}>
-      <ToggleGroupContext.Provider value={{ variant, size, spacing, orientation }}>
-        {children}
-      </ToggleGroupContext.Provider>
+      <ToggleGroupContext.Provider value={context}>{children}</ToggleGroupContext.Provider>
     </ToggleGroupPrimitive>
   );
 }

--- a/apps/web/src/components/usage/charts/embedding-usage-cost-chart.tsx
+++ b/apps/web/src/components/usage/charts/embedding-usage-cost-chart.tsx
@@ -22,7 +22,7 @@ export function EmbeddingUsageCostChart({ usageData }: EmbeddingUsageCostChartPr
         keys.add(key);
       }
     }
-    return Array.from(keys).sort((a, b) => a.localeCompare(b));
+    return Array.from(keys).toSorted((a, b) => a.localeCompare(b));
   }, [usageData?.buckets]);
 
   const labels = usageData?.buckets.map((b) => b.label) ?? [];

--- a/apps/web/src/components/usage/charts/stt-usage-cost-chart.tsx
+++ b/apps/web/src/components/usage/charts/stt-usage-cost-chart.tsx
@@ -24,7 +24,7 @@ type SttUsageCostChartProps = { usageData: SttUsageDashboardResponse | undefined
 
 export function SttUsageCostChart({ usageData }: SttUsageCostChartProps) {
   const services = React.useMemo(
-    () => [...(usageData?.services ?? [])].sort((a, b) => a.localeCompare(b)),
+    () => [...(usageData?.services ?? [])].toSorted((a, b) => a.localeCompare(b)),
     [usageData?.services],
   );
   const labels = usageData?.buckets.map((b) => b.label) ?? [];

--- a/apps/web/src/components/usage/hooks/use-embedding-usage-dashboard-data.ts
+++ b/apps/web/src/components/usage/hooks/use-embedding-usage-dashboard-data.ts
@@ -26,8 +26,8 @@ type EmbeddingModelOption = {
 export function useEmbeddingUsageDashboardData(rangeFilter: UsageDateRange) {
   const { data: embeddingProviderModels } = useSuspenseQuery(embeddingProviderModelsQueryOptions);
 
-  const [providerFilter, setProviderFilter] = React.useState<string>(ALL_FILTER);
-  const [modelFilter, setModelFilter] = React.useState<string>(ALL_FILTER);
+  const [selectedProvider, setProviderFilter] = React.useState<string>(ALL_FILTER);
+  const [selectedModel, setModelFilter] = React.useState<string>(ALL_FILTER);
 
   const { data: usageRangeData } = useQuery({
     ...embeddingUsageDashboardQueryOptions({ range: rangeFilter }),
@@ -56,6 +56,11 @@ export function useEmbeddingUsageDashboardData(rangeFilter: UsageDateRange) {
       .map((p) => ({ providerId: p.providerId, providerName: p.providerName }));
   }, [embeddingProviderModels, usageRangeData?.usedProviders]);
 
+  // A selection falls back to ALL_FILTER once its provider/model drops out of the active range.
+  const providerFilter = availableProviders.some((p) => p.providerId === selectedProvider)
+    ? selectedProvider
+    : ALL_FILTER;
+
   const availableModels = React.useMemo<EmbeddingModelOption[]>(() => {
     const usedModels = usageRangeData?.usedModels ?? [];
     return usedModels
@@ -74,20 +79,9 @@ export function useEmbeddingUsageDashboardData(rangeFilter: UsageDateRange) {
       });
   }, [modelNameByKey, providerById, providerFilter, usageRangeData?.usedModels]);
 
-  React.useEffect(() => {
-    if (providerFilter === ALL_FILTER) return;
-    const stillAvailable = availableProviders.some((p) => p.providerId === providerFilter);
-    if (!stillAvailable) {
-      setProviderFilter(ALL_FILTER);
-      setModelFilter(ALL_FILTER);
-    }
-  }, [availableProviders, providerFilter]);
-
-  React.useEffect(() => {
-    if (modelFilter === ALL_FILTER) return;
-    const isStillAvailable = availableModels.some((m) => encodeModelFilter(m.providerId, m.modelId) === modelFilter);
-    if (!isStillAvailable) setModelFilter(ALL_FILTER);
-  }, [availableModels, modelFilter]);
+  const modelFilter = availableModels.some((m) => encodeModelFilter(m.providerId, m.modelId) === selectedModel)
+    ? selectedModel
+    : ALL_FILTER;
 
   const usageFilters = React.useMemo(() => {
     const decodedModel = modelFilter === ALL_FILTER ? null : decodeModelFilter(modelFilter);

--- a/apps/web/src/components/usage/hooks/use-stt-usage-dashboard-data.ts
+++ b/apps/web/src/components/usage/hooks/use-stt-usage-dashboard-data.ts
@@ -20,8 +20,8 @@ type SttModelOption = { label: string; providerId: string; providerName: string;
 export function useSttUsageDashboardData(rangeFilter: UsageDateRange) {
   const { data: sttProviderModels } = useSuspenseQuery(sttProviderModelsQueryOptions);
 
-  const [providerFilter, setProviderFilter] = React.useState<string>(ALL_FILTER);
-  const [modelFilter, setModelFilter] = React.useState<string>(ALL_FILTER);
+  const [selectedProvider, setProviderFilter] = React.useState<string>(ALL_FILTER);
+  const [selectedModel, setModelFilter] = React.useState<string>(ALL_FILTER);
 
   const { data: usageRangeData } = useQuery({
     ...sttUsageDashboardQueryOptions({ range: rangeFilter }),
@@ -50,6 +50,11 @@ export function useSttUsageDashboardData(rangeFilter: UsageDateRange) {
       .map((p) => ({ providerId: p.providerId, providerName: p.providerName }));
   }, [sttProviderModels, usageRangeData?.usedProviders]);
 
+  // A selection falls back to ALL_FILTER once its provider/model drops out of the active range.
+  const providerFilter = availableProviders.some((p) => p.providerId === selectedProvider)
+    ? selectedProvider
+    : ALL_FILTER;
+
   const availableModels = React.useMemo<SttModelOption[]>(() => {
     const usedModels = usageRangeData?.usedModels ?? [];
     return usedModels
@@ -68,20 +73,9 @@ export function useSttUsageDashboardData(rangeFilter: UsageDateRange) {
       });
   }, [modelNameByKey, providerById, providerFilter, usageRangeData?.usedModels]);
 
-  React.useEffect(() => {
-    if (providerFilter === ALL_FILTER) return;
-    const stillAvailable = availableProviders.some((p) => p.providerId === providerFilter);
-    if (!stillAvailable) {
-      setProviderFilter(ALL_FILTER);
-      setModelFilter(ALL_FILTER);
-    }
-  }, [availableProviders, providerFilter]);
-
-  React.useEffect(() => {
-    if (modelFilter === ALL_FILTER) return;
-    const isStillAvailable = availableModels.some((m) => encodeModelFilter(m.providerId, m.modelId) === modelFilter);
-    if (!isStillAvailable) setModelFilter(ALL_FILTER);
-  }, [availableModels, modelFilter]);
+  const modelFilter = availableModels.some((m) => encodeModelFilter(m.providerId, m.modelId) === selectedModel)
+    ? selectedModel
+    : ALL_FILTER;
 
   const usageFilters = React.useMemo(() => {
     const decodedModel = modelFilter === ALL_FILTER ? null : decodeModelFilter(modelFilter);

--- a/apps/web/src/components/usage/hooks/use-usage-dashboard-data.ts
+++ b/apps/web/src/components/usage/hooks/use-usage-dashboard-data.ts
@@ -26,8 +26,8 @@ export type ModelOption = {
 export function useUsageDashboardData() {
   const { data: providerModels } = useSuspenseQuery(enabledProviderModelsQueryOptions);
 
-  const [providerFilter, setProviderFilter] = React.useState<string>(ALL_FILTER);
-  const [modelFilter, setModelFilter] = React.useState<string>(ALL_FILTER);
+  const [selectedProvider, setProviderFilter] = React.useState<string>(ALL_FILTER);
+  const [selectedModel, setModelFilter] = React.useState<string>(ALL_FILTER);
   const [rangeFilter, setRangeFilter] = React.useState<UsageDateRange>('30d');
 
   const { data: usageRangeData } = useQuery({
@@ -57,6 +57,11 @@ export function useUsageDashboardData() {
       .map((provider) => ({ providerId: provider.providerId, providerName: provider.providerName }));
   }, [providerModels, usageRangeData?.usedProviders]);
 
+  // A selection falls back to ALL_FILTER once its provider/model drops out of the active range.
+  const providerFilter = availableProviders.some((p) => p.providerId === selectedProvider)
+    ? selectedProvider
+    : ALL_FILTER;
+
   const availableModels = React.useMemo<ModelOption[]>(() => {
     const usedModels = usageRangeData?.usedModels ?? [];
     return usedModels
@@ -75,20 +80,9 @@ export function useUsageDashboardData() {
       });
   }, [modelNameByKey, providerById, providerFilter, usageRangeData?.usedModels]);
 
-  React.useEffect(() => {
-    if (providerFilter === ALL_FILTER) return;
-    const stillAvailable = availableProviders.some((p) => p.providerId === providerFilter);
-    if (!stillAvailable) {
-      setProviderFilter(ALL_FILTER);
-      setModelFilter(ALL_FILTER);
-    }
-  }, [availableProviders, providerFilter]);
-
-  React.useEffect(() => {
-    if (modelFilter === ALL_FILTER) return;
-    const isStillAvailable = availableModels.some((m) => encodeModelFilter(m.providerId, m.modelId) === modelFilter);
-    if (!isStillAvailable) setModelFilter(ALL_FILTER);
-  }, [availableModels, modelFilter]);
+  const modelFilter = availableModels.some((m) => encodeModelFilter(m.providerId, m.modelId) === selectedModel)
+    ? selectedModel
+    : ALL_FILTER;
 
   const usageFilters = React.useMemo(() => {
     const decodedModel = modelFilter === ALL_FILTER ? null : decodeModelFilter(modelFilter);

--- a/apps/web/src/components/usage/utils/usage-dashboard-utils.ts
+++ b/apps/web/src/components/usage/utils/usage-dashboard-utils.ts
@@ -48,7 +48,7 @@ export function decodeModelFilter(value: string): { providerId: string; modelId:
 export function useSourceOrder(sources: string[]): string[] {
   return React.useMemo(() => {
     const order = new Map<string, number>(USAGE_SOURCES.map((source, index) => [source, index]));
-    return [...sources].sort((a, b) => {
+    return [...sources].toSorted((a, b) => {
       const aOrder = order.get(a) ?? Number.MAX_SAFE_INTEGER;
       const bOrder = order.get(b) ?? Number.MAX_SAFE_INTEGER;
       if (aOrder !== bOrder) return aOrder - bOrder;

--- a/apps/web/src/context/dialog-context.tsx
+++ b/apps/web/src/context/dialog-context.tsx
@@ -13,12 +13,12 @@ export function DialogProvider({ children }: { children: React.ReactNode }) {
   const [commandPaletteOpen, setCommandPaletteOpen] = React.useState(false);
   const [renameSessionOpen, setRenameSessionOpen] = React.useState(false);
 
-  return (
-    <DialogContext.Provider
-      value={{ commandPaletteOpen, setCommandPaletteOpen, renameSessionOpen, setRenameSessionOpen }}>
-      {children}
-    </DialogContext.Provider>
+  const value = React.useMemo(
+    () => ({ commandPaletteOpen, setCommandPaletteOpen, renameSessionOpen, setRenameSessionOpen }),
+    [commandPaletteOpen, renameSessionOpen],
   );
+
+  return <DialogContext.Provider value={value}>{children}</DialogContext.Provider>;
 }
 
 export function useDialogContext(): DialogContextValue {

--- a/apps/web/src/hooks/sse/server-event-sync.ts
+++ b/apps/web/src/hooks/sse/server-event-sync.ts
@@ -54,16 +54,14 @@ function useServerEventSync(): void {
   const params = useParams({ strict: false });
   const currentSessionId = params.id;
 
-  const {
-    applyStreamStart,
-    applyPartUpdate,
-    applyPartDeltas,
-    applyToolState,
-    finishStream,
-    errorStream,
-    retryStream,
-    doomLoopDetected,
-  } = useStreamStore.getState();
+  const applyStreamStart = useStreamStore((s) => s.applyStreamStart);
+  const applyPartUpdate = useStreamStore((s) => s.applyPartUpdate);
+  const applyPartDeltas = useStreamStore((s) => s.applyPartDeltas);
+  const applyToolState = useStreamStore((s) => s.applyToolState);
+  const finishStream = useStreamStore((s) => s.finishStream);
+  const errorStream = useStreamStore((s) => s.errorStream);
+  const retryStream = useStreamStore((s) => s.retryStream);
+  const doomLoopDetected = useStreamStore((s) => s.doomLoopDetected);
 
   const pendingDeltasRef = useRef<PendingDelta[]>([]);
   const rafIdRef = useRef<number | null>(null);

--- a/apps/web/src/hooks/sse/sse-context.tsx
+++ b/apps/web/src/hooks/sse/sse-context.tsx
@@ -129,10 +129,12 @@ export function SseProvider({ children }: { children: React.ReactNode }) {
     const entries = Object.entries(handlers) as [SseEventName, AnyHandler][];
 
     entries.forEach(([eventName, handler]) => {
-      if (!handlersRef.current.has(eventName)) {
-        handlersRef.current.set(eventName, new Set());
+      let eventHandlers = handlersRef.current.get(eventName);
+      if (!eventHandlers) {
+        eventHandlers = new Set();
+        handlersRef.current.set(eventName, eventHandlers);
       }
-      handlersRef.current.get(eventName)!.add(handler);
+      eventHandlers.add(handler);
     });
 
     return () => {
@@ -142,7 +144,9 @@ export function SseProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  return <SseContext.Provider value={{ status, lastHeartbeat, subscribe }}>{children}</SseContext.Provider>;
+  const value = React.useMemo(() => ({ status, lastHeartbeat, subscribe }), [status, lastHeartbeat, subscribe]);
+
+  return <SseContext.Provider value={value}>{children}</SseContext.Provider>;
 }
 
 function useSseContext(): SseContextValue {
@@ -157,8 +161,12 @@ export function useSSE(handlers: SseHandlers = {}): UseSseResult {
   const { status, lastHeartbeat, subscribe } = useSseContext();
 
   // Stable ref so the subscribe effect only runs once per mount, not on every render.
+  // Synced in a layout effect so the latest handlers are in place before the browser
+  // can deliver another SSE message.
   const handlersRef = React.useRef(handlers);
-  handlersRef.current = handlers;
+  React.useLayoutEffect(() => {
+    handlersRef.current = handlers;
+  });
 
   // Capture event names on mount for stable useEffect dependencies
   const [eventNames] = React.useState(() => Object.keys(handlers) as SseEventName[]);
@@ -189,10 +197,11 @@ export function useSessionEvents(
   const { subscribe } = useSseContext();
 
   const handlersRef = React.useRef(handlers);
-  handlersRef.current = handlers;
-
   const sessionIdRef = React.useRef(sessionId);
-  sessionIdRef.current = sessionId;
+  React.useLayoutEffect(() => {
+    handlersRef.current = handlers;
+    sessionIdRef.current = sessionId;
+  });
 
   const [eventNames] = React.useState(() => Object.keys(handlers) as SessionScopedName[]);
 
@@ -222,10 +231,11 @@ export function useRecordingEvents(
   const { subscribe } = useSseContext();
 
   const handlersRef = React.useRef(handlers);
-  handlersRef.current = handlers;
-
   const recordingIdRef = React.useRef(recordingId);
-  recordingIdRef.current = recordingId;
+  React.useLayoutEffect(() => {
+    handlersRef.current = handlers;
+    recordingIdRef.current = recordingId;
+  });
 
   const [eventNames] = React.useState(() => Object.keys(handlers) as RecordingScopedName[]);
 

--- a/apps/web/src/hooks/ui/use-mobile.ts
+++ b/apps/web/src/hooks/ui/use-mobile.ts
@@ -2,18 +2,16 @@ import * as React from 'react';
 
 const MOBILE_BREAKPOINT = 768;
 
+function subscribeToBreakpoint(onChange: () => void) {
+  const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+  mql.addEventListener('change', onChange);
+  return () => mql.removeEventListener('change', onChange);
+}
+
+function getIsMobile() {
+  return window.innerWidth < MOBILE_BREAKPOINT;
+}
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined);
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
-    mql.addEventListener('change', onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener('change', onChange);
-  }, []);
-
-  return !!isMobile;
+  return React.useSyncExternalStore(subscribeToBreakpoint, getIsMobile);
 }

--- a/apps/web/src/lib/code-highlighting.ts
+++ b/apps/web/src/lib/code-highlighting.ts
@@ -1,4 +1,6 @@
-import type { BundledLanguage } from 'shiki';
+import type { BundledLanguage, Highlighter } from 'shiki';
+
+export type HighlightedCodeHast = ReturnType<Highlighter['codeToHast']>;
 
 interface LRUEntry<T> {
   value: T;
@@ -49,7 +51,10 @@ class LRUCache<T> {
 const MAX_HIGHLIGHT_CACHE_ENTRIES = 500;
 const MAX_HIGHLIGHT_CACHE_MEMORY_BYTES = 50 * 1024 * 1024;
 
-const _highlightedCodeCache = new LRUCache<string>(MAX_HIGHLIGHT_CACHE_ENTRIES, MAX_HIGHLIGHT_CACHE_MEMORY_BYTES);
+const _highlightedCodeCache = new LRUCache<HighlightedCodeHast>(
+  MAX_HIGHLIGHT_CACHE_ENTRIES,
+  MAX_HIGHLIGHT_CACHE_MEMORY_BYTES,
+);
 
 export const highlightedCodeCache = _highlightedCodeCache;
 
@@ -63,8 +68,8 @@ export function createHighlightCacheKey(code: string, language: string, themeNam
   return `${Math.abs(hash).toString(36)}:${code.length}:${language}:${themeName}`;
 }
 
-export function estimateHighlightedSize(html: string, code: string): number {
-  return Math.max(html.length * 2, code.length * 3);
+export function estimateHighlightedSize(hast: HighlightedCodeHast, code: string): number {
+  return Math.max(JSON.stringify(hast).length * 2, code.length * 3);
 }
 
 export type SupportedLanguage = BundledLanguage | 'text';

--- a/apps/web/src/lib/shiki-highlighter.ts
+++ b/apps/web/src/lib/shiki-highlighter.ts
@@ -7,7 +7,7 @@ let currentLangs: string[] = [];
 const highlighterPromiseCache = new Map<string, Promise<Highlighter>>();
 
 async function getSharedHighlighter(themes: string[], langs: string[]): Promise<Highlighter> {
-  const cacheKey = `${themes.sort().join(',')}-${langs.sort().join(',')}`;
+  const cacheKey = `${themes.toSorted().join(',')}-${langs.toSorted().join(',')}`;
 
   const cached = highlighterPromiseCache.get(cacheKey);
   if (cached) return cached;

--- a/apps/web/src/lib/use-global-hotkeys.ts
+++ b/apps/web/src/lib/use-global-hotkeys.ts
@@ -12,7 +12,7 @@ import { useShortcuts } from '@/lib/shortcuts';
 
 const LEADER_PREFIX = 'LEADER+';
 
-const defaultLeaderKey = SETTINGS_DEFAULTS.find((s) => s.key === 'shortcuts.leaderKey')!.value;
+const defaultLeaderKey = SETTINGS_DEFAULTS.find((s) => s.key === 'shortcuts.leaderKey')?.value ?? 'Mod+X';
 const defaultShortcutHotkeys = new Map(SHORTCUT_DEFAULTS.map((shortcut) => [shortcut.actionId, shortcut.hotkey]));
 
 function getDefaultShortcutHotkey(actionId: ShortcutActionId): string | null {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -29,7 +29,9 @@ declare module '@tanstack/react-router' {
   }
 }
 
-const rootElement = document.getElementById('root')!;
+const rootElement = document.getElementById('root');
+if (!rootElement) throw new Error('Root element #root not found');
+
 const isDesktopNotificationWindow = window.location.hash.startsWith('#/desktop-notifications');
 
 if (isDesktopNotificationWindow) {

--- a/apps/web/src/stores/stream-store.ts
+++ b/apps/web/src/stores/stream-store.ts
@@ -115,7 +115,7 @@ function getSession(sessions: Record<string, SessionStreamState>, sessionId: str
   return sessions[sessionId] ?? null;
 }
 
-function guardMessage(session: SessionStreamState | null, messageId: string): boolean {
+function guardMessage(session: SessionStreamState | null, messageId: string): session is SessionStreamState {
   return session !== null && session.activeMessageId === messageId;
 }
 
@@ -249,21 +249,21 @@ export const useStreamStore = create<StreamStoreState & StreamStoreActions>()((s
     set((state) => {
       const session = getSession(state.sessions, sessionId);
       if (!guardMessage(session, messageId)) return state;
-      return { sessions: { ...state.sessions, [sessionId]: applyPartUpdateToSession(session!, partId, part) } };
+      return { sessions: { ...state.sessions, [sessionId]: applyPartUpdateToSession(session, partId, part) } };
     }),
 
   applyPartDelta: (sessionId, messageId, partId, delta) =>
     set((state) => {
       const session = getSession(state.sessions, sessionId);
       if (!guardMessage(session, messageId)) return state;
-      return { sessions: { ...state.sessions, [sessionId]: applyPartDeltaToSession(session!, partId, delta) } };
+      return { sessions: { ...state.sessions, [sessionId]: applyPartDeltaToSession(session, partId, delta) } };
     }),
 
   applyPartDeltas: (sessionId, messageId, deltas) =>
     set((state) => {
       const session = getSession(state.sessions, sessionId);
       if (!guardMessage(session, messageId)) return state;
-      let current = session!;
+      let current = session;
       for (const { partId, delta } of deltas) {
         current = applyPartDeltaToSession(current, partId, delta);
       }
@@ -275,13 +275,13 @@ export const useStreamStore = create<StreamStoreState & StreamStoreActions>()((s
       const session = getSession(state.sessions, sessionId);
       if (!guardMessage(session, messageId)) return state;
 
-      const existing = session!.parts[toolCallId];
+      const existing = session.parts[toolCallId];
 
       if (existing && existing.type === 'tool-call') {
         return {
           sessions: {
             ...state.sessions,
-            [sessionId]: updatePart(session!, toolCallId, {
+            [sessionId]: updatePart(session, toolCallId, {
               ...existing,
               status,
               ...(input !== undefined && { input }),
@@ -296,7 +296,7 @@ export const useStreamStore = create<StreamStoreState & StreamStoreActions>()((s
       return {
         sessions: {
           ...state.sessions,
-          [sessionId]: addPart(session!, toolCallId, {
+          [sessionId]: addPart(session, toolCallId, {
             type: 'tool-call',
             toolCallId,
             toolName,
@@ -319,7 +319,7 @@ export const useStreamStore = create<StreamStoreState & StreamStoreActions>()((s
         sessions: {
           ...state.sessions,
           [sessionId]: {
-            ...session!,
+            ...session,
             isStreaming: false,
             finishReason,
             usage: usage ?? null,
@@ -338,7 +338,7 @@ export const useStreamStore = create<StreamStoreState & StreamStoreActions>()((s
         sessions: {
           ...state.sessions,
           [sessionId]: {
-            ...session!,
+            ...session,
             isStreaming: false,
             error: { message: error, details },
             retry: null,
@@ -352,16 +352,14 @@ export const useStreamStore = create<StreamStoreState & StreamStoreActions>()((s
     set((state) => {
       const session = getSession(state.sessions, sessionId);
       if (!guardMessage(session, messageId)) return state;
-      return { sessions: { ...state.sessions, [sessionId]: { ...session!, retry } } };
+      return { sessions: { ...state.sessions, [sessionId]: { ...session, retry } } };
     }),
 
   doomLoopDetected: (sessionId, messageId, toolName, consecutiveCount) =>
     set((state) => {
       const session = getSession(state.sessions, sessionId);
       if (!guardMessage(session, messageId)) return state;
-      return {
-        sessions: { ...state.sessions, [sessionId]: { ...session!, doomLoop: { toolName, consecutiveCount } } },
-      };
+      return { sessions: { ...state.sessions, [sessionId]: { ...session, doomLoop: { toolName, consecutiveCount } } } };
     }),
 
   resetSession: (sessionId) =>

--- a/apps/website/src/main.ts
+++ b/apps/website/src/main.ts
@@ -39,7 +39,10 @@ document.addEventListener('click', (e: MouseEvent) => {
     document.documentElement.setAttribute('data-theme', stored);
   }
 
-  document.getElementById('theme-toggle')!.addEventListener('click', () => {
+  const themeToggle = document.getElementById('theme-toggle');
+  if (!themeToggle) throw new Error('Theme toggle element #theme-toggle not found');
+
+  themeToggle.addEventListener('click', () => {
     const current = document.documentElement.getAttribute('data-theme');
     let isLight: boolean;
 
@@ -58,10 +61,12 @@ document.addEventListener('click', (e: MouseEvent) => {
 // Waitlist dialog
 (() => {
   const dialog = document.getElementById('waitlist-dialog') as HTMLDialogElement;
-  const openBtn = document.getElementById('open-waitlist-dialog')!;
-  const closeBtn = document.getElementById('close-waitlist-dialog')!;
+  const openBtn = document.getElementById('open-waitlist-dialog');
+  const closeBtn = document.getElementById('close-waitlist-dialog');
   const form = document.getElementById('waitlist-form') as HTMLFormElement;
-  const successMsg = document.getElementById('waitlist-success')!;
+  const successMsg = document.getElementById('waitlist-success');
+
+  if (!openBtn || !closeBtn || !successMsg) throw new Error('Waitlist dialog elements not found');
 
   openBtn.addEventListener('click', () => {
     dialog.showModal();

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "@stitch/desktop",
-      "version": "0.7.1",
+      "version": "0.7.3",
       "dependencies": {
         "@stitch/audio-capture": "workspace:*",
         "@stitch/meeting-detection": "workspace:*",
@@ -38,7 +38,7 @@
     },
     "apps/web": {
       "name": "@stitch/web",
-      "version": "0.7.1",
+      "version": "0.7.3",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@stitch/scheduler": "workspace:*",
@@ -53,6 +53,7 @@
         "cmdk": "^1.1.1",
         "cnfast": "^0.0.7",
         "date-fns": "^4.1.0",
+        "hast-util-to-jsx-runtime": "^2.3.6",
         "katex": "^0.16.38",
         "lucide-react": "^0.577.0",
         "react": "19.2.4",

--- a/connectors/sdk/src/upgrade.ts
+++ b/connectors/sdk/src/upgrade.ts
@@ -3,7 +3,7 @@ import type { ConnectorUpgradeAction, ConnectorVersion } from '@stitch/shared/co
 import type { ConnectorDefinitionInput, ConnectorUpgradeState } from './types.js';
 
 function getSortedVersions(definition: ConnectorDefinitionInput): ConnectorVersion[] {
-  return [...definition.versionHistory].sort((a, b) => a.version - b.version);
+  return [...definition.versionHistory].toSorted((a, b) => a.version - b.version);
 }
 
 export function getCapabilitiesForVersion(definition: ConnectorDefinitionInput, appliedVersion: number): string[] {

--- a/oxlint.json
+++ b/oxlint.json
@@ -1,25 +1,68 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["unicorn", "typescript", "oxc", "import", "react"],
+  "plugins": ["unicorn", "typescript", "oxc", "import", "react", "jsx-a11y"],
   "jsPlugins": [{ "name": "stitch", "specifier": "./tools/oxlint-plugins/index.mjs" }],
   "options": { "typeAware": true },
   "rules": {
     "unicorn/no-useless-fallback-in-spread": "error",
+    "unicorn/prefer-set-has": "error",
+    "unicorn/no-array-sort": "error",
     "no-unused-vars": "error",
     "eqeqeq": "error",
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-floating-promises": "error",
+    "typescript/no-non-null-assertion": "error",
     "import/no-dynamic-require": ["error", { "esmodule": true }],
     "react/jsx-key": "error",
     "react/no-direct-mutation-state": "error",
+    "react/no-danger": "error",
     "react/no-danger-with-children": "error",
     "react/jsx-no-duplicate-props": "error",
     "react/jsx-no-target-blank": "error",
+    "react/jsx-no-constructed-context-values": "error",
+    "react/no-array-index-key": "error",
+    "react/no-unstable-nested-components": "error",
+    "react/button-has-type": "error",
     "react/react-in-jsx-scope": "off",
     "react/rules-of-hooks": "error",
     "react/exhaustive-deps": "error",
+    "react/react-compiler": "error",
+    "jsx-a11y/anchor-has-content": "error",
+    "jsx-a11y/control-has-associated-label": "error",
+    "jsx-a11y/label-has-associated-control": "error",
+    "jsx-a11y/no-autofocus": "error",
+    "jsx-a11y/no-redundant-roles": "error",
     "stitch/no-collapsible-if": "error"
   },
+  "overrides": [
+    {
+      "files": [
+        "apps/web/src/components/automations/automation-runs-table.tsx",
+        "apps/web/src/components/automations/automations-table.tsx",
+        "apps/web/src/components/chat/message-list.tsx",
+        "apps/web/src/components/mail/thread-list.tsx",
+        "apps/web/src/components/recordings/analysis/transcript-sidebar.tsx",
+        "apps/web/src/components/recordings/list/recordings-table.tsx"
+      ],
+      "rules": { "react/react-compiler": "off" }
+    },
+    {
+      "files": [
+        "apps/web/src/components/ui/button-group.tsx",
+        "apps/web/src/components/ui/input-group.tsx",
+        "apps/web/src/components/ui/textarea-completions.tsx"
+      ],
+      "rules": { "jsx-a11y/prefer-tag-over-role": "off" }
+    },
+    { "files": ["apps/web/src/components/ui/label.tsx"], "rules": { "jsx-a11y/label-has-associated-control": "off" } },
+    {
+      "files": ["apps/web/src/components/ui/input-group.tsx"],
+      "rules": {
+        "jsx-a11y/click-events-have-key-events": "off",
+        "jsx-a11y/no-noninteractive-element-interactions": "off"
+      }
+    }
+  ],
   "ignorePatterns": ["node_modules", "dist", "out", "dist-electron", ".turbo"],
   "env": { "browser": true, "node": true, "es2022": true }
 }

--- a/packages/mail/src/db/queries.ts
+++ b/packages/mail/src/db/queries.ts
@@ -1,5 +1,16 @@
 import { and, asc, count, desc, eq, inArray, lt, or, sql } from 'drizzle-orm';
 
+import type {
+  MailAccountView,
+  MailAddressView,
+  MailAttachmentView,
+  MailDraftView,
+  MailLabelView,
+  MailMessageView,
+  MailThreadDetail,
+  MailThreadListItem,
+} from '@stitch/shared/mail/types';
+
 import { getMailDb, type MailDb } from './client.js';
 import {
   mailAccounts,
@@ -16,16 +27,6 @@ import {
   type MailMessageId,
   type MailThreadId,
 } from './schema.js';
-import type {
-  MailAccountView,
-  MailAddressView,
-  MailAttachmentView,
-  MailDraftView,
-  MailLabelView,
-  MailMessageView,
-  MailThreadDetail,
-  MailThreadListItem,
-} from '@stitch/shared/mail/types';
 
 type ListThreadsOptions = {
   accountId: MailAccountId;
@@ -116,7 +117,10 @@ async function labelsForThreads(db: MailDb, threadIds: MailThreadId[]): Promise<
   return labelsByThread;
 }
 
-async function sendersForThreads(db: MailDb, threadIds: MailThreadId[]): Promise<Map<MailThreadId, MailAddressView | null>> {
+async function sendersForThreads(
+  db: MailDb,
+  threadIds: MailThreadId[],
+): Promise<Map<MailThreadId, MailAddressView | null>> {
   const sendersByThread = new Map<MailThreadId, MailAddressView | null>();
   if (threadIds.length === 0) return sendersByThread;
 
@@ -139,12 +143,17 @@ export async function listThreads(options: ListThreadsOptions): Promise<ListThre
   const db = dbOrDefault(options.db);
   const limit = Math.min(Math.max(options.limit ?? 50, 1), 100);
   const cursor = parseThreadCursor(options.cursor);
-  const conditions = [eq(mailThreads.accountId, options.accountId), eq(mailThreads.isTrashed, options.isTrashed ?? false)];
+  const conditions = [
+    eq(mailThreads.accountId, options.accountId),
+    eq(mailThreads.isTrashed, options.isTrashed ?? false),
+  ];
 
   if (cursor) {
-    conditions.push(
-      or(lt(mailThreads.lastMessageAt, cursor.lastMessageAt), and(eq(mailThreads.lastMessageAt, cursor.lastMessageAt), lt(mailThreads.id, cursor.id)))!,
+    const cursorCondition = or(
+      lt(mailThreads.lastMessageAt, cursor.lastMessageAt),
+      and(eq(mailThreads.lastMessageAt, cursor.lastMessageAt), lt(mailThreads.id, cursor.id)),
     );
+    if (cursorCondition) conditions.push(cursorCondition);
   }
 
   if (options.labelId) {
@@ -170,7 +179,11 @@ export async function listThreads(options: ListThreadsOptions): Promise<ListThre
   ]);
 
   return {
-    threads: pageRows.map((thread) => ({ ...thread, from: sendersByThread.get(thread.id) ?? null, labels: labelsByThread.get(thread.id) ?? [] })),
+    threads: pageRows.map((thread) => ({
+      ...thread,
+      from: sendersByThread.get(thread.id) ?? null,
+      labels: labelsByThread.get(thread.id) ?? [],
+    })),
     nextCursor: rows.length > limit ? encodeThreadCursor(pageRows[pageRows.length - 1]) : null,
   };
 }
@@ -180,7 +193,11 @@ export async function getThread(threadId: MailThreadId, dbOption?: MailDb): Prom
   const [thread] = await db.select().from(mailThreads).where(eq(mailThreads.id, threadId)).limit(1);
   if (!thread) return null;
 
-  const messages = await db.select().from(mailMessages).where(eq(mailMessages.threadId, threadId)).orderBy(asc(mailMessages.internalDate));
+  const messages = await db
+    .select()
+    .from(mailMessages)
+    .where(eq(mailMessages.threadId, threadId))
+    .orderBy(asc(mailMessages.internalDate));
   const messageIds = messages.map((message) => message.id);
   const labelRows =
     messageIds.length === 0
@@ -190,14 +207,21 @@ export async function getThread(threadId: MailThreadId, dbOption?: MailDb): Prom
           .from(mailMessageLabels)
           .innerJoin(mailLabels, eq(mailLabels.id, mailMessageLabels.labelId))
           .where(inArray(mailMessageLabels.messageId, messageIds));
-  const attachmentRows = messageIds.length === 0 ? [] : await db.select().from(mailAttachments).where(inArray(mailAttachments.messageId, messageIds));
+  const attachmentRows =
+    messageIds.length === 0
+      ? []
+      : await db.select().from(mailAttachments).where(inArray(mailAttachments.messageId, messageIds));
 
   const labelsByMessage = new Map<MailMessageId, MailLabelView[]>();
-  for (const row of labelRows) labelsByMessage.set(row.messageId, [...(labelsByMessage.get(row.messageId) ?? []), toLabelView(row.label)]);
+  for (const row of labelRows)
+    labelsByMessage.set(row.messageId, [...(labelsByMessage.get(row.messageId) ?? []), toLabelView(row.label)]);
 
   const attachmentsByMessage = new Map<MailMessageId, MailAttachmentView[]>();
   for (const attachment of attachmentRows) {
-    attachmentsByMessage.set(attachment.messageId, [...(attachmentsByMessage.get(attachment.messageId) ?? []), toAttachmentView(attachment)]);
+    attachmentsByMessage.set(attachment.messageId, [
+      ...(attachmentsByMessage.get(attachment.messageId) ?? []),
+      toAttachmentView(attachment),
+    ]);
   }
 
   const messageViews: MailMessageView[] = messages.map((message) => ({
@@ -224,13 +248,25 @@ export async function getThread(threadId: MailThreadId, dbOption?: MailDb): Prom
     attachments: attachmentsByMessage.get(message.id) ?? [],
   }));
 
-  const [threadLabels, threadSenders] = await Promise.all([labelsForThreads(db, [thread.id]), sendersForThreads(db, [thread.id])]);
-  return { ...thread, from: threadSenders.get(thread.id) ?? null, labels: threadLabels.get(thread.id) ?? [], messages: messageViews };
+  const [threadLabels, threadSenders] = await Promise.all([
+    labelsForThreads(db, [thread.id]),
+    sendersForThreads(db, [thread.id]),
+  ]);
+  return {
+    ...thread,
+    from: threadSenders.get(thread.id) ?? null,
+    labels: threadLabels.get(thread.id) ?? [],
+    messages: messageViews,
+  };
 }
 
 export async function listLabels(accountId: MailAccountId, dbOption?: MailDb): Promise<MailLabelView[]> {
   const db = dbOrDefault(dbOption);
-  const labels = await db.select().from(mailLabels).where(eq(mailLabels.accountId, accountId)).orderBy(asc(mailLabels.kind), asc(mailLabels.name));
+  const labels = await db
+    .select()
+    .from(mailLabels)
+    .where(eq(mailLabels.accountId, accountId))
+    .orderBy(asc(mailLabels.kind), asc(mailLabels.name));
   return labels.map(toLabelView);
 }
 
@@ -248,19 +284,31 @@ export async function getAccount(accountId: MailAccountId, dbOption?: MailDb): P
 
 export async function listDrafts(accountId: MailAccountId, dbOption?: MailDb): Promise<MailDraftView[]> {
   const db = dbOrDefault(dbOption);
-  const drafts = await db.select().from(mailDrafts).where(eq(mailDrafts.accountId, accountId)).orderBy(desc(mailDrafts.updatedAt));
+  const drafts = await db
+    .select()
+    .from(mailDrafts)
+    .where(eq(mailDrafts.accountId, accountId))
+    .orderBy(desc(mailDrafts.updatedAt));
   return drafts.map(toDraftView);
 }
 
 async function getAccountView(db: MailDb, account: typeof mailAccounts.$inferSelect): Promise<MailAccountView> {
   const [[threadCount], [unreadThreadCount], [draftCount], [outboxPendingCount]] = await Promise.all([
     db.select({ value: count() }).from(mailThreads).where(eq(mailThreads.accountId, account.id)),
-    db.select({ value: count() }).from(mailThreads).where(and(eq(mailThreads.accountId, account.id), eq(mailThreads.hasUnread, true))),
+    db
+      .select({ value: count() })
+      .from(mailThreads)
+      .where(and(eq(mailThreads.accountId, account.id), eq(mailThreads.hasUnread, true))),
     db.select({ value: count() }).from(mailDrafts).where(eq(mailDrafts.accountId, account.id)),
     db
       .select({ value: count() })
       .from(mailOutbox)
-      .where(and(eq(mailOutbox.accountId, account.id), or(eq(mailOutbox.status, 'pending'), eq(mailOutbox.status, 'failed')))),
+      .where(
+        and(
+          eq(mailOutbox.accountId, account.id),
+          or(eq(mailOutbox.status, 'pending'), eq(mailOutbox.status, 'failed')),
+        ),
+      ),
   ]);
 
   return {

--- a/packages/mail/src/sync/engine.ts
+++ b/packages/mail/src/sync/engine.ts
@@ -155,7 +155,8 @@ export function createMailEngine(deps: MailEngineDeps): MailEngine {
   });
 
   async function runAccount(accountId: MailAccountId, forcedMode?: 'full' | 'incremental'): Promise<void> {
-    if (running.has(accountId)) return running.get(accountId)!.promise;
+    const inFlight = running.get(accountId);
+    if (inFlight) return inFlight.promise;
     const controller = new AbortController();
     const promise = (async () => {
       const db = getMailDb();
@@ -172,7 +173,9 @@ export function createMailEngine(deps: MailEngineDeps): MailEngine {
             updatedAt: Date.now(),
           })
           .where(eq(mailAccounts.id, account.id));
-        account = (await readAccount(accountId))!;
+        const refreshed = await readAccount(accountId);
+        if (!refreshed) return;
+        account = refreshed;
       }
 
       const provider = getMailProvider(account.provider).sync;

--- a/packages/scheduler/src/scheduler.test.ts
+++ b/packages/scheduler/src/scheduler.test.ts
@@ -206,8 +206,8 @@ describe('scheduler', () => {
     await scheduler.stop();
 
     const status = await store.getJob('concurrency-job');
-    expect(status!.totalRuns).toBeGreaterThanOrEqual(2);
-    expect(status!.runningCount).toBe(0);
+    expect(status?.totalRuns).toBeGreaterThanOrEqual(2);
+    expect(status?.runningCount).toBe(0);
   });
 
   test('catchup none drops backlog but runs the current due occurrence', async () => {

--- a/packages/server/scripts/new-lance-migration.ts
+++ b/packages/server/scripts/new-lance-migration.ts
@@ -61,7 +61,7 @@ function getConstName(versionTag: string, slug: string): string {
 async function getLastMigrationId(migrationsDir: string): Promise<string | null> {
   const files = (await fs.readdir(migrationsDir))
     .filter((file) => /^\d{4}-.+\.ts$/.test(file))
-    .sort((a, b) => a.localeCompare(b));
+    .toSorted((a, b) => a.localeCompare(b));
 
   const last = files.at(-1);
   if (!last) return null;
@@ -77,7 +77,7 @@ async function getLastMigrationId(migrationsDir: string): Promise<string | null>
 
 async function rewriteManifest(migrationsDir: string): Promise<void> {
   const allFiles = await fs.readdir(migrationsDir);
-  const migrationFiles = allFiles.filter((file) => /^\d{4}-.+\.ts$/.test(file)).sort((a, b) => a.localeCompare(b));
+  const migrationFiles = allFiles.filter((file) => /^\d{4}-.+\.ts$/.test(file)).toSorted((a, b) => a.localeCompare(b));
 
   const imports = migrationFiles
     .map((file) => {

--- a/packages/server/src/agenda/service.ts
+++ b/packages/server/src/agenda/service.ts
@@ -80,9 +80,11 @@ export function getAgendaLists(input?: { includeArchived?: boolean }): ServiceRe
 
   type Counts = AgendaListWithCounts['itemCounts'];
   const countMap = new Map<string, Counts>();
-  for (const list of lists) {
-    countMap.set(list.id, { open: 0, in_progress: 0, done: 0, cancelled: 0, total: 0, overdue: 0, dueSoon: 0 });
-  }
+  const listsWithCounts = lists.map((row) => {
+    const itemCounts: Counts = { open: 0, in_progress: 0, done: 0, cancelled: 0, total: 0, overdue: 0, dueSoon: 0 };
+    countMap.set(row.id, itemCounts);
+    return { ...toAgendaList(row), itemCounts };
+  });
 
   for (const item of allItems) {
     const counts = countMap.get(item.listId);
@@ -98,7 +100,7 @@ export function getAgendaLists(input?: { includeArchived?: boolean }): ServiceRe
     }
   }
 
-  return ok(lists.map((row) => ({ ...toAgendaList(row), itemCounts: countMap.get(row.id)! })));
+  return ok(listsWithCounts);
 }
 
 export function getAgendaListByName(name: string): ServiceResult<AgendaList | null> {

--- a/packages/server/src/automations/generation.ts
+++ b/packages/server/src/automations/generation.ts
@@ -64,7 +64,7 @@ function collectToolsetContext(messageList: GenerationMessageContext[]): {
   availableToolsets: string[];
 } {
   const available = listToolsets();
-  const availableToolsets = available.map((toolset) => toolset.id).sort();
+  const availableToolsets = available.map((toolset) => toolset.id).toSorted();
   const toolToToolset = new Map<string, string>();
 
   for (const toolset of available) {
@@ -85,7 +85,11 @@ function collectToolsetContext(messageList: GenerationMessageContext[]): {
     }
   }
 
-  return { usedToolNames: dedupeStrings(toolNames), inferredToolsets: [...inferredToolsets].sort(), availableToolsets };
+  return {
+    usedToolNames: dedupeStrings(toolNames),
+    inferredToolsets: [...inferredToolsets].toSorted(),
+    availableToolsets,
+  };
 }
 
 function buildAutomationPrompt(input: {

--- a/packages/server/src/chat/history-search-service.ts
+++ b/packages/server/src/chat/history-search-service.ts
@@ -244,7 +244,7 @@ export async function searchSessionHistory(
   }
 
   const sorted = hits
-    .sort((a, b) => {
+    .toSorted((a, b) => {
       if (b.score !== a.score) {
         return b.score - a.score;
       }

--- a/packages/server/src/chat/service.test.ts
+++ b/packages/server/src/chat/service.test.ts
@@ -74,8 +74,9 @@ describe('splitSession', () => {
     expect(result.error).toBeNull();
     expect(result.data?.prefillText).toBe('Continue from here');
     expect(result.data?.session.parentSessionId).toBeNull();
+    if (!result.data) throw new Error('expected split session data');
 
-    const clonedSessionId = result.data!.session.id;
+    const clonedSessionId = result.data.session.id;
     const [clonedSession] = await getDb().select().from(sessions).where(eq(sessions.id, clonedSessionId));
     expect(clonedSession.parentSessionId).toBeNull();
 
@@ -158,7 +159,9 @@ describe('splitSession', () => {
     const result = await splitSession(sessionId, splitMessageId);
 
     expect(result.error).toBeNull();
-    const clonedSessionId = result.data!.session.id;
+    if (!result.data) throw new Error('expected split session data');
+
+    const clonedSessionId = result.data.session.id;
     const clonedMessages = await getDb().select().from(messages).where(eq(messages.sessionId, clonedSessionId));
 
     expect(clonedMessages).toHaveLength(1);

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -529,12 +529,16 @@ export async function getSessionStats(sessionId: PrefixedString<'ses'>): Promise
 
   // Resolve provider/model labels and context limit
   // Find the latest real assistant message (skip background tasks like title generation, compaction, automation)
-  const BACKGROUND_PART_TYPES: StoredPart['type'][] = ['session-title', 'compaction', 'automation-generation'];
+  const BACKGROUND_PART_TYPES: Set<StoredPart['type']> = new Set([
+    'session-title',
+    'compaction',
+    'automation-generation',
+  ]);
   let latestRealMessage: (typeof sessionMessages)[number] | null = null;
   for (let i = sessionMessages.length - 1; i >= 0; i--) {
     const msg = sessionMessages[i];
     if (!msg || msg.role !== 'assistant') continue;
-    if (msg.parts?.some((p) => BACKGROUND_PART_TYPES.includes(p.type))) continue;
+    if (msg.parts?.some((p) => BACKGROUND_PART_TYPES.has(p.type))) continue;
     latestRealMessage = msg;
     break;
   }

--- a/packages/server/src/code-mode/bindings/tool-binding.ts
+++ b/packages/server/src/code-mode/bindings/tool-binding.ts
@@ -38,20 +38,21 @@ type ToolMeta = {
   bindingName: string;
   description: string;
   schema: Record<string, unknown>;
-  tool: Tool;
+  execute: NonNullable<Tool['execute']>;
 };
 
 function mapExecutableTools<T>(tools: Record<string, Tool>, mapper: (meta: ToolMeta) => T): Record<string, T> {
   const result: Record<string, T> = {};
 
   for (const [name, tool] of Object.entries(tools)) {
-    if (!tool.execute) continue;
+    const execute = tool.execute;
+    if (!execute) continue;
 
     const bindingName = `${EXTERNAL_PREFIX}${name}`;
     const description = tool.description ?? `Tool: ${name}`;
     const schema = getToolSchema(tool);
 
-    result[bindingName] = mapper({ originalName: name, bindingName, description, schema, tool });
+    result[bindingName] = mapper({ originalName: name, bindingName, description, schema, execute });
   }
 
   return result;
@@ -71,8 +72,7 @@ export function toolsToTypeInfo(tools: Record<string, Tool>): Record<string, Too
 }
 
 export function toolsToBindings(tools: Record<string, Tool>, abortSignal?: AbortSignal): Record<string, ToolBinding> {
-  return mapExecutableTools(tools, ({ bindingName, description, schema, tool }) => {
-    const execute = tool.execute!;
+  return mapExecutableTools(tools, ({ bindingName, description, schema, execute }) => {
     return {
       name: bindingName,
       description,

--- a/packages/server/src/db/lance-migrations.ts
+++ b/packages/server/src/db/lance-migrations.ts
@@ -109,7 +109,7 @@ function assertChecksumMatches(
 }
 
 export async function runPendingMigrations(db: Db, deps?: { getConnection?: typeof GetConnectionFn }): Promise<void> {
-  const orderedMigrations = [...MIGRATIONS].sort((a, b) => a.version - b.version);
+  const orderedMigrations = [...MIGRATIONS].toSorted((a, b) => a.version - b.version);
   ensureMigrationsAreValid(orderedMigrations);
 
   if (orderedMigrations.length === 0) return;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -40,11 +40,12 @@ function parseArgs() {
   let hostname = process.env['HOSTNAME'] || '127.0.0.1';
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--port' && args[i + 1]) {
-      port = Number(args[i + 1]);
+    const next = args[i + 1];
+    if (args[i] === '--port' && next) {
+      port = Number(next);
       i++;
-    } else if (args[i] === '--hostname' && args[i + 1]) {
-      hostname = args[i + 1]!;
+    } else if (args[i] === '--hostname' && next) {
+      hostname = next;
       i++;
     }
   }

--- a/packages/server/src/lib/log.ts
+++ b/packages/server/src/lib/log.ts
@@ -105,7 +105,7 @@ export async function cleanup(dir = PATHS.logDir): Promise<void> {
     return;
   }
 
-  const logFiles = entries.filter((f) => LOG_FILE_PATTERN.test(f)).sort();
+  const logFiles = entries.filter((f) => LOG_FILE_PATTERN.test(f)).toSorted();
 
   if (logFiles.length <= 10) return;
 

--- a/packages/server/src/llm/provider-schema.test.ts
+++ b/packages/server/src/llm/provider-schema.test.ts
@@ -14,6 +14,10 @@ function resolvedSchema(tool: Tool): JSONSchema7 {
   return (tool as { inputSchema: Schema }).inputSchema.jsonSchema as JSONSchema7;
 }
 
+function resolvedProperties(tool: Tool): Record<string, JSONSchema7> {
+  return resolvedSchema(tool).properties as Record<string, JSONSchema7>;
+}
+
 describe('sanitizeToolSchemasForProvider', () => {
   test('strips required from non-object anyOf branches for google (Apollo repro)', () => {
     const schema: JSONSchema7 = {
@@ -28,7 +32,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
     const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
-    const items = (resolvedSchema(out.t).properties!.tasks_attributes as JSONSchema7).items as JSONSchema7;
+    const items = resolvedProperties(out.t).tasks_attributes.items as JSONSchema7;
     const branches = items.anyOf as JSONSchema7[];
     expect(branches[0].required).toBeUndefined();
     expect(branches[1].required).toBeUndefined();
@@ -42,7 +46,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
     const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
-    const name = resolvedSchema(out.t).properties!.name as JSONSchema7;
+    const name = resolvedProperties(out.t).name;
     expect(name.required).toBeUndefined();
     expect(name.properties).toBeUndefined();
   });
@@ -60,7 +64,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
     const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
-    const level = resolvedSchema(out.t).properties!.level as JSONSchema7;
+    const level = resolvedProperties(out.t).level;
     expect(level.type).toBe('string');
     expect(level.enum).toEqual(['1', '2', '3']);
   });
@@ -73,7 +77,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
     const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
-    const value = resolvedSchema(out.t).properties!.value as Record<string, unknown>;
+    const value = resolvedProperties(out.t).value as Record<string, unknown>;
     expect(value.type).toBeUndefined();
     expect(value.anyOf).toEqual([{ type: 'string' }, { type: 'number' }]);
     expect(value.nullable).toBe(true);
@@ -84,7 +88,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
     const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
-    const tags = resolvedSchema(out.t).properties!.tags as JSONSchema7;
+    const tags = resolvedProperties(out.t).tags;
     expect(tags.items).toEqual({ type: 'string' });
   });
 
@@ -113,7 +117,7 @@ describe('sanitizeToolSchemasForProvider', () => {
       'google-vertex' as LlmProviderId,
       'gemini-2.5-pro',
     );
-    expect((resolvedSchema(geminiOut.t).properties!.p as JSONSchema7).required).toBeUndefined();
+    expect(resolvedProperties(geminiOut.t).p.required).toBeUndefined();
   });
 
   describe('openai sanitizer', () => {
@@ -124,7 +128,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
       const root = resolvedSchema(out.t);
       expect(root.type).toBe('object');
-      const mode = root.properties!.mode as JSONSchema7;
+      const mode = resolvedProperties(out.t).mode;
       expect(mode).toEqual({ enum: ['fast'], type: 'string' });
     });
 
@@ -133,7 +137,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
       const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
-      expect(resolvedSchema(out.t).properties!.anything).toEqual({ type: 'string' });
+      expect(resolvedProperties(out.t).anything).toEqual({ type: 'string' });
     });
 
     test('infers array type and defaults missing items to string', () => {
@@ -141,7 +145,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
       const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
-      const tags = resolvedSchema(out.t).properties!.tags as JSONSchema7;
+      const tags = resolvedProperties(out.t).tags;
       expect(tags.type).toBe('array');
     });
 
@@ -153,7 +157,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
       const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
-      const value = resolvedSchema(out.t).properties!.value as JSONSchema7;
+      const value = resolvedProperties(out.t).value;
       expect(value.type).toBeUndefined();
       expect(value.anyOf).toEqual([{ type: 'string' }, { type: 'number' }]);
     });
@@ -169,7 +173,7 @@ describe('sanitizeToolSchemasForProvider', () => {
         'google/gemini-2.5-pro',
       );
 
-      const level = resolvedSchema(out.t).properties!.level as JSONSchema7;
+      const level = resolvedProperties(out.t).level;
       expect(level.type).toBe('string');
       expect(level.enum).toEqual(['1', '2']);
     });
@@ -183,7 +187,7 @@ describe('sanitizeToolSchemasForProvider', () => {
         'openai/gpt-4o',
       );
 
-      expect((resolvedSchema(out.t).properties!.mode as JSONSchema7).enum).toEqual(['x']);
+      expect(resolvedProperties(out.t).mode.enum).toEqual(['x']);
     });
   });
 });

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -220,7 +220,7 @@ class StreamRunner {
   private getCurrentTools(): Record<string, Tool> {
     const dynamicTools = this.ctx.toolsetManager.getActiveTools();
     const all = { ...this.ctx.coreTools, ...dynamicTools };
-    return Object.fromEntries(Object.entries(all).sort(([a], [b]) => a.localeCompare(b)));
+    return Object.fromEntries(Object.entries(all).toSorted(([a], [b]) => a.localeCompare(b)));
   }
 
   private buildStepOptions(step: number, conversation = this.state.conversation): StepOptions {

--- a/packages/server/src/mail/eligibility.ts
+++ b/packages/server/src/mail/eligibility.ts
@@ -31,14 +31,14 @@ export function filterEligibleMailAccounts(
 ): EligibleMailAccount[] {
   return instances
     .filter(
-      (instance) =>
+      (instance): instance is EligibleConnectorInstance & { accountEmail: string } =>
         instance.connectorId === 'google' &&
         instance.status === 'connected' &&
         instance.accountEmail !== null &&
         !enrolledConnectorInstanceIds.has(instance.id) &&
         hasRequiredGmailScopes(instance.scopes),
     )
-    .map((instance) => ({ connectorInstanceId: instance.id, email: instance.accountEmail! }));
+    .map((instance) => ({ connectorInstanceId: instance.id, email: instance.accountEmail }));
 }
 
 export function assertCanEnrollMailAccount(

--- a/packages/server/src/mcp/icons.test.ts
+++ b/packages/server/src/mcp/icons.test.ts
@@ -31,7 +31,8 @@ describe('mcp icon cache', () => {
     });
 
     expect(cached).not.toBeNull();
-    const icon = await getMcpIconByKey(cached!.key, { cacheDir });
+    if (!cached) throw new Error('expected icon to be cached');
+    const icon = await getMcpIconByKey(cached.key, { cacheDir });
     expect(icon?.mimeType).toBe('image/png');
     expect(icon?.body.length).toBeGreaterThan(0);
   });

--- a/packages/server/src/memory/consolidation.ts
+++ b/packages/server/src/memory/consolidation.ts
@@ -127,7 +127,7 @@ async function findCandidateGroups(): Promise<ConsolidationMemory[][]> {
   const allResult = await getAllSemanticMemories({ page: 1, pageSize: 1000 });
   if (allResult.error || allResult.data.memories.length < MIN_GROUP_SIZE) return [];
 
-  const memories = [...allResult.data.memories].sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
+  const memories = [...allResult.data.memories].toSorted((a, b) => a.updatedAt.localeCompare(b.updatedAt));
   const used = new Set<string>();
   const groups: ConsolidationMemory[][] = [];
 

--- a/packages/server/src/memory/processor.ts
+++ b/packages/server/src/memory/processor.ts
@@ -197,7 +197,7 @@ export async function processMemories(input: {
     // Apply per-turn cap
     if (facts.length > config.maxFactsPerTurn) {
       // Keep highest-importance facts when capping
-      facts = facts.sort((a, b) => b.importanceScore - a.importanceScore).slice(0, config.maxFactsPerTurn);
+      facts = facts.toSorted((a, b) => b.importanceScore - a.importanceScore).slice(0, config.maxFactsPerTurn);
     }
 
     // Apply remaining session budget

--- a/packages/server/src/memory/retriever.ts
+++ b/packages/server/src/memory/retriever.ts
@@ -5,7 +5,7 @@ import type { MemoryCategory } from '@/memory/types.js';
 import type { MemorySource } from '@/memory/types.js';
 
 const log = Log.create({ service: 'memory-retriever' });
-const CHAT_MEMORY_CATEGORIES: MemoryCategory[] = ['preference', 'fact', 'constraint'];
+const CHAT_MEMORY_CATEGORIES: Set<MemoryCategory> = new Set(['preference', 'fact', 'constraint']);
 
 function tokenize(value: string): Set<string> {
   return new Set(
@@ -71,7 +71,7 @@ export async function retrieveMemoryContext(query: string, sourceFilter?: Memory
 
   // Apply category and score filters before reranking.
   const candidates = semantic.memories.filter(
-    (m) => CHAT_MEMORY_CATEGORIES.includes(m.category) && m.score >= config.retrievalMinScore,
+    (m) => CHAT_MEMORY_CATEGORIES.has(m.category) && m.score >= config.retrievalMinScore,
   );
 
   const scoredCandidates = candidates.map((m) => {

--- a/packages/server/src/permission/default-permissions.test.ts
+++ b/packages/server/src/permission/default-permissions.test.ts
@@ -16,7 +16,7 @@ describe('syncDefaultPermissions', () => {
     const rows = await getDb().select().from(toolPermissions);
     const skillsRule = rows.find((r) => r.toolName === 'read' && r.pattern === `${PATHS.dirPaths.skills}${path.sep}*`);
 
-    expect(skillsRule!.permission).toBe('allow');
+    expect(skillsRule?.permission).toBe('allow');
   });
 
   test('creates file tool permissions for recordings directory', async () => {
@@ -30,7 +30,7 @@ describe('syncDefaultPermissions', () => {
         (r) => r.toolName === toolName && r.pattern === `${PATHS.dirPaths.recordings}${path.sep}*`,
       );
 
-      expect(rule!.permission).toBe('allow');
+      expect(rule?.permission).toBe('allow');
     }
   });
 

--- a/packages/server/src/permission/policy.ts
+++ b/packages/server/src/permission/policy.ts
@@ -29,7 +29,7 @@ export function resolvePermissionFromRules(
 
   const patternMatchesBySpecificity = patternRules
     .filter((row) => wildcardPatternMatches(row.pattern, patternTargets))
-    .sort((a, b) => b.pattern.length - a.pattern.length);
+    .toSorted((a, b) => b.pattern.length - a.pattern.length);
 
   const firstMatch = patternMatchesBySpecificity[0];
   if (!firstMatch) return 'ask';

--- a/packages/server/src/permission/service.test.ts
+++ b/packages/server/src/permission/service.test.ts
@@ -82,7 +82,7 @@ describe('permission service interactions', () => {
     await waitForEvents(1);
 
     const requestedEvent = emittedEvents.find(([name]) => name === 'permission.requested');
-    const requestedData = requestedEvent![1] as InternalEventMap['permission.requested'];
+    const requestedData = requestedEvent?.[1] as InternalEventMap['permission.requested'];
     expect(requestedData.permissionResponse).toMatchObject({
       sessionId,
       messageId,
@@ -96,7 +96,7 @@ describe('permission service interactions', () => {
     expect(promise).resolves.toEqual({ decision: 'allow' });
 
     const resolvedEvent = emittedEvents.find(([name]) => name === 'permission.resolved');
-    expect(resolvedEvent![1]).toEqual({ permissionResponseId, sessionId });
+    expect(resolvedEvent?.[1]).toEqual({ permissionResponseId, sessionId });
   });
 
   test('deduplicates concurrent permission requests with the same key', async () => {
@@ -186,7 +186,7 @@ describe('permission service interactions', () => {
     await waitForRequestedEvents(1);
     const firstRequested = emittedEvents.find(
       ([name]) => name === 'permission.requested',
-    )![1] as InternalEventMap['permission.requested'];
+    )?.[1] as InternalEventMap['permission.requested'];
 
     await allowPermissionResponse(firstRequested.permissionResponse.id);
     expect(first).resolves.toEqual({ decision: 'allow' });
@@ -268,7 +268,7 @@ describe('permission service interactions', () => {
 
     const requestedData = emittedEvents.find(
       ([name]) => name === 'permission.requested',
-    )![1] as InternalEventMap['permission.requested'];
+    )?.[1] as InternalEventMap['permission.requested'];
     const permissionResponseId = requestedData.permissionResponse.id;
 
     expect(alternativePermissionResponse(permissionResponseId, 'Use read instead')).resolves.toEqual({
@@ -322,7 +322,8 @@ describe('permission service interactions', () => {
     ).toBe(true);
 
     // Second permission (different session) is unaffected - still resolvable
-    await rejectPermissionResponse(secondId!);
+    if (!secondId) throw new Error('expected a permission request for the other session');
+    await rejectPermissionResponse(secondId);
     expect(second).resolves.toEqual({ decision: 'reject' });
   });
 });

--- a/packages/server/src/permission/service.ts
+++ b/packages/server/src/permission/service.ts
@@ -137,17 +137,18 @@ async function createPermissionResponse(opts: RequestPermissionResponseOptions):
 export async function requestPermissionResponse(
   opts: RequestPermissionResponseOptions,
 ): Promise<PermissionDecisionResult> {
-  if (!opts.dedupeKey) {
+  const dedupeKey = opts.dedupeKey;
+  if (!dedupeKey) {
     return createPermissionResponse(opts);
   }
 
-  const existing = pendingPermissionRequests.get(opts.dedupeKey);
+  const existing = pendingPermissionRequests.get(dedupeKey);
   if (existing) return existing;
 
   const promise = createPermissionResponse(opts).finally(() => {
-    pendingPermissionRequests.delete(opts.dedupeKey!);
+    pendingPermissionRequests.delete(dedupeKey);
   });
-  pendingPermissionRequests.set(opts.dedupeKey, promise);
+  pendingPermissionRequests.set(dedupeKey, promise);
   return promise;
 }
 

--- a/packages/server/src/provider/service.ts
+++ b/packages/server/src/provider/service.ts
@@ -33,8 +33,11 @@ export async function listProvidersWithCapabilities(): Promise<ServiceResult<Pro
   const capabilitiesMap = new Map<string, Set<ProviderCapability>>();
 
   function ensureEntry(id: string): Set<ProviderCapability> {
-    if (!capabilitiesMap.has(id)) capabilitiesMap.set(id, new Set());
-    return capabilitiesMap.get(id)!;
+    const existing = capabilitiesMap.get(id);
+    if (existing) return existing;
+    const created = new Set<ProviderCapability>();
+    capabilitiesMap.set(id, created);
+    return created;
   }
 
   for (const id of Object.keys(llmProviders)) {

--- a/packages/server/src/question/service.test.ts
+++ b/packages/server/src/question/service.test.ts
@@ -68,7 +68,7 @@ describe('question service interactions', () => {
     await waitForEvents(1);
 
     const askedEvent = emittedEvents.find(([name]) => name === 'question.asked');
-    const askedData = askedEvent![1] as InternalEventMap['question.asked'];
+    const askedData = askedEvent?.[1] as InternalEventMap['question.asked'];
     expect(askedData.question).toMatchObject({ sessionId, messageId, toolCallId: 'call_question', status: 'pending' });
 
     const questionId = askedData.question.id;
@@ -79,7 +79,7 @@ describe('question service interactions', () => {
     expect(promise).resolves.toEqual([['A']]);
 
     const repliedEvent = emittedEvents.find(([name]) => name === 'question.replied');
-    expect(repliedEvent![1]).toEqual({ questionId, sessionId, answers: [['A']] });
+    expect(repliedEvent?.[1]).toEqual({ questionId, sessionId, answers: [['A']] });
 
     const db = getDb();
     const [row] = await db.select().from(questions).where(eq(questions.id, questionId));
@@ -101,7 +101,7 @@ describe('question service interactions', () => {
 
     const askedData = emittedEvents.find(
       ([name]) => name === 'question.asked',
-    )![1] as InternalEventMap['question.asked'];
+    )?.[1] as InternalEventMap['question.asked'];
     const questionId = askedData.question.id;
 
     const rejectResult = await rejectQuestion(questionId);
@@ -110,7 +110,7 @@ describe('question service interactions', () => {
     expect(promise).rejects.toThrow('Question rejected by user');
 
     const rejectedEvent = emittedEvents.find(([name]) => name === 'question.rejected');
-    expect(rejectedEvent![1]).toEqual({ questionId, sessionId });
+    expect(rejectedEvent?.[1]).toEqual({ questionId, sessionId });
 
     const db = getDb();
     const [row] = await db.select().from(questions).where(eq(questions.id, questionId));
@@ -222,7 +222,8 @@ describe('question service interactions', () => {
     ).toBe(true);
 
     // Second question (different session) is unaffected - still resolvable
-    await replyQuestion(secondId!, [['ok']]);
+    if (!secondId) throw new Error('expected a question for the other session');
+    await replyQuestion(secondId, [['ok']]);
     expect(second).resolves.toEqual([['ok']]);
   });
 });

--- a/packages/server/src/recordings/meeting-note-templates.test.ts
+++ b/packages/server/src/recordings/meeting-note-templates.test.ts
@@ -18,8 +18,8 @@ describe('meeting note templates', () => {
 
     expect(result.error).toBeNull();
     if (result.error) return;
-    expect(result.data.templates.map((template) => template.id).sort()).toEqual(
-      PREBUILT_MEETING_NOTE_TEMPLATES.map((template) => template.id).sort(),
+    expect(result.data.templates.map((template) => template.id).toSorted()).toEqual(
+      PREBUILT_MEETING_NOTE_TEMPLATES.map((template) => template.id).toSorted(),
     );
   });
 

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -76,7 +76,7 @@ configRouter.get('/toolsets', async (c) => {
         tools: (view.tools ?? []).map((tool) => ({ toolName: tool.name, displayName: tool.displayName })),
       };
     })
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .toSorted((a, b) => a.name.localeCompare(b.name));
 
   return c.json({ toolsets });
 });

--- a/packages/server/src/skills/filesystem.test.ts
+++ b/packages/server/src/skills/filesystem.test.ts
@@ -218,7 +218,7 @@ describe('collectSkillDirFiles', () => {
     await fs.writeFile(path.join(skillDir, 'scripts', 'run.py'), 'print()', 'utf8');
 
     const files = await collectSkillDirFiles(skillDir, skillDir);
-    const paths = files.map((f) => f.relativePath).sort();
+    const paths = files.map((f) => f.relativePath).toSorted();
 
     expect(paths).toEqual(['agents/helper.md', 'scripts/run.py']);
   });

--- a/packages/server/src/skills/service.ts
+++ b/packages/server/src/skills/service.ts
@@ -208,7 +208,7 @@ export async function searchSkillsDirectory(query: string): Promise<ServiceResul
           },
         ];
       })
-      .sort((a, b) => b.installs - a.installs);
+      .toSorted((a, b) => b.installs - a.installs);
 
     return ok(results);
   } catch (error) {

--- a/packages/server/src/stt/base-adapter.ts
+++ b/packages/server/src/stt/base-adapter.ts
@@ -99,7 +99,7 @@ export async function createManagedConnection(config: ManagedConnectionConfig): 
     nextChunkStartMs = endMs;
 
     while (totalBufferedMs > bufferConfig.maxBufferedMs && ringBuffer.length > 1) {
-      const dropped = ringBuffer.shift()!;
+      const [dropped] = ringBuffer.splice(0, 1);
       totalBufferedMs -= dropped.durationMs;
       log.warn('buffer overflow, dropping oldest chunk');
     }
@@ -111,7 +111,7 @@ export async function createManagedConnection(config: ManagedConnectionConfig): 
 
   function trimBufferBefore(offsetMs: number): void {
     while (ringBuffer.length > 1 && ringBuffer[0].endMs <= offsetMs) {
-      const dropped = ringBuffer.shift()!;
+      const [dropped] = ringBuffer.splice(0, 1);
       totalBufferedMs -= dropped.durationMs;
     }
   }

--- a/packages/server/src/stt/ws-transport.test.ts
+++ b/packages/server/src/stt/ws-transport.test.ts
@@ -126,7 +126,8 @@ describe('createWsTransport', () => {
       () => 'commit',
     );
     FakeWebSocket.last?.open();
-    const socket = FakeWebSocket.last!;
+    const socket = FakeWebSocket.last;
+    if (!socket) throw new Error('expected a socket to have been created');
     const transport = await transportPromise;
 
     expect(socket.listenerCount).toBeGreaterThan(0);

--- a/packages/server/src/stt/ws-transport.ts
+++ b/packages/server/src/stt/ws-transport.ts
@@ -162,8 +162,8 @@ export function createWsTransport(
         },
         onError(cb) {
           errorListeners.push(cb);
-          while (pendingErrors.length > 0) {
-            cb(pendingErrors.shift()!);
+          for (const pending of pendingErrors.splice(0)) {
+            cb(pending);
           }
         },
         onClose(cb) {

--- a/packages/server/src/title-generation/generator.test.ts
+++ b/packages/server/src/title-generation/generator.test.ts
@@ -38,16 +38,16 @@ describe('generateTitleFromContent', () => {
       getModel: () => model,
     });
 
-    expect(result!.title).toBe('Project Setup');
-    expect(result!.providerId).toBe('openai');
-    expect(result!.modelId).toBe('gpt-5-nano');
-    expect(result!.usage!.inputTokens).toBe(10);
-    expect(result!.usage!.outputTokens).toBe(5);
+    expect(result?.title).toBe('Project Setup');
+    expect(result?.providerId).toBe('openai');
+    expect(result?.modelId).toBe('gpt-5-nano');
+    expect(result?.usage?.inputTokens).toBe(10);
+    expect(result?.usage?.outputTokens).toBe(5);
 
     expect(model.doGenerateCalls).toHaveLength(1);
     const messages = model.doGenerateCalls[0].prompt;
     const userMessage = messages.find((m) => m.role === 'user');
-    const textContent = userMessage!.content.find((c): c is { type: 'text'; text: string } => c.type === 'text');
+    const textContent = userMessage?.content.find((c): c is { type: 'text'; text: string } => c.type === 'text');
     expect(textContent?.text).toBe(content);
   });
 
@@ -58,7 +58,7 @@ describe('generateTitleFromContent', () => {
       getModel: () => model,
     });
 
-    expect(result!.title).toBe('Debug Auth Flow');
+    expect(result?.title).toBe('Debug Auth Flow');
   });
 
   test('returns null when model returns empty text', async () => {

--- a/packages/server/src/tools/core/glob.ts
+++ b/packages/server/src/tools/core/glob.ts
@@ -47,7 +47,7 @@ export async function globPaths(input: z.infer<typeof globInputSchema>): Promise
     }),
   );
 
-  const sorted = withMtime.sort((a, b) => b.mtime - a.mtime).map((entry) => entry.filePath);
+  const sorted = withMtime.toSorted((a, b) => b.mtime - a.mtime).map((entry) => entry.filePath);
   const truncated = sorted.length > MAX_RESULTS;
   const finalPaths = truncated ? sorted.slice(0, MAX_RESULTS) : sorted;
 

--- a/packages/server/src/tools/core/grep.ts
+++ b/packages/server/src/tools/core/grep.ts
@@ -62,7 +62,7 @@ export async function grepContent(input: z.infer<typeof grepInputSchema>): Promi
 
   const searchableFiles = filesWithMtime
     .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry))
-    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+    .toSorted((a, b) => b.mtimeMs - a.mtimeMs);
 
   const matches: Match[] = [];
   let scannedFiles = 0;

--- a/packages/server/src/tools/core/read.ts
+++ b/packages/server/src/tools/core/read.ts
@@ -71,7 +71,7 @@ export async function readPathContent(input: z.infer<typeof readInputSchema>): P
     const entries = await fs.readdir(targetPath, { withFileTypes: true });
     const output = entries
       .map((entry) => (entry.isDirectory() ? `${entry.name}/` : entry.name))
-      .sort((a, b) => a.localeCompare(b))
+      .toSorted((a, b) => a.localeCompare(b))
       .join('\n');
 
     return { output, filePath: targetPath };

--- a/packages/server/src/tools/runtime/middleware.ts
+++ b/packages/server/src/tools/runtime/middleware.ts
@@ -15,7 +15,7 @@ function createPermissionDedupeKey(input: ToolExecutionInput, patternTargets: st
     input.context.messageId,
     input.context.streamRunId,
     input.toolName,
-    [...patternTargets].sort(),
+    [...patternTargets].toSorted(),
   ]);
 }
 

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -211,7 +211,7 @@ export class ToolsetManager {
     for (const [, entry] of this.getActiveEntries()) {
       Object.assign(merged, entry.tools);
     }
-    return Object.fromEntries(Object.entries(merged).sort(([a], [b]) => a.localeCompare(b)));
+    return Object.fromEntries(Object.entries(merged).toSorted(([a], [b]) => a.localeCompare(b)));
   }
 
   /**

--- a/packages/server/src/usage/service.ts
+++ b/packages/server/src/usage/service.ts
@@ -370,7 +370,7 @@ export async function getUsageDashboard(input: GetUsageDashboardInput): Promise<
   }
 
   const sourceOrder = new Map<string, number>(USAGE_SOURCES.map((source, index) => [source, index]));
-  const sources = Array.from(sourceSet).sort((a, b) => {
+  const sources = Array.from(sourceSet).toSorted((a, b) => {
     const aIndex = sourceOrder.get(a) ?? Number.MAX_SAFE_INTEGER;
     const bIndex = sourceOrder.get(b) ?? Number.MAX_SAFE_INTEGER;
     if (aIndex !== bIndex) return aIndex - bIndex;
@@ -386,13 +386,13 @@ export async function getUsageDashboard(input: GetUsageDashboardInput): Promise<
   return ok({
     range: { from: window.from, to: window.to, granularity, bucketCount: buckets.length },
     filters: { providerId: input.providerId ?? null, modelId: input.modelId ?? null },
-    usedProviders: Array.from(usedProviderIds).sort((a, b) => a.localeCompare(b)),
+    usedProviders: Array.from(usedProviderIds).toSorted((a, b) => a.localeCompare(b)),
     usedModels: Array.from(usedModelKeys)
       .map((key) => {
         const separator = key.indexOf('::');
         return { providerId: key.slice(0, separator), modelId: key.slice(separator + 2) };
       })
-      .sort((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
+      .toSorted((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
     sources,
     totals: { costUsd: totalCostUsd, tokenMetrics: totalTokenMetrics },
     buckets,
@@ -467,18 +467,18 @@ export async function getSttUsageDashboard(
     bucket.durationMsByService[service] = (bucket.durationMsByService[service] ?? 0) + durationMs;
   }
 
-  const services = Array.from(serviceSet).sort((a, b) => a.localeCompare(b));
+  const services = Array.from(serviceSet).toSorted((a, b) => a.localeCompare(b));
 
   return ok({
     range: { from: window.from, to: window.to, granularity, bucketCount: buckets.length },
     filters: { providerId: input.providerId ?? null, modelId: input.modelId ?? null },
-    usedProviders: Array.from(usedProviderIds).sort((a, b) => a.localeCompare(b)),
+    usedProviders: Array.from(usedProviderIds).toSorted((a, b) => a.localeCompare(b)),
     usedModels: Array.from(usedModelKeys)
       .map((key) => {
         const separator = key.indexOf('::');
         return { providerId: key.slice(0, separator), modelId: key.slice(separator + 2) };
       })
-      .sort((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
+      .toSorted((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
     services,
     totals: { costUsd: totalCostUsd, durationMs: totalDurationMs },
     buckets,
@@ -553,13 +553,13 @@ export async function getEmbeddingUsageDashboard(
   return ok({
     range: { from: window.from, to: window.to, granularity, bucketCount: buckets.length },
     filters: { providerId: input.providerId ?? null, modelId: input.modelId ?? null },
-    usedProviders: Array.from(usedProviderIds).sort((a, b) => a.localeCompare(b)),
+    usedProviders: Array.from(usedProviderIds).toSorted((a, b) => a.localeCompare(b)),
     usedModels: Array.from(usedModelKeys)
       .map((key) => {
         const separator = key.indexOf('::');
         return { providerId: key.slice(0, separator), modelId: key.slice(separator + 2) };
       })
-      .sort((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
+      .toSorted((a, b) => a.providerId.localeCompare(b.providerId) || a.modelId.localeCompare(b.modelId)),
     totals: { costUsd: totalCostUsd, totalTokens },
     buckets,
   });

--- a/packages/server/src/utils/stable-stringify.ts
+++ b/packages/server/src/utils/stable-stringify.ts
@@ -16,7 +16,7 @@ function sortKeys(value: unknown): unknown {
   }
 
   const sorted: Record<string, unknown> = {};
-  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+  for (const key of Object.keys(value as Record<string, unknown>).toSorted()) {
     sorted[key] = sortKeys((value as Record<string, unknown>)[key]);
   }
   return sorted;

--- a/packages/shared/src/tools/bash-families.ts
+++ b/packages/shared/src/tools/bash-families.ts
@@ -50,4 +50,4 @@ export const FAMILY_RULES: FamilyRule[] = [
   { tokens: ['grep'], arity: 1, description: 'search text in files', showAsPreset: true },
   { tokens: ['where'], arity: 1, description: 'find files or commands', showAsPreset: false },
   { tokens: ['which'], arity: 1, description: 'find files or commands', showAsPreset: false },
-].sort((a, b) => b.tokens.length - a.tokens.length);
+].toSorted((a, b) => b.tokens.length - a.tokens.length);

--- a/scripts/check-catalogs.ts
+++ b/scripts/check-catalogs.ts
@@ -72,9 +72,10 @@ for (const pkgPath of workspacePkgPaths) {
   for (const field of DEP_FIELDS) {
     const deps: Record<string, string> = pkg[field] ?? {};
     for (const [name, version] of Object.entries(deps)) {
-      if (!catalogPackages.has(name)) continue;
+      const expected = catalogPackages.get(name);
+      if (!expected) continue;
       if (version.startsWith('catalog:')) continue; // already using catalog
-      violations.push({ file: relPath, field, pkg: name, actual: version, expected: catalogPackages.get(name)! });
+      violations.push({ file: relPath, field, pkg: name, actual: version, expected });
     }
   }
 }


### PR DESCRIPTION
## 🚀 Change Summary

Enables a substantial set of stricter oxlint rules repo-wide (React Compiler, a11y, and TypeScript safety) and migrates ~75 web components to satisfy them.

### ✨ New Features

- **React Compiler linting**: `react/react-compiler` is now an error, with a short, explicit override list for the remaining virtualized-table components.
- **jsx-a11y plugin**: enables `anchor-has-content`, `control-has-associated-label`, `label-has-associated-control`, `no-autofocus`, and `no-redundant-roles`.
- **Stricter TS/React rules**: `typescript/no-non-null-assertion`, `react/no-danger`, `react/jsx-no-constructed-context-values`, `react/no-array-index-key`, `react/no-unstable-nested-components`, `react/button-has-type`, `unicorn/prefer-set-has`, `unicorn/no-array-sort`.

### 🛠 Improvements & Refactors

- **Web component alignment**: stable keys instead of array indices, memoized context values, hoisted nested component definitions, removed non-null assertions, and added a11y labels across agenda, automations, chat, mail, memories, recordings, settings, usage, and UI primitives.

### 📌 Stack

Stacked on `refactor/web-hast-code-highlighting`. Requires both prior PRs — the rules only pass once the core and web migrations have landed.
