### PR TITLE
fix(web): only show server status subtitle on non-ok states

### DIFF
--- a/apps/web/src/components/layout/server-status-state.test.ts
+++ b/apps/web/src/components/layout/server-status-state.test.ts
@@ -37,17 +37,11 @@ describe('worstState', () => {
 
 describe('formatEventBusSubtitle', () => {
   it('reports connecting before any heartbeat has arrived', () => {
-    expect(formatEventBusSubtitle('connecting', null)).toBe('Connecting');
-    expect(formatEventBusSubtitle('reconnecting', null)).toBe('Connecting');
+    expect(formatEventBusSubtitle(null)).toBe('Connecting');
   });
 
-  it('distinguishes a healthy connection from a recovering one', () => {
+  it('reports reconnecting with the last heartbeat age', () => {
     const heartbeat = new Date(Date.now() - 30_000);
-    expect(formatEventBusSubtitle('connected', heartbeat)).toBe('Last heartbeat 30s ago');
-    expect(formatEventBusSubtitle('reconnecting', heartbeat)).toBe('Reconnecting; last heartbeat 30s ago');
-  });
-
-  it('flags a connected-but-silent stream', () => {
-    expect(formatEventBusSubtitle('connected', null)).toBe('Waiting for heartbeat');
+    expect(formatEventBusSubtitle(heartbeat)).toBe('Reconnecting; last heartbeat 30s ago');
   });
 });

--- a/apps/web/src/components/layout/server-status-state.ts
+++ b/apps/web/src/components/layout/server-status-state.ts
@@ -21,9 +21,9 @@ export function worstState(...states: StatusState[]): StatusState {
   return states.includes('pending') ? 'pending' : 'ok';
 }
 
-export function formatEventBusSubtitle(status: SseConnectionStatus, lastHeartbeat: Date | null): string {
-  if (!lastHeartbeat) return status === 'connected' ? 'Waiting for heartbeat' : 'Connecting';
+export function formatEventBusSubtitle(lastHeartbeat: Date | null): string {
+  if (!lastHeartbeat) return 'Connecting';
 
   const age = formatTimeAgo(lastHeartbeat);
-  return status === 'connected' ? `Last heartbeat ${age}` : `Reconnecting; last heartbeat ${age}`;
+  return `Reconnecting; last heartbeat ${age}`;
 }

--- a/apps/web/src/components/layout/server-status.tsx
+++ b/apps/web/src/components/layout/server-status.tsx
@@ -107,7 +107,7 @@ export function ServerStatus() {
             <StatusItem
               state={eventBusState}
               label="Event Bus"
-              subtitle={formatEventBusSubtitle(sseStatus, lastHeartbeat)}
+              subtitle={formatEventBusSubtitle(lastHeartbeat)}
             />
           </TabsContent>
           <TabsContent value="info" className="bg-popover p-space-xl">
@@ -123,6 +123,7 @@ type StatusItemProps = { state: StatusState; label: string; subtitle?: string };
 
 function StatusItem({ state, label, subtitle }: StatusItemProps) {
   const isOk = state === 'ok';
+  const showSubtitle = state !== 'ok';
   return (
     <div className="cursor-default">
       <Stack direction="row" align="center" justify="between">
@@ -132,7 +133,7 @@ function StatusItem({ state, label, subtitle }: StatusItemProps) {
             <Text as="span" variant={isOk ? 'body-strong' : 'body'} tone={isOk ? 'default' : 'muted'}>
               {label}
             </Text>
-            {subtitle && (
+            {showSubtitle && subtitle && (
               <Text as="span" variant="micro" tone="muted">
                 {subtitle}
               </Text>


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>