### PR TITLE
feat: add privacy-controlled PostHog telemetry for DAU/MAU tracking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,8 @@ jobs:
         working-directory: apps/desktop
         env:
           GH_TOKEN: ${{ github.token }}
+          VITE_POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          STITCH_POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
           DEBUG: ${{ matrix.os == 'macos' && 'electron-builder,@electron/osx-sign*,electron-notarize*' || '' }}
           CSC_LINK: ${{ matrix.os == 'macos' && secrets.CSC_LINK || '' }}
           CSC_KEY_PASSWORD: ${{ matrix.os == 'macos' && secrets.CSC_KEY_PASSWORD || '' }}
@@ -298,6 +300,8 @@ jobs:
 
       - name: Build Linux server binary
         working-directory: packages/server
+        env:
+          STITCH_POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
         run: bun run build
 
       - name: Upload Linux server artifact

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/UseStitch/stitch)
 
-**Stitch** is a local-first, AI-powered desktop assistant that runs entirely on your machine — no cloud accounts, no tracking, no data leaving your computer.
+**Stitch** is a local-first, AI-powered desktop assistant that runs entirely on your machine — no cloud accounts, no data leaving your computer.
 
 Think of it as an AI pair programmer for your entire operating system: it can read and write files, run shell commands, search code, browse the web, manage your calendar and email, record and summarize meetings, and execute recurring automations — all through a natural language chat interface.
 
@@ -16,7 +16,7 @@ Think of it as an AI pair programmer for your entire operating system: it can re
 - **Memory System** — Semantic memory using LanceDB vector storage so the AI remembers your preferences, workflows, and key facts across conversations
 - **Connectors** — Integrate with external services (Google: Gmail, Drive, Calendar) via a pluggable connector framework
 - **MCP Support** — Model Context Protocol integration for additional tool ecosystems
-- **100% Local** — SQLite database, local vector store, sidecar server. No accounts, no telemetry, no cloud dependency
+- **100% Local** — SQLite database, local vector store, sidecar server. No accounts, no cloud dependency. Anonymous telemetry is enabled by default and can be disabled in Settings > General > Privacy
 
 ## Architecture
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -10,6 +10,7 @@ import { registerIpcHandler } from './ipc/register.js';
 import { registerServerHandlers } from './ipc/server.js';
 import { registerShellHandlers } from './ipc/shell.js';
 import { registerSpellcheckHandlers } from './ipc/spellcheck.js';
+import { registerTelemetryHandlers } from './ipc/telemetry.js';
 import { registerUpdaterHandlers } from './ipc/updater.js';
 import { registerWindowHandlers } from './ipc/window.js';
 import { startMeetingDetection, stopMeetingDetection, dismissMeetingDetection } from './meeting-detection.js';
