### PR TITLE
chore: upgrade @tanstack/react-table to stable v9.0.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,7 @@
     "@tanstack/react-hotkeys": "0.4.1",
     "@tanstack/react-query": "5.90.21",
     "@tanstack/react-router": "1.166.7",
-    "@tanstack/react-table": "9.0.0-beta.58",
+    "@tanstack/react-table": "9.0.0",
     "@tanstack/react-virtual": "^3.14.1",
     "class-variance-authority": "^0.7.1",
     "cmdk": "^1.1.1",

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/desktop": {
       "name": "@stitch/desktop",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "dependencies": {
         "@stitch/audio-capture": "workspace:*",
         "@stitch/meeting-detection": "workspace:*",
@@ -40,7 +40,7 @@
     },
     "apps/web": {
       "name": "@stitch/web",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@stitch/scheduler": "workspace:*",
@@ -52,7 +52,7 @@
         "@tanstack/react-hotkeys": "0.4.1",
         "@tanstack/react-query": "5.90.21",
         "@tanstack/react-router": "1.166.7",
-        "@tanstack/react-table": "9.0.0-beta.58",
+        "@tanstack/react-table": "9.0.0",
         "@tanstack/react-virtual": "^3.14.1",
         "class-variance-authority": "^0.7.1",
         "cmdk": "^1.1.1",
@@ -1129,7 +1129,7 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.11.0", "", { "dependencies": { "@tanstack/store": "0.11.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tX4YXh3PDkmpvGQWkWqKpzs/MSqbtuwY9dWdWhtV9Q50PmO+jOkUKIWIX4G85dwt7lxdHLXsiaEKPdKmC8F41w=="],
 
-    "@tanstack/react-table": ["@tanstack/react-table@9.0.0-beta.58", "", { "dependencies": { "@tanstack/react-store": "^0.11.0", "@tanstack/table-core": "9.0.0-beta.58" }, "peerDependencies": { "react": ">=18" } }, "sha512-pvacQiA9pymAivt2dOOsOcnNEp5FMPvX2hjbnkWsh0lvlBtf6mh9bnZ7q14iAakGMiGs+o+/tbSr5jT19XfTgg=="],
+    "@tanstack/react-table": ["@tanstack/react-table@9.0.0", "", { "dependencies": { "@tanstack/react-store": "^0.11.0", "@tanstack/table-core": "9.0.0" }, "peerDependencies": { "react": ">=18" } }, "sha512-Q/Z49MQcdMwge67U+LTjSEQJCnQE9/tNWK5IpiYex9JFDzfjNkLIi7yzGA4dfW4UpuMBrtqbSnSzn7oPr60T+w=="],
 
     "@tanstack/react-virtual": ["@tanstack/react-virtual@3.14.6", "", { "dependencies": { "@tanstack/virtual-core": "3.17.4" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA=="],
 
@@ -1143,7 +1143,7 @@
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
 
-    "@tanstack/table-core": ["@tanstack/table-core@9.0.0-beta.58", "", { "dependencies": { "@tanstack/store": "^0.11.0" } }, "sha512-iP2N6AA4iU6NbLF/DOHoA/mJUDspz5cRIvPkqfTtuoURcjNp4MxbJPxTRUizuX8JejDL2PDfmLUMj3zU+znhyA=="],
+    "@tanstack/table-core": ["@tanstack/table-core@9.0.0", "", { "dependencies": { "@tanstack/store": "^0.11.0" } }, "sha512-IyKCc4D7d/+I9euQntlVDQ7lnilmFRKpIROBeI5/866adFy+65xWvCFPz76NZ5j2lXe/RFDvFVV7bfETmwHEMA=="],
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.17.4", "", {}, "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw=="],
 


### PR DESCRIPTION
## 🚀 Change Summary

TanStack Table v9 has reached its full stable release (`9.0.0`). This upgrades `@tanstack/react-table` in `apps/web` from the `9.0.0-beta.58` pre-release to the stable `9.0.0` release.

### 🛠 Improvements & Refactors
- Bump `@tanstack/react-table` (and transitively `@tanstack/table-core`) from `9.0.0-beta.58` to `9.0.0` in `apps/web/package.json`.
- No source changes were required — the feature-based table APIs already in use (`useTable`, `tableFeatures`, `createColumnHelper`, `createSortedRowModel`, `metaHelper`, `rowSortingFeature`, `sortFn_alphanumeric`, `sortFn_text`) are unchanged between beta.58 and the stable release.

### ✅ Verification
- `bun install` regenerated the lockfile for the new version.
- `bun run check` passes (design-system, knip, typecheck, test, lint, lint:check, catalogs, format:changed:check).
