### PR TITLE
chore(lint): add TanStack Router rules

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/eslint-plugin-query": "^5.101.4",
+    "@tanstack/eslint-plugin-router": "^1.162.0",
     "@tanstack/router-plugin": "1.166.7",
     "@types/bun": "catalog:",
     "@types/react": "19.2.14",

--- a/bun.lock
+++ b/bun.lock
@@ -78,6 +78,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/eslint-plugin-query": "^5.101.4",
+        "@tanstack/eslint-plugin-router": "^1.162.0",
         "@tanstack/router-plugin": "1.166.7",
         "@types/bun": "catalog:",
         "@types/react": "19.2.14",
@@ -1086,6 +1087,8 @@
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.2", "", { "dependencies": { "@tailwindcss/node": "4.3.2", "@tailwindcss/oxide": "4.3.2", "tailwindcss": "4.3.2" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA=="],
 
     "@tanstack/eslint-plugin-query": ["@tanstack/eslint-plugin-query@5.101.4", "", { "dependencies": { "@typescript-eslint/utils": "^8.58.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": "^5.4.0 || ^6.0.0" }, "optionalPeers": ["typescript"] }, "sha512-jqAZJWXGd5PthJYH9wmC2O5Ry5xAN2/7zxi9qcANQ+Xix8V5JkqNRjZ8Fh+rYzqzVYGiHqbrHekt+uh38OZVpw=="],
+
+    "@tanstack/eslint-plugin-router": ["@tanstack/eslint-plugin-router@1.162.0", "", { "dependencies": { "@typescript-eslint/utils": "^8.23.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0" } }, "sha512-0mv+5fOnWXeorh6zd3VyHVfpejIzc7+z68Ts0CQMDzMiwjM5rvea46fyl2m50zx5JFennsu7RO/QJAfnqkKJXw=="],
 
     "@tanstack/history": ["@tanstack/history@1.161.4", "", {}, "sha512-Kp/WSt411ZWYvgXy6uiv5RmhHrz9cAml05AQPrtdAp7eUqvIDbMGPnML25OKbzR3RJ1q4wgENxDTvlGPa9+Mww=="],
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -35,6 +35,7 @@ const config: KnipConfig = {
     'oxlint',
     'oxlint-tsgolint',
     '@tanstack/eslint-plugin-query',
+    '@tanstack/eslint-plugin-router',
     // Referenced via CSS @import / @plugin in apps/web/src/styles/global.css, not TS imports
     'katex',
     'shadcn',

--- a/oxlint.json
+++ b/oxlint.json
@@ -37,7 +37,10 @@
   "overrides": [
     {
       "files": ["apps/web/**/*.{ts,tsx}"],
-      "jsPlugins": [{ "name": "@tanstack/query", "specifier": "@tanstack/eslint-plugin-query" }],
+      "jsPlugins": [
+        { "name": "@tanstack/query", "specifier": "@tanstack/eslint-plugin-query" },
+        { "name": "@tanstack/router", "specifier": "@tanstack/eslint-plugin-router" }
+      ],
       "rules": {
         "@tanstack/query/exhaustive-deps": "error",
         "@tanstack/query/no-rest-destructuring": "warn",
@@ -45,7 +48,9 @@
         "@tanstack/query/no-unstable-deps": "error",
         "@tanstack/query/infinite-query-property-order": "error",
         "@tanstack/query/no-void-query-fn": "error",
-        "@tanstack/query/mutation-property-order": "error"
+        "@tanstack/query/mutation-property-order": "error",
+        "@tanstack/router/create-route-property-order": "warn",
+        "@tanstack/router/route-param-names": "error"
       }
     },
     {


### PR DESCRIPTION
## 🚀 Change Summary

Adds `@tanstack/eslint-plugin-router` as an oxlint JS plugin scoped to `apps/web`, catching TanStack Router misuse at lint time.

### ✨ New Features

- **TanStack Router lint rules**: `route-param-names` as an error and `create-route-property-order` as a warning, with the plugin registered in `knip.config.ts`.

### 📌 Stack

Stacked on `chore/lint-tanstack-query-rules` (shares `oxlint.json`, `knip.config.ts`, `apps/web/package.json`, and `bun.lock`).