@@ -22,6 +23,7 @@ import {
 import { stopRecordingCapture } from './recording-capture.js';
 import { readServerConnectionConfig, type ServerConnectionConfig } from './server-config.js';
 import { findAvailablePort, killServer, spawnServer } from './sidecar.js';
+import { initTelemetryState } from './telemetry-state.js';
 import { destroyTray, initTray } from './tray.js';
 import { createUpdater } from './updater.js';
 import { createWindow } from './window.js';
@@ -107,6 +109,7 @@ function registerAllIpcHandlers(): void {
   registerRecordingHandlers(getServerUrl, getWindow);
   registerServerHandlers(serverState, startLocalServer, getWindow);
   registerUpdaterHandlers(updater, getWindow);
+  registerTelemetryHandlers();
   registerNotificationHandlers((event) => {
     if (event.type === 'meeting-detected') {
       dismissMeetingCall(event.payload.key);
@@ -145,6 +148,7 @@ async function spawnMainWindow(): Promise<BrowserWindow> {
 
 void app.whenReady().then(async () => {
   try {
+    await initTelemetryState();
     browserBridgePort = await findAvailablePort();
     browserManager = new ElectronBrowserManager(() => mainWindow);
     browserManager.startBridge(browserBridgePort);

--- a/apps/desktop/src/main/ipc/telemetry.ts
+++ b/apps/desktop/src/main/ipc/telemetry.ts
@@ -1,0 +1,12 @@
+import { getTelemetryState, setTelemetryEnabled } from '../telemetry-state.js';
+import { registerIpcHandler } from './register.js';
+
+export function registerTelemetryHandlers(): void {
+  registerIpcHandler('telemetry:getState', () => {
+    return getTelemetryState();
+  });
+
+  registerIpcHandler('telemetry:setEnabled', (_event, enabled) => {
+    return setTelemetryEnabled(enabled);
+  });
+}

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -149,6 +149,9 @@ async function spawnServerOnce(port: number, extraEnv: NodeJS.ProcessEnv): Promi
     STITCH_APP_VERSION: app.getVersion(),
     STITCH_CHANNEL: app.isPackaged ? 'production' : 'development',
     STITCH_CLIENT: 'desktop',
+    STITCH_POSTHOG_KEY: process.env['STITCH_POSTHOG_KEY'] ?? '',
+    STITCH_POSTHOG_HOST: process.env['STITCH_POSTHOG_HOST'] ?? '',
+    STITCH_TELEMETRY_ENABLED: process.env['STITCH_TELEMETRY_ENABLED'] ?? '',
   };
 
   if (app.isPackaged) {

--- a/apps/desktop/src/main/telemetry-state.ts
+++ b/apps/desktop/src/main/telemetry-state.ts
@@ -1,0 +1,87 @@
+import { app } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { createTelemetryClientId, ID_PREFIXES, isIdOfType } from '@stitch/shared/id';
+import type { TelemetryState } from '@stitch/shared/telemetry/types';
+
+const TELEMETRY_FILE = 'telemetry.json';
+let state: TelemetryState | null = null;
+let initPromise: Promise<TelemetryState> | null = null;
+
+function getTelemetryFilePath(): string {
+  return path.join(app.getPath('userData'), TELEMETRY_FILE);
+}
+
+function readStateFromDisk(): TelemetryState | null {
+  try {
+    const raw = fs.readFileSync(getTelemetryFilePath(), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<TelemetryState>;
+    if (
+      typeof parsed.clientInstallationId === 'string' &&
+      isIdOfType(parsed.clientInstallationId, ID_PREFIXES.telemetryClient) &&
+      typeof parsed.enabled === 'boolean'
+    ) {
+      return {
+        clientInstallationId: parsed.clientInstallationId,
+        enabled: parsed.enabled,
+        lastActiveDate: typeof parsed.lastActiveDate === 'string' ? parsed.lastActiveDate : null,
+      };
+    }
+  } catch {
+    // missing, malformed, or unreadable — will bootstrap fresh
+  }
+  return null;
+}
+
+function writeStateToDisk(s: TelemetryState): void {
+  try {
+    fs.writeFileSync(getTelemetryFilePath(), JSON.stringify(s), 'utf-8');
+  } catch {
+    // best-effort persistence
+  }
+}
+
+/**
+ * Initialize telemetry state. Idempotent — concurrent calls return the same promise.
+ */
+export function initTelemetryState(): Promise<TelemetryState> {
+  if (initPromise) return initPromise;
+  initPromise = Promise.resolve().then(() => {
+    if (state) return state;
+
+    const existing = readStateFromDisk();
+    if (existing) {
+      state = existing;
+      return state;
+    }
+
+    const newState: TelemetryState = {
+      clientInstallationId: createTelemetryClientId(),
+      enabled: true,
+      lastActiveDate: null,
+    };
+    writeStateToDisk(newState);
+    state = newState;
+    return state;
+  });
+  return initPromise;
+}
+
+/**
+ * Get the current telemetry state synchronously. Must call initTelemetryState first.
+ */
+export function getTelemetryState(): TelemetryState {
+  if (!state) throw new Error('Telemetry state not initialized.');
+  return state;
+}
+
+/**
+ * Update telemetry enabled preference. Persists to disk immediately.
+ */
+export function setTelemetryEnabled(enabled: boolean): TelemetryState {
+  if (!state) throw new Error('Telemetry state not initialized.');
+  state = { ...state, enabled };
+  writeStateToDisk(state);
+  return state;
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -14,6 +14,7 @@ import type {
   RecordingWarningPayload,
   ServerConfigPayload,
   StartRecordingInput,
+  TelemetryState,
 } from '@stitch/shared/ipc/types';
 
 function invokeIpc<TKey extends keyof IpcContract>(
@@ -124,6 +125,10 @@ const api = {
     recordHumanInput: () => invokeIpc('browser:recordHumanInput'),
     onStateChanged: (callback: (state: ElectronBrowserState) => void) => onIpc('browser:state-changed', callback),
     onShowRequested: (callback: () => void) => onIpc('browser:show-requested', callback),
+  },
+  telemetry: {
+    getState: (): Promise<TelemetryState> => invokeIpc('telemetry:getState'),
+    setEnabled: (enabled: boolean): Promise<TelemetryState> => invokeIpc('telemetry:setEnabled', enabled),
   },
 } satisfies DesktopBridge;
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "hast-util-to-jsx-runtime": "^2.3.6",
     "katex": "^0.16.38",
     "lucide-react": "^0.577.0",
+    "posthog-js": "^1.410.6",
     "react": "19.2.4",
     "react-day-picker": "^9",
     "react-dom": "19.2.4",

--- a/apps/web/src/components/settings/general.tsx
+++ b/apps/web/src/components/settings/general.tsx
@@ -17,8 +17,10 @@ import {
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
 import { Spinner } from '@/components/ui/spinner';
+import { Switch } from '@/components/ui/switch';
 import { sttProviderModelsQueryOptions, visibleProviderModelsQueryOptions } from '@/lib/queries/providers';
 import { deleteSettingMutationOptions, saveSettingMutationOptions, settingsQueryOptions } from '@/lib/queries/settings';
+import { getClientTelemetryState, setClientTelemetryEnabled } from '@/lib/telemetry/client';
 import { useUpdaterStore } from '@/stores/updater-store';
 
 const MODEL_PREFERENCES = [
@@ -142,6 +144,9 @@ export function GeneralSettings() {
       <SettingSection title="Notifications">
         <NotificationsContent />
       </SettingSection>
+      <SettingSection title="Privacy">
+        <PrivacyContent />
+      </SettingSection>
     </SettingPage>
   );
 }
@@ -256,6 +261,32 @@ function DictationContent() {
         description="Record only while the dictation shortcut is held, finalizing on release. When off, the shortcut toggles recording on and off."
         checked={settings['stt.holdToTalk'] === 'true'}
       />
+    </SettingRows>
+  );
+}
+
+function PrivacyContent() {
+  const telemetryState = getClientTelemetryState();
+  const [enabled, setEnabled] = React.useState(telemetryState?.enabled ?? true);
+  const [pending, setPending] = React.useState(false);
+
+  async function handleToggle(checked: boolean) {
+    setPending(true);
+    try {
+      const newState = await setClientTelemetryEnabled(checked);
+      setEnabled(newState.enabled);
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <SettingRows>
+      <SettingRow
+        label="Share anonymous usage analytics"
+        description="Help improve Stitch by sending anonymous feature usage and reliability data. Prompts, file contents, recordings, and personal data are never collected.">
+        <Switch checked={enabled} disabled={pending} onCheckedChange={handleToggle} />
+      </SettingRow>
     </SettingRows>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,7 @@
 import type { DesktopBridge, ElectronBridge } from '@stitch/shared/desktop/bridge';
+import { TELEMETRY_HEADER_ENABLED, TELEMETRY_HEADER_ID } from '@stitch/shared/telemetry/types';
+
+import { getClientInstallationId, isClientTelemetryEnabled } from '@/lib/telemetry/client';
 
 export type ContextMenuParams = {
   x: number;
@@ -10,14 +13,7 @@ export type ContextMenuParams = {
   editFlags: { canCut: boolean; canCopy: boolean; canPaste: boolean; canSelectAll: boolean };
 };
 
-type DesktopUpdaterStatus =
-  | 'idle'
-  | 'checking'
-  | 'available'
-  | 'downloading'
-  | 'downloaded'
-  | 'no-update'
-  | 'error';
+type DesktopUpdaterStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'downloaded' | 'no-update' | 'error';
 
 export type DesktopUpdaterState = { status: DesktopUpdaterStatus; version?: string; progress?: number; error?: string };
 
@@ -59,7 +55,17 @@ export async function getServerUrl(): Promise<string> {
 
 export async function serverFetch(path: string, init?: RequestInit): Promise<Response> {
   const baseUrl = await getServerUrl();
-  return fetch(`${baseUrl}${path}`, init);
+  const headers = new Headers(init?.headers);
+
+  // Attach telemetry attribution headers
+  const telemetryEnabled = isClientTelemetryEnabled();
+  headers.set(TELEMETRY_HEADER_ENABLED, telemetryEnabled ? 'true' : 'false');
+  if (telemetryEnabled) {
+    const clientId = getClientInstallationId();
+    if (clientId) headers.set(TELEMETRY_HEADER_ID, clientId);
+  }
+
+  return fetch(`${baseUrl}${path}`, { ...init, headers });
 }
 
 type QueryParams = Record<string, string | number | undefined>;

--- a/apps/web/src/lib/telemetry/client.ts
+++ b/apps/web/src/lib/telemetry/client.ts
@@ -1,0 +1,218 @@
+import { createTelemetryClientId, ID_PREFIXES, isIdOfType } from '@stitch/shared/id';
+import { EVENT_SCHEMA_VERSION, type TelemetryEventName, type TelemetryEvents } from '@stitch/shared/telemetry/events';
+import { DEFAULT_POSTHOG_HOST, type TelemetryState } from '@stitch/shared/telemetry/types';
+
+const LOCALSTORAGE_KEY = 'stitch_telemetry_state';
+const APP_VERSION: string = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'dev';
+
+let state: TelemetryState | null = null;
+let posthogLoaded = false;
+let posthog: typeof import('posthog-js').default | null = null;
+
+// ---------------------------------------------------------------------------
+// State management (Electron IPC with localStorage fallback)
+// ---------------------------------------------------------------------------
+
+async function loadState(): Promise<TelemetryState> {
+  // Prefer Electron IPC
+  if (window.api?.telemetry) {
+    return window.api.telemetry.getState();
+  }
+
+  // localStorage fallback for browser/dev
+  try {
+    const raw = localStorage.getItem(LOCALSTORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<TelemetryState>;
+      if (
+        typeof parsed.clientInstallationId === 'string' &&
+        isIdOfType(parsed.clientInstallationId, ID_PREFIXES.telemetryClient) &&
+        typeof parsed.enabled === 'boolean'
+      ) {
+        return {
+          clientInstallationId: parsed.clientInstallationId,
+          enabled: parsed.enabled,
+          lastActiveDate: typeof parsed.lastActiveDate === 'string' ? parsed.lastActiveDate : null,
+        };
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  // Generate new state
+  const newState: TelemetryState = {
+    clientInstallationId: createTelemetryClientId(),
+    enabled: true,
+    lastActiveDate: null,
+  };
+  persistLocalState(newState);
+  return newState;
+}
+
+function persistLocalState(s: TelemetryState): void {
+  try {
+    localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(s));
+  } catch {
+    // quota or private browsing
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialize the client telemetry service. Must be called once during app startup.
+ * No-op if PostHog key is not configured or telemetry is disabled.
+ */
+export async function initClientTelemetry(): Promise<void> {
+  state = await loadState();
+
+  const key = getPostHogKey();
+  if (!key || !state.enabled) return;
+
+  await loadPostHog(key);
+}
+
+/**
+ * Get the current telemetry state.
+ */
+export function getClientTelemetryState(): TelemetryState | null {
+  return state;
+}
+
+/**
+ * Set telemetry enabled/disabled. Persists via Electron IPC or localStorage.
+ */
+export async function setClientTelemetryEnabled(enabled: boolean): Promise<TelemetryState> {
+  if (window.api?.telemetry) {
+    state = await window.api.telemetry.setEnabled(enabled);
+  } else if (state) {
+    state = { ...state, enabled };
+    persistLocalState(state);
+  }
+
+  if (!enabled) {
+    if (posthog) {
+      posthog.opt_out_capturing();
+    }
+  } else {
+    if (posthog) {
+      posthog.opt_in_capturing();
+    } else {
+      const key = getPostHogKey();
+      if (key) await loadPostHog(key);
+    }
+  }
+
+  return state as TelemetryState;
+}
+
+/**
+ * Capture a client-owned event, respecting consent and daily rate-limiting.
+ */
+export function captureClientEvent<T extends TelemetryEventName>(
+  eventName: T,
+  extraProperties?: TelemetryEvents[T],
+): void {
+  if (!state?.enabled || !posthog || !posthogLoaded) return;
+
+  // Rate limit app_active to once per UTC day
+  if (eventName === 'app_active') {
+    const today = getUtcDateString();
+    if (state.lastActiveDate === today) return;
+    state = { ...state, lastActiveDate: today };
+
+    if (window.api?.telemetry) {
+      void window.api.telemetry.setEnabled(state.enabled);
+    } else {
+      persistLocalState(state);
+    }
+  }
+
+  posthog.capture(eventName, {
+    event_schema_version: EVENT_SCHEMA_VERSION,
+    app_version: APP_VERSION,
+    platform: getPlatform(),
+    release_channel: getReleaseChannel(),
+    client_type: getClientType(),
+    actor_type: 'client',
+    ...extraProperties,
+  });
+}
+
+/**
+ * Check if client telemetry is currently enabled.
+ */
+export function isClientTelemetryEnabled(): boolean {
+  return state?.enabled ?? false;
+}
+
+/**
+ * Get the client installation ID (for header attribution).
+ */
+export function getClientInstallationId(): string | null {
+  return state?.clientInstallationId ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// PostHog loader
+// ---------------------------------------------------------------------------
+
+async function loadPostHog(key: string): Promise<void> {
+  if (posthogLoaded) return;
+
+  try {
+    const mod = await import('posthog-js');
+    posthog = mod.default;
+
+    posthog.init(key, {
+      api_host: DEFAULT_POSTHOG_HOST,
+      autocapture: false,
+      capture_pageview: false,
+      capture_pageleave: false,
+      disable_session_recording: true,
+      person_profiles: 'never',
+      persistence: 'memory',
+      loaded: (ph) => {
+        if (state) {
+          ph.identify(state.clientInstallationId);
+        }
+      },
+    });
+
+    posthogLoaded = true;
+  } catch {
+    posthog = null;
+    posthogLoaded = false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getPostHogKey(): string | null {
+  const key = (import.meta as { env?: Record<string, string> }).env?.['VITE_POSTHOG_KEY'] ?? '';
+  return key.length > 0 ? key : null;
+}
+
+function getUtcDateString(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function getPlatform(): string {
+  return window.electron?.platform ?? navigator.platform ?? 'unknown';
+}
+
+function getReleaseChannel(): string {
+  if (typeof __APP_VERSION__ === 'string' && __APP_VERSION__ !== 'dev') {
+    return 'production';
+  }
+  return 'development';
+}
+
+function getClientType(): string {
+  return window.api ? 'desktop' : 'web';
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,7 @@ import { RouterProvider, createHashHistory, createRouter } from '@tanstack/react
 
 import { DesktopNotificationRoot } from '@/components/desktop-notifications/desktop-notification-root';
 import { SseProvider } from '@/hooks/sse/sse-context';
+import { initClientTelemetry, captureClientEvent } from '@/lib/telemetry/client';
 import { applyAppearanceMode, DEFAULT_MODE, DEFAULT_THEME, getTheme, injectThemeCss } from '@/lib/theme';
 import { routeTree } from '@/routeTree.gen';
 import '@/styles/global.css';
@@ -38,6 +39,13 @@ if (isDesktopNotificationWindow) {
   injectThemeCss(getTheme(DEFAULT_THEME));
   applyAppearanceMode(DEFAULT_MODE);
   document.getElementById('stitch-splash')?.remove();
+}
+
+// Initialize telemetry (non-blocking, best-effort)
+if (!isDesktopNotificationWindow) {
+  void initClientTelemetry().then(() => {
+    captureClientEvent('app_active', { connection_mode: 'local' });
+  });
 }
 
 ReactDOM.createRoot(rootElement).render(

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,5 +1,13 @@
 declare const __APP_VERSION__: string;
 
+interface ImportMetaEnv {
+  readonly VITE_POSTHOG_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 declare namespace React.JSX {
   interface IntrinsicElements {
     webview: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/desktop": {
       "name": "@stitch/desktop",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "dependencies": {
         "@stitch/audio-capture": "workspace:*",
         "@stitch/meeting-detection": "workspace:*",
@@ -40,7 +40,7 @@
     },
     "apps/web": {
       "name": "@stitch/web",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@stitch/scheduler": "workspace:*",
@@ -62,6 +62,7 @@
         "hast-util-to-jsx-runtime": "^2.3.6",
         "katex": "^0.16.38",
         "lucide-react": "^0.577.0",
+        "posthog-js": "^1.410.6",
         "react": "19.2.4",
         "react-day-picker": "^9",
         "react-dom": "19.2.4",
@@ -917,9 +918,11 @@
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.74.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA=="],
 
-    "@posthog/core": ["@posthog/core@1.41.1", "", { "dependencies": { "@posthog/types": "^1.394.0" } }, "sha512-lKjPdeawDSvRhHnP14RwTSI5CofuyluhG3ISHRa+Kj6PyfSrEUyIkoVOpYWicFGgWikeaJCZzFQpo7ngHt9BcA=="],
+    "@posthog/browser-common": ["@posthog/browser-common@0.3.1", "", { "dependencies": { "@posthog/core": "^1.46.0", "@posthog/types": "^1.399.0" } }, "sha512-1nhMVY1wnHADTg8tR9yvm+lPAz5ROxznfQlBtLzB2FFo4lp/LU8lk9KyFPsARDkBxCfYachsJfvRjocL1G/AJQ=="],
 
-    "@posthog/types": ["@posthog/types@1.394.0", "", {}, "sha512-ifQ7p8o8hoHErlJmpzCFzHQcuRam0vXk8LBVhBu4BlPYP6S0tog4FSAFItnI/nwN6cHZI0WFQilr7sIqQa7Flg=="],
+    "@posthog/core": ["@posthog/core@1.46.5", "", { "dependencies": { "@posthog/types": "^1.400.0" } }, "sha512-zJr9v4bhV9DRGJENWj/FepD9S+bvsc/bwl0Sb46Md4jV7NoPWYp+2QdH4iskv8t1uZhkmCk1XxHn38RXaak/7A=="],
+
+    "@posthog/types": ["@posthog/types@1.400.0", "", {}, "sha512-0VVOXFrkh0TEAfmptoUqFGbhEzygQyWYQZYPlw0v0QYJfXTYlnlhr/QMMF3NAGKakFwOAn9ZZnlpEFeaLhZ/Cg=="],
 
     "@radix-ui/primitive": ["@radix-ui/primitive@1.1.5", "", {}, "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg=="],
 
@@ -2349,7 +2352,7 @@
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
-    "posthog-js": ["posthog-js@1.400.1", "", { "dependencies": { "@posthog/core": "^1.41.1", "@posthog/types": "^1.394.0", "core-js": "^3.49.0", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-NGfzNwTu+VBw4FekgYs/aQbEkTFkvmpTFUKDGZw/9K6R/sG2WyuLsnnXySRcNH8RMki0Io8v9flNATrrTfmT+Q=="],
+    "posthog-js": ["posthog-js@1.410.6", "", { "dependencies": { "@posthog/browser-common": "^0.3.1", "@posthog/core": "^1.46.5", "@posthog/types": "^1.400.0", "core-js": "^3.49.0", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-/LRekY3DN0SRDD98xS7DPXeTRGozMhkxO/mi+i9F783c3YnaGRP7UGKyS9In1adjmp0xXKc4PfKkwKHonB2liQ=="],
 
     "postject": ["postject@1.0.0-alpha.6", "", { "dependencies": { "commander": "^9.4.0" }, "bin": { "postject": "dist/cli.js" } }, "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A=="],
 
@@ -2889,6 +2892,8 @@
 
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg=="],
 
+    "@stitch/website/posthog-js": ["posthog-js@1.400.1", "", { "dependencies": { "@posthog/core": "^1.41.1", "@posthog/types": "^1.394.0", "core-js": "^3.49.0", "dompurify": "^3.3.2", "fflate": "^0.4.8", "preact": "^10.29.3", "query-selector-shadow-dom": "^1.0.1", "web-vitals": "^5.3.0" } }, "sha512-NGfzNwTu+VBw4FekgYs/aQbEkTFkvmpTFUKDGZw/9K6R/sG2WyuLsnnXySRcNH8RMki0Io8v9flNATrrTfmT+Q=="],
+
     "@stitch/website/vite": ["vite@8.1.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.16", "rolldown": "~1.1.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ=="],
 
     "@tailwindcss/node/tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
@@ -3406,6 +3411,10 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@stitch/website/posthog-js/@posthog/core": ["@posthog/core@1.41.1", "", { "dependencies": { "@posthog/types": "^1.394.0" } }, "sha512-lKjPdeawDSvRhHnP14RwTSI5CofuyluhG3ISHRa+Kj6PyfSrEUyIkoVOpYWicFGgWikeaJCZzFQpo7ngHt9BcA=="],
+
+    "@stitch/website/posthog-js/@posthog/types": ["@posthog/types@1.394.0", "", {}, "sha512-ifQ7p8o8hoHErlJmpzCFzHQcuRam0vXk8LBVhBu4BlPYP6S0tog4FSAFItnI/nwN6cHZI0WFQilr7sIqQa7Flg=="],
 
     "@tanstack/router-plugin/@babel/core/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -31,6 +31,7 @@ import { usageRouter } from '@/routes/usage.js';
 import { registerShutdownHandlers } from '@/shutdown.js';
 import { initSttAdapters } from '@/stt/init.js';
 import { createSttRouter } from '@/stt/route.js';
+import { telemetryMiddleware } from '@/telemetry/middleware.js';
 
 const SOCKET_KEEPALIVE_DELAY_MS = 15_000;
 
@@ -59,7 +60,14 @@ const log = Log.create({ service: 'server' });
 const app = new Hono();
 const nodeWebSocket = createNodeWebSocket({ app });
 
-app.use(cors());
+app.use(
+  cors({
+    origin: '*',
+    allowHeaders: ['Content-Type', 'x-stitch-telemetry-enabled', 'x-stitch-telemetry-id'],
+    exposeHeaders: [],
+  }),
+);
+app.use(telemetryMiddleware());
 app.get('/health', (c) => c.json({ status: 'ok', paths: PATHS }));
 app.route('/automations', automationsRouter);
 app.route('/chat', chatRouter);

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -18,6 +18,8 @@ import { syncDefaultPermissions } from '@/permission/default-permissions.js';
 import { startScheduler } from '@/scheduler/runtime.js';
 import { loadBuiltInSkills } from '@/skills/built-in-skills.js';
 import { syncBuiltInSkills } from '@/skills/service.js';
+import { initServerInstallationId } from '@/telemetry/identity.js';
+import { initServerTelemetry } from '@/telemetry/service.js';
 import { registerDefaultToolsets } from '@/tools/toolsets/register-default-toolsets.js';
 
 const log = Log.create({ service: 'init' });
@@ -36,6 +38,8 @@ export async function init() {
   registerAdapters();
 
   await initDb();
+  initServerInstallationId();
+  initServerTelemetry();
   await initMailDb(PATHS.filePaths.mailDb, resolveMailMigrationsDir());
   await runPendingMigrations(getDb());
 

--- a/packages/server/src/shutdown.ts
+++ b/packages/server/src/shutdown.ts
@@ -6,6 +6,7 @@ import * as Log from '@/lib/log.js';
 import { stopMailEngine } from '@/mail/wiring.js';
 import { stopRecording } from '@/recordings/service.js';
 import { stopScheduler } from '@/scheduler/runtime.js';
+import { shutdownServerTelemetry } from '@/telemetry/service.js';
 
 const log = Log.create({ service: 'shutdown' });
 
@@ -19,6 +20,9 @@ async function shutdown(signal: string) {
     log.warn({ error }, 'failed to stop recording during shutdown');
   });
   await shutdownConnectorRuntime();
+  await shutdownServerTelemetry().catch((error) => {
+    log.warn({ error }, 'failed to flush telemetry during shutdown');
+  });
   closeMailDb();
   closeDb();
   await Log.close();

--- a/packages/server/src/telemetry/identity.ts
+++ b/packages/server/src/telemetry/identity.ts
@@ -1,0 +1,46 @@
+import { eq } from 'drizzle-orm';
+
+import { createTelemetryServerId, ID_PREFIXES, isIdOfType } from '@stitch/shared/id';
+
+import { getDb } from '@/db/client.js';
+import { userSettings } from '@/db/schema/settings.js';
+
+const SETTING_KEY = 'telemetry.serverId';
+let cachedServerId: string | null = null;
+
+export function initServerInstallationId(): string {
+  if (cachedServerId) return cachedServerId;
+
+  const db = getDb();
+  const existing = db
+    .select({ value: userSettings.value })
+    .from(userSettings)
+    .where(eq(userSettings.key, SETTING_KEY))
+    .get();
+
+  if (existing && isIdOfType(existing.value, ID_PREFIXES.telemetryServer)) {
+    cachedServerId = existing.value;
+    return cachedServerId;
+  }
+
+  const newId = createTelemetryServerId();
+  db.insert(userSettings)
+    .values({ key: SETTING_KEY, value: newId, description: 'Anonymous server installation identifier for telemetry.' })
+    .onConflictDoNothing()
+    .run();
+
+  // Re-read in case of concurrent insert
+  const persisted = db
+    .select({ value: userSettings.value })
+    .from(userSettings)
+    .where(eq(userSettings.key, SETTING_KEY))
+    .get();
+
+  cachedServerId = persisted && isIdOfType(persisted.value, ID_PREFIXES.telemetryServer) ? persisted.value : newId;
+  return cachedServerId;
+}
+
+export function getServerInstallationId(): string {
+  if (!cachedServerId) throw new Error('Server installation ID not initialized.');
+  return cachedServerId;
+}

--- a/packages/server/src/telemetry/middleware.ts
+++ b/packages/server/src/telemetry/middleware.ts
@@ -1,0 +1,42 @@
+import { ID_PREFIXES, isIdOfType } from '@stitch/shared/id';
+import { TELEMETRY_HEADER_ENABLED, TELEMETRY_HEADER_ID } from '@stitch/shared/telemetry/types';
+
+import { getServerInstallationId } from '@/telemetry/identity.js';
+import { isServerTelemetryEnabled } from '@/telemetry/service.js';
+import type { Context, MiddlewareHandler } from 'hono';
+
+type TelemetryContext = { enabled: boolean; clientInstallationId: string | null; serverInstallationId: string };
+
+const TELEMETRY_CONTEXT_KEY = 'telemetryContext';
+
+/**
+ * Hono middleware that extracts telemetry context from request headers
+ * and makes it available via `c.get('telemetryContext')`.
+ */
+export function telemetryMiddleware(): MiddlewareHandler {
+  return async (c, next) => {
+    const context = extractTelemetryContext(c);
+    c.set(TELEMETRY_CONTEXT_KEY, context);
+    await next();
+  };
+}
+
+function extractTelemetryContext(c: Context): TelemetryContext {
+  if (!isServerTelemetryEnabled()) {
+    return { enabled: false, clientInstallationId: null, serverInstallationId: getServerInstallationId() };
+  }
+
+  const enabledHeader = c.req.header(TELEMETRY_HEADER_ENABLED);
+  if (enabledHeader === 'false') {
+    return { enabled: false, clientInstallationId: null, serverInstallationId: getServerInstallationId() };
+  }
+
+  const idHeader = c.req.header(TELEMETRY_HEADER_ID);
+  const clientInstallationId = idHeader && isIdOfType(idHeader, ID_PREFIXES.telemetryClient) ? idHeader : null;
+
+  return {
+    enabled: enabledHeader === 'true' && clientInstallationId !== null,
+    clientInstallationId,
+    serverInstallationId: getServerInstallationId(),
+  };
+}

--- a/packages/server/src/telemetry/service.ts
+++ b/packages/server/src/telemetry/service.ts
@@ -1,0 +1,114 @@
+import { DEFAULT_POSTHOG_HOST } from '@stitch/shared/telemetry/types';
+
+import * as Log from '@/lib/log.js';
+
+const log = Log.create({ service: 'telemetry:service' });
+
+const BATCH_SIZE = 20;
+const FLUSH_INTERVAL_MS = 30_000;
+const FETCH_TIMEOUT_MS = 5_000;
+const MAX_QUEUE_SIZE = 200;
+
+type QueuedEvent = { event: string; distinct_id: string; properties: Record<string, unknown>; timestamp: string };
+
+let queue: QueuedEvent[] = [];
+let flushTimer: ReturnType<typeof setInterval> | null = null;
+let posthogKey: string | null = null;
+let posthogHost: string = DEFAULT_POSTHOG_HOST;
+let enabled = true;
+
+function isConfigured(): boolean {
+  return enabled && posthogKey !== null && posthogKey.length > 0;
+}
+
+/**
+ * Initialize the server telemetry service.
+ * No-op if key is missing or telemetry is disabled.
+ */
+export function initServerTelemetry(): void {
+  const key = process.env['STITCH_POSTHOG_KEY']?.trim() ?? '';
+  const host = process.env['STITCH_POSTHOG_HOST']?.trim() ?? '';
+  const disabledEnv = process.env['STITCH_TELEMETRY_ENABLED']?.trim();
+
+  if (disabledEnv === 'false') {
+    enabled = false;
+    log.info('server telemetry disabled via STITCH_TELEMETRY_ENABLED=false');
+    return;
+  }
+
+  if (!key) {
+    enabled = false;
+    log.info('server telemetry disabled: no STITCH_POSTHOG_KEY configured');
+    return;
+  }
+
+  posthogKey = key;
+  if (host) posthogHost = host;
+  enabled = true;
+
+  flushTimer = setInterval(() => {
+    void flushQueue();
+  }, FLUSH_INTERVAL_MS);
+
+  // Unref so the timer doesn't keep the process alive during shutdown
+  if (flushTimer && typeof flushTimer.unref === 'function') {
+    flushTimer.unref();
+  }
+
+  log.info({ host: posthogHost }, 'server telemetry initialized');
+}
+
+/**
+ * Flush queued events to PostHog. Best-effort — never throws.
+ */
+async function flushQueue(): Promise<void> {
+  if (!isConfigured() || queue.length === 0) return;
+
+  const batch = queue.splice(0, BATCH_SIZE);
+
+  try {
+    const response = await fetch(`${posthogHost}/batch`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ api_key: posthogKey, batch: batch.map((e) => ({ ...e, type: 'capture' })) }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      log.warn({ status: response.status }, 'telemetry batch delivery failed');
+      if (queue.length + batch.length <= MAX_QUEUE_SIZE) {
+        queue.unshift(...batch);
+      }
+    }
+  } catch (error) {
+    log.warn({ error }, 'telemetry batch delivery error');
+    if (queue.length + batch.length <= MAX_QUEUE_SIZE) {
+      queue.unshift(...batch);
+    }
+  }
+}
+
+/**
+ * Graceful shutdown: flush remaining events and stop timer.
+ */
+export async function shutdownServerTelemetry(): Promise<void> {
+  if (flushTimer) {
+    clearInterval(flushTimer);
+    flushTimer = null;
+  }
+
+  if (!isConfigured() || queue.length === 0) return;
+
+  while (queue.length > 0) {
+    await flushQueue();
+  }
+
+  log.info('server telemetry flushed and shut down');
+}
+
+/**
+ * Check if server telemetry is enabled (for middleware decisions).
+ */
+export function isServerTelemetryEnabled(): boolean {
+  return enabled && posthogKey !== null && posthogKey.length > 0;
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,6 +50,8 @@
     "./skills/events": "./src/skills/events.ts",
     "./skills/types": "./src/skills/types.ts",
     "./stt/types": "./src/stt/types.ts",
+    "./telemetry/events": "./src/telemetry/events.ts",
+    "./telemetry/types": "./src/telemetry/types.ts",
     "./logger": "./src/logger.ts"
   },
   "scripts": {

--- a/packages/shared/src/desktop/bridge.ts
+++ b/packages/shared/src/desktop/bridge.ts
@@ -14,6 +14,7 @@ import type {
   StartRecordingInput,
   StartRecordingResponse,
   StopRecordingResponse,
+  TelemetryState,
   UpdaterStatePayload,
 } from '../ipc/types.js';
 
@@ -86,6 +87,7 @@ export type DesktopBridge = {
     onStateChanged: (callback: (state: ElectronBrowserState) => void) => () => void;
     onShowRequested: (callback: () => void) => () => void;
   };
+  telemetry: { getState: () => Promise<TelemetryState>; setEnabled: (enabled: boolean) => Promise<TelemetryState> };
 };
 
 export type ElectronBridge = {

--- a/packages/shared/src/id/index.ts
+++ b/packages/shared/src/id/index.ts
@@ -26,6 +26,8 @@ export const ID_PREFIXES = {
   mailMessage: 'mmsg',
   mailAttachment: 'matt',
   mailDraft: 'mdrf',
+  telemetryClient: 'tcli',
+  telemetryServer: 'tsrv',
 } as const;
 
 export type IdPrefix = (typeof ID_PREFIXES)[keyof typeof ID_PREFIXES];
@@ -90,6 +92,15 @@ export const createMeetingNoteTemplateId = createIdFactory(ID_PREFIXES.meetingNo
 export const createAgendaListId = createIdFactory(ID_PREFIXES.agendaList);
 export const createAgendaItemId = createIdFactory(ID_PREFIXES.agendaItem);
 export const createTodoId = createIdFactory(ID_PREFIXES.todo);
+export const createTelemetryClientId = createIdFactory(ID_PREFIXES.telemetryClient);
+export const createTelemetryServerId = createIdFactory(ID_PREFIXES.telemetryServer);
+
+/**
+ * Check whether an ID string belongs to a given prefix type.
+ */
+export function isIdOfType(id: string, prefix: IdPrefix): boolean {
+  return typeof id === 'string' && id.startsWith(prefix + '_') && id.length > prefix.length + 1 && id.length <= 80;
+}
 
 export function extractTimestamp(id: string): number {
   const prefix = id.split('_')[0];

--- a/packages/shared/src/ipc/types.ts
+++ b/packages/shared/src/ipc/types.ts
@@ -2,6 +2,7 @@ import type { ElectronBrowserState } from '../browser/electron.js';
 import type { RecordingDeviceChangedPayload, RecordingWarningPayload } from '../recordings/events.js';
 import type { MeetingCallDetectedPayload, MeetingCallEndedPayload } from '../recordings/meeting-ipc.js';
 import type { StartRecordingInput, StartRecordingResponse, StopRecordingResponse } from '../recordings/types.js';
+import type { TelemetryState } from '../telemetry/types.js';
 
 export type {
   MeetingCallDetectedPayload,
@@ -11,6 +12,7 @@ export type {
   StartRecordingInput,
   StartRecordingResponse,
   StopRecordingResponse,
+  TelemetryState,
 };
 
 export type ServerConfigPayload = { url: string; mode: 'local' | 'remote'; remoteUrl: string | null };
@@ -92,6 +94,8 @@ export interface IpcContract {
   'browser:focusTab': { args: [tabId: string]; return: ElectronBrowserState };
   'browser:closeTab': { args: [tabId: string]; return: ElectronBrowserState };
   'browser:recordHumanInput': { args: []; return: void };
+  'telemetry:getState': { args: []; return: TelemetryState };
+  'telemetry:setEnabled': { args: [enabled: boolean]; return: TelemetryState };
 }
 
 export interface IpcEventContract {

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -281,6 +281,11 @@ const SETTINGS_REGISTRY = {
     default: 'true',
     description: 'Always load remote images in Mail message bodies.',
   },
+  'telemetry.serverId': {
+    schema: z.string().max(80),
+    default: '',
+    description: 'Anonymous server installation identifier for telemetry.',
+  },
 } as const;
 
 export type SettingsKey = keyof typeof SETTINGS_REGISTRY;

--- a/packages/shared/src/telemetry/events.ts
+++ b/packages/shared/src/telemetry/events.ts
@@ -1,0 +1,19 @@
+/**
+ * Telemetry event registry — single source of truth for all analytics events.
+ *
+ * To add a new event:
+ * 1. Add a key to TelemetryEvents with its allowed properties type.
+ * 2. Capture it via `captureClientEvent('your_event', { ... })`.
+ */
+
+export const EVENT_SCHEMA_VERSION = 1;
+
+// ---------------------------------------------------------------------------
+// Event registry: event name → allowed extra properties
+// ---------------------------------------------------------------------------
+
+export type TelemetryEvents = {
+  app_active: { connection_mode?: 'local' | 'remote' };
+};
+
+export type TelemetryEventName = keyof TelemetryEvents;

--- a/packages/shared/src/telemetry/types.ts
+++ b/packages/shared/src/telemetry/types.ts
@@ -1,0 +1,15 @@
+/**
+ * Client telemetry state persisted locally (Electron userData or localStorage).
+ */
+export type TelemetryState = { clientInstallationId: string; enabled: boolean; lastActiveDate: string | null };
+
+/**
+ * HTTP headers used for client-to-server telemetry attribution.
+ */
+export const TELEMETRY_HEADER_ENABLED = 'x-stitch-telemetry-enabled';
+export const TELEMETRY_HEADER_ID = 'x-stitch-telemetry-id';
+
+/**
+ * Default PostHog ingest host.
+ */
+export const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com';


### PR DESCRIPTION
## 🚀 Change Summary

Adds minimal, privacy-controlled anonymous telemetry to measure active installations via a single daily `app_active` event, with a client-local consent toggle and a kill switch.

### ✨ New Features

- **PostHog telemetry client**: Initializes in the renderer, sends `app_active` directly to PostHog, rate-limited to once per client per UTC day. Client installation ID (`tcli_*`) persisted in Electron userData / localStorage.
- **Privacy toggle**: New consent toggle in General settings to opt out of telemetry (client-local).
- **Server telemetry identity & queue**: Server installation ID (`tsrv_*`) stored in `user_settings`, with a bounded in-memory queue and batch flush to PostHog (currently unused) and graceful flush on shutdown.
- **Telemetry attribution headers**: All server requests now attach telemetry headers for future attribution; middleware extracts telemetry context from request headers.
- **Typed event registry**: `TelemetryEvents` map for compile-time safety on event names/payloads, plus `isIdOfType()` generic ID validator and new `telemetryClient`/`telemetryServer` ID prefixes.
- **Kill switch**: `STITCH_TELEMETRY_ENABLED=false` disables server-side telemetry entirely.
- **Build wiring**: `POSTHOG_KEY` passed through `release.yml` to desktop builds, sidecar env passthrough for `STITCH_POSTHOG_KEY`/`STITCH_POSTHOG_HOST`, and `VITE_POSTHOG_KEY` for the renderer build.
