### PR TITLE
chore(web): remove redundant manual memoization

### DIFF
--- a/apps/web/src/components/agenda/agenda-page.tsx
+++ b/apps/web/src/components/agenda/agenda-page.tsx
@@ -84,12 +84,10 @@ export function AgendaPage({ listId }: { listId?: string }) {
     }),
   );
 
-  const items = React.useMemo(() => {
-    const all = itemsData?.items ?? [];
-    const active = all.filter((i) => i.status !== 'done' && i.status !== 'cancelled');
-    const completed = all.filter((i) => i.status === 'done' || i.status === 'cancelled');
-    return [...active, ...completed];
-  }, [itemsData?.items]);
+  const all = itemsData?.items ?? [];
+  const active = all.filter((i) => i.status !== 'done' && i.status !== 'cancelled');
+  const completed = all.filter((i) => i.status === 'done' || i.status === 'cancelled');
+  const items = [...active, ...completed];
   const totalPages = itemsData?.totalPages ?? 0;
   const total = itemsData?.total ?? 0;
 
@@ -253,8 +251,10 @@ export function AgendaPage({ listId }: { listId?: string }) {
   }
 
   const currentPage = (itemsData?.page ?? page) - 1;
-  const pageNumbers = React.useMemo(() => {
-    if (totalPages <= 1) return [] as number[];
+  let pageNumbers: number[];
+  if (totalPages <= 1) {
+    pageNumbers = [];
+  } else {
     const firstPage = 0;
     const lastPage = totalPages - 1;
     const start = Math.max(firstPage, currentPage - 1);
@@ -263,8 +263,8 @@ export function AgendaPage({ listId }: { listId?: string }) {
     for (let index = start; index <= end; index += 1) {
       pages.add(index);
     }
-    return [...pages].toSorted((a, b) => a - b);
-  }, [currentPage, totalPages]);
+    pageNumbers = [...pages].toSorted((a, b) => a - b);
+  }
 
   const allSelected = items.length > 0 && selectedIds.size === items.length;
   const someSelected = selectedIds.size > 0 && selectedIds.size < items.length;

--- a/apps/web/src/components/browser/browser-panel.tsx
+++ b/apps/web/src/components/browser/browser-panel.tsx
@@ -75,13 +75,10 @@ export function BrowserPanel({ sessionId, onClose }: BrowserPanelProps) {
     };
   }, [registerWebview]);
 
-  const submitAddress = React.useCallback(
-    (event: React.FormEvent<HTMLFormElement>) => {
-      event.preventDefault();
-      void window.api?.browser.userNavigate(address);
-    },
-    [address],
-  );
+  const submitAddress = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    void window.api?.browser.userNavigate(address);
+  };
 
   const controllerBadgeClass =
     state.controller === 'agent'

--- a/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
@@ -85,16 +85,13 @@ export function ChatInputInner({
     consumeForSubmit,
   } = useAttachments({ pendingAttachments, onPendingAttachmentsConsumed });
 
-  const allOptions = React.useMemo(() => buildProviderModelOptions(providerModels), [providerModels]);
-  const selectedModelOption = React.useMemo(
-    () => findProviderModelOption(allOptions, selectedModel),
-    [allOptions, selectedModel],
-  );
+  const allOptions = buildProviderModelOptions(providerModels);
+  const selectedModelOption = findProviderModelOption(allOptions, selectedModel);
   const canAttach = supportsAnyAttachment(selectedModelOption?.modelSummary ?? null);
 
-  const submit = React.useCallback(() => {
+  const submit = () => {
     onSubmit(value, consumeForSubmit());
-  }, [consumeForSubmit, onSubmit, value]);
+  };
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (event.key === 'Enter' && !event.shiftKey) {

--- a/apps/web/src/components/chat/chat-input-parts/model-selector-popover.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/model-selector-popover.tsx
@@ -20,12 +20,9 @@ type ModelSelectorPopoverProps = {
 export function ModelSelectorPopover({ selectedValue, onSelect, providerModels }: ModelSelectorPopoverProps) {
   const [search, setSearch] = React.useState('');
 
-  const allOptions = React.useMemo(() => buildProviderModelOptions(providerModels), [providerModels]);
-  const filtered = React.useMemo(() => filterProviderModels(providerModels, search), [providerModels, search]);
-  const selectedOption = React.useMemo(
-    () => findProviderModelOption(allOptions, selectedValue),
-    [allOptions, selectedValue],
-  );
+  const allOptions = buildProviderModelOptions(providerModels);
+  const filtered = filterProviderModels(providerModels, search);
+  const selectedOption = findProviderModelOption(allOptions, selectedValue);
 
   return (
     <PopoverPrimitive.Root>

--- a/apps/web/src/components/chat/chat-input-parts/use-attachments.ts
+++ b/apps/web/src/components/chat/chat-input-parts/use-attachments.ts
@@ -97,71 +97,62 @@ export function useAttachments(options: UseAttachmentsOptions) {
     }
   }, [pendingAttachments, onPendingAttachmentsConsumed]);
 
-  const addFiles = React.useCallback(async (files: FileList | File[]) => {
+  const addFiles = async (files: FileList | File[]) => {
     const fileArray = Array.from(files);
     const processed = await Promise.all(fileArray.map(fileToAttachment));
     const valid = processed.filter((attachment): attachment is Attachment => attachment !== null);
     setAttachments((previous) => [...previous, ...valid]);
-  }, []);
+  };
 
-  const removeAttachment = React.useCallback((id: string) => {
+  const removeAttachment = (id: string) => {
     setAttachments((previous) => {
       const attachment = previous.find((item) => item.id === id);
       if (attachment?.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
       return previous.filter((item) => item.id !== id);
     });
-  }, []);
+  };
 
-  const handlePaste = React.useCallback(
-    async (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
-      const items = Array.from(event.clipboardData.items);
-      const imageItems = items.filter((item) => item.type.startsWith('image/'));
-      if (imageItems.length === 0) return;
+  const handlePaste = async (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = Array.from(event.clipboardData.items);
+    const imageItems = items.filter((item) => item.type.startsWith('image/'));
+    if (imageItems.length === 0) return;
 
-      event.preventDefault();
-      const files = imageItems.map((item) => item.getAsFile()).filter((file): file is File => file !== null);
-      await addFiles(files);
-    },
-    [addFiles],
-  );
+    event.preventDefault();
+    const files = imageItems.map((item) => item.getAsFile()).filter((file): file is File => file !== null);
+    await addFiles(files);
+  };
 
-  const handleDragOver = React.useCallback((event: React.DragEvent) => {
+  const handleDragOver = (event: React.DragEvent) => {
     event.preventDefault();
     setIsDragging(true);
-  }, []);
+  };
 
-  const handleDragLeave = React.useCallback((event: React.DragEvent) => {
+  const handleDragLeave = (event: React.DragEvent) => {
     if (!event.currentTarget.contains(event.relatedTarget as Node)) {
       setIsDragging(false);
     }
-  }, []);
+  };
 
-  const handleDrop = React.useCallback(
-    async (event: React.DragEvent) => {
-      event.preventDefault();
-      setIsDragging(false);
-      if (event.dataTransfer.files.length > 0) {
-        await addFiles(event.dataTransfer.files);
-      }
-    },
-    [addFiles],
-  );
+  const handleDrop = async (event: React.DragEvent) => {
+    event.preventDefault();
+    setIsDragging(false);
+    if (event.dataTransfer.files.length > 0) {
+      await addFiles(event.dataTransfer.files);
+    }
+  };
 
-  const handleFileInputChange = React.useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (event.target.files && event.target.files.length > 0) {
-        await addFiles(event.target.files);
-      }
-      event.target.value = '';
-    },
-    [addFiles],
-  );
+  const handleFileInputChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files.length > 0) {
+      await addFiles(event.target.files);
+    }
+    event.target.value = '';
+  };
 
