### PR TITLE
improvement(web): adopt TanStack Table v9 createTableHook with cellComponents

### DIFF
--- a/apps/web/src/components/automations/automation-runs-table.tsx
+++ b/apps/web/src/components/automations/automation-runs-table.tsx
@@ -1,71 +1,49 @@
 import { ArrowUpRightIcon } from 'lucide-react';
 import * as React from 'react';
 
-import {
-  type CellContext,
-  createColumnHelper,
-  createSortedRowModel,
-  metaHelper,
-  rowSortingFeature,
-  sortFn_alphanumeric,
-  sortFn_text,
-  type SortingState,
-  tableFeatures,
-  useTable,
-} from '@tanstack/react-table';
+import { type SortingState } from '@tanstack/react-table';
 
 import type { Session } from '@stitch/shared/chat/messages';
 
 import { Icon } from '@/components/primitives/icon';
 import { Button } from '@/components/ui/button';
 import { Table } from '@/components/ui/table';
+import { createAppColumnHelper, useAppTable } from '@/hooks/table-hook';
 
 type AutomationRunsTableProps = { sessions: Session[]; onOpen: (sessionId: string) => void };
 
 type AutomationRunsTableMeta = { onOpen: (sessionId: string) => void };
 
-const features = tableFeatures({
-  rowSortingFeature,
-  sortedRowModel: createSortedRowModel(),
-  sortFns: { alphanumeric: sortFn_alphanumeric, text: sortFn_text },
-  tableMeta: metaHelper<AutomationRunsTableMeta>(),
-});
-
-const columnHelper = createColumnHelper<typeof features, Session>();
-
-function TitleCell({ row }: CellContext<typeof features, Session, Session['title']>) {
-  return <Table.Title>{row.original.title ?? 'Untitled run'}</Table.Title>;
-}
-
-function TimeCell({ getValue }: CellContext<typeof features, Session, number>) {
-  return <Table.Time value={getValue()} />;
-}
-
-function ActionsCell({ row, table }: CellContext<typeof features, Session, unknown>) {
-  const { onOpen } = table.options.meta as AutomationRunsTableMeta;
-
-  return (
-    <Table.Actions>
-      <Button variant="outline" size="sm" onClick={() => onOpen(row.original.id)}>
-        <Icon as={ArrowUpRightIcon} size="m" data-icon="inline-start" />
-        View
-      </Button>
-    </Table.Actions>
-  );
-}
+const columnHelper = createAppColumnHelper<Session>();
 
 const columns = columnHelper.columns([
-  columnHelper.accessor('title', { header: 'Run', cell: TitleCell }),
-  columnHelper.accessor('createdAt', { header: 'Started', cell: TimeCell }),
-  columnHelper.accessor('updatedAt', { header: 'Updated', cell: TimeCell }),
-  columnHelper.display({ id: 'actions', header: '', cell: ActionsCell }),
+  columnHelper.accessor('title', {
+    header: 'Run',
+    cell: ({ row }) => <Table.Title>{row.original.title ?? 'Untitled run'}</Table.Title>,
+  }),
+  columnHelper.accessor('createdAt', { header: 'Started', cell: ({ cell }) => <cell.TimeCell /> }),
+  columnHelper.accessor('updatedAt', { header: 'Updated', cell: ({ cell }) => <cell.TimeCell /> }),
+  columnHelper.display({
+    id: 'actions',
+    header: '',
+    cell: ({ row, table }) => {
+      const { onOpen } = table.options.meta as AutomationRunsTableMeta;
+      return (
+        <Table.Actions>
+          <Button variant="outline" size="sm" onClick={() => onOpen(row.original.id)}>
+            <Icon as={ArrowUpRightIcon} size="m" data-icon="inline-start" />
+            View
+          </Button>
+        </Table.Actions>
+      );
+    },
+  }),
 ]);
 
 export function AutomationRunsTable({ sessions, onOpen }: AutomationRunsTableProps) {
   const [sorting, setSorting] = React.useState<SortingState>([{ id: 'updatedAt', desc: true }]);
 
-  const table = useTable({
-    features,
+  const table = useAppTable({
     data: sessions,
     columns,
     state: { sorting },
@@ -91,10 +69,14 @@ export function AutomationRunsTable({ sessions, onOpen }: AutomationRunsTablePro
           <Table.Body>
             {table.getRowModel().rows.map((row) => (
               <Table.Row key={row.id}>
-                {row.getAllCells().map((cell) => (
-                  <Table.Cell key={cell.id}>
-                    <table.FlexRender cell={cell} />
-                  </Table.Cell>
+                {row.getAllCells().map((c) => (
+                  <table.AppCell cell={c} key={c.id}>
+                    {(cell) => (
+                      <Table.Cell>
+                        <cell.FlexRender />
+                      </Table.Cell>
+                    )}
+                  </table.AppCell>
                 ))}
               </Table.Row>
             ))}

--- a/apps/web/src/components/automations/automations-table.tsx
+++ b/apps/web/src/components/automations/automations-table.tsx
@@ -2,18 +2,7 @@ import { PlayIcon, PencilIcon, Trash2Icon, BotIcon } from 'lucide-react';
 import * as React from 'react';
 
 import { Link } from '@tanstack/react-router';
-import {
-  type CellContext,
-  createColumnHelper,
-  createSortedRowModel,
-  metaHelper,
-  rowSortingFeature,
-  sortFn_alphanumeric,
-  sortFn_text,
-  type SortingState,
-  tableFeatures,
-  useTable,
-} from '@tanstack/react-table';
+import { type SortingState } from '@tanstack/react-table';
 
 import type { Automation } from '@stitch/shared/automations/types';
 
@@ -30,6 +19,7 @@ import {
   PaginationPrevious,
 } from '@/components/ui/pagination';
 import { Table } from '@/components/ui/table';
+import { createAppColumnHelper, useAppTable } from '@/hooks/table-hook';
 import { getAutomationScheduleLabel } from '@/lib/automations/schedule-label';
 import type { ProviderModels } from '@/lib/queries/providers';
 
@@ -46,15 +36,6 @@ type AutomationsTableProps = {
   onDelete: (automation: Automation) => void;
 };
 
-const features = tableFeatures({
-  rowSortingFeature,
-  sortedRowModel: createSortedRowModel(),
-  sortFns: { alphanumeric: sortFn_alphanumeric, text: sortFn_text },
-  tableMeta: metaHelper<AutomationsTableMeta>(),
-});
-
-const columnHelper = createColumnHelper<typeof features, Automation>();
-
 type AutomationsTableMeta = {
   modelLabelByKey: Map<string, string>;
   runPending: boolean;
@@ -64,77 +45,73 @@ type AutomationsTableMeta = {
   onDelete: (automation: Automation) => void;
 };
 
-function TitleCell({ row }: CellContext<typeof features, Automation, Automation['title']>) {
-  return (
-    <Table.Title className="block">
-      <Link
-        to="/automations/$automationId"
-        params={{ automationId: row.original.id }}
-        className="text-foreground hover:underline">
-        {row.original.title}
-      </Link>
-    </Table.Title>
-  );
-}
-
-function ModelCell({ row, table }: CellContext<typeof features, Automation, unknown>) {
-  const { modelLabelByKey } = table.options.meta as AutomationsTableMeta;
-  const automation = row.original;
-  const label = modelLabelByKey.get(`${automation.providerId}:${automation.modelId}`) ?? automation.modelId;
-  return <Table.Badge>{label}</Table.Badge>;
-}
-
-function RunCountCell({ getValue }: CellContext<typeof features, Automation, Automation['runCount']>) {
-  return <Table.Number value={getValue()} />;
-}
-
-function ScheduleCell({ row }: CellContext<typeof features, Automation, unknown>) {
-  return <Table.Text>{getAutomationScheduleLabel(row.original.schedule)}</Table.Text>;
-}
-
-function UpdatedAtCell({ getValue }: CellContext<typeof features, Automation, Automation['updatedAt']>) {
-  return <Table.Time value={getValue()} />;
-}
-
-function ActionsCell({ row, table }: CellContext<typeof features, Automation, unknown>) {
-  const { runPending, deletePending, onRun, onEdit, onDelete } = table.options.meta as AutomationsTableMeta;
-
-  return (
-    <Table.Actions>
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={() => onRun(row.original)}
-        disabled={runPending}
-        aria-label={`Run ${row.original.title}`}>
-        <Icon as={PlayIcon} size="s" />
-      </Button>
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={() => onEdit(row.original.id)}
-        aria-label={`Edit ${row.original.title}`}>
-        <Icon as={PencilIcon} size="s" />
-      </Button>
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={() => onDelete(row.original)}
-        disabled={deletePending}
-        aria-label={`Delete ${row.original.title}`}>
-        <Icon as={Trash2Icon} size="s" tone="destructive" />
-      </Button>
-    </Table.Actions>
-  );
-}
+const columnHelper = createAppColumnHelper<Automation>();
 
 const columns = columnHelper.columns([
-  columnHelper.accessor('title', { header: 'Title', cell: TitleCell }),
-  columnHelper.display({ id: 'model', header: 'Model', cell: ModelCell }),
-  columnHelper.accessor('runCount', { header: 'Runs', cell: RunCountCell }),
-  columnHelper.display({ id: 'schedule', header: 'Schedule', cell: ScheduleCell }),
-  columnHelper.accessor('updatedAt', { header: 'Updated', cell: UpdatedAtCell }),
-  columnHelper.display({ id: 'actions', header: '', cell: ActionsCell }),
+  columnHelper.accessor('title', {
+    header: 'Title',
+    cell: ({ row }) => (
+      <Table.Title className="block">
+        <Link
+          to="/automations/$automationId"
+          params={{ automationId: row.original.id }}
+          className="text-foreground hover:underline">
+          {row.original.title}
+        </Link>
+      </Table.Title>
+    ),
+  }),
+  columnHelper.display({
+    id: 'model',
+    header: 'Model',
+    cell: ({ row, table }) => {
+      const { modelLabelByKey } = table.options.meta as AutomationsTableMeta;
+      const automation = row.original;
+      const label = modelLabelByKey.get(`${automation.providerId}:${automation.modelId}`) ?? automation.modelId;
+      return <Table.Badge>{label}</Table.Badge>;
+    },
+  }),
+  columnHelper.accessor('runCount', { header: 'Runs', cell: ({ cell }) => <cell.NumberCell /> }),
+  columnHelper.display({
+    id: 'schedule',
+    header: 'Schedule',
+    cell: ({ row }) => <Table.Text>{getAutomationScheduleLabel(row.original.schedule)}</Table.Text>,
+  }),
+  columnHelper.accessor('updatedAt', { header: 'Updated', cell: ({ cell }) => <cell.TimeCell /> }),
+  columnHelper.display({
+    id: 'actions',
+    header: '',
+    cell: ({ row, table }) => {
+      const { runPending, deletePending, onRun, onEdit, onDelete } = table.options.meta as AutomationsTableMeta;
+      return (
+        <Table.Actions>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => onRun(row.original)}
+            disabled={runPending}
+            aria-label={`Run ${row.original.title}`}>
+            <Icon as={PlayIcon} size="s" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => onEdit(row.original.id)}
+            aria-label={`Edit ${row.original.title}`}>
+            <Icon as={PencilIcon} size="s" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => onDelete(row.original)}
+            disabled={deletePending}
+            aria-label={`Delete ${row.original.title}`}>
+            <Icon as={Trash2Icon} size="s" tone="destructive" />
+          </Button>
+        </Table.Actions>
+      );
+    },
+  }),
 ]);
 
 export function AutomationsTable({
@@ -161,8 +138,7 @@ export function AutomationsTable({
     return map;
   }, [providerModels]);
 
-  const table = useTable({
-    features,
+  const table = useAppTable({
     data: automations,
     columns,
     state: { sorting },
@@ -218,10 +194,14 @@ export function AutomationsTable({
             ) : (
               table.getRowModel().rows.map((row) => (
                 <Table.Row key={row.id}>
-                  {row.getAllCells().map((cell) => (
-                    <Table.Cell key={cell.id}>
-                      <table.FlexRender cell={cell} />
-                    </Table.Cell>
+                  {row.getAllCells().map((c) => (
+                    <table.AppCell cell={c} key={c.id}>
+                      {(cell) => (
+                        <Table.Cell>
+                          <cell.FlexRender />
+                        </Table.Cell>
+                      )}
+                    </table.AppCell>
                   ))}
                 </Table.Row>
               ))

--- a/apps/web/src/components/recordings/list/recordings-table.tsx
+++ b/apps/web/src/components/recordings/list/recordings-table.tsx
@@ -1,18 +1,7 @@
 import { Trash2Icon, MicIcon } from 'lucide-react';
 import * as React from 'react';
 
-import {
-  type CellContext,
-  createColumnHelper,
-  createSortedRowModel,
-  metaHelper,
-  rowSortingFeature,
-  sortFn_alphanumeric,
-  sortFn_text,
-  type SortingState,
-  tableFeatures,
-  useTable,
-} from '@tanstack/react-table';
+import { type SortingState } from '@tanstack/react-table';
 
 import type { Recording } from '@stitch/shared/recordings/types';
 
@@ -24,85 +13,69 @@ import { Icon } from '@/components/primitives/icon';
 import { Button } from '@/components/ui/button';
 import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
 import { Table } from '@/components/ui/table';
+import { createAppColumnHelper, useAppTable } from '@/hooks/table-hook';
 
 type RecordingsTableMeta = { activeRecordingId: string | null; onDelete: (recording: Recording) => void };
 
-const features = tableFeatures({
-  rowSortingFeature,
-  sortedRowModel: createSortedRowModel(),
-  sortFns: { alphanumeric: sortFn_alphanumeric, text: sortFn_text },
-  tableMeta: metaHelper<RecordingsTableMeta>(),
-});
-
-const columnHelper = createColumnHelper<typeof features, Recording>();
-
-function TitleCell({ row }: CellContext<typeof features, Recording, string>) {
-  return (
-    <div className="flex min-w-0 flex-col">
-      <Table.Title>{getRecordingDisplayTitle(row.original)}</Table.Title>
-    </div>
-  );
-}
-
-function PlatformCell({ getValue }: CellContext<typeof features, Recording, Recording['platform']>) {
-  return <PlatformBadge platform={getValue()} />;
-}
-
-function StatusCell({ getValue }: CellContext<typeof features, Recording, Recording['status']>) {
-  return <Table.Badge variant={STATUS_VARIANTS[getValue()]}>{STATUS_LABELS[getValue()]}</Table.Badge>;
-}
-
-function StartedAtCell({ getValue }: CellContext<typeof features, Recording, Recording['startedAt']>) {
-  return <Table.Time value={getValue()} />;
-}
-
-function DurationCell({ row, table }: CellContext<typeof features, Recording, unknown>) {
-  const { activeRecordingId } = table.options.meta as RecordingsTableMeta;
-  const recording = row.original;
-  if (recording.id === activeRecordingId) {
-    return <LiveDuration startedAt={recording.startedAt} />;
-  }
-  return <Table.Duration>{formatClockDuration(recording.durationMs)}</Table.Duration>;
-}
-
-function CostCell({ getValue }: CellContext<typeof features, Recording, Recording['costUsd']>) {
-  return <Table.Money value={getValue()} />;
-}
-
-function ActionsHeader() {
-  return <div className="pr-space-xs text-right">Actions</div>;
-}
-
-function ActionsCell({ row, table }: CellContext<typeof features, Recording, unknown>) {
-  const { activeRecordingId, onDelete } = table.options.meta as RecordingsTableMeta;
-
-  return (
-    <Table.Actions className="-mr-space-s">
-      <Button
-        type="button"
-        variant="destructive-quiet"
-        size="icon-sm"
-        onClick={(e) => {
-          e.stopPropagation();
-          onDelete(row.original);
-        }}
-        title="Delete recording"
-        aria-label="Delete recording"
-        disabled={row.original.id === activeRecordingId}>
-        <Icon as={Trash2Icon} size="m" />
-      </Button>
-    </Table.Actions>
-  );
-}
+const columnHelper = createAppColumnHelper<Recording>();
 
 const columns = columnHelper.columns([
-  columnHelper.accessor('title', { header: 'Title', cell: TitleCell }),
-  columnHelper.accessor('platform', { header: 'Platform', cell: PlatformCell }),
-  columnHelper.accessor('status', { header: 'Capturing', cell: StatusCell }),
-  columnHelper.accessor('startedAt', { header: 'Date', cell: StartedAtCell }),
-  columnHelper.display({ id: 'duration', header: 'Duration', cell: DurationCell }),
-  columnHelper.accessor('costUsd', { header: 'Cost', cell: CostCell }),
-  columnHelper.display({ id: 'actions', header: ActionsHeader, cell: ActionsCell }),
+  columnHelper.accessor('title', {
+    header: 'Title',
+    cell: ({ row }) => (
+      <div className="flex min-w-0 flex-col">
+        <Table.Title>{getRecordingDisplayTitle(row.original)}</Table.Title>
+      </div>
+    ),
+  }),
+  columnHelper.accessor('platform', {
+    header: 'Platform',
+    cell: ({ cell }) => <PlatformBadge platform={cell.getValue()} />,
+  }),
+  columnHelper.accessor('status', {
+    header: 'Capturing',
+    cell: ({ cell }) => (
+      <Table.Badge variant={STATUS_VARIANTS[cell.getValue()]}>{STATUS_LABELS[cell.getValue()]}</Table.Badge>
+    ),
+  }),
+  columnHelper.accessor('startedAt', { header: 'Date', cell: ({ cell }) => <cell.TimeCell /> }),
+  columnHelper.display({
+    id: 'duration',
+    header: 'Duration',
+    cell: ({ row, table }) => {
+      const { activeRecordingId } = table.options.meta as RecordingsTableMeta;
+      const recording = row.original;
+      if (recording.id === activeRecordingId) {
+        return <LiveDuration startedAt={recording.startedAt} />;
+      }
+      return <Table.Duration>{formatClockDuration(recording.durationMs)}</Table.Duration>;
+    },
+  }),
+  columnHelper.accessor('costUsd', { header: 'Cost', cell: ({ cell }) => <cell.MoneyCell /> }),
+  columnHelper.display({
+    id: 'actions',
+    header: () => <div className="pr-space-xs text-right">Actions</div>,
+    cell: ({ row, table }) => {
+      const { activeRecordingId, onDelete } = table.options.meta as RecordingsTableMeta;
+      return (
+        <Table.Actions className="-mr-space-s">
+          <Button
+            type="button"
+            variant="destructive-quiet"
+            size="icon-sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(row.original);
+            }}
+            title="Delete recording"
+            aria-label="Delete recording"
+            disabled={row.original.id === activeRecordingId}>
+            <Icon as={Trash2Icon} size="m" />
+          </Button>
+        </Table.Actions>
+      );
+    },
+  }),
 ]);
 
 interface RecordingsTableProps {
@@ -122,8 +95,7 @@ export function RecordingsTable({
   onDelete,
   onNavigate,
 }: RecordingsTableProps) {
-  const table = useTable({
-    features,
+  const table = useAppTable({
     data: recordings,
     columns,
     getRowId: (row) => row.id,
@@ -166,16 +138,19 @@ export function RecordingsTable({
           ) : (
             table.getRowModel().rows.map((row) => (
               <Table.Row key={row.id} className="cursor-pointer" onClick={() => onNavigate(row.original.id)}>
-                {row.getAllCells().map((cell) => (
-                  <Table.Cell
-                    key={cell.id}
-                    className={
-                      cell.column.id === 'title'
-                        ? 'w-full max-w-xs min-w-48 px-space-xl py-space-l'
-                        : 'px-space-xl py-space-l whitespace-nowrap'
-                    }>
-                    <table.FlexRender cell={cell} />
-                  </Table.Cell>
+                {row.getAllCells().map((c) => (
+                  <table.AppCell cell={c} key={c.id}>
+                    {(cell) => (
+                      <Table.Cell
+                        className={
+                          cell.column.id === 'title'
+                            ? 'w-full max-w-xs min-w-48 px-space-xl py-space-l'
+                            : 'px-space-xl py-space-l whitespace-nowrap'
+                        }>
+                        <cell.FlexRender />
+                      </Table.Cell>
+                    )}
+                  </table.AppCell>
                 ))}
               </Table.Row>
             ))

--- a/apps/web/src/hooks/table-hook.tsx
+++ b/apps/web/src/hooks/table-hook.tsx
@@ -1,0 +1,113 @@
+import {
+  createSortedRowModel,
+  createTableHook,
+  createTableHookContexts,
+  rowSortingFeature,
+  sortFn_alphanumeric,
+  sortFn_text,
+  tableFeatures,
+} from '@tanstack/react-table';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { Table } from '@/components/ui/table';
+
+// --- Shared features ---
+
+const features = tableFeatures({
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  sortFns: { alphanumeric: sortFn_alphanumeric, text: sortFn_text },
+});
+
+// --- Scoped contexts (created before cell components so they can call useCellContext) ---
+
+const { tableContext, cellContext, headerContext, useCellContext } =
+  createTableHookContexts<typeof features>();
+
+// --- Cell Components ---
+// These use useCellContext() internally via the createTableHook pattern.
+// When used in column defs: cell: ({ cell }) => <cell.TitleCell />
+
+function TitleCell() {
+  const cell = useCellContext();
+  return <Table.Title>{cell.getValue() as string}</Table.Title>;
+}
+
+function TextCell() {
+  const cell = useCellContext();
+  return <Table.Text>{cell.getValue() as string}</Table.Text>;
+}
+
+function BadgeCell() {
+  const cell = useCellContext();
+  return <Table.Badge>{cell.getValue() as string}</Table.Badge>;
+}
+
+function TimeCell() {
+  const cell = useCellContext();
+  return <Table.Time value={cell.getValue() as number | string | Date} />;
+}
+
+function DateTimeCell() {
+  const cell = useCellContext();
+  return <Table.Time value={cell.getValue() as number | string | Date} format="dateTime" />;
+}
+
+function ShortDateCell() {
+  const cell = useCellContext();
+  return <Table.Time value={cell.getValue() as number | string | Date} format="shortDate" />;
+}
+
+function NumberCell() {
+  const cell = useCellContext();
+  return <Table.Number value={cell.getValue() as number} />;
+}
+
+function MoneyCell() {
+  const cell = useCellContext();
+  return <Table.Money value={cell.getValue() as number | null} />;
+}
+
+function DurationCell() {
+  const cell = useCellContext();
+  return <Table.Duration>{cell.getValue() as string}</Table.Duration>;
+}
+
+function StatusCell() {
+  const cell = useCellContext();
+  return <Table.Status>{cell.getValue() as string}</Table.Status>;
+}
+
+function SkeletonCell() {
+  return <Skeleton className="h-4 w-24" />;
+}
+
+// --- createTableHook ---
+
+export const {
+  useAppTable,
+  createAppColumnHelper,
+  
+  
+  
+} = createTableHook({
+  features,
+  tableContext,
+  cellContext,
+  headerContext,
+  cellComponents: {
+    TitleCell,
+    TextCell,
+    BadgeCell,
+    TimeCell,
+    DateTimeCell,
+    ShortDateCell,
+    NumberCell,
+    MoneyCell,
+    DurationCell,
+    StatusCell,
+    SkeletonCell,
+  },
+});
+
+;


### PR DESCRIPTION
## Change Summary

Adopts TanStack Table v9's `createTableHook` + `cellComponents` API to centralize table configuration and provide reusable, composable cell components across all data tables.

### New Features
- **Shared table hook** (`hooks/table-hook.tsx`): Single source of truth for table features (sorting, row models, sort fns) and registered cell components using `createTableHookContexts` + `createTableHook`
- **Composable cell components**: `TitleCell`, `TextCell`, `BadgeCell`, `TimeCell`, `DateTimeCell`, `ShortDateCell`, `NumberCell`, `MoneyCell`, `DurationCell`, `StatusCell`, `SkeletonCell` — usable in column defs as `({ cell }) => <cell.TimeCell />`

### Improvements & Refactors
- Tables now use `useAppTable` + `createAppColumnHelper` instead of manually wiring `tableFeatures()` + `useTable` in each file
- Cell rendering uses `<table.AppCell>` wrapper for proper context injection, enabling registered cell components to access cell data via `useCellContext()`
- Removes ~60 lines of duplicated feature/sort setup across table files
