### PR TITLE
chore(web): upgrade @tanstack/react-table to v9

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-hotkeys": "0.4.1",
     "@tanstack/react-query": "5.90.21",
     "@tanstack/react-router": "1.166.7",
-    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-table": "9.0.0-beta.58",
     "@tanstack/react-virtual": "^3.14.1",
     "chart.js": "^4.5.1",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/components/automations/automation-runs-table.tsx
+++ b/apps/web/src/components/automations/automation-runs-table.tsx
@@ -4,11 +4,14 @@ import * as React from 'react';
 import {
   type CellContext,
   createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
+  createSortedRowModel,
+  metaHelper,
+  rowSortingFeature,
+  sortFn_alphanumeric,
+  sortFn_text,
   type SortingState,
-  useReactTable,
+  tableFeatures,
+  useTable,
 } from '@tanstack/react-table';
 
 import type { Session } from '@stitch/shared/chat/messages';
@@ -18,19 +21,26 @@ import { Table } from '@/components/ui/table';
 
 type AutomationRunsTableProps = { sessions: Session[]; onOpen: (sessionId: string) => void };
 
-const columnHelper = createColumnHelper<Session>();
-
 type AutomationRunsTableMeta = { onOpen: (sessionId: string) => void };
 
-function TitleCell({ row }: CellContext<Session, Session['title']>) {
+const features = tableFeatures({
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  sortFns: { alphanumeric: sortFn_alphanumeric, text: sortFn_text },
+  tableMeta: metaHelper<AutomationRunsTableMeta>(),
+});
+
+const columnHelper = createColumnHelper<typeof features, Session>();
+
+function TitleCell({ row }: CellContext<typeof features, Session, Session['title']>) {
   return <Table.Title>{row.original.title ?? 'Untitled run'}</Table.Title>;
 }
 
-function TimeCell({ getValue }: CellContext<Session, number>) {
+function TimeCell({ getValue }: CellContext<typeof features, Session, number>) {
   return <Table.Time value={getValue()} />;
 }
 
-function ActionsCell({ row, table }: CellContext<Session, unknown>) {
+function ActionsCell({ row, table }: CellContext<typeof features, Session, unknown>) {
   const { onOpen } = table.options.meta as AutomationRunsTableMeta;
 
   return (
@@ -43,24 +53,23 @@ function ActionsCell({ row, table }: CellContext<Session, unknown>) {
   );
 }
 
-const columns = [
+const columns = columnHelper.columns([
   columnHelper.accessor('title', { header: 'Run', cell: TitleCell }),
   columnHelper.accessor('createdAt', { header: 'Started', cell: TimeCell }),
   columnHelper.accessor('updatedAt', { header: 'Updated', cell: TimeCell }),
   columnHelper.display({ id: 'actions', header: '', cell: ActionsCell }),
-];
+]);
 
 export function AutomationRunsTable({ sessions, onOpen }: AutomationRunsTableProps) {
   const [sorting, setSorting] = React.useState<SortingState>([{ id: 'updatedAt', desc: true }]);
 
-  const table = useReactTable({
+  const table = useTable({
+    features,
     data: sessions,
     columns,
     state: { sorting },
     onSortingChange: setSorting,
-    meta: { onOpen } satisfies AutomationRunsTableMeta,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
+    meta: { onOpen },
   });
 
   return (
@@ -72,7 +81,7 @@ export function AutomationRunsTable({ sessions, onOpen }: AutomationRunsTablePro
               <Table.Row key={headerGroup.id} className="hover:bg-transparent">
                 {headerGroup.headers.map((header) => (
                   <Table.Head key={header.id}>
-                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                    {header.isPlaceholder ? null : <table.FlexRender header={header} />}
                   </Table.Head>
                 ))}
               </Table.Row>
@@ -81,8 +90,10 @@ export function AutomationRunsTable({ sessions, onOpen }: AutomationRunsTablePro
           <Table.Body>
             {table.getRowModel().rows.map((row) => (
               <Table.Row key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <Table.Cell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</Table.Cell>
+                {row.getAllCells().map((cell) => (
+                  <Table.Cell key={cell.id}>
+                    <table.FlexRender cell={cell} />
+                  </Table.Cell>
                 ))}
               </Table.Row>
             ))}

--- a/apps/web/src/components/automations/automations-table.tsx
+++ b/apps/web/src/components/automations/automations-table.tsx
@@ -5,11 +5,14 @@ import { Link } from '@tanstack/react-router';
 import {
   type CellContext,
   createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
+  createSortedRowModel,
+  metaHelper,
+  rowSortingFeature,
+  sortFn_alphanumeric,
+  sortFn_text,
   type SortingState,
-  useReactTable,
+  tableFeatures,
+  useTable,
 } from '@tanstack/react-table';
 
 import type { Automation } from '@stitch/shared/automations/types';
@@ -42,7 +45,14 @@ type AutomationsTableProps = {
   onDelete: (automation: Automation) => void;
 };
 
-const columnHelper = createColumnHelper<Automation>();
+const features = tableFeatures({
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  sortFns: { alphanumeric: sortFn_alphanumeric, text: sortFn_text },
+  tableMeta: metaHelper<AutomationsTableMeta>(),
+});
+
+const columnHelper = createColumnHelper<typeof features, Automation>();
 
 type AutomationsTableMeta = {
   modelLabelByKey: Map<string, string>;
@@ -53,7 +63,7 @@ type AutomationsTableMeta = {
   onDelete: (automation: Automation) => void;
 };
 
-function TitleCell({ row }: CellContext<Automation, Automation['title']>) {
+function TitleCell({ row }: CellContext<typeof features, Automation, Automation['title']>) {
   return (
     <Table.Title className="block">
       <Link
@@ -66,26 +76,26 @@ function TitleCell({ row }: CellContext<Automation, Automation['title']>) {
   );
 }
 
-function ModelCell({ row, table }: CellContext<Automation, unknown>) {
+function ModelCell({ row, table }: CellContext<typeof features, Automation, unknown>) {
   const { modelLabelByKey } = table.options.meta as AutomationsTableMeta;
   const automation = row.original;
   const label = modelLabelByKey.get(`${automation.providerId}:${automation.modelId}`) ?? automation.modelId;
   return <Table.Badge>{label}</Table.Badge>;
 }
 
-function RunCountCell({ getValue }: CellContext<Automation, Automation['runCount']>) {
+function RunCountCell({ getValue }: CellContext<typeof features, Automation, Automation['runCount']>) {
   return <Table.Number value={getValue()} />;
 }
 
-function ScheduleCell({ row }: CellContext<Automation, unknown>) {
+function ScheduleCell({ row }: CellContext<typeof features, Automation, unknown>) {
   return <Table.Text>{getAutomationScheduleLabel(row.original.schedule)}</Table.Text>;
 }
 
-function UpdatedAtCell({ getValue }: CellContext<Automation, Automation['updatedAt']>) {
+function UpdatedAtCell({ getValue }: CellContext<typeof features, Automation, Automation['updatedAt']>) {
   return <Table.Time value={getValue()} />;
 }
 
-function ActionsCell({ row, table }: CellContext<Automation, unknown>) {
+function ActionsCell({ row, table }: CellContext<typeof features, Automation, unknown>) {
   const { runPending, deletePending, onRun, onEdit, onDelete } = table.options.meta as AutomationsTableMeta;
 
   return (
@@ -117,14 +127,14 @@ function ActionsCell({ row, table }: CellContext<Automation, unknown>) {
   );
 }
 
-const columns = [
+const columns = columnHelper.columns([
   columnHelper.accessor('title', { header: 'Title', cell: TitleCell }),
   columnHelper.display({ id: 'model', header: 'Model', cell: ModelCell }),
   columnHelper.accessor('runCount', { header: 'Runs', cell: RunCountCell }),
   columnHelper.display({ id: 'schedule', header: 'Schedule', cell: ScheduleCell }),
   columnHelper.accessor('updatedAt', { header: 'Updated', cell: UpdatedAtCell }),
   columnHelper.display({ id: 'actions', header: '', cell: ActionsCell }),
-];
+]);
 
 export function AutomationsTable({
   automations,
@@ -150,14 +160,13 @@ export function AutomationsTable({
     return map;
   }, [providerModels]);
 
-  const table = useReactTable({
+  const table = useTable({
+    features,
     data: automations,
     columns,
     state: { sorting },
     onSortingChange: setSorting,
-    meta: { modelLabelByKey, runPending, deletePending, onRun, onEdit, onDelete } satisfies AutomationsTableMeta,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
+    meta: { modelLabelByKey, runPending, deletePending, onRun, onEdit, onDelete },
   });
 
   const currentPage = page - 1;
@@ -188,7 +197,7 @@ export function AutomationsTable({
               <Table.Row key={headerGroup.id} className="hover:bg-transparent">
                 {headerGroup.headers.map((header) => (
                   <Table.Head key={header.id}>
-                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                    {header.isPlaceholder ? null : <table.FlexRender header={header} />}
                   </Table.Head>
                 ))}
               </Table.Row>
@@ -208,8 +217,10 @@ export function AutomationsTable({
             ) : (
               table.getRowModel().rows.map((row) => (
                 <Table.Row key={row.id}>
-                  {row.getVisibleCells().map((cell) => (
-                    <Table.Cell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</Table.Cell>
+                  {row.getAllCells().map((cell) => (
+                    <Table.Cell key={cell.id}>
+                      <table.FlexRender cell={cell} />
+                    </Table.Cell>
                   ))}
                 </Table.Row>
               ))

--- a/apps/web/src/components/recordings/list/recordings-table.tsx
+++ b/apps/web/src/components/recordings/list/recordings-table.tsx
@@ -4,11 +4,14 @@ import * as React from 'react';
 import {
   type CellContext,
   createColumnHelper,
-  flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
+  createSortedRowModel,
+  metaHelper,
+  rowSortingFeature,
+  sortFn_alphanumeric,
+  sortFn_text,
   type SortingState,
-  useReactTable,
+  tableFeatures,
+  useTable,
 } from '@tanstack/react-table';
 
 import type { Recording } from '@stitch/shared/recordings/types';
@@ -21,11 +24,18 @@ import { Button } from '@/components/ui/button';
 import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
 import { Table } from '@/components/ui/table';
 
-const columnHelper = createColumnHelper<Recording>();
-
 type RecordingsTableMeta = { activeRecordingId: string | null; onDelete: (recording: Recording) => void };
 
-function TitleCell({ row }: CellContext<Recording, string>) {
+const features = tableFeatures({
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  sortFns: { alphanumeric: sortFn_alphanumeric, text: sortFn_text },
+  tableMeta: metaHelper<RecordingsTableMeta>(),
+});
+
+const columnHelper = createColumnHelper<typeof features, Recording>();
+
+function TitleCell({ row }: CellContext<typeof features, Recording, string>) {
   return (
     <div className="flex min-w-0 flex-col">
       <Table.Title>{getRecordingDisplayTitle(row.original)}</Table.Title>
@@ -33,19 +43,19 @@ function TitleCell({ row }: CellContext<Recording, string>) {
   );
 }
 
-function PlatformCell({ getValue }: CellContext<Recording, Recording['platform']>) {
+function PlatformCell({ getValue }: CellContext<typeof features, Recording, Recording['platform']>) {
   return <PlatformBadge platform={getValue()} />;
 }
 
-function StatusCell({ getValue }: CellContext<Recording, Recording['status']>) {
+function StatusCell({ getValue }: CellContext<typeof features, Recording, Recording['status']>) {
   return <Table.Badge variant={STATUS_VARIANTS[getValue()]}>{STATUS_LABELS[getValue()]}</Table.Badge>;
 }
 
-function StartedAtCell({ getValue }: CellContext<Recording, Recording['startedAt']>) {
+function StartedAtCell({ getValue }: CellContext<typeof features, Recording, Recording['startedAt']>) {
   return <Table.Time value={getValue()} />;
 }
 
-function DurationCell({ row, table }: CellContext<Recording, unknown>) {
+function DurationCell({ row, table }: CellContext<typeof features, Recording, unknown>) {
   const { activeRecordingId } = table.options.meta as RecordingsTableMeta;
   const recording = row.original;
   if (recording.id === activeRecordingId) {
@@ -54,7 +64,7 @@ function DurationCell({ row, table }: CellContext<Recording, unknown>) {
   return <Table.Duration>{formatClockDuration(recording.durationMs)}</Table.Duration>;
 }
 
-function CostCell({ getValue }: CellContext<Recording, Recording['costUsd']>) {
+function CostCell({ getValue }: CellContext<typeof features, Recording, Recording['costUsd']>) {
   return <Table.Money value={getValue()} />;
 }
 
@@ -62,7 +72,7 @@ function ActionsHeader() {
   return <div className="pr-1 text-right">Actions</div>;
 }
 
-function ActionsCell({ row, table }: CellContext<Recording, unknown>) {
+function ActionsCell({ row, table }: CellContext<typeof features, Recording, unknown>) {
   const { activeRecordingId, onDelete } = table.options.meta as RecordingsTableMeta;
 
   return (
@@ -85,7 +95,7 @@ function ActionsCell({ row, table }: CellContext<Recording, unknown>) {
   );
 }
 
-const columns = [
+const columns = columnHelper.columns([
   columnHelper.accessor('title', { header: 'Title', cell: TitleCell }),
   columnHelper.accessor('platform', { header: 'Platform', cell: PlatformCell }),
   columnHelper.accessor('status', { header: 'Capturing', cell: StatusCell }),
@@ -93,7 +103,7 @@ const columns = [
   columnHelper.display({ id: 'duration', header: 'Duration', cell: DurationCell }),
   columnHelper.accessor('costUsd', { header: 'Cost', cell: CostCell }),
   columnHelper.display({ id: 'actions', header: ActionsHeader, cell: ActionsCell }),
-];
+]);
 
 interface RecordingsTableProps {
   recordings: Recording[];
@@ -112,15 +122,14 @@ export function RecordingsTable({
   onDelete,
   onNavigate,
 }: RecordingsTableProps) {
-  const table = useReactTable({
+  const table = useTable({
+    features,
     data: recordings,
     columns,
     getRowId: (row) => row.id,
     state: { sorting },
     onSortingChange,
-    meta: { activeRecordingId, onDelete } satisfies RecordingsTableMeta,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
+    meta: { activeRecordingId, onDelete },
   });
 
   return (
@@ -137,7 +146,7 @@ export function RecordingsTable({
                       ? 'w-full max-w-xs min-w-48 px-4 py-2 font-medium'
                       : 'px-4 py-2 font-medium whitespace-nowrap'
                   }>
-                  {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  {header.isPlaceholder ? null : <table.FlexRender header={header} />}
                 </Table.Head>
               ))}
             </Table.Row>
@@ -157,13 +166,13 @@ export function RecordingsTable({
           ) : (
             table.getRowModel().rows.map((row) => (
               <Table.Row key={row.id} className="cursor-pointer" onClick={() => onNavigate(row.original.id)}>
-                {row.getVisibleCells().map((cell) => (
+                {row.getAllCells().map((cell) => (
                   <Table.Cell
                     key={cell.id}
                     className={
                       cell.column.id === 'title' ? 'w-full max-w-xs min-w-48 px-4 py-3' : 'px-4 py-3 whitespace-nowrap'
                     }>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    <table.FlexRender cell={cell} />
                   </Table.Cell>
                 ))}
               </Table.Row>

--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
         "@tanstack/react-hotkeys": "0.4.1",
         "@tanstack/react-query": "5.90.21",
         "@tanstack/react-router": "1.166.7",
-        "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-table": "9.0.0-beta.58",
         "@tanstack/react-virtual": "^3.14.1",
         "chart.js": "^4.5.1",
         "class-variance-authority": "^0.7.1",
@@ -1115,7 +1115,7 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.11.0", "", { "dependencies": { "@tanstack/store": "0.11.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w=="],
 
-    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+    "@tanstack/react-table": ["@tanstack/react-table@9.0.0-beta.58", "", { "dependencies": { "@tanstack/react-store": "^0.11.0", "@tanstack/table-core": "9.0.0-beta.58" }, "peerDependencies": { "react": ">=18" } }, "sha512-pvacQiA9pymAivt2dOOsOcnNEp5FMPvX2hjbnkWsh0lvlBtf6mh9bnZ7q14iAakGMiGs+o+/tbSr5jT19XfTgg=="],
 
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.6", "", { "dependencies": { "@tanstack/virtual-core": "3.17.4" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA=="],
 
@@ -1129,7 +1129,7 @@
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
-    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
+    "@tanstack/table-core": ["@tanstack/table-core@9.0.0-beta.58", "", { "dependencies": { "@tanstack/store": "^0.11.0" } }, "sha512-iP2N6AA4iU6NbLF/DOHoA/mJUDspz5cRIvPkqfTtuoURcjNp4MxbJPxTRUizuX8JejDL2PDfmLUMj3zU+znhyA=="],
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.4", "", {}, "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw=="],
 
@@ -2834,6 +2834,8 @@
     "@tanstack/router-utils/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "@tanstack/router-utils/@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@tanstack/table-core/@tanstack/store": ["@tanstack/store@0.11.0", "", {}, "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="],
 
     "ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 

--- a/oxlint.json
+++ b/oxlint.json
@@ -105,12 +105,9 @@
     { "files": ["apps/web/src/components/ui/**/*.{ts,tsx}"], "rules": { "stitch/no-native-button": "off" } },
     {
       "files": [
-        "apps/web/src/components/automations/automation-runs-table.tsx",
-        "apps/web/src/components/automations/automations-table.tsx",
         "apps/web/src/components/chat/message-list.tsx",
         "apps/web/src/components/mail/thread-list.tsx",
-        "apps/web/src/components/recordings/analysis/transcript-sidebar.tsx",
-        "apps/web/src/components/recordings/list/recordings-table.tsx"
+        "apps/web/src/components/recordings/analysis/transcript-sidebar.tsx"
       ],
       "rules": { "react/react-compiler": "off" }
     },


### PR DESCRIPTION
## 🚀 Change Summary

Upgrades `@tanstack/react-table` from `^8.21.3` to `9.0.0-beta.58` and migrates the three table components in `apps/web` to the v9 API. The v9 architecture is React Compiler compatible, so the `react/react-compiler` oxlint overrides for those files are no longer needed and have been removed.

### 🛠 Improvements & Refactors

- **TanStack Table v9 migration**: `useReactTable` → `useTable`; row models moved out of table options into `tableFeatures()` slots (`rowSortingFeature` + `sortedRowModel: createSortedRowModel()`), with `getCoreRowModel()` dropped since the core model is now automatic.
- **Explicit sort function registration**: v9 no longer bundles built-ins and `sortFn: 'auto'` only resolves registered functions, so `sortFns: { alphanumeric, text }` is registered to preserve existing sort behavior on string columns.
- **Feature-aware generics**: `createColumnHelper<typeof features, TData>()` and `CellContext<typeof features, TData, TValue>` throughout; column arrays wrapped in `columnHelper.columns([...])` to preserve per-column `TValue` inference.
- **Typed table meta**: moved from `satisfies` assertions to the v9 `tableMeta: metaHelper<...>()` feature slot.
- **Rendering**: `flexRender(...)` calls replaced with `<table.FlexRender header={header} />` / `<table.FlexRender cell={cell} />`, and `row.getVisibleCells()` replaced with `row.getAllCells()` (the visible-cells API is gated behind `columnVisibilityFeature`, which none of these tables register).
- **Lint config**: removed the `react/react-compiler: off` override for `automations-table.tsx`, `automation-runs-table.tsx`, and `recordings-table.tsx`. The override remains scoped to the three `useVirtualizer` components (`message-list.tsx`, `thread-list.tsx`, `transcript-sidebar.tsx`), which are unaffected by this upgrade — `@tanstack/react-virtual` has no v9/v4 equivalent.

### ⚠️ Note on versioning

`@tanstack/react-table` v9 has no stable release yet; `latest` on npm is still `8.21.3`. This pins the exact beta (`9.0.0-beta.58`, no `^`) because the v9 API is still shifting between betas, so future beta bumps will likely require code changes.