-  const consumeForSubmit = React.useCallback(() => {
+  const consumeForSubmit = () => {
     const next = attachments;
     setAttachments([]);
     return next;
-  }, [attachments]);
+  };
 
   return {
     attachments,

--- a/apps/web/src/components/chat/chat-input-parts/use-dictation.ts
+++ b/apps/web/src/components/chat/chat-input-parts/use-dictation.ts
@@ -53,38 +53,32 @@ export function useDictation({
   // push-to-talk taps). Finalizes as soon as the session reaches 'recording'.
   const pendingStopRef = React.useRef(false);
 
-  const resolveModel = React.useCallback(
-    (model?: SttModelSelection) => {
-      const providerId = model?.providerId ?? defaultProviderId;
-      const modelId = model?.modelId ?? defaultModelId;
-      if (!providerId || !modelId) {
-        toast.error('No STT model configured. Set one in Settings → General → STT Model.', { id: 'stt-no-model' });
-        return null;
-      }
-      const provider = sttProviders.find((p) => p.providerId === providerId);
-      const found = provider?.models.find((m) => m.id === modelId);
-      if (!found) {
-        toast.error('Configured STT model not found. Check Settings → General → STT Model.', {
-          id: 'stt-model-not-found',
-        });
-        return null;
-      }
-      return { providerId, modelId, sampleRateHz: found.sampleRateHz };
-    },
-    [sttProviders, defaultProviderId, defaultModelId],
-  );
+  const resolveModel = (model?: SttModelSelection) => {
+    const providerId = model?.providerId ?? defaultProviderId;
+    const modelId = model?.modelId ?? defaultModelId;
+    if (!providerId || !modelId) {
+      toast.error('No STT model configured. Set one in Settings → General → STT Model.', { id: 'stt-no-model' });
+      return null;
+    }
+    const provider = sttProviders.find((p) => p.providerId === providerId);
+    const found = provider?.models.find((m) => m.id === modelId);
+    if (!found) {
+      toast.error('Configured STT model not found. Check Settings → General → STT Model.', {
+        id: 'stt-model-not-found',
+      });
+      return null;
+    }
+    return { providerId, modelId, sampleRateHz: found.sampleRateHz };
+  };
 
-  const start = React.useCallback(
-    (model?: SttModelSelection) => {
-      if (stt.state !== 'idle') return;
-      const resolved = resolveModel(model);
-      if (!resolved) return;
-      pendingStopRef.current = false;
-      baseOffsetRef.current = value.length;
-      void stt.start(resolved.providerId, resolved.modelId, resolved.sampleRateHz);
-    },
-    [stt, resolveModel, value],
-  );
+  const start = (model?: SttModelSelection) => {
+    if (stt.state !== 'idle') return;
+    const resolved = resolveModel(model);
+    if (!resolved) return;
+    pendingStopRef.current = false;
+    baseOffsetRef.current = value.length;
+    void stt.start(resolved.providerId, resolved.modelId, resolved.sampleRateHz);
+  };
 
   const stopAndCommit = React.useCallback(async () => {
     // Release requested before the session finished starting up — finalize
@@ -96,7 +90,7 @@ export function useDictation({
     const transcript = await stt.stop();
     const base = value.slice(0, baseOffsetRef.current);
     onChange(spliceTranscript(base, transcript));
-  }, [stt, onChange, value]);
+  }, [stt, value, onChange]);
 
   // Honor a stop requested during the startup window.
   React.useEffect(() => {
@@ -106,16 +100,13 @@ export function useDictation({
     }
   }, [stt.state, stopAndCommit]);
 
-  const toggle = React.useCallback(
-    (model?: SttModelSelection) => {
-      if (stt.state === 'recording') {
-        void stopAndCommit();
-        return;
-      }
-      start(model);
-    },
-    [stt.state, start, stopAndCommit],
-  );
+  const toggle = (model?: SttModelSelection) => {
+    if (stt.state === 'recording') {
+      void stopAndCommit();
+      return;
+    }
+    start(model);
+  };
 
   // Splice live partial + committed text into the input while recording.
   React.useEffect(() => {
@@ -128,10 +119,10 @@ export function useDictation({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [stt.committedText, stt.partialText, stt.state]);
 
-  const cancel = React.useCallback(() => {
+  const cancel = () => {
     pendingStopRef.current = false;
     stt.cancel();
-  }, [stt]);
+  };
 
   return {
     state: stt.state,

--- a/apps/web/src/components/chat/chat-input-parts/use-stt.ts
+++ b/apps/web/src/components/chat/chat-input-parts/use-stt.ts
@@ -99,162 +99,159 @@ export function useStt(): UseSttReturn {
     wsRef.current = null;
   }, []);
 
-  const send = React.useCallback((msg: SttInboundMessage) => {
+  const send = (msg: SttInboundMessage) => {
     wsRef.current?.send(JSON.stringify(msg));
-  }, []);
+  };
 
-  const start = React.useCallback(
-    async (providerId: string, modelId: string, sampleRateHz: number) => {
-      if (state !== 'idle') return;
+  const start = async (providerId: string, modelId: string, sampleRateHz: number) => {
+    if (state !== 'idle') return;
 
-      const serverUrl = await getServerUrl();
-      const sessionId = nextSessionId();
-      sessionIdRef.current = sessionId;
-      finalTextRef.current = '';
-      setCommittedText('');
-      setPartialText('');
+    const serverUrl = await getServerUrl();
+    const sessionId = nextSessionId();
+    sessionIdRef.current = sessionId;
+    finalTextRef.current = '';
+    setCommittedText('');
+    setPartialText('');
 
-      // Open mic
-      let stream: MediaStream;
+    // Open mic
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+    } catch {
+      toast.error('Microphone access denied', { id: 'stt-mic-denied' });
+      return;
+    }
+    streamRef.current = stream;
+
+    // Set up AudioContext for PCM capture at the model's required sample rate
+    const audioCtx = new AudioContext({ sampleRate: sampleRateHz });
+    audioCtxRef.current = audioCtx;
+    const source = audioCtx.createMediaStreamSource(stream);
+
+    // Load AudioWorklet processor module
+    // Use relative path for Electron file:// compatibility
+    const workletUrl = new URL('pcm-capture-processor.js', window.location.href).href;
+    await audioCtx.audioWorklet.addModule(workletUrl);
+    const workletNode = new AudioWorkletNode(audioCtx, 'pcm-capture-processor', {
+      processorOptions: { chunkSize: Math.round(sampleRateHz * 0.1) },
+    });
+    workletRef.current = workletNode;
+
+    // Open WebSocket
+    const ws = new WebSocket(toWsUrl(serverUrl));
+    wsRef.current = ws;
+
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => resolve();
+      ws.onerror = () => reject(new Error('WebSocket connection failed'));
+    }).catch((err: Error) => {
+      cleanup();
+      toast.error(err.message, { id: 'stt-ws-error' });
+      throw err;
+    });
+
+    ws.onmessage = (event) => {
+      let msg: SttOutboundMessage;
       try {
-        stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+        msg = JSON.parse(event.data as string) as SttOutboundMessage;
       } catch {
-        toast.error('Microphone access denied', { id: 'stt-mic-denied' });
         return;
       }
-      streamRef.current = stream;
 
-      // Set up AudioContext for PCM capture at the model's required sample rate
-      const audioCtx = new AudioContext({ sampleRate: sampleRateHz });
-      audioCtxRef.current = audioCtx;
-      const source = audioCtx.createMediaStreamSource(stream);
-
-      // Load AudioWorklet processor module
-      // Use relative path for Electron file:// compatibility
-      const workletUrl = new URL('pcm-capture-processor.js', window.location.href).href;
-      await audioCtx.audioWorklet.addModule(workletUrl);
-      const workletNode = new AudioWorkletNode(audioCtx, 'pcm-capture-processor', {
-        processorOptions: { chunkSize: Math.round(sampleRateHz * 0.1) },
-      });
-      workletRef.current = workletNode;
-
-      // Open WebSocket
-      const ws = new WebSocket(toWsUrl(serverUrl));
-      wsRef.current = ws;
-
-      await new Promise<void>((resolve, reject) => {
-        ws.onopen = () => resolve();
-        ws.onerror = () => reject(new Error('WebSocket connection failed'));
-      }).catch((err: Error) => {
-        cleanup();
-        toast.error(err.message, { id: 'stt-ws-error' });
-        throw err;
-      });
-
-      ws.onmessage = (event) => {
-        let msg: SttOutboundMessage;
-        try {
-          msg = JSON.parse(event.data as string) as SttOutboundMessage;
-        } catch {
-          return;
-        }
-
-        switch (msg.type) {
-          case 'transcript': {
-            if (msg.kind === 'partial') {
-              setPartialText(msg.text);
-            } else {
-              finalTextRef.current += (finalTextRef.current ? ' ' : '') + msg.text;
-              setCommittedText(finalTextRef.current);
-              setPartialText('');
-            }
-            break;
-          }
-          case 'done': {
-            const result = finalTextRef.current;
-            stopResolveRef.current?.(result);
-            stopResolveRef.current = null;
-            stopRejectRef.current = null;
-            setState('idle');
-            setCommittedText('');
+      switch (msg.type) {
+        case 'transcript': {
+          if (msg.kind === 'partial') {
+            setPartialText(msg.text);
+          } else {
+            finalTextRef.current += (finalTextRef.current ? ' ' : '') + msg.text;
+            setCommittedText(finalTextRef.current);
             setPartialText('');
-            cleanup();
-            break;
           }
-          case 'error': {
-            const err = new Error(msg.message);
-            if (stopRejectRef.current) {
-              stopRejectRef.current(err);
-              stopResolveRef.current = null;
-              stopRejectRef.current = null;
-            } else {
-              toast.error(`STT error: ${msg.message}`, { id: 'stt-msg-error' });
-            }
-            setState('idle');
-            setCommittedText('');
-            setPartialText('');
-            cleanup();
-            break;
-          }
+          break;
         }
-      };
-
-      ws.onclose = (_event) => {
-        if (stopRejectRef.current) {
-          stopRejectRef.current(new Error('WebSocket closed unexpectedly'));
+        case 'done': {
+          const result = finalTextRef.current;
+          stopResolveRef.current?.(result);
           stopResolveRef.current = null;
           stopRejectRef.current = null;
+          setState('idle');
+          setCommittedText('');
+          setPartialText('');
+          cleanup();
+          break;
         }
-        setState('idle');
-        setCommittedText('');
-        setPartialText('');
-        cleanup();
-      };
-
-      // Send start message
-      send({
-        type: 'start',
-        sttSessionId: sessionId,
-        providerId,
-        modelId,
-        service: 'chat-input',
-        recordingId: sessionId,
-        capabilityRequest: { partials: 'preferred', native_vad: 'preferred' },
-        audioChunkConfig: { encoding: 'pcm_s16le', sampleRateHz },
-      });
-
-      // Wire up audio worklet message handler
-      workletNode.port.onmessage = (e: MessageEvent<ArrayBuffer>) => {
-        if (wsRef.current?.readyState !== WebSocket.OPEN) return;
-        const f32 = new Float32Array(e.data);
-        levelRef.current = computeAudioLevel(f32);
-        if (levelRafRef.current === null) {
-          levelRafRef.current = requestAnimationFrame(() => {
-            levelRafRef.current = null;
-            setAudioLevel(levelRef.current);
-          });
+        case 'error': {
+          const err = new Error(msg.message);
+          if (stopRejectRef.current) {
+            stopRejectRef.current(err);
+            stopResolveRef.current = null;
+            stopRejectRef.current = null;
+          } else {
+            toast.error(`STT error: ${msg.message}`, { id: 'stt-msg-error' });
+          }
+          setState('idle');
+          setCommittedText('');
+          setPartialText('');
+          cleanup();
+          break;
         }
-        const pcm = encodeF32ToPcmS16le(f32);
-        send({
-          type: 'chunk',
-          sttSessionId: sessionId,
-          source: 'mic',
-          samplesB64: int16ToBase64(pcm),
-          sampleRateHz,
-          numSamples: pcm.length,
+      }
+    };
+
+    ws.onclose = (_event) => {
+      if (stopRejectRef.current) {
+        stopRejectRef.current(new Error('WebSocket closed unexpectedly'));
+        stopResolveRef.current = null;
+        stopRejectRef.current = null;
+      }
+      setState('idle');
+      setCommittedText('');
+      setPartialText('');
+      cleanup();
+    };
+
+    // Send start message
+    send({
+      type: 'start',
+      sttSessionId: sessionId,
+      providerId,
+      modelId,
+      service: 'chat-input',
+      recordingId: sessionId,
+      capabilityRequest: { partials: 'preferred', native_vad: 'preferred' },
+      audioChunkConfig: { encoding: 'pcm_s16le', sampleRateHz },
+    });
+
+    // Wire up audio worklet message handler
+    workletNode.port.onmessage = (e: MessageEvent<ArrayBuffer>) => {
+      if (wsRef.current?.readyState !== WebSocket.OPEN) return;
+      const f32 = new Float32Array(e.data);
+      levelRef.current = computeAudioLevel(f32);
+      if (levelRafRef.current === null) {
+        levelRafRef.current = requestAnimationFrame(() => {
+          levelRafRef.current = null;
+          setAudioLevel(levelRef.current);
         });
-      };
+      }
+      const pcm = encodeF32ToPcmS16le(f32);
+      send({
+        type: 'chunk',
+        sttSessionId: sessionId,
+        source: 'mic',
+        samplesB64: int16ToBase64(pcm),
+        sampleRateHz,
+        numSamples: pcm.length,
+      });
+    };
 
-      source.connect(workletNode);
-      workletNode.connect(audioCtx.destination);
+    source.connect(workletNode);
+    workletNode.connect(audioCtx.destination);
 
-      setStartedAt(Date.now());
-      setState('recording');
-    },
-    [state, send, cleanup],
-  );
+    setStartedAt(Date.now());
+    setState('recording');
+  };
 
-  const stop = React.useCallback((): Promise<string> => {
+  const stop = (): Promise<string> => {
     if (state !== 'recording') return Promise.resolve('');
 
     setState('stopping');
@@ -265,10 +262,10 @@ export function useStt(): UseSttReturn {
       stopRejectRef.current = reject;
       send({ type: 'stop', sttSessionId: sessionIdRef.current });
     });
-  }, [state, send]);
+  };
 
   // Discard the in-progress recording without committing any transcript.
-  const cancel = React.useCallback(() => {
+  const cancel = () => {
     if (state === 'idle') return;
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       send({ type: 'stop', sttSessionId: sessionIdRef.current });
@@ -280,7 +277,7 @@ export function useStt(): UseSttReturn {
     setCommittedText('');
     setPartialText('');
     cleanup();
-  }, [state, send, cleanup]);
+  };
 
   // Clean up on unmount
   React.useEffect(() => {

--- a/apps/web/src/components/chat/chat-markdown.tsx
+++ b/apps/web/src/components/chat/chat-markdown.tsx
@@ -1,18 +1,7 @@
 import { toJsxRuntime } from 'hast-util-to-jsx-runtime';
 import { CheckIcon, CopyIcon } from 'lucide-react';
 import * as React from 'react';
-import {
-  Children,
-  Suspense,
-  isValidElement,
-  use,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  memo,
-} from 'react';
+import { Children, Suspense, isValidElement, use, useEffect, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Fragment, jsx, jsxs } from 'react/jsx-runtime';
 import rehypeKatex from 'rehype-katex';
@@ -85,7 +74,7 @@ function MarkdownCodeBlock({ code, children }: { code: string; children: React.R
   const [copied, setCopied] = useState(false);
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleCopy = useCallback(() => {
+  const handleCopy = () => {
     if (typeof navigator === 'undefined' || navigator.clipboard === null) {
       return;
     }
@@ -102,7 +91,7 @@ function MarkdownCodeBlock({ code, children }: { code: string; children: React.R
         }, 1200);
       })
       .catch(() => undefined);
-  }, [code]);
+  };
 
   useEffect(() => {
     return () => {
@@ -264,20 +253,17 @@ function transformLatexCommandTextNodes(node: MarkdownNode) {
 }
 
 function MarkdownAnchor({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
-  const handleClick = useCallback(
-    (e: React.MouseEvent<HTMLAnchorElement>) => {
-      if (!href) return;
-      const isExternal = /^https?:\/\//i.test(href);
-      if (!isExternal) return;
-      e.preventDefault();
-      if (window.api?.shell?.openExternal) {
-        void window.api.shell.openExternal(href);
-      } else {
-        window.open(href, '_blank', 'noopener,noreferrer');
-      }
-    },
-    [href],
-  );
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!href) return;
+    const isExternal = /^https?:\/\//i.test(href);
+    if (!isExternal) return;
+    e.preventDefault();
+    if (window.api?.shell?.openExternal) {
+      void window.api.shell.openExternal(href);
+    } else {
+      window.open(href, '_blank', 'noopener,noreferrer');
+    }
+  };
 
   return (
     <a {...props} href={href} onClick={handleClick} rel="noopener noreferrer">
@@ -334,11 +320,11 @@ function HighlightedMarkdownPre({ node: _node, children, ...props }: MarkdownPre
 const STREAMING_COMPONENTS: Components = { img: MarkdownImage, a: MarkdownAnchor, pre: StreamingMarkdownPre };
 const HIGHLIGHTED_COMPONENTS: Components = { img: MarkdownImage, a: MarkdownAnchor, pre: HighlightedMarkdownPre };
 
-function ChatMarkdown({ text, className, isStreaming = false }: ChatMarkdownProps) {
+export default function ChatMarkdown({ text, className, isStreaming = false }: ChatMarkdownProps) {
   const markdownComponents = isStreaming ? STREAMING_COMPONENTS : HIGHLIGHTED_COMPONENTS;
 
   // During streaming: use remarkGfm only — skip remark-math + rehype-katex (heavy)
-  const remarkPlugins = useMemo(() => {
+  const remarkPlugins = (() => {
     if (isStreaming) return [remarkGfm, remarkStreamingSingleDollarLatexCommands];
 
     const remarkMathWithoutSingleDollar = [remarkMath, { singleDollarTextMath: false }] as [
@@ -346,9 +332,9 @@ function ChatMarkdown({ text, className, isStreaming = false }: ChatMarkdownProp
       { singleDollarTextMath: false },
     ];
     return [remarkGfm, remarkMathWithoutSingleDollar];
-  }, [isStreaming]);
-  const rehypePlugins = useMemo(() => (isStreaming ? [] : [rehypeKatex]), [isStreaming]);
-  const source = useMemo(() => (isStreaming ? text : normalizeInlineMath(text)), [text, isStreaming]);
+  })();
+  const rehypePlugins = isStreaming ? [] : [rehypeKatex];
+  const source = isStreaming ? text : normalizeInlineMath(text);
 
   return (
     <div className={cn('prose prose-sm prose-neutral dark:prose-invert max-w-none leading-relaxed', className)}>
@@ -358,5 +344,3 @@ function ChatMarkdown({ text, className, isStreaming = false }: ChatMarkdownProp
     </div>
   );
 }
-
-export default memo(ChatMarkdown);

--- a/apps/web/src/components/chat/chat-sidebar.tsx
+++ b/apps/web/src/components/chat/chat-sidebar.tsx
@@ -28,13 +28,7 @@ const selectSidebarSessions = (data: InfiniteData<SessionsPage>) => ({
   })),
 });
 
-const SessionStatusIcon = React.memo(function SessionStatusIcon({
-  isStreaming,
-  isUnread,
-}: {
-  isStreaming: boolean;
-  isUnread: boolean;
-}) {
+function SessionStatusIcon({ isStreaming, isUnread }: { isStreaming: boolean; isUnread: boolean }) {
   if (isStreaming) {
     return (
       <div className="flex size-3.5 shrink-0 items-center justify-center">
@@ -52,7 +46,7 @@ const SessionStatusIcon = React.memo(function SessionStatusIcon({
   }
 
   return null;
-});
+}
 
 export function ChatSidebarContent() {
   const [search, setSearch] = React.useState('');
@@ -67,7 +61,7 @@ export function ChatSidebarContent() {
   const archiveSession = useArchiveSession();
   const deleteSession = useDeleteSession();
   const streamingIds = useStreamingSessionIds();
-  const streamingIdSet = React.useMemo(() => new Set(streamingIds), [streamingIds]);
+  const streamingIdSet = new Set(streamingIds);
   const sessions = data?.pages.flatMap((page) => page.sessions) ?? [];
   const deletingSession = sessions.find((session) => session.id === deletingSessionId);
 

--- a/apps/web/src/components/chat/docks/dock.tsx
+++ b/apps/web/src/components/chat/docks/dock.tsx
@@ -178,14 +178,11 @@ export function DockContainer({ docks, className }: DockContainerProps) {
     return () => cancelAnimationFrame(frame);
   }, [hasDocks]);
 
-  const handleTransitionEnd = React.useCallback(
-    (event: React.TransitionEvent<HTMLDivElement>) => {
-      if (!hasDocks && !isOpen && event.target === event.currentTarget && event.propertyName === 'grid-template-rows') {
-        setRenderedDocks([]);
-      }
-    },
-    [hasDocks, isOpen],
-  );
+  const handleTransitionEnd = (event: React.TransitionEvent<HTMLDivElement>) => {
+    if (!hasDocks && !isOpen && event.target === event.currentTarget && event.propertyName === 'grid-template-rows') {
+      setRenderedDocks([]);
+    }
+  };
 
   if (renderedDocks.length === 0) return null;
 

--- a/apps/web/src/components/chat/message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import type { StoredPart } from '@stitch/shared/chat/messages';
 
 import { AssistantMessageBubble } from '@/components/chat/message-bubble/assistant-message-bubble';
@@ -14,17 +12,10 @@ type MessageBubbleProps = {
   onEdit?: () => void;
 };
 
-export const MessageBubble = React.memo(function MessageBubble({
-  role,
-  parts,
-  finishReason,
-  onAbortTool,
-  onSplit,
-  onEdit,
-}: MessageBubbleProps) {
+export function MessageBubble({ role, parts, finishReason, onAbortTool, onSplit, onEdit }: MessageBubbleProps) {
   if (role === 'user') {
     return <UserMessageBubble parts={parts} onSplit={onSplit} onEdit={onEdit} />;
   }
 
   return <AssistantMessageBubble parts={parts} finishReason={finishReason} onAbortTool={onAbortTool} />;
-});
+}

--- a/apps/web/src/components/chat/message-bubble/streaming-message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble/streaming-message-bubble.tsx
@@ -24,11 +24,7 @@ type StreamingMessageBubbleProps = {
   onAbortTool?: () => void;
 };
 
-export const StreamingMessageBubble = React.memo(function StreamingMessageBubble({
-  partIds,
-  parts,
-  onAbortTool,
-}: StreamingMessageBubbleProps) {
+export function StreamingMessageBubble({ partIds, parts, onAbortTool }: StreamingMessageBubbleProps) {
   const visibleIds = partIds.filter((id) => id in parts);
 
   const hasAnyContent = visibleIds.some((partId) => {
@@ -111,4 +107,4 @@ export const StreamingMessageBubble = React.memo(function StreamingMessageBubble
   flushToolGroup();
 
   return <AssistantBubbleWrapper>{nodes}</AssistantBubbleWrapper>;
-});
+}

--- a/apps/web/src/components/chat/message-bubble/tool-call/card-primitives.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call/card-primitives.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { useQueryClient } from '@tanstack/react-query';
 
 import { toolKeys } from '@/lib/queries/tools';
@@ -8,10 +6,8 @@ type KnownTool = { toolName: string; displayName: string };
 
 export function useStitchToolDisplayName(toolName: string): string {
   const queryClient = useQueryClient();
-  return React.useMemo(() => {
-    const knownTools = queryClient.getQueryData<KnownTool[]>(toolKeys.knownTools());
-    return knownTools?.find((t) => t.toolName === toolName)?.displayName ?? formatToolDisplayName(toolName);
-  }, [queryClient, toolName]);
+  const knownTools = queryClient.getQueryData<KnownTool[]>(toolKeys.knownTools());
+  return knownTools?.find((t) => t.toolName === toolName)?.displayName ?? formatToolDisplayName(toolName);
 }
 
 export function truncateText(value: string, max = 84): string {

--- a/apps/web/src/components/connectors/connectors-page.tsx
+++ b/apps/web/src/components/connectors/connectors-page.tsx
@@ -1,5 +1,5 @@
 import { PlugIcon } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 
@@ -36,15 +36,13 @@ export function ConnectorsPage() {
   const [search, setSearch] = useState('');
   const pendingUpdates = instances.filter((instance) => instance.upgrade?.available).length;
 
-  const filteredDefinitions = useMemo(() => {
-    const query = search.trim().toLowerCase();
-    if (!query) return definitions;
-
-    return definitions.filter((definition) => {
-      const searchableText = `${definition.name} ${definition.description}`.toLowerCase();
-      return searchableText.includes(query);
-    });
-  }, [definitions, search]);
+  const query = search.trim().toLowerCase();
+  const filteredDefinitions = !query
+    ? definitions
+    : definitions.filter((definition) => {
+        const searchableText = `${definition.name} ${definition.description}`.toLowerCase();
+        return searchableText.includes(query);
+      });
 
   return (
     <Page>

--- a/apps/web/src/components/cron-expression-builder.tsx
+++ b/apps/web/src/components/cron-expression-builder.tsx
@@ -129,18 +129,17 @@ export function CronExpressionBuilder({ value, onChange, timezone = 'UTC', class
   }
 
   // Calculate upcoming executions
-  const upcomingExecutions = React.useMemo(() => {
-    const options = { tz: timezone };
-    try {
-      return getUpcomingCronRuns(value, 5, options.tz).map((date) => ({
-        date: format(date, 'MMM d, yyyy'),
-        time: format(date, 'h:mm a'),
-        key: date.toISOString(),
-      }));
-    } catch {
-      return [];
-    }
-  }, [value, timezone]);
+  const options = { tz: timezone };
+  let upcomingExecutions: { date: string; time: string; key: string }[];
+  try {
+    upcomingExecutions = getUpcomingCronRuns(value, 5, options.tz).map((date) => ({
+      date: format(date, 'MMM d, yyyy'),
+      time: format(date, 'h:mm a'),
+      key: date.toISOString(),
+    }));
+  } catch {
+    upcomingExecutions = [];
+  }
 
   // Renderers for grid sections
   const renderMinutes = () => (

--- a/apps/web/src/components/mail/mail-sidebar.tsx
+++ b/apps/web/src/components/mail/mail-sidebar.tsx
@@ -274,8 +274,8 @@ function UserLabelTreeItem({
 function MailLabelList({ accountId }: { accountId: MailAccountId }) {
   const { selectedLabelId, setSelectedLabelId } = useMailStore();
   const { data: labels = [] } = useQuery(mailLabelsQueryOptions(accountId));
-  const sortedLabels = React.useMemo(() => sortLabels(labels), [labels]);
-  const initialCollapsedState = React.useMemo(() => readCollapsedLabelState(accountId), [accountId]);
+  const sortedLabels = sortLabels(labels);
+  const initialCollapsedState = readCollapsedLabelState(accountId);
   const [collapsedLabels, setCollapsedLabels] = React.useState<Set<string>>(
     () => new Set(initialCollapsedState.labels),
   );
@@ -285,36 +285,27 @@ function MailLabelList({ accountId }: { accountId: MailAccountId }) {
   const primaryLabels = sortedLabels.filter((label) => getSystemLabelGroup(label) === 'primary');
   const categoryLabels = sortedLabels.filter((label) => getSystemLabelGroup(label) === 'category');
   const markerLabels = sortedLabels.filter((label) => getSystemLabelGroup(label) === 'marker');
-  const userLabelTree = React.useMemo(
-    () => buildUserLabelTree(sortedLabels.filter((label) => label.kind === 'user')),
-    [sortedLabels],
-  );
+  const userLabelTree = buildUserLabelTree(sortedLabels.filter((label) => label.kind === 'user'));
 
-  const toggleCollapsedLabel = React.useCallback(
-    (key: string) => {
-      setCollapsedLabels((currentLabels) => {
-        const nextLabels = new Set(currentLabels);
-        if (nextLabels.has(key)) nextLabels.delete(key);
-        else nextLabels.add(key);
-        writeCollapsedLabelState(accountId, nextLabels, collapsedSections);
-        return nextLabels;
-      });
-    },
-    [accountId, collapsedSections],
-  );
+  const toggleCollapsedLabel = (key: string) => {
+    setCollapsedLabels((currentLabels) => {
+      const nextLabels = new Set(currentLabels);
+      if (nextLabels.has(key)) nextLabels.delete(key);
+      else nextLabels.add(key);
+      writeCollapsedLabelState(accountId, nextLabels, collapsedSections);
+      return nextLabels;
+    });
+  };
 
-  const toggleSection = React.useCallback(
-    (section: LabelSection) => {
-      setCollapsedSections((currentSections) => {
-        const nextSections = new Set(currentSections);
-        if (nextSections.has(section)) nextSections.delete(section);
-        else nextSections.add(section);
-        writeCollapsedLabelState(accountId, collapsedLabels, nextSections);
-        return nextSections;
-      });
-    },
-    [accountId, collapsedLabels],
-  );
+  const toggleSection = (section: LabelSection) => {
+    setCollapsedSections((currentSections) => {
+      const nextSections = new Set(currentSections);
+      if (nextSections.has(section)) nextSections.delete(section);
+      else nextSections.add(section);
+      writeCollapsedLabelState(accountId, collapsedLabels, nextSections);
+      return nextSections;
+    });
+  };
 
   React.useEffect(() => {
     if (!selectedLabelId && labels.length > 0) setSelectedLabelId(getDefaultMailLabel(labels)?.id ?? null);

--- a/apps/web/src/components/mail/message-body.tsx
+++ b/apps/web/src/components/mail/message-body.tsx
@@ -350,10 +350,7 @@ export function MessageBody({
   const resizeObserverRef = React.useRef<ResizeObserver | null>(null);
   const mutationObserverRef = React.useRef<MutationObserver | null>(null);
   const isDark = useIsDarkMode();
-  const srcDoc = React.useMemo(
-    () => buildSandboxedMailHtml({ bodyHtml, bodyText, loadImages, isDark, collapseQuotedReplies }),
-    [bodyHtml, bodyText, collapseQuotedReplies, isDark, loadImages],
-  );
+  const srcDoc = buildSandboxedMailHtml({ bodyHtml, bodyText, loadImages, isDark, collapseQuotedReplies });
 
   React.useEffect(() => {
     return () => {

--- a/apps/web/src/components/memories/memories-page.tsx
+++ b/apps/web/src/components/memories/memories-page.tsx
@@ -154,11 +154,8 @@ export function MemoriesPage() {
   const isLoading = isSearching ? searchQuery.isLoading : listQuery.isLoading;
   const totalPages = pageData?.totalPages ?? 0;
   const currentPage = (pageData?.page ?? page) - 1;
-  const pageNumbers = React.useMemo(() => {
-    if (totalPages <= 1) {
-      return [] as number[];
-    }
-
+  let pageNumbers: number[] = [];
+  if (totalPages > 1) {
     const firstPage = 0;
     const lastPage = totalPages - 1;
     const start = Math.max(firstPage, currentPage - 1);
@@ -169,8 +166,8 @@ export function MemoriesPage() {
       pages.add(index);
     }
 
-    return [...pages].toSorted((a, b) => a - b);
-  }, [currentPage, totalPages]);
+    pageNumbers = [...pages].toSorted((a, b) => a - b);
+  }
 
   const allSelected = memories.length > 0 && selectedIds.size === memories.length;
   const someSelected = selectedIds.size > 0 && selectedIds.size < memories.length;

--- a/apps/web/src/components/model-selectors/model-combobox.tsx
+++ b/apps/web/src/components/model-selectors/model-combobox.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import {
   Combobox,
   ComboboxCollection,
@@ -52,8 +50,8 @@ export function ModelCombobox({
   placeholder = 'Search models...',
   showClear,
 }: ModelComboboxProps) {
-  const groups = React.useMemo(() => buildGroups(providerModels), [providerModels]);
-  const allOptions = React.useMemo(() => flattenGroups(groups), [groups]);
+  const groups = buildGroups(providerModels);
+  const allOptions = flattenGroups(groups);
 
   const selectedOption = value
     ? (allOptions.find((o) => o.providerId === value.providerId && o.modelId === value.modelId) ?? null)

--- a/apps/web/src/components/model-selectors/stt-model-selector-popover.tsx
+++ b/apps/web/src/components/model-selectors/stt-model-selector-popover.tsx
@@ -28,18 +28,17 @@ export function SttModelSelectorPopover({
 }: SttModelSelectorPopoverProps) {
   const [search, setSearch] = React.useState('');
 
-  const filtered = React.useMemo(() => {
-    if (!search.trim()) return sttProviders;
-    const lower = search.toLowerCase();
-    return sttProviders
-      .map((provider) => ({
-        ...provider,
-        models: provider.models.filter(
-          (m) => m.name.toLowerCase().includes(lower) || provider.providerName.toLowerCase().includes(lower),
-        ),
-      }))
-      .filter((p) => p.models.length > 0);
-  }, [sttProviders, search]);
+  const lower = search.toLowerCase();
+  const filtered = !search.trim()
+    ? sttProviders
+    : sttProviders
+        .map((provider) => ({
+          ...provider,
+          models: provider.models.filter(
+            (m) => m.name.toLowerCase().includes(lower) || provider.providerName.toLowerCase().includes(lower),
+          ),
+        }))
+        .filter((p) => p.models.length > 0);
 
   return (
     <PopoverPrimitive.Root>

--- a/apps/web/src/components/navigation/right-click-menu.tsx
+++ b/apps/web/src/components/navigation/right-click-menu.tsx
@@ -1,5 +1,5 @@
 import { BookPlus, Scissors, Copy, ClipboardPaste, Terminal, ChevronRight, SpellCheck } from 'lucide-react';
-import { useEffect, useLayoutEffect, useCallback, useState, useRef, forwardRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState, useRef, forwardRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import { Button } from '@/components/ui/button';
@@ -150,56 +150,53 @@ export function RightClickMenu({ children }: RightClickMenuProps) {
     };
   }, [params, close]);
 
-  const handleSpellingMouseEnter = useCallback(() => {
+  const handleSpellingMouseEnter = () => {
     if (spellingCloseTimer.current) clearTimeout(spellingCloseTimer.current);
     setSpellingOpen(true);
-  }, []);
+  };
 
-  const handleSpellingMouseLeave = useCallback(() => {
+  const handleSpellingMouseLeave = () => {
     spellingCloseTimer.current = setTimeout(() => setSpellingOpen(false), 150);
-  }, []);
+  };
 
-  const handleSubmenuMouseEnter = useCallback(() => {
+  const handleSubmenuMouseEnter = () => {
     if (spellingCloseTimer.current) clearTimeout(spellingCloseTimer.current);
-  }, []);
+  };
 
-  const handleSubmenuMouseLeave = useCallback(() => {
+  const handleSubmenuMouseLeave = () => {
     spellingCloseTimer.current = setTimeout(() => setSpellingOpen(false), 150);
-  }, []);
+  };
 
-  const handleReplaceMisspelling = useCallback(
-    (suggestion: string) => {
-      void window.api?.spellcheck?.replaceMisspelling(suggestion);
-      close();
-    },
-    [close],
-  );
+  const handleReplaceMisspelling = (suggestion: string) => {
+    void window.api?.spellcheck?.replaceMisspelling(suggestion);
+    close();
+  };
 
   const misspelledWord = params?.misspelledWord ?? null;
 
-  const handleAddToDictionary = useCallback(() => {
+  const handleAddToDictionary = () => {
     if (misspelledWord) {
       void window.api?.spellcheck?.addToDictionary(misspelledWord);
     }
     close();
-  }, [misspelledWord, close]);
+  };
 
-  const handleCut = useCallback(() => {
+  const handleCut = () => {
     document.execCommand('cut');
     close();
-  }, [close]);
-  const handleCopy = useCallback(() => {
+  };
+  const handleCopy = () => {
     document.execCommand('copy');
     close();
-  }, [close]);
-  const handlePaste = useCallback(() => {
+  };
+  const handlePaste = () => {
     document.execCommand('paste');
     close();
-  }, [close]);
-  const handleOpenDevTools = useCallback(() => {
+  };
+  const handleOpenDevTools = () => {
     void window.api?.devtools?.toggle();
     close();
-  }, [close]);
+  };
 
   const isMisspelled = !!misspelledWord;
   const isEditable = params?.isEditable ?? false;

--- a/apps/web/src/components/onboarding/steps/memory-step.tsx
+++ b/apps/web/src/components/onboarding/steps/memory-step.tsx
@@ -41,7 +41,7 @@ export function MemoryStep({ onComplete, onBackToProviders }: Props) {
   );
   const saveModel = useMutation(saveSettingMutationOptions('memory.embedding.modelId', queryClient, { silent: true }));
 
-  const modelOptions = React.useMemo(() => buildModelOptions(providerModels), [providerModels]);
+  const modelOptions = buildModelOptions(providerModels);
 
   const [chosenValue, setChosenValue] = React.useState<string | null>(null);
 

--- a/apps/web/src/components/onboarding/steps/profile-step.tsx
+++ b/apps/web/src/components/onboarding/steps/profile-step.tsx
@@ -30,14 +30,11 @@ type Props = {
 };
 
 export function ProfileStep({ initialName, initialTimezone, isSaving, onContinue }: Props) {
-  const detectedTimezone = React.useMemo(() => getDetectedTimezone(), []);
+  const detectedTimezone = getDetectedTimezone();
   const [name, setName] = React.useState(initialName);
   const [timezone, setTimezone] = React.useState(initialTimezone || detectedTimezone);
   const [touched, setTouched] = React.useState(false);
-  const timezoneOptions = React.useMemo(
-    () => getTimezoneOptions(initialTimezone || detectedTimezone),
-    [detectedTimezone, initialTimezone],
-  );
+  const timezoneOptions = getTimezoneOptions(initialTimezone || detectedTimezone);
 
   const trimmed = name.trim();
   const trimmedTimezone = timezone.trim();

--- a/apps/web/src/components/onboarding/steps/provider-step.tsx
+++ b/apps/web/src/components/onboarding/steps/provider-step.tsx
@@ -42,7 +42,7 @@ export function ProviderStep({ onConnected }: Props) {
   const [selected, setSelected] = React.useState<ProviderSummary | null>(null);
   const [search, setSearch] = React.useState('');
 
-  const selectableProviders = React.useMemo(() => {
+  const selectableProviders = (() => {
     if (!providers) return [];
     return providers.filter((provider) => {
       if (provider.enabled) return false;
@@ -50,18 +50,18 @@ export function ProviderStep({ onConnected }: Props) {
       const meta = PROVIDER_META[provider.id as ProviderId];
       return meta.authMethods.some((method) => method.enabled);
     });
-  }, [providers]);
+  })();
 
-  const filteredProviders = React.useMemo(() => {
+  const filteredProviders = (() => {
     if (!search) return selectableProviders;
     const q = search.toLowerCase();
     return selectableProviders.filter((provider) => {
       const meta = PROVIDER_META[provider.id as ProviderId];
       return meta.displayName.toLowerCase().includes(q) || meta.description?.toLowerCase().includes(q);
     });
-  }, [selectableProviders, search]);
+  })();
 
-  const handleBack = React.useCallback(() => setSelected(null), []);
+  const handleBack = () => setSelected(null);
 
   if (!providers) {
     return <div className="text-sm text-muted-foreground">Loading providers...</div>;

--- a/apps/web/src/components/recordings/list/recordings-pagination.tsx
+++ b/apps/web/src/components/recordings/list/recordings-pagination.tsx
@@ -38,7 +38,7 @@ export function RecordingsPagination({
   onPageChange: (page: number) => void;
 }) {
   const currentPage = page - 1;
-  const pageNumbers = React.useMemo(() => getPageNumbers(currentPage, pageCount), [currentPage, pageCount]);
+  const pageNumbers = getPageNumbers(currentPage, pageCount);
 
   if (pageCount <= 1) return null;
 

--- a/apps/web/src/components/recordings/recording-analysis-page.tsx
+++ b/apps/web/src/components/recordings/recording-analysis-page.tsx
@@ -46,7 +46,7 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
 
   const isRunning = analysis?.status === 'processing';
 
-  const deleteRecordingById = React.useCallback(() => {
+  const deleteRecordingById = () => {
     void deleteRecording.mutateAsync(recordingId).then(
       () => {
         setShowDeleteConfirm(false);
@@ -56,7 +56,7 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
       (error: unknown) =>
         toast.error(getErrorMessage(error, 'Failed to delete recording'), { id: 'analysis-recording-delete' }),
     );
-  }, [deleteRecording, navigate, recordingId]);
+  };
 
   const handleStartAnalysis = () => {
     if (!selectedTemplate) {

--- a/apps/web/src/components/recordings/recordings-page.tsx
+++ b/apps/web/src/components/recordings/recordings-page.tsx
@@ -50,23 +50,19 @@ export function RecordingsPage() {
 
   const activeRecording = data.recordings.find((recording) => recording.id === data.activeRecordingId);
 
-  const deleteById = React.useCallback(
-    (recordingId: string, onSuccess?: () => void) => {
-      void deleteRecording.mutateAsync(recordingId).then(
-        () => {
-          onSuccess?.();
-          toast.success('Recording deleted', { id: 'recording-delete' });
-        },
-        (error: unknown) =>
-          toast.error(getErrorMessage(error, 'Failed to delete recording'), { id: 'recording-delete' }),
-      );
-    },
-    [deleteRecording],
-  );
+  const deleteById = (recordingId: string, onSuccess?: () => void) => {
+    void deleteRecording.mutateAsync(recordingId).then(
+      () => {
+        onSuccess?.();
+        toast.success('Recording deleted', { id: 'recording-delete' });
+      },
+      (error: unknown) => toast.error(getErrorMessage(error, 'Failed to delete recording'), { id: 'recording-delete' }),
+    );
+  };
 
-  const handleDelete = React.useCallback((recording: Recording) => {
+  const handleDelete = (recording: Recording) => {
     setRecordingToDelete(recording);
-  }, []);
+  };
 
   return (
     <Page>

--- a/apps/web/src/components/recordings/shared/platform-badge.tsx
+++ b/apps/web/src/components/recordings/shared/platform-badge.tsx
@@ -1,5 +1,4 @@
 import { VideoIcon } from 'lucide-react';
-import * as React from 'react';
 
 import type { RecordingPlatform } from '@stitch/shared/recordings/types';
 
@@ -8,7 +7,7 @@ import { PLATFORM_CONFIG } from './formatting';
 import { SimpleIcon } from '@/components/ui/simple-icon';
 import { Table } from '@/components/ui/table';
 
-export const PlatformBadge = React.memo(function PlatformBadge({ platform }: { platform: RecordingPlatform }) {
+export function PlatformBadge({ platform }: { platform: RecordingPlatform }) {
   const config = PLATFORM_CONFIG[platform] ?? PLATFORM_CONFIG.manual;
 
   return (
@@ -25,4 +24,4 @@ export const PlatformBadge = React.memo(function PlatformBadge({ platform }: { p
       <span>{config.label}</span>
     </Table.IconText>
   );
-});
+}

--- a/apps/web/src/components/session/session-chat-pane.tsx
+++ b/apps/web/src/components/session/session-chat-pane.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { createMessageId, type PrefixedString } from '@stitch/shared/id';
 
 import { ChatInput } from '@/components/chat/chat-input';
-import type { Attachment, ModelSpec } from '@/components/chat/chat-input-parts/types';
+import type { Attachment } from '@/components/chat/chat-input-parts/types';
 import { DockContainer } from '@/components/chat/docks/dock';
 import { extractTextFromParts } from '@/components/chat/message-bubble/extract-text';
 import { MessageList } from '@/components/chat/message-list';
@@ -42,9 +42,9 @@ export function SessionChatPane({ sessionId, onGenerateAutomation }: SessionChat
   const isChildSession = session.parentSessionId !== null;
   const messagesQuery = useSuspenseInfiniteQuery(sessionMessagesInfiniteQueryOptions(id));
   const { data: todos } = useSuspenseQuery(sessionTodosQueryOptions(id));
-  const messages = React.useMemo(() => flattenMessages(messagesQuery.data), [messagesQuery.data]);
+  const messages = flattenMessages(messagesQuery.data);
 
-  const lastUsedModel = React.useMemo((): ModelSpec | null => findLastUsedModel(messages), [messages]);
+  const lastUsedModel = findLastUsedModel(messages);
   const { value, setValue } = useSeededInput();
   const [editingMsgId, setEditingMsgId] = React.useState<string | null>(null);
   const { selectedModel, handleModelChange } = useChatModel({ lastUsedModel });
@@ -73,32 +73,26 @@ export function SessionChatPane({ sessionId, onGenerateAutomation }: SessionChat
 
   const isStreaming = streamState.isStreaming;
   const canSend = !sendMessage.isPending && !redoMessage.isPending && !isStreaming && !isCompacting;
-  const editingMessage = React.useMemo(
-    () => (editingMsgId ? messages.find((message) => message.id === editingMsgId) : null),
-    [editingMsgId, messages],
-  );
-  const visibleMessages = React.useMemo(() => {
+  const editingMessage = editingMsgId ? messages.find((message) => message.id === editingMsgId) : null;
+  const visibleMessages = (() => {
     if (!editingMessage) return messages;
     return messages.filter((message) => message.createdAt < editingMessage.createdAt);
-  }, [editingMessage, messages]);
+  })();
 
-  const submitTextMessage = React.useCallback(
-    async (text: string) => {
-      if (!selectedModel || !canSend) return;
+  const submitTextMessage = async (text: string) => {
+    if (!selectedModel || !canSend) return;
 
-      const assistantMessageId = createMessageId();
-      startStream(id, assistantMessageId);
+    const assistantMessageId = createMessageId();
+    startStream(id, assistantMessageId);
 
-      await sendMessage.mutateAsync({
-        sessionId: id as PrefixedString<'ses'>,
-        content: text,
-        providerId: selectedModel.providerId,
-        modelId: selectedModel.modelId,
-        assistantMessageId,
-      });
-    },
-    [canSend, id, selectedModel, sendMessage, startStream],
-  );
+    await sendMessage.mutateAsync({
+      sessionId: id as PrefixedString<'ses'>,
+      content: text,
+      providerId: selectedModel.providerId,
+      modelId: selectedModel.modelId,
+      assistantMessageId,
+    });
+  };
 
   const slashCommands = useSlashCommands({
     sessionId: id,

--- a/apps/web/src/components/session/session-page.tsx
+++ b/apps/web/src/components/session/session-page.tsx
@@ -49,13 +49,13 @@ export function SessionPage({ sessionId }: SessionPageProps) {
   const rightPanel = requestedRightPanel === 'browser' && !hasBrowser ? 'closed' : requestedRightPanel;
   const rightPanelOpen = rightPanel !== 'closed';
 
-  const toggleDetails = React.useCallback(() => {
+  const toggleDetails = () => {
     setRequestedRightPanel((previous) => (previous === 'details' ? 'closed' : 'details'));
-  }, []);
+  };
 
-  const toggleBrowser = React.useCallback(() => {
+  const toggleBrowser = () => {
     setRequestedRightPanel((previous) => (previous === 'browser' ? 'closed' : 'browser'));
-  }, []);
+  };
 
   React.useEffect(() => {
     return window.api?.browser.onShowRequested(() => {
@@ -93,7 +93,7 @@ export function SessionPage({ sessionId }: SessionPageProps) {
     streamState.error,
   ]);
 
-  const handleGenerateAutomation = React.useCallback(async () => {
+  const handleGenerateAutomation = async () => {
     const toastId = toast.loading('Generating automation draft...');
     try {
       const draft = await generateAutomation.mutateAsync(sessionId);
@@ -103,7 +103,7 @@ export function SessionPage({ sessionId }: SessionPageProps) {
     } catch (error) {
       toast.error(getErrorMessage(error, 'Failed to generate automation draft'), { id: toastId });
     }
-  }, [generateAutomation, sessionId]);
+  };
 
   return (
     <>

--- a/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
+++ b/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
@@ -39,18 +39,16 @@ export function InstallRegistryMcpServer({
   const addServer = useAddMcpServer();
   const startAuth = useStartMcpAuth();
 
-  const authOptions = React.useMemo(() => {
-    const configs = [server.install.authConfig, ...(server.install.optionalAuthConfigs ?? [])];
-    const uniqueByKey = new Map<string, (typeof configs)[number]>();
-    for (const config of configs) {
-      uniqueByKey.set(JSON.stringify(config), config);
-    }
-    return [...uniqueByKey.values()].map((config, index) => ({
-      id: String(index),
-      config,
-      label: index === 0 ? `Default (${describeAuthConfig(config)})` : describeAuthConfig(config),
-    }));
-  }, [server.install.authConfig, server.install.optionalAuthConfigs]);
+  const configs = [server.install.authConfig, ...(server.install.optionalAuthConfigs ?? [])];
+  const uniqueByKey = new Map<string, (typeof configs)[number]>();
+  for (const config of configs) {
+    uniqueByKey.set(JSON.stringify(config), config);
+  }
+  const authOptions = [...uniqueByKey.values()].map((config, index) => ({
+    id: String(index),
+    config,
+    label: index === 0 ? `Default (${describeAuthConfig(config)})` : describeAuthConfig(config),
+  }));
 
   const [selectedAuthId, setSelectedAuthId] = React.useState(authOptions[0]?.id ?? '0');
   const form = useForm({

--- a/apps/web/src/components/settings/mcp-servers/mcp-registry-list.tsx
+++ b/apps/web/src/components/settings/mcp-servers/mcp-registry-list.tsx
@@ -26,14 +26,13 @@ export function McpRegistryList({
   const refreshRegistry = useRefreshMcpRegistry();
   const [search, setSearch] = React.useState('');
 
-  const filteredServers = React.useMemo(() => {
-    const query = search.trim().toLowerCase();
-    if (!query) return registryServers;
-    return registryServers.filter((server) => {
-      const haystack = [server.name, server.description, server.tags.join(' '), server.id].join(' ').toLowerCase();
-      return haystack.includes(query);
-    });
-  }, [registryServers, search]);
+  const query = search.trim().toLowerCase();
+  const filteredServers = !query
+    ? registryServers
+    : registryServers.filter((server) => {
+        const haystack = [server.name, server.description, server.tags.join(' '), server.id].join(' ').toLowerCase();
+        return haystack.includes(query);
+      });
 
   const handleRefresh = async () => {
     try {

--- a/apps/web/src/components/settings/models.tsx
+++ b/apps/web/src/components/settings/models.tsx
@@ -39,44 +39,33 @@ function ModelsListContent() {
   const [search, setSearch] = React.useState('');
   const [selectedProviderId, setSelectedProviderId] = React.useState('all');
 
-  const overridesMap = React.useMemo(
-    () => new Map(overridesList.map((o) => [`${o.providerId}:${o.modelId}`, o.visibility])),
-    [overridesList],
+  const overridesMap = new Map(overridesList.map((o) => [`${o.providerId}:${o.modelId}`, o.visibility]));
+
+  const defaultVisibleSet = buildDefaultVisibleSet(
+    allProviderModels.map((p) => ({
+      providerId: p.providerId,
+      models: p.models.map((m) => ({ id: m.id, family: m.family, release_date: m.release_date })),
+    })),
   );
 
-  const defaultVisibleSet = React.useMemo(
-    () =>
-      buildDefaultVisibleSet(
-        allProviderModels.map((p) => ({
-          providerId: p.providerId,
-          models: p.models.map((m) => ({ id: m.id, family: m.family, release_date: m.release_date })),
-        })),
-      ),
-    [allProviderModels],
-  );
+  const selectedProviderModels =
+    selectedProviderId === 'all'
+      ? allProviderModels
+      : allProviderModels.filter((provider) => provider.providerId === selectedProviderId);
 
-  const selectedProviderModels = React.useMemo(() => {
-    if (selectedProviderId === 'all') return allProviderModels;
-    return allProviderModels.filter((provider) => provider.providerId === selectedProviderId);
-  }, [allProviderModels, selectedProviderId]);
+  const selectedProvider = allProviderModels.find((provider) => provider.providerId === selectedProviderId);
 
-  const selectedProvider = React.useMemo(
-    () => allProviderModels.find((provider) => provider.providerId === selectedProviderId),
-    [allProviderModels, selectedProviderId],
-  );
-
-  const filtered = React.useMemo(() => {
-    if (!search.trim()) return selectedProviderModels;
-    const q = search.toLowerCase();
-    return selectedProviderModels
-      .map((provider) => ({
-        ...provider,
-        models: provider.models.filter(
-          (m) => m.name.toLowerCase().includes(q) || provider.providerName.toLowerCase().includes(q),
-        ),
-      }))
-      .filter((p) => p.models.length > 0);
-  }, [search, selectedProviderModels]);
+  const q = search.toLowerCase();
+  const filtered = !search.trim()
+    ? selectedProviderModels
+    : selectedProviderModels
+        .map((provider) => ({
+          ...provider,
+          models: provider.models.filter(
+            (m) => m.name.toLowerCase().includes(q) || provider.providerName.toLowerCase().includes(q),
+          ),
+        }))
+        .filter((p) => p.models.length > 0);
 
   async function handleToggle(provider: ProviderModels, modelId: string, checked: boolean) {
     const key = `${provider.providerId}:${modelId}`;

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -110,39 +110,29 @@ function ToolsContent() {
   const [scope, setScope] = React.useState<ScopeFilter>('stitch');
   const [editingTarget, setEditingTarget] = React.useState<EditingTarget | null>(null);
 
-  const mcpToolMetaByName = React.useMemo(() => {
-    return new Map(
-      knownMcpTools.map((tool) => [
-        tool.name,
-        {
-          serverId: tool.serverId,
-          serverName: tool.serverName,
-          serverIconPath: tool.serverIconPath,
-          toolIconPath: tool.toolIconPath,
-        },
-      ]),
-    );
-  }, [knownMcpTools]);
-
-  const enabledMap = React.useMemo(() => {
-    return new Map(enabledStates.map((state) => [`${state.scope}:${state.identifier}`, state.enabled]));
-  }, [enabledStates]);
-
-  const getEnabled = React.useCallback(
-    (kind: 'tool' | 'toolset' | 'mcp_tool', identifier: string) => {
-      return enabledMap.get(`${kind}:${identifier}`) ?? true;
-    },
-    [enabledMap],
+  const mcpToolMetaByName = new Map(
+    knownMcpTools.map((tool) => [
+      tool.name,
+      {
+        serverId: tool.serverId,
+        serverName: tool.serverName,
+        serverIconPath: tool.serverIconPath,
+        toolIconPath: tool.toolIconPath,
+      },
+    ]),
   );
 
-  const updateEnabled = React.useCallback(
-    (kind: 'tool' | 'toolset' | 'mcp_tool', identifier: string, enabled: boolean) => {
-      void setToolEnabledState.mutateAsync({ scope: kind, identifier, enabled }).catch((error: unknown) => {
-        toast.error(getErrorMessage(error, 'Failed to update tool state'), { id: 'tool-state' });
-      });
-    },
-    [setToolEnabledState],
-  );
+  const enabledMap = new Map(enabledStates.map((state) => [`${state.scope}:${state.identifier}`, state.enabled]));
+
+  const getEnabled = (kind: 'tool' | 'toolset' | 'mcp_tool', identifier: string) => {
+    return enabledMap.get(`${kind}:${identifier}`) ?? true;
+  };
+
+  const updateEnabled = (kind: 'tool' | 'toolset' | 'mcp_tool', identifier: string, enabled: boolean) => {
+    void setToolEnabledState.mutateAsync({ scope: kind, identifier, enabled }).catch((error: unknown) => {
+      toast.error(getErrorMessage(error, 'Failed to update tool state'), { id: 'tool-state' });
+    });
+  };
 
   const query = search.trim().toLowerCase();
   const stitchTools = filterCoreTools(knownTools, query);

--- a/apps/web/src/components/settings/permissions/mcp-tools-tab.tsx
+++ b/apps/web/src/components/settings/permissions/mcp-tools-tab.tsx
@@ -1,5 +1,4 @@
 import { Settings2Icon } from 'lucide-react';
-import * as React from 'react';
 
 import { EmptyState, SectionCard } from './components';
 
@@ -23,33 +22,31 @@ export function useMcpToolsetGroups(
   knownTools: KnownTool[],
   mcpToolMetaByName: Map<string, McpToolMeta>,
 ): McpToolGroup[] {
-  return React.useMemo(() => {
-    const groups = new Map<string, McpToolGroup>();
+  const groups = new Map<string, McpToolGroup>();
 
-    for (const tool of knownTools) {
-      if (tool.toolType !== 'mcp') continue;
-      const meta = mcpToolMetaByName.get(tool.toolName);
-      if (!meta) continue;
+  for (const tool of knownTools) {
+    if (tool.toolType !== 'mcp') continue;
+    const meta = mcpToolMetaByName.get(tool.toolName);
+    if (!meta) continue;
 
-      const current = groups.get(meta.serverId) ?? {
-        serverId: meta.serverId,
-        serverName: meta.serverName,
-        serverIconPath: meta.serverIconPath,
-        tools: [],
-      };
+    const current = groups.get(meta.serverId) ?? {
+      serverId: meta.serverId,
+      serverName: meta.serverName,
+      serverIconPath: meta.serverIconPath,
+      tools: [],
+    };
 
-      current.tools.push({
-        toolName: tool.toolName,
-        displayName: tool.displayName,
-        iconPath: meta.toolIconPath ?? meta.serverIconPath,
-      });
-      groups.set(meta.serverId, current);
-    }
+    current.tools.push({
+      toolName: tool.toolName,
+      displayName: tool.displayName,
+      iconPath: meta.toolIconPath ?? meta.serverIconPath,
+    });
+    groups.set(meta.serverId, current);
+  }
 
-    return Array.from(groups.values())
-      .map((group) => ({ ...group, tools: group.tools.toSorted((a, b) => a.displayName.localeCompare(b.displayName)) }))
-      .toSorted((a, b) => a.serverName.localeCompare(b.serverName));
-  }, [knownTools, mcpToolMetaByName]);
+  return Array.from(groups.values())
+    .map((group) => ({ ...group, tools: group.tools.toSorted((a, b) => a.displayName.localeCompare(b.displayName)) }))
+    .toSorted((a, b) => a.serverName.localeCompare(b.serverName));
 }
 
 export function filterMcpGroups(groups: McpToolGroup[], query: string): McpToolGroup[] {

--- a/apps/web/src/components/settings/providers/provider-config.tsx
+++ b/apps/web/src/components/settings/providers/provider-config.tsx
@@ -140,14 +140,8 @@ export function ProviderConfig({ provider, onBack, saveLabel = 'Save', onSaved, 
 
   const [activeTab, setActiveTab] = React.useState(defaultMethod);
   const hydrationRef = React.useRef<{ providerId: string; enabled: boolean; hydrated: boolean } | null>(null);
-  const activeMethodFields = React.useMemo(
-    () => enabledAuthMethods.find((method) => method.method === activeTab)?.fields ?? [],
-    [activeTab, enabledAuthMethods],
-  );
-  const providerConfigSchema = React.useMemo(
-    () => createProviderConfigSchema(meta?.extraFields ?? [], activeTab, activeMethodFields),
-    [activeMethodFields, activeTab, meta?.extraFields],
-  );
+  const activeMethodFields = enabledAuthMethods.find((method) => method.method === activeTab)?.fields ?? [];
+  const providerConfigSchema = createProviderConfigSchema(meta?.extraFields ?? [], activeTab, activeMethodFields);
 
   const saveMutation = useSaveProviderConfigMutation({
     providerId: provider.id,

--- a/apps/web/src/components/settings/shortcuts.tsx
+++ b/apps/web/src/components/settings/shortcuts.tsx
@@ -241,30 +241,25 @@ function ShortcutsContent() {
     recorder.startRecording();
   }
 
-  const filtered = React.useMemo(() => {
-    const q = search.toLowerCase();
-    return q ? shortcuts.filter((e) => e.label.toLowerCase().includes(q)) : shortcuts;
-  }, [search, shortcuts]);
+  const q = search.toLowerCase();
+  const filtered = q ? shortcuts.filter((e) => e.label.toLowerCase().includes(q)) : shortcuts;
 
-  const groups = React.useMemo(() => groupByCategory(filtered), [filtered]);
+  const groups = groupByCategory(filtered);
 
-  const conflicts = React.useMemo(() => {
-    const map = new Map<string, string>();
-    const hotkeyToDef = new Map<string, ShortcutEntry>();
-    for (const entry of shortcuts) {
-      if (!entry.hotkey) continue;
-      // Use hotkey + isSequence as the conflict key so single-press and double-press don't clash
-      const conflictKey = `${entry.hotkey}:${entry.isSequence}`;
-      const existing = hotkeyToDef.get(conflictKey);
-      if (existing) {
-        map.set(entry.actionId, existing.label);
-        map.set(existing.actionId, entry.label);
-      } else {
-        hotkeyToDef.set(conflictKey, entry);
-      }
+  const conflicts = new Map<string, string>();
+  const hotkeyToDef = new Map<string, ShortcutEntry>();
+  for (const entry of shortcuts) {
+    if (!entry.hotkey) continue;
+    // Use hotkey + isSequence as the conflict key so single-press and double-press don't clash
+    const conflictKey = `${entry.hotkey}:${entry.isSequence}`;
+    const existing = hotkeyToDef.get(conflictKey);
+    if (existing) {
+      conflicts.set(entry.actionId, existing.label);
+      conflicts.set(existing.actionId, entry.label);
+    } else {
+      hotkeyToDef.set(conflictKey, entry);
     }
-    return map;
-  }, [shortcuts]);
+  }
 
   return (
     <div className="flex flex-col gap-8">

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -72,13 +72,13 @@ function SidebarProvider({
       // This sets the cookie to keep the sidebar state.
       document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
     },
-    [setOpenProp, open],
+    [open, setOpenProp],
   );
 
   // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
-  }, [isMobile, setOpen, setOpenMobile]);
+  }, [isMobile, setOpen]);
 
   const shortcuts = useShortcuts();
   const toggleSidebarKey = shortcuts.get('toggle-sidebar')?.hotkey;
@@ -88,7 +88,7 @@ function SidebarProvider({
   // This makes it easier to style the sidebar with Tailwind classes.
   const state = open ? 'expanded' : 'collapsed';
 
-  const contextValue = React.useMemo<SidebarContextProps>(
+  const contextValue: SidebarContextProps = React.useMemo(
     () => ({ state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar }),
     [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
   );

--- a/apps/web/src/components/ui/textarea-completions.tsx
+++ b/apps/web/src/components/ui/textarea-completions.tsx
@@ -165,24 +165,19 @@ export function TextareaCompletions({
   const completionOptions = filterCompletionOptions(completionState);
   const isOpen = completionState !== null && completionOptions.length > 0 && !disabled;
 
-  const completionAnchor = React.useMemo(() => {
-    return {
-      getBoundingClientRect: () => {
-        const textarea = textareaRef.current;
-        if (!textarea || !completionState) return new DOMRect();
+  const completionAnchor = {
+    getBoundingClientRect: () => {
+      const textarea = textareaRef.current;
+      if (!textarea || !completionState) return new DOMRect();
 
-        return getTextareaCharacterRect(textarea, completionState.anchorIndex);
-      },
-    };
-  }, [completionState, textareaRef]);
-
-  const updateCompletionState = React.useCallback(
-    (textarea: HTMLTextAreaElement) => {
-      setCompletionState(getCompletionState(textarea, groups));
-      setActiveIndex(0);
+      return getTextareaCharacterRect(textarea, completionState.anchorIndex);
     },
-    [groups],
-  );
+  };
+
+  const updateCompletionState = (textarea: HTMLTextAreaElement) => {
+    setCompletionState(getCompletionState(textarea, groups));
+    setActiveIndex(0);
+  };
 
   function applyCompletion(textarea: HTMLTextAreaElement, option: TextareaCompletionOption) {
     if (!completionState) return;

--- a/apps/web/src/components/usage/charts/embedding-usage-cost-chart.tsx
+++ b/apps/web/src/components/usage/charts/embedding-usage-cost-chart.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import type { EmbeddingUsageDashboardResponse } from '@stitch/shared/usage/types';
 
 import { StackedBarChart } from '@/components/usage/charts/stacked-bar-chart';
@@ -15,30 +13,24 @@ function labelForModelKey(modelKey: string): string {
 type EmbeddingUsageCostChartProps = { usageData: EmbeddingUsageDashboardResponse | undefined };
 
 export function EmbeddingUsageCostChart({ usageData }: EmbeddingUsageCostChartProps) {
-  const modelKeys = React.useMemo(() => {
-    const keys = new Set<string>();
-    for (const bucket of usageData?.buckets ?? []) {
-      for (const key of Object.keys(bucket.costUsdByModel)) {
-        keys.add(key);
-      }
+  const keys = new Set<string>();
+  for (const bucket of usageData?.buckets ?? []) {
+    for (const key of Object.keys(bucket.costUsdByModel)) {
+      keys.add(key);
     }
-    return Array.from(keys).toSorted((a, b) => a.localeCompare(b));
-  }, [usageData?.buckets]);
+  }
+  const modelKeys = Array.from(keys).toSorted((a, b) => a.localeCompare(b));
 
   const labels = usageData?.buckets.map((b) => b.label) ?? [];
 
-  const datasets = React.useMemo(
-    () =>
-      modelKeys.map((key, i) => ({
-        label: labelForModelKey(key),
-        data: usageData?.buckets.map((b) => b.costUsdByModel[key] ?? 0) ?? [],
-        backgroundColor: getChartColor(i),
-        borderRadius: (ctx: import('chart.js').ScriptableContext<'bar'>) => getStackSegmentRadius(ctx),
-        borderSkipped: false as const,
-        inflateAmount: 0,
-      })),
-    [modelKeys, usageData],
-  );
+  const datasets = modelKeys.map((key, i) => ({
+    label: labelForModelKey(key),
+    data: usageData?.buckets.map((b) => b.costUsdByModel[key] ?? 0) ?? [],
+    backgroundColor: getChartColor(i),
+    borderRadius: (ctx: import('chart.js').ScriptableContext<'bar'>) => getStackSegmentRadius(ctx),
+    borderSkipped: false as const,
+    inflateAmount: 0,
+  }));
 
   return (
     <StackedBarChart

--- a/apps/web/src/components/usage/charts/stacked-bar-chart.tsx
+++ b/apps/web/src/components/usage/charts/stacked-bar-chart.tsx
@@ -8,7 +8,6 @@ import {
   Tooltip,
   type TooltipItem,
 } from 'chart.js';
-import * as React from 'react';
 import { Bar } from 'react-chartjs-2';
 
 import { EmptyChart, useChartTheme } from '@/components/usage/charts/usage-chart-utils';
@@ -42,61 +41,52 @@ export function StackedBarChart({ title, subtitle, emptyMessage, labels, dataset
   const { tickColor, gridColor } = useChartTheme();
   const hasData = labels.length > 0;
 
-  const baseScales = React.useMemo(
-    () => ({
-      x: { stacked: true, grid: { display: false }, ticks: { color: tickColor }, border: { color: gridColor } },
-      y: {
-        stacked: true,
-        beginAtZero: true,
-        grid: { color: gridColor },
-        ticks: { color: tickColor },
-        border: { display: false },
-      },
-    }),
-    [gridColor, tickColor],
-  );
+  const baseScales = {
+    x: { stacked: true, grid: { display: false }, ticks: { color: tickColor }, border: { color: gridColor } },
+    y: {
+      stacked: true,
+      beginAtZero: true,
+      grid: { color: gridColor },
+      ticks: { color: tickColor },
+      border: { display: false },
+    },
+  };
 
-  const baseLegend = React.useMemo(
-    () => ({
-      position: 'bottom' as const,
-      labels: {
-        usePointStyle: true,
-        pointStyle: 'rectRounded' as const,
-        color: tickColor,
-        padding: 16,
-        font: { size: 12 },
-      },
-    }),
-    [tickColor],
-  );
+  const baseLegend = {
+    position: 'bottom' as const,
+    labels: {
+      usePointStyle: true,
+      pointStyle: 'rectRounded' as const,
+      color: tickColor,
+      padding: 16,
+      font: { size: 12 },
+    },
+  };
 
-  const chartOptions = React.useMemo(
-    () => ({
-      responsive: true,
-      maintainAspectRatio: false,
-      interaction: { mode: 'index' as const, intersect: false },
-      plugins: {
-        legend: baseLegend,
-        tooltip: {
-          callbacks: {
-            label: (ctx: TooltipItem<'bar'>) => {
-              const value = Number(ctx.raw ?? 0);
-              if (value === 0) return [];
-              return `${ctx.dataset.label}: ${formatCost(value)}`;
-            },
+  const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index' as const, intersect: false },
+    plugins: {
+      legend: baseLegend,
+      tooltip: {
+        callbacks: {
+          label: (ctx: TooltipItem<'bar'>) => {
+            const value = Number(ctx.raw ?? 0);
+            if (value === 0) return [];
+            return `${ctx.dataset.label}: ${formatCost(value)}`;
           },
         },
       },
-      scales: {
-        ...baseScales,
-        y: {
-          ...baseScales.y,
-          ticks: { ...baseScales.y.ticks, callback: (value: string | number) => formatCost(Number(value)) },
-        },
+    },
+    scales: {
+      ...baseScales,
+      y: {
+        ...baseScales.y,
+        ticks: { ...baseScales.y.ticks, callback: (value: string | number) => formatCost(Number(value)) },
       },
-    }),
-    [baseScales, baseLegend],
-  );
+    },
+  };
 
   return (
     <div className="rounded-xl bg-muted/20 p-4">

--- a/apps/web/src/components/usage/charts/stt-usage-cost-chart.tsx
+++ b/apps/web/src/components/usage/charts/stt-usage-cost-chart.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import type { SttUsageDashboardResponse } from '@stitch/shared/usage/types';
 
 import { StackedBarChart } from '@/components/usage/charts/stacked-bar-chart';
@@ -23,24 +21,17 @@ function getServiceLabel(service: string): string {
 type SttUsageCostChartProps = { usageData: SttUsageDashboardResponse | undefined };
 
 export function SttUsageCostChart({ usageData }: SttUsageCostChartProps) {
-  const services = React.useMemo(
-    () => [...(usageData?.services ?? [])].toSorted((a, b) => a.localeCompare(b)),
-    [usageData?.services],
-  );
+  const services = [...(usageData?.services ?? [])].toSorted((a, b) => a.localeCompare(b));
   const labels = usageData?.buckets.map((b) => b.label) ?? [];
 
-  const datasets = React.useMemo(
-    () =>
-      services.map((service) => ({
-        label: getServiceLabel(service),
-        data: usageData?.buckets.map((b) => b.costUsdByService[service] ?? 0) ?? [],
-        backgroundColor: getServiceColor(service),
-        borderRadius: (ctx: import('chart.js').ScriptableContext<'bar'>) => getStackSegmentRadius(ctx),
-        borderSkipped: false as const,
-        inflateAmount: 0,
-      })),
-    [services, usageData],
-  );
+  const datasets = services.map((service) => ({
+    label: getServiceLabel(service),
+    data: usageData?.buckets.map((b) => b.costUsdByService[service] ?? 0) ?? [],
+    backgroundColor: getServiceColor(service),
+    borderRadius: (ctx: import('chart.js').ScriptableContext<'bar'>) => getStackSegmentRadius(ctx),
+    borderSkipped: false as const,
+    inflateAmount: 0,
+  }));
 
   return (
     <StackedBarChart

--- a/apps/web/src/components/usage/charts/usage-chart-utils.tsx
+++ b/apps/web/src/components/usage/charts/usage-chart-utils.tsx
@@ -1,5 +1,4 @@
 import { BarChart3Icon } from 'lucide-react';
-import * as React from 'react';
 
 import { getChartGridColor, getChartTickColor } from '@/lib/chart-colors';
 import type { ScriptableContext } from 'chart.js';
@@ -22,7 +21,7 @@ export function getStackSegmentRadius(ctx: ScriptableContext<'bar'>, radius = 5)
 }
 
 export function useChartTheme() {
-  return React.useMemo(() => ({ tickColor: getChartTickColor(), gridColor: getChartGridColor() }), []);
+  return { tickColor: getChartTickColor(), gridColor: getChartGridColor() };
 }
 
 export function EmptyChart({ message }: { message: string }) {

--- a/apps/web/src/components/usage/charts/usage-dashboard-cost-chart.tsx
+++ b/apps/web/src/components/usage/charts/usage-dashboard-cost-chart.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import type { UsageDashboardResponse } from '@stitch/shared/usage/types';
 
 import { StackedBarChart } from '@/components/usage/charts/stacked-bar-chart';
@@ -28,18 +26,14 @@ export function UsageDashboardCostChart({ usageData }: UsageDashboardCostChartPr
   const sources = useSourceOrder(usageData?.sources ?? []);
   const labels = usageData?.buckets.map((b) => b.label) ?? [];
 
-  const datasets = React.useMemo(
-    () =>
-      sources.map((source) => ({
-        label: getSourceLabel(source),
-        data: usageData?.buckets.map((b) => b.costUsdBySource[source] ?? 0) ?? [],
-        backgroundColor: getSourceColor(source),
-        borderRadius: (ctx: import('chart.js').ScriptableContext<'bar'>) => getStackSegmentRadius(ctx),
-        borderSkipped: false as const,
-        inflateAmount: 0,
-      })),
-    [sources, usageData],
-  );
+  const datasets = sources.map((source) => ({
+    label: getSourceLabel(source),
+    data: usageData?.buckets.map((b) => b.costUsdBySource[source] ?? 0) ?? [],
+    backgroundColor: getSourceColor(source),
+    borderRadius: (ctx: import('chart.js').ScriptableContext<'bar'>) => getStackSegmentRadius(ctx),
+    borderSkipped: false as const,
+    inflateAmount: 0,
+  }));
 
   return (
     <StackedBarChart

--- a/apps/web/src/components/usage/hooks/use-embedding-usage-dashboard-data.ts
+++ b/apps/web/src/components/usage/hooks/use-embedding-usage-dashboard-data.ts
@@ -34,79 +34,60 @@ export function useEmbeddingUsageDashboardData(rangeFilter: UsageDateRange) {
     placeholderData: keepPreviousData,
   });
 
-  const providerById = React.useMemo(
-    () => new Map(embeddingProviderModels.map((p) => [p.providerId, p] as const)),
-    [embeddingProviderModels],
-  );
+  const providerById = new Map(embeddingProviderModels.map((p) => [p.providerId, p] as const));
 
-  const modelNameByKey = React.useMemo(() => {
-    const map = new Map<string, string>();
-    for (const provider of embeddingProviderModels) {
-      for (const model of provider.models) {
-        map.set(encodeModelFilter(provider.providerId, model.id), model.name);
-      }
+  const modelNameByKey = new Map<string, string>();
+  for (const provider of embeddingProviderModels) {
+    for (const model of provider.models) {
+      modelNameByKey.set(encodeModelFilter(provider.providerId, model.id), model.name);
     }
-    return map;
-  }, [embeddingProviderModels]);
+  }
 
-  const availableProviders = React.useMemo<EmbeddingProviderOption[]>(() => {
-    const used = new Set(usageRangeData?.usedProviders ?? []);
-    return embeddingProviderModels
-      .filter((p) => used.has(p.providerId))
-      .map((p) => ({ providerId: p.providerId, providerName: p.providerName }));
-  }, [embeddingProviderModels, usageRangeData?.usedProviders]);
+  const used = new Set(usageRangeData?.usedProviders ?? []);
+  const availableProviders: EmbeddingProviderOption[] = embeddingProviderModels
+    .filter((p) => used.has(p.providerId))
+    .map((p) => ({ providerId: p.providerId, providerName: p.providerName }));
 
   // A selection falls back to ALL_FILTER once its provider/model drops out of the active range.
   const providerFilter = availableProviders.some((p) => p.providerId === selectedProvider)
     ? selectedProvider
     : ALL_FILTER;
 
-  const availableModels = React.useMemo<EmbeddingModelOption[]>(() => {
-    const usedModels = usageRangeData?.usedModels ?? [];
-    return usedModels
-      .filter((m) => providerFilter === ALL_FILTER || m.providerId === providerFilter)
-      .map((m) => {
-        const provider = providerById.get(m.providerId);
-        const key = encodeModelFilter(m.providerId, m.modelId);
-        const modelName = modelNameByKey.get(key) ?? m.modelId;
-        return {
-          label: modelName,
-          providerId: m.providerId,
-          providerName: provider?.providerName ?? m.providerId,
-          modelId: m.modelId,
-          modelName,
-        };
-      });
-  }, [modelNameByKey, providerById, providerFilter, usageRangeData?.usedModels]);
+  const usedModels = usageRangeData?.usedModels ?? [];
+  const availableModels: EmbeddingModelOption[] = usedModels
+    .filter((m) => providerFilter === ALL_FILTER || m.providerId === providerFilter)
+    .map((m) => {
+      const provider = providerById.get(m.providerId);
+      const key = encodeModelFilter(m.providerId, m.modelId);
+      const modelName = modelNameByKey.get(key) ?? m.modelId;
+      return {
+        label: modelName,
+        providerId: m.providerId,
+        providerName: provider?.providerName ?? m.providerId,
+        modelId: m.modelId,
+        modelName,
+      };
+    });
 
   const modelFilter = availableModels.some((m) => encodeModelFilter(m.providerId, m.modelId) === selectedModel)
     ? selectedModel
     : ALL_FILTER;
 
-  const usageFilters = React.useMemo(() => {
-    const decodedModel = modelFilter === ALL_FILTER ? null : decodeModelFilter(modelFilter);
-    const providerIdFromModel = providerFilter === ALL_FILTER ? decodedModel?.providerId : providerFilter;
-    return { range: rangeFilter, providerId: providerIdFromModel, modelId: decodedModel?.modelId };
-  }, [modelFilter, providerFilter, rangeFilter]);
+  const decodedModel = modelFilter === ALL_FILTER ? null : decodeModelFilter(modelFilter);
+  const providerIdFromModel = providerFilter === ALL_FILTER ? decodedModel?.providerId : providerFilter;
+  const usageFilters = { range: rangeFilter, providerId: providerIdFromModel, modelId: decodedModel?.modelId };
 
   const { data: usageData, isFetching } = useQuery({
     ...embeddingUsageDashboardQueryOptions(usageFilters),
     placeholderData: keepPreviousData,
   });
 
-  const providerLabelById = React.useMemo(
-    () => new Map(availableProviders.map((p) => [p.providerId, p.providerName] as const)),
-    [availableProviders],
-  );
+  const providerLabelById = new Map(availableProviders.map((p) => [p.providerId, p.providerName] as const));
 
-  const modelLabelByValue = React.useMemo(
-    () =>
-      new Map(
-        availableModels.map(
-          (m) => [encodeModelFilter(m.providerId, m.modelId), `${m.providerName} · ${m.modelName}`] as const,
-        ),
-      ),
-    [availableModels],
+  const modelLabelByValue = new Map(
+    availableModels.map(
+      (m) => [encodeModelFilter(m.providerId, m.modelId), `${m.providerName} · ${m.modelName}`] as const,
+    ),
   );
 
   return {

--- a/apps/web/src/components/usage/hooks/use-stt-usage-dashboard-data.ts
+++ b/apps/web/src/components/usage/hooks/use-stt-usage-dashboard-data.ts
@@ -28,79 +28,60 @@ export function useSttUsageDashboardData(rangeFilter: UsageDateRange) {
     placeholderData: keepPreviousData,
   });
 
-  const providerById = React.useMemo(
-    () => new Map(sttProviderModels.map((p) => [p.providerId, p] as const)),
-    [sttProviderModels],
-  );
+  const providerById = new Map(sttProviderModels.map((p) => [p.providerId, p] as const));
 
-  const modelNameByKey = React.useMemo(() => {
-    const map = new Map<string, string>();
-    for (const provider of sttProviderModels) {
-      for (const model of provider.models) {
-        map.set(encodeModelFilter(provider.providerId, model.id), model.name);
-      }
+  const modelNameByKey = new Map<string, string>();
+  for (const provider of sttProviderModels) {
+    for (const model of provider.models) {
+      modelNameByKey.set(encodeModelFilter(provider.providerId, model.id), model.name);
     }
-    return map;
-  }, [sttProviderModels]);
+  }
 
-  const availableProviders = React.useMemo<SttProviderOption[]>(() => {
-    const used = new Set(usageRangeData?.usedProviders ?? []);
-    return sttProviderModels
-      .filter((p) => used.has(p.providerId))
-      .map((p) => ({ providerId: p.providerId, providerName: p.providerName }));
-  }, [sttProviderModels, usageRangeData?.usedProviders]);
+  const used = new Set(usageRangeData?.usedProviders ?? []);
+  const availableProviders: SttProviderOption[] = sttProviderModels
+    .filter((p) => used.has(p.providerId))
+    .map((p) => ({ providerId: p.providerId, providerName: p.providerName }));
 
   // A selection falls back to ALL_FILTER once its provider/model drops out of the active range.
   const providerFilter = availableProviders.some((p) => p.providerId === selectedProvider)
     ? selectedProvider
     : ALL_FILTER;
 
-  const availableModels = React.useMemo<SttModelOption[]>(() => {
-    const usedModels = usageRangeData?.usedModels ?? [];
-    return usedModels
-      .filter((m) => providerFilter === ALL_FILTER || m.providerId === providerFilter)
-      .map((m) => {
-        const provider = providerById.get(m.providerId);
-        const key = encodeModelFilter(m.providerId, m.modelId);
-        const modelName = modelNameByKey.get(key) ?? m.modelId;
-        return {
-          label: modelName,
-          providerId: m.providerId,
-          providerName: provider?.providerName ?? m.providerId,
-          modelId: m.modelId,
-          modelName,
-        };
-      });
-  }, [modelNameByKey, providerById, providerFilter, usageRangeData?.usedModels]);
+  const usedModels = usageRangeData?.usedModels ?? [];
+  const availableModels: SttModelOption[] = usedModels
+    .filter((m) => providerFilter === ALL_FILTER || m.providerId === providerFilter)
+    .map((m) => {
+      const provider = providerById.get(m.providerId);
+      const key = encodeModelFilter(m.providerId, m.modelId);
+      const modelName = modelNameByKey.get(key) ?? m.modelId;
+      return {
+        label: modelName,
+        providerId: m.providerId,
+        providerName: provider?.providerName ?? m.providerId,
+        modelId: m.modelId,
+        modelName,
+      };
+    });
 
   const modelFilter = availableModels.some((m) => encodeModelFilter(m.providerId, m.modelId) === selectedModel)
     ? selectedModel
     : ALL_FILTER;
 
-  const usageFilters = React.useMemo(() => {
-    const decodedModel = modelFilter === ALL_FILTER ? null : decodeModelFilter(modelFilter);
-    const providerIdFromModel = providerFilter === ALL_FILTER ? decodedModel?.providerId : providerFilter;
-    return { range: rangeFilter, providerId: providerIdFromModel, modelId: decodedModel?.modelId };
-  }, [modelFilter, providerFilter, rangeFilter]);
+  const decodedModel = modelFilter === ALL_FILTER ? null : decodeModelFilter(modelFilter);
+  const providerIdFromModel = providerFilter === ALL_FILTER ? decodedModel?.providerId : providerFilter;
+  const usageFilters = { range: rangeFilter, providerId: providerIdFromModel, modelId: decodedModel?.modelId };
 
   const { data: usageData, isFetching } = useQuery({
     ...sttUsageDashboardQueryOptions(usageFilters),
     placeholderData: keepPreviousData,
   });
 
-  const providerLabelById = React.useMemo(
-    () => new Map(availableProviders.map((p) => [p.providerId, p.providerName] as const)),
-    [availableProviders],
-  );
+  const providerLabelById = new Map(availableProviders.map((p) => [p.providerId, p.providerName] as const));
 
-  const modelLabelByValue = React.useMemo(
-    () =>
-      new Map(
-        availableModels.map(
-          (m) => [encodeModelFilter(m.providerId, m.modelId), `${m.providerName} · ${m.modelName}`] as const,
-        ),
-      ),
-    [availableModels],
+  const modelLabelByValue = new Map(
+    availableModels.map(
+      (m) => [encodeModelFilter(m.providerId, m.modelId), `${m.providerName} · ${m.modelName}`] as const,
+    ),
   );
 
   return {

--- a/apps/web/src/components/usage/hooks/use-usage-dashboard-data.ts
+++ b/apps/web/src/components/usage/hooks/use-usage-dashboard-data.ts
@@ -35,80 +35,61 @@ export function useUsageDashboardData() {
     placeholderData: keepPreviousData,
   });
 
-  const providerById = React.useMemo(
-    () => new Map(providerModels.map((provider) => [provider.providerId, provider] as const)),
-    [providerModels],
-  );
+  const providerById = new Map(providerModels.map((provider) => [provider.providerId, provider] as const));
 
-  const modelNameByKey = React.useMemo(() => {
-    const map = new Map<string, string>();
-    for (const provider of providerModels) {
-      for (const model of provider.models) {
-        map.set(encodeModelFilter(provider.providerId, model.id), model.name);
-      }
+  const modelNameByKey = new Map<string, string>();
+  for (const provider of providerModels) {
+    for (const model of provider.models) {
+      modelNameByKey.set(encodeModelFilter(provider.providerId, model.id), model.name);
     }
-    return map;
-  }, [providerModels]);
+  }
 
-  const availableProviders = React.useMemo<ProviderOption[]>(() => {
-    const used = new Set(usageRangeData?.usedProviders ?? []);
-    return providerModels
-      .filter((provider) => used.has(provider.providerId))
-      .map((provider) => ({ providerId: provider.providerId, providerName: provider.providerName }));
-  }, [providerModels, usageRangeData?.usedProviders]);
+  const used = new Set(usageRangeData?.usedProviders ?? []);
+  const availableProviders: ProviderOption[] = providerModels
+    .filter((provider) => used.has(provider.providerId))
+    .map((provider) => ({ providerId: provider.providerId, providerName: provider.providerName }));
 
   // A selection falls back to ALL_FILTER once its provider/model drops out of the active range.
   const providerFilter = availableProviders.some((p) => p.providerId === selectedProvider)
     ? selectedProvider
     : ALL_FILTER;
 
-  const availableModels = React.useMemo<ModelOption[]>(() => {
-    const usedModels = usageRangeData?.usedModels ?? [];
-    return usedModels
-      .filter((model) => providerFilter === ALL_FILTER || model.providerId === providerFilter)
-      .map((model) => {
-        const provider = providerById.get(model.providerId);
-        const key = encodeModelFilter(model.providerId, model.modelId);
-        const modelName = modelNameByKey.get(key) ?? model.modelId;
-        return {
-          label: modelName,
-          providerId: model.providerId,
-          providerName: provider?.providerName ?? model.providerId,
-          modelId: model.modelId,
-          modelName,
-        };
-      });
-  }, [modelNameByKey, providerById, providerFilter, usageRangeData?.usedModels]);
+  const usedModels = usageRangeData?.usedModels ?? [];
+  const availableModels: ModelOption[] = usedModels
+    .filter((model) => providerFilter === ALL_FILTER || model.providerId === providerFilter)
+    .map((model) => {
+      const provider = providerById.get(model.providerId);
+      const key = encodeModelFilter(model.providerId, model.modelId);
+      const modelName = modelNameByKey.get(key) ?? model.modelId;
+      return {
+        label: modelName,
+        providerId: model.providerId,
+        providerName: provider?.providerName ?? model.providerId,
+        modelId: model.modelId,
+        modelName,
+      };
+    });
 
   const modelFilter = availableModels.some((m) => encodeModelFilter(m.providerId, m.modelId) === selectedModel)
     ? selectedModel
     : ALL_FILTER;
 
-  const usageFilters = React.useMemo(() => {
-    const decodedModel = modelFilter === ALL_FILTER ? null : decodeModelFilter(modelFilter);
-    const providerIdFromModel = providerFilter === ALL_FILTER ? decodedModel?.providerId : providerFilter;
-    return { range: rangeFilter, providerId: providerIdFromModel, modelId: decodedModel?.modelId };
-  }, [modelFilter, providerFilter, rangeFilter]);
+  const decodedModel = modelFilter === ALL_FILTER ? null : decodeModelFilter(modelFilter);
+  const providerIdFromModel = providerFilter === ALL_FILTER ? decodedModel?.providerId : providerFilter;
+  const usageFilters = { range: rangeFilter, providerId: providerIdFromModel, modelId: decodedModel?.modelId };
 
   const { data: usageData, isFetching } = useQuery({
     ...usageDashboardQueryOptions(usageFilters),
     placeholderData: keepPreviousData,
   });
 
-  const providerLabelById = React.useMemo(
-    () => new Map(availableProviders.map((p) => [p.providerId, p.providerName] as const)),
-    [availableProviders],
-  );
+  const providerLabelById = new Map(availableProviders.map((p) => [p.providerId, p.providerName] as const));
 
-  const modelLabelByValue = React.useMemo(
-    () =>
-      new Map(
-        availableModels.map(
-          (model) =>
-            [encodeModelFilter(model.providerId, model.modelId), `${model.providerName} · ${model.modelName}`] as const,
-        ),
-      ),
-    [availableModels],
+  const modelLabelByValue = new Map(
+    availableModels.map(
+      (model) =>
+        [encodeModelFilter(model.providerId, model.modelId), `${model.providerName} · ${model.modelName}`] as const,
+    ),
   );
 
   return {

--- a/apps/web/src/components/usage/utils/usage-dashboard-utils.ts
+++ b/apps/web/src/components/usage/utils/usage-dashboard-utils.ts
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { USAGE_SOURCES, type UsageDateRange } from '@stitch/shared/usage/types';
 
 import { formatUsdCost } from '@/lib/format-cost';
@@ -46,13 +44,11 @@ export function decodeModelFilter(value: string): { providerId: string; modelId:
 }
 
 export function useSourceOrder(sources: string[]): string[] {
-  return React.useMemo(() => {
-    const order = new Map<string, number>(USAGE_SOURCES.map((source, index) => [source, index]));
-    return [...sources].toSorted((a, b) => {
-      const aOrder = order.get(a) ?? Number.MAX_SAFE_INTEGER;
-      const bOrder = order.get(b) ?? Number.MAX_SAFE_INTEGER;
-      if (aOrder !== bOrder) return aOrder - bOrder;
-      return a.localeCompare(b);
-    });
-  }, [sources]);
+  const order = new Map<string, number>(USAGE_SOURCES.map((source, index) => [source, index]));
+  return [...sources].toSorted((a, b) => {
+    const aOrder = order.get(a) ?? Number.MAX_SAFE_INTEGER;
+    const bOrder = order.get(b) ?? Number.MAX_SAFE_INTEGER;
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    return a.localeCompare(b);
+  });
 }

--- a/apps/web/src/hooks/session/use-session-docks.tsx
+++ b/apps/web/src/hooks/session/use-session-docks.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import type { UseMutationResult } from '@tanstack/react-query';
 
 import { parseMcpToolName } from '@stitch/shared/mcp/types';
@@ -62,156 +60,142 @@ export function useSessionDocks({
   rejectPermissionResponse,
   alternativePermissionResponse,
 }: UseSessionDocksOptions): DockItem[] {
-  return React.useMemo(() => {
-    const items: DockItem[] = [];
+  const items: DockItem[] = [];
 
-    const runMutation = async (action: () => Promise<unknown>, errorMessage: string) => {
-      try {
-        await action();
-      } catch (error) {
-        console.error(errorMessage, error);
-      }
-    };
+  const runMutation = async (action: () => Promise<unknown>, errorMessage: string) => {
+    try {
+      await action();
+    } catch (error) {
+      console.error(errorMessage, error);
+    }
+  };
 
-    if (doomLoop) {
+  if (doomLoop) {
+    items.push({
+      id: 'doom-loop',
+      title: 'Repeated action detected',
+      defaultExpanded: true,
+      variant: 'warning',
+      children: <DoomLoopDock sessionId={sessionId} toolName={doomLoop.toolName} />,
+    });
+  }
+
+  if (retry) {
+    items.push({
+      id: 'retry',
+      title: `Retrying... (attempt ${retry.attempt}/${retry.maxRetries})`,
+      defaultExpanded: true,
+      variant: 'destructive',
+      children: <RetryDock retry={retry} />,
+    });
+  }
+
+  if (pendingQuestions.length > 0) {
+    const request = pendingQuestions[0];
+    if (request) {
       items.push({
-        id: 'doom-loop',
-        title: 'Repeated action detected',
+        id: 'questions',
+        title: 'Questions',
         defaultExpanded: true,
-        variant: 'warning',
-        children: <DoomLoopDock sessionId={sessionId} toolName={doomLoop.toolName} />,
+        variant: 'primary',
+        children: (
+          <QuestionDock
+            request={request}
+            onReply={async (questionId, answers) => {
+              await runMutation(
+                () => replyQuestion.mutateAsync({ sessionId, questionId, answers }),
+                'Failed to reply to question:',
+              );
+            }}
+            onReject={async (questionId) => {
+              await runMutation(
+                () => rejectQuestion.mutateAsync({ sessionId, questionId }),
+                'Failed to reject question:',
+              );
+            }}
+          />
+        ),
       });
     }
+  }
 
-    if (retry) {
+  if (pendingPermissionResponses.length > 0) {
+    const permissionResponse = pendingPermissionResponses[0];
+    if (permissionResponse) {
+      const parsedTool = parseMcpToolName(permissionResponse.toolName);
+      const toolLabel = parsedTool?.toolName ?? permissionResponse.toolName;
+
       items.push({
-        id: 'retry',
-        title: `Retrying... (attempt ${retry.attempt}/${retry.maxRetries})`,
+        id: 'permission-response',
+        title: `Allow ${toolLabel}?`,
         defaultExpanded: true,
-        variant: 'destructive',
-        children: <RetryDock retry={retry} />,
+        variant: 'primary',
+        children: (
+          <PermissionResponseDock
+            permissionResponse={permissionResponse}
+            toolLabel={toolLabel}
+            isPending={
+              allowPermissionResponse.isPending ||
+              rejectPermissionResponse.isPending ||
+              alternativePermissionResponse.isPending
+            }
+            onAllow={async (permissionResponseId) => {
+              await runMutation(
+                () => allowPermissionResponse.mutateAsync({ sessionId, permissionResponseId }),
+                'Failed to allow tool:',
+              );
+            }}
+            onAlwaysAllow={async (permissionResponseId) => {
+              await runMutation(
+                () =>
+                  allowPermissionResponse.mutateAsync({
+                    sessionId,
+                    permissionResponseId,
+                    setPermission: { permission: 'allow', pattern: null },
+                  }),
+                'Failed to always allow tool:',
+              );
+            }}
+            onReject={async (permissionResponseId) => {
+              await runMutation(
+                () => rejectPermissionResponse.mutateAsync({ sessionId, permissionResponseId }),
+                'Failed to reject tool:',
+              );
+            }}
+            onAlternative={async (permissionResponseId, entry) => {
+              await runMutation(
+                () => alternativePermissionResponse.mutateAsync({ sessionId, permissionResponseId, entry }),
+                'Failed to submit alternative action:',
+              );
+            }}
+            onApplySuggestion={async (permissionResponseId, pattern) => {
+              await runMutation(
+                () =>
+                  allowPermissionResponse.mutateAsync({
+                    sessionId,
+                    permissionResponseId,
+                    setPermission: { permission: 'allow', pattern },
+                  }),
+                'Failed to apply permission suggestion:',
+              );
+            }}
+          />
+        ),
       });
     }
+  }
 
-    if (pendingQuestions.length > 0) {
-      const request = pendingQuestions[0];
-      if (request) {
-        items.push({
-          id: 'questions',
-          title: 'Questions',
-          defaultExpanded: true,
-          variant: 'primary',
-          children: (
-            <QuestionDock
-              request={request}
-              onReply={async (questionId, answers) => {
-                await runMutation(
-                  () => replyQuestion.mutateAsync({ sessionId, questionId, answers }),
-                  'Failed to reply to question:',
-                );
-              }}
-              onReject={async (questionId) => {
-                await runMutation(
-                  () => rejectQuestion.mutateAsync({ sessionId, questionId }),
-                  'Failed to reject question:',
-                );
-              }}
-            />
-          ),
-        });
-      }
-    }
+  const activeCount = todos.filter((todo) => todo.status === 'pending' || todo.status === 'in_progress').length;
 
-    if (pendingPermissionResponses.length > 0) {
-      const permissionResponse = pendingPermissionResponses[0];
-      if (permissionResponse) {
-        const parsedTool = parseMcpToolName(permissionResponse.toolName);
-        const toolLabel = parsedTool?.toolName ?? permissionResponse.toolName;
+  if (todos.length > 0 && activeCount > 0) {
+    items.push({
+      id: 'todos',
+      title: `Todos (${activeCount} active)`,
+      defaultExpanded: false,
+      variant: 'default',
+      children: <TodoDock todos={todos} />,
+    });
+  }
 
-        items.push({
-          id: 'permission-response',
-          title: `Allow ${toolLabel}?`,
-          defaultExpanded: true,
-          variant: 'primary',
-          children: (
-            <PermissionResponseDock
-              permissionResponse={permissionResponse}
-              toolLabel={toolLabel}
-              isPending={
-                allowPermissionResponse.isPending ||
-                rejectPermissionResponse.isPending ||
-                alternativePermissionResponse.isPending
-              }
-              onAllow={async (permissionResponseId) => {
-                await runMutation(
-                  () => allowPermissionResponse.mutateAsync({ sessionId, permissionResponseId }),
-                  'Failed to allow tool:',
-                );
-              }}
-              onAlwaysAllow={async (permissionResponseId) => {
-                await runMutation(
-                  () =>
-                    allowPermissionResponse.mutateAsync({
-                      sessionId,
-                      permissionResponseId,
-                      setPermission: { permission: 'allow', pattern: null },
-                    }),
-                  'Failed to always allow tool:',
-                );
-              }}
-              onReject={async (permissionResponseId) => {
-                await runMutation(
-                  () => rejectPermissionResponse.mutateAsync({ sessionId, permissionResponseId }),
-                  'Failed to reject tool:',
-                );
-              }}
-              onAlternative={async (permissionResponseId, entry) => {
-                await runMutation(
-                  () => alternativePermissionResponse.mutateAsync({ sessionId, permissionResponseId, entry }),
-                  'Failed to submit alternative action:',
-                );
-              }}
-              onApplySuggestion={async (permissionResponseId, pattern) => {
-                await runMutation(
-                  () =>
-                    allowPermissionResponse.mutateAsync({
-                      sessionId,
-                      permissionResponseId,
-                      setPermission: { permission: 'allow', pattern },
-                    }),
-                  'Failed to apply permission suggestion:',
-                );
-              }}
-            />
-          ),
-        });
-      }
-    }
-
-    const activeCount = todos.filter((todo) => todo.status === 'pending' || todo.status === 'in_progress').length;
-
-    if (todos.length > 0 && activeCount > 0) {
-      items.push({
-        id: 'todos',
-        title: `Todos (${activeCount} active)`,
-        defaultExpanded: false,
-        variant: 'default',
-        children: <TodoDock todos={todos} />,
-      });
-    }
-
-    return items;
-  }, [
-    doomLoop,
-    retry,
-    pendingQuestions,
-    pendingPermissionResponses,
-    todos,
-    sessionId,
-    replyQuestion,
-    rejectQuestion,
-    allowPermissionResponse,
-    rejectPermissionResponse,
-    alternativePermissionResponse,
-  ]);
+  return items;
 }

--- a/apps/web/src/hooks/session/use-session-pending-items.ts
+++ b/apps/web/src/hooks/session/use-session-pending-items.ts
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { useQuery } from '@tanstack/react-query';
 
 import {
@@ -14,15 +12,9 @@ export function useSessionPendingItems(sessionId: string) {
   const questionsQuery = useQuery(questionsQueryOptions(sessionId));
   const permissionResponsesQuery = useQuery(permissionResponsesQueryOptions(sessionId));
 
-  const pendingQuestions = React.useMemo(
-    () => questionsQuery.data?.filter((question) => question.status === 'pending') ?? [],
-    [questionsQuery.data],
-  );
+  const pendingQuestions = questionsQuery.data?.filter((question) => question.status === 'pending') ?? [];
 
-  const pendingPermissionResponses = React.useMemo(
-    () => permissionResponsesQuery.data ?? [],
-    [permissionResponsesQuery.data],
-  );
+  const pendingPermissionResponses = permissionResponsesQuery.data ?? [];
 
   return {
     pendingQuestions,

--- a/apps/web/src/hooks/use-session-stream-state.ts
+++ b/apps/web/src/hooks/use-session-stream-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useRef } from 'react';
 
 import { useStreamStore, INITIAL_SESSION_STATE } from '@/stores/stream-store';
 import type { SessionStreamState } from '@/stores/stream-store';
@@ -13,10 +13,7 @@ import type { SessionStreamState } from '@/stores/stream-store';
  */
 export function useSessionStreamState(sessionId: string): SessionStreamState {
   return useStreamStore(
-    useCallback(
-      (state: { sessions: Record<string, SessionStreamState> }) => state.sessions[sessionId] ?? INITIAL_SESSION_STATE,
-      [sessionId],
-    ),
+    (state: { sessions: Record<string, SessionStreamState> }) => state.sessions[sessionId] ?? INITIAL_SESSION_STATE,
   );
 }
 

--- a/apps/web/src/hooks/use-slash-commands.ts
+++ b/apps/web/src/hooks/use-slash-commands.ts
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 import { useQueryClient } from '@tanstack/react-query';
 
 import type { ModelSpec } from '@/components/chat/chat-input-parts/types';
@@ -42,63 +40,48 @@ export function useSlashCommands({
   const queryClient = useQueryClient();
   const requestCompaction = useRequestCompaction();
 
-  const buildContext = React.useCallback(
-    (): CommandContext => ({
-      sessionId,
-      selectedModel,
-      isStreaming,
-      setInput,
-      queryClient,
-      actions: {
-        requestCompaction: async (id: string) => {
-          await requestCompaction.mutateAsync(id);
-        },
-        generateAutomation: async () => {
-          await onGenerateAutomation?.();
-        },
-        submitPrompt: onSubmitPrompt,
+  const buildContext = (): CommandContext => ({
+    sessionId,
+    selectedModel,
+    isStreaming,
+    setInput,
+    queryClient,
+    actions: {
+      requestCompaction: async (id: string) => {
+        await requestCompaction.mutateAsync(id);
       },
-    }),
-    [
-      sessionId,
-      selectedModel,
-      isStreaming,
-      setInput,
-      queryClient,
-      requestCompaction,
-      onSubmitPrompt,
-      onGenerateAutomation,
-    ],
-  );
+      generateAutomation: async () => {
+        await onGenerateAutomation?.();
+      },
+      submitPrompt: onSubmitPrompt,
+    },
+  });
 
-  const completionGroups = React.useMemo(() => [buildSlashCompletionGroup(buildContext())], [buildContext]);
+  const completionGroups = [buildSlashCompletionGroup(buildContext())];
 
-  const tryRun = React.useCallback(
-    (input: string): boolean => {
-      const parsed = parseSlashCommand(input);
-      if (!parsed) return false;
+  const tryRun = (input: string): boolean => {
+    const parsed = parseSlashCommand(input);
+    if (!parsed) return false;
 
-      const command = findCommand(parsed.name);
-      if (!command) return false;
+    const command = findCommand(parsed.name);
+    if (!command) return false;
 
-      const ctx = buildContext();
-      if (command.isAvailable && !command.isAvailable(ctx)) return false;
+    const ctx = buildContext();
+    if (command.isAvailable && !command.isAvailable(ctx)) return false;
 
-      if (command.kind === 'prompt') {
-        const prompt = command.buildPrompt(parsed.args, ctx);
-        void ctx.actions.submitPrompt(prompt).catch((error) => {
-          console.error(`Slash command "${command.name}" failed:`, error);
-        });
-        return true;
-      }
-
-      void Promise.resolve(command.run(parsed.args, ctx)).catch((error) => {
+    if (command.kind === 'prompt') {
+      const prompt = command.buildPrompt(parsed.args, ctx);
+      void ctx.actions.submitPrompt(prompt).catch((error) => {
         console.error(`Slash command "${command.name}" failed:`, error);
       });
       return true;
-    },
-    [buildContext],
-  );
+    }
+
+    void Promise.resolve(command.run(parsed.args, ctx)).catch((error) => {
+      console.error(`Slash command "${command.name}" failed:`, error);
+    });
+    return true;
+  };
 
   return { completionGroups, tryRun };
 }

--- a/apps/web/src/lib/shortcuts.ts
+++ b/apps/web/src/lib/shortcuts.ts
@@ -1,5 +1,3 @@
-import { useMemo } from 'react';
-
 import type { Hotkey } from '@tanstack/react-hotkeys';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
@@ -13,11 +11,9 @@ interface ShortcutInfo {
 export function useShortcuts(): Map<string, ShortcutInfo> {
   const { data: shortcuts } = useSuspenseQuery(shortcutsQueryOptions);
 
-  return useMemo(() => {
-    const resolved = new Map<string, ShortcutInfo>();
-    for (const entry of shortcuts) {
-      resolved.set(entry.actionId, { hotkey: entry.hotkey as Hotkey | null, isSequence: entry.isSequence });
-    }
-    return resolved;
-  }, [shortcuts]);
+  const resolved = new Map<string, ShortcutInfo>();
+  for (const entry of shortcuts) {
+    resolved.set(entry.actionId, { hotkey: entry.hotkey as Hotkey | null, isSequence: entry.isSequence });
+  }
+  return resolved;
 }


### PR DESCRIPTION
## 🚀 Change Summary

Removes 147 redundant manual memoization calls (`useMemo` / `useCallback` / `memo`) flagged by react-doctor's `react-compiler-no-manual-memoization` rule across 55 files in `apps/web`. React Compiler (via `babel-plugin-react-compiler`) already memoizes values and functions automatically at build time, so these manual wrappers were dead weight.

### 🛠 Improvements & Refactors

- Inlined plain values/functions in place of `useMemo`/`useCallback` wrappers, and unwrapped components from `memo()`, across components, hooks, and chart/usage utilities.
- Kept memoization at a small number of call sites (context provider values in `dialog-context.tsx`, `ui/sidebar.tsx`, `ui/toggle-group.tsx`, `tool-call-group.tsx`, and a few functions referenced in `useEffect` dependency arrays in `use-dictation.ts`, `use-stt.ts`, `right-click-menu.tsx`, `browser-panel.tsx`, `provider-config.tsx`) since removing it there conflicts with the `react/jsx-no-constructed-context-values` and `react/exhaustive-deps` oxlint rules, which aren't aware of the compiler's runtime stability guarantees.

No behavior changes — this is a mechanical cleanup. `bun run check` passes (knip, typecheck, test, lint, format).
