### PR TITLE
fix(web): single update toast with restart action button

### DIFF
--- a/apps/web/src/hooks/ui/use-updater-sync.tsx
+++ b/apps/web/src/hooks/ui/use-updater-sync.tsx
@@ -22,6 +22,7 @@ function isDesktopUpdaterState(value: unknown): value is DesktopUpdaterState {
 
 export function UpdaterSync() {
   const setUpdaterState = useUpdaterStore((state) => state.setUpdaterState);
+  const setInstalling = useUpdaterStore((state) => state.setInstalling);
   const previousStatus = useRef<string>('idle');
 
   useEffect(() => {
@@ -31,12 +32,17 @@ export function UpdaterSync() {
       setUpdaterState(payload);
       if (payload.status === previousStatus.current) return;
 
-      if (payload.status === 'available') {
-        toast.info(`Update available${payload.version ? `: v${payload.version}` : ''}`, { id: 'update-available' });
-      }
-
       if (payload.status === 'downloaded') {
-        toast.success('Update ready. Open Settings > General to restart and install.', { id: 'update-ready' });
+        toast.success(`Update ready${payload.version ? `: v${payload.version}` : ''}`, {
+          id: 'update-ready',
+          action: {
+            label: 'Restart to update',
+            onClick: () => {
+              setInstalling();
+              void window.api?.updater?.install();
+            },
+          },
+        });
       }
 
       if (payload.status === 'error') {
@@ -53,7 +59,7 @@ export function UpdaterSync() {
     });
 
     return () => unsub?.();
-  }, [setUpdaterState]);
+  }, [setUpdaterState, setInstalling]);
 
   return null;
 }


### PR DESCRIPTION
## 🚀 Change Summary

The desktop app's update detector was showing two separate sonner toasts ("Update available" and "Update ready. Open Settings > General to restart and install."), which was noisy and required navigating to Settings to actually apply the update. This consolidates the flow into a single toast with a direct action.

### 🐛 Bug Fixes
- Removed the redundant "Update available" toast — the update already auto-downloads in the background (`autoUpdater.autoDownload = true`), so this toast added no value.
- The remaining "Update ready" toast now includes a **Restart to update** action button that triggers install directly from the toast, instead of requiring the user to go to Settings > General.
