### PR TITLE
feat(telemetry): add daily message_sent PostHog event

### DIFF
--- a/apps/desktop/src/main/telemetry-state.ts
+++ b/apps/desktop/src/main/telemetry-state.ts
@@ -26,6 +26,7 @@ function readStateFromDisk(): TelemetryState | null {
         clientInstallationId: parsed.clientInstallationId,
         enabled: parsed.enabled,
         lastActiveDate: typeof parsed.lastActiveDate === 'string' ? parsed.lastActiveDate : null,
+        lastMessageDate: typeof parsed.lastMessageDate === 'string' ? parsed.lastMessageDate : null,
       };
     }
   } catch {
@@ -60,6 +61,7 @@ export function initTelemetryState(): Promise<TelemetryState> {
       clientInstallationId: createTelemetryClientId(),
       enabled: true,
       lastActiveDate: null,
+      lastMessageDate: null,
     };
     writeStateToDisk(newState);
     state = newState;

--- a/apps/web/src/lib/queries/chat.ts
+++ b/apps/web/src/lib/queries/chat.ts
@@ -21,6 +21,7 @@ import type { PrefixedString } from '@stitch/shared/id';
 import { createMessageId, createPartId } from '@stitch/shared/id';
 
 import { serverRequest } from '@/lib/api';
+import { captureClientEvent } from '@/lib/telemetry/client';
 
 const EMPTY_USAGE: LanguageModelUsage = {
   inputTokens: 0,
@@ -299,6 +300,8 @@ export function useSendMessage() {
         }),
       }),
     onMutate: async (input) => {
+      captureClientEvent('message_sent');
+
       const queryKey = sessionKeys.messages(input.sessionId);
       await queryClient.cancelQueries({ queryKey });
 

--- a/apps/web/src/lib/telemetry/client.ts
+++ b/apps/web/src/lib/telemetry/client.ts
@@ -33,6 +33,7 @@ async function loadState(): Promise<TelemetryState> {
           clientInstallationId: parsed.clientInstallationId,
           enabled: parsed.enabled,
           lastActiveDate: typeof parsed.lastActiveDate === 'string' ? parsed.lastActiveDate : null,
+          lastMessageDate: typeof parsed.lastMessageDate === 'string' ? parsed.lastMessageDate : null,
         };
       }
     }
@@ -45,6 +46,7 @@ async function loadState(): Promise<TelemetryState> {
     clientInstallationId: createTelemetryClientId(),
     enabled: true,
     lastActiveDate: null,
+    lastMessageDate: null,
   };
   persistLocalState(newState);
   return newState;
@@ -123,6 +125,19 @@ export function captureClientEvent<T extends TelemetryEventName>(
     const today = getUtcDateString();
     if (state.lastActiveDate === today) return;
     state = { ...state, lastActiveDate: today };
+
+    if (window.api?.telemetry) {
+      void window.api.telemetry.setEnabled(state.enabled);
+    } else {
+      persistLocalState(state);
+    }
+  }
+
+  // Rate limit message_sent to once per UTC day
+  if (eventName === 'message_sent') {
+    const today = getUtcDateString();
+    if (state.lastMessageDate === today) return;
+    state = { ...state, lastMessageDate: today };
 
     if (window.api?.telemetry) {
       void window.api.telemetry.setEnabled(state.enabled);

--- a/packages/shared/src/telemetry/events.ts
+++ b/packages/shared/src/telemetry/events.ts
@@ -12,6 +12,9 @@ export const EVENT_SCHEMA_VERSION = 1;
 // Event registry: event name → allowed extra properties
 // ---------------------------------------------------------------------------
 
-export type TelemetryEvents = { app_active: { connection_mode?: 'local' | 'remote' } };
+export type TelemetryEvents = {
+  app_active: { connection_mode?: 'local' | 'remote' };
+  message_sent: Record<string, never>;
+};
 
 export type TelemetryEventName = keyof TelemetryEvents;

--- a/packages/shared/src/telemetry/types.ts
+++ b/packages/shared/src/telemetry/types.ts
@@ -1,7 +1,12 @@
 /**
  * Client telemetry state persisted locally (Electron userData or localStorage).
  */
-export type TelemetryState = { clientInstallationId: string; enabled: boolean; lastActiveDate: string | null };
+export type TelemetryState = {
+  clientInstallationId: string;
+  enabled: boolean;
+  lastActiveDate: string | null;
+  lastMessageDate: string | null;
+};
 
 /**
  * HTTP headers used for client-to-server telemetry attribution.


### PR DESCRIPTION
## Change Summary

Adds a `message_sent` PostHog event that fires at most once per UTC day, indicating the user sent at least one message that day.

### New Features
- **Daily message_sent telemetry event**: Captures whether a user has sent a message on a given day, rate-limited to one event per UTC day (same pattern as `app_active`)

### Implementation
- Added `message_sent` to the `TelemetryEvents` registry
- Added `lastMessageDate` to `TelemetryState` for daily deduplication
- Fires from `useSendMessage` onMutate so it triggers immediately on user action
- Persisted via Electron IPC or localStorage fallback
