### PR TITLE
improvement(web): remove unnecessary window.api nullish checks

### DIFF
--- a/apps/web/src/components/browser/browser-panel.tsx
+++ b/apps/web/src/components/browser/browser-panel.tsx
@@ -36,8 +36,8 @@ export function BrowserPanel({ sessionId, onClose }: BrowserPanelProps) {
   const [address, setAddress] = React.useState('about:blank');
 
   React.useEffect(() => {
-    void window.api?.browser.getState().then(setState);
-    return window.api?.browser.onStateChanged((next) => {
+    void window.api.browser.getState().then(setState);
+    return window.api.browser.onStateChanged((next) => {
       setState(next);
       const active = next.tabs.find((tab) => tab.active);
       if (active) setAddress(active.url || 'about:blank');
@@ -46,20 +46,20 @@ export function BrowserPanel({ sessionId, onClose }: BrowserPanelProps) {
 
   // When sessionId changes while panel is already open, switch sessions
   React.useEffect(() => {
-    if (!sessionId || !window.api?.browser) return;
+    if (!sessionId) return;
     void window.api.browser.switchSession(sessionId).then(setState);
   }, [sessionId]);
 
   const registerWebview = React.useCallback(() => {
     const webview = webviewRef.current;
-    if (!webview || !window.api?.browser) return;
+    if (!webview) return;
     void window.api.browser.registerWebview(webview.getWebContentsId(), sessionId).then(setState);
   }, [sessionId]);
 
   React.useEffect(() => {
     const webview = webviewRef.current;
     if (!webview) return;
-    const recordHumanInput = () => void window.api?.browser.recordHumanInput();
+    const recordHumanInput = () => void window.api.browser.recordHumanInput();
     const updateAddress = () => setAddress(webview.getURL());
 
     webview.addEventListener('dom-ready', registerWebview);
@@ -81,7 +81,7 @@ export function BrowserPanel({ sessionId, onClose }: BrowserPanelProps) {
 
   const submitAddress = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    void window.api?.browser.userNavigate(address);
+    void window.api.browser.userNavigate(address);
   };
 
   const controllerBadgeClass =
@@ -117,7 +117,7 @@ export function BrowserPanel({ sessionId, onClose }: BrowserPanelProps) {
                   size="inline"
                   align="start"
                   className="min-w-0 flex-1 truncate"
-                  onClick={() => void window.api?.browser.focusTab(tab.id)}
+                  onClick={() => void window.api.browser.focusTab(tab.id)}
                   type="button"
                   title={tab.url}>
                   <Text as="span" variant="caption" tone={tab.active ? 'default' : 'muted'} truncate>
@@ -128,7 +128,7 @@ export function BrowserPanel({ sessionId, onClose }: BrowserPanelProps) {
                   <Button
                     variant="ghost"
                     size="inline"
-                    onClick={() => void window.api?.browser.closeTab(tab.id)}
+                    onClick={() => void window.api.browser.closeTab(tab.id)}
                     type="button"
                     aria-label="Close tab">
                     <Icon as={XIcon} size="xs" />
@@ -141,7 +141,7 @@ export function BrowserPanel({ sessionId, onClose }: BrowserPanelProps) {
             variant="ghost"
             size="icon-sm"
             className="ml-space-2xs shrink-0"
-            onClick={() => void window.api?.browser.newTab()}
+            onClick={() => void window.api.browser.newTab()}
             aria-label="New tab">
             <Icon as={PlusIcon} size="s" />
           </Button>
@@ -149,17 +149,17 @@ export function BrowserPanel({ sessionId, onClose }: BrowserPanelProps) {
 
         {/* Nav bar */}
         <div className="flex h-9 shrink-0 items-center gap-space-xs border-b border-border px-space-m">
-          <Button variant="ghost" size="icon-sm" onClick={() => void window.api?.browser.goBack()} aria-label="Back">
+          <Button variant="ghost" size="icon-sm" onClick={() => void window.api.browser.goBack()} aria-label="Back">
             <Icon as={ArrowLeftIcon} size="m" />
           </Button>
           <Button
             variant="ghost"
             size="icon-sm"
-            onClick={() => void window.api?.browser.goForward()}
+            onClick={() => void window.api.browser.goForward()}
             aria-label="Forward">
             <Icon as={ArrowRightIcon} size="m" />
           </Button>
-          <Button variant="ghost" size="icon-sm" onClick={() => void window.api?.browser.reload()} aria-label="Reload">
+          <Button variant="ghost" size="icon-sm" onClick={() => void window.api.browser.reload()} aria-label="Reload">
             <Icon as={RotateCwIcon} size="m" />
           </Button>
 

--- a/apps/web/src/components/chat/chat-input-parts/use-attachments.ts
+++ b/apps/web/src/components/chat/chat-input-parts/use-attachments.ts
@@ -33,8 +33,6 @@ async function fileToAttachment(file: File): Promise<Attachment | null> {
     };
   }
 
-  if (!window.api?.files?.writeTmp) return null;
-
   const arrayBuffer = await file.arrayBuffer();
   const ext = mimeToExt(file.type);
   const filePath = await window.api.files.writeTmp(arrayBuffer, ext);

--- a/apps/web/src/components/chat/chat-markdown.tsx
+++ b/apps/web/src/components/chat/chat-markdown.tsx
@@ -244,11 +244,7 @@ function MarkdownAnchor({ href, children, ...props }: React.AnchorHTMLAttributes
     const isExternal = /^https?:\/\//i.test(href);
     if (!isExternal) return;
     e.preventDefault();
-    if (window.api?.shell?.openExternal) {
-      void window.api.shell.openExternal(href);
-    } else {
-      window.open(href, '_blank', 'noopener,noreferrer');
-    }
+    void window.api.shell.openExternal(href);
   };
 
   return (

--- a/apps/web/src/components/connectors/connector-instance-list.tsx
+++ b/apps/web/src/components/connectors/connector-instance-list.tsx
@@ -99,7 +99,7 @@ export function ConnectorInstanceList({ instances, definitions }: Props) {
   async function handleReauthorize(instanceId: string) {
     try {
       const { authUrl } = await authorizeMutation.mutateAsync(instanceId);
-      void (window.api?.shell?.openExternal(authUrl) ?? window.open(authUrl, '_blank'));
+      void window.api.shell.openExternal(authUrl);
       toast.info('Opening browser for authorization...', { id: 'connector-auth' });
     } catch (e) {
       toast.error(getErrorMessage(e, 'Failed to start authorization'), { id: 'connector-auth' });
@@ -124,7 +124,7 @@ export function ConnectorInstanceList({ instances, definitions }: Props) {
       const result = await upgradeMutation.mutateAsync({ instanceId: instance.id, apiKey });
 
       if (result.type === 'reauthorize') {
-        void (window.api?.shell?.openExternal(result.authUrl) ?? window.open(result.authUrl, '_blank'));
+        void window.api.shell.openExternal(result.authUrl);
         toast.info('Opening browser to complete connector upgrade...', { id: 'connector-upgrade' });
         return;
       }

--- a/apps/web/src/components/connectors/setup-wizard.tsx
+++ b/apps/web/src/components/connectors/setup-wizard.tsx
@@ -140,7 +140,7 @@ export function SetupWizard({ definition, connectors, onClose }: Props) {
         }
 
         const { authUrl } = await authorize.mutateAsync(progress.instanceId);
-        void (window.api?.shell?.openExternal(authUrl) ?? window.open(authUrl, '_blank'));
+        void window.api.shell.openExternal(authUrl);
         setStep('done');
       } catch (e) {
         const fallback = !progress.connectorRefId
@@ -344,7 +344,7 @@ function InstructionsStep({ instructions, onNext }: { instructions: ConnectorSet
                       variant="link"
                       size="inline"
                       onClick={() => {
-                        void (window.api?.shell?.openExternal(href) ?? window.open(href, '_blank'));
+                        void window.api.shell.openExternal(href);
                       }}>
                       {instruction.hrefLabel ?? 'Open'}
                       <Icon as={ExternalLinkIcon} size="xs" />
@@ -492,7 +492,7 @@ function ConnectorCredentialsStep({
                       }
                       onClick={(event) => {
                         event.preventDefault();
-                        void (window.api?.shell?.openExternal(helpUrl) ?? window.open(helpUrl, '_blank'));
+                        void window.api.shell.openExternal(helpUrl);
                       }}>
                       <Icon as={ExternalLinkIcon} size="xs" />
                       Get your API key
@@ -651,7 +651,7 @@ function ScopesStep({
                 variant="link"
                 size="inline"
                 onClick={() => {
-                  void (window.api?.shell?.openExternal(enableApisUrl) ?? window.open(enableApisUrl, '_blank'));
+                  void window.api.shell.openExternal(enableApisUrl);
                 }}>
                 <Icon as={ExternalLinkIcon} size="s" />
                 Enable required Google APIs in Cloud Console

--- a/apps/web/src/components/desktop-notifications/desktop-notification-root.tsx
+++ b/apps/web/src/components/desktop-notifications/desktop-notification-root.tsx
@@ -47,7 +47,7 @@ export function DesktopNotificationRoot() {
 
     const observer = new ResizeObserver(([entry]) => {
       const height = entry?.contentRect.height ?? 0;
-      void window.api?.notifications?.setHeight(height);
+      void window.api.notifications.setHeight(height);
     });
 
     observer.observe(element);
@@ -55,7 +55,7 @@ export function DesktopNotificationRoot() {
   }, []);
 
   React.useEffect(() => {
-    return window.api?.notifications?.onDismissed((id) => {
+    return window.api.notifications.onDismissed((id) => {
       setNotification((current) => {
         if (!current || current.id !== id) return current;
 
@@ -67,10 +67,7 @@ export function DesktopNotificationRoot() {
   }, []);
 
   function dismiss(id: string): void {
-    if (window.api?.notifications?.dismiss) {
-      void window.api.notifications.dismiss(id);
-      return;
-    }
+    void window.api.notifications.dismiss(id);
 
     setExiting(true);
     window.setTimeout(() => setNotification(null), EXIT_ANIMATION_MS);

--- a/apps/web/src/components/layout/server-status.tsx
+++ b/apps/web/src/components/layout/server-status.tsx
@@ -29,8 +29,8 @@ function useServerConfig() {
   const [config, setConfig] = React.useState<ServerConnectionConfig | null>(null);
 
   React.useEffect(() => {
-    void window.api?.getServerConfig().then(setConfig);
-    return window.api?.server?.onConfigChanged(setConfig);
+    void window.api.getServerConfig().then(setConfig);
+    return window.api.server.onConfigChanged(setConfig);
   }, []);
 
   return config;
@@ -104,11 +104,7 @@ export function ServerStatus() {
           </div>
           <TabsContent value="servers" className="flex flex-col gap-space-xl bg-popover p-space-xl">
             <StatusItem state={serverState} label={serverLabel} subtitle={serverSubtitle} />
-            <StatusItem
-              state={eventBusState}
-              label="Event Bus"
-              subtitle={formatEventBusSubtitle(lastHeartbeat)}
-            />
+            <StatusItem state={eventBusState} label="Event Bus" subtitle={formatEventBusSubtitle(lastHeartbeat)} />
           </TabsContent>
           <TabsContent value="info" className="bg-popover p-space-xl">
             <InfoPanel />

--- a/apps/web/src/components/layout/title-bar.tsx
+++ b/apps/web/src/components/layout/title-bar.tsx
@@ -63,29 +63,21 @@ function WindowsControls() {
   const [isMaximized, setIsMaximized] = useState(false);
 
   useEffect(() => {
-    const checkMaximized = async () => {
-      if (!window.api?.window?.isMaximized) {
-        return;
-      }
-
-      const maximized = await window.api.window.isMaximized();
-      setIsMaximized(maximized);
-    };
-    void checkMaximized();
+    void window.api.window.isMaximized().then(setIsMaximized);
   }, []);
 
   const handleMinimize = () => {
-    void window.api?.window?.minimize();
+    void window.api.window.minimize();
   };
 
   const handleMaximize = async () => {
-    await window.api?.window?.maximize();
-    const maximized = await window.api?.window?.isMaximized();
-    setIsMaximized(maximized ?? false);
+    await window.api.window.maximize();
+    const maximized = await window.api.window.isMaximized();
+    setIsMaximized(maximized);
   };
 
   const handleClose = () => {
-    void window.api?.window?.close();
+    void window.api.window.close();
   };
 
   return (

--- a/apps/web/src/components/navigation/right-click-menu.tsx
+++ b/apps/web/src/components/navigation/right-click-menu.tsx
@@ -174,7 +174,7 @@ export function RightClickMenu({ children }: RightClickMenuProps) {
   };
 
   const handleReplaceMisspelling = (suggestion: string) => {
-    void window.api?.spellcheck?.replaceMisspelling(suggestion);
+    void window.api.spellcheck.replaceMisspelling(suggestion);
     close();
   };
 
@@ -182,7 +182,7 @@ export function RightClickMenu({ children }: RightClickMenuProps) {
 
   const handleAddToDictionary = () => {
     if (misspelledWord) {
-      void window.api?.spellcheck?.addToDictionary(misspelledWord);
+      void window.api.spellcheck.addToDictionary(misspelledWord);
     }
     close();
   };
@@ -200,7 +200,7 @@ export function RightClickMenu({ children }: RightClickMenuProps) {
     close();
   };
   const handleOpenDevTools = () => {
-    void window.api?.devtools?.toggle();
+    void window.api.devtools.toggle();
     close();
   };
 

--- a/apps/web/src/components/recordings/meeting-recording-banner.tsx
+++ b/apps/web/src/components/recordings/meeting-recording-banner.tsx
@@ -45,7 +45,7 @@ export function RecordingEventListener() {
   }, [stopRecording]);
 
   React.useEffect(() => {
-    const unsubscribeWarning = window.api?.recording?.onWarning((payload) => {
+    const unsubscribeWarning = window.api.recording.onWarning((payload) => {
       if (payload.code === UNRECOVERABLE_WARNING_CODE) {
         toast.error('Audio capture could not be recovered — stopping the recording.', {
           id: 'recording.unrecoverable',
@@ -58,14 +58,14 @@ export function RecordingEventListener() {
       const label = WARNING_LABELS[payload.code] ?? payload.message;
       toast.warning(label, { id: `recording-warning-${payload.code}` });
     });
-    const unsubscribeDeviceChanged = window.api?.recording?.onDeviceChanged((payload) => {
+    const unsubscribeDeviceChanged = window.api.recording.onDeviceChanged((payload) => {
       const deviceLabel = payload.deviceName ?? 'unknown device';
       toast.info(`Audio ${payload.kind} device changed to: ${deviceLabel}`, { id: 'recording-device-change' });
     });
 
     return () => {
-      unsubscribeWarning?.();
-      unsubscribeDeviceChanged?.();
+      unsubscribeWarning();
+      unsubscribeDeviceChanged();
     };
   }, []);
 
@@ -122,16 +122,12 @@ export function MeetingRecordingBanner() {
   }
 
   function requestDismissMeeting(key: string): void {
-    if (window.api?.meeting?.dismissCall) {
-      void window.api.meeting.dismissCall(key);
-      return;
-    }
-
+    void window.api.meeting.dismissCall(key);
     dismissMeeting(key);
   }
 
   React.useEffect(() => {
-    const unsubscribeDetected = window.api?.meeting?.onCallDetected((payload) => {
+    const unsubscribeDetected = window.api.meeting.onCallDetected((payload) => {
       if (activeRecordingIdRef.current) {
         return;
       }
@@ -144,7 +140,7 @@ export function MeetingRecordingBanner() {
         return payload;
       });
     });
-    const unsubscribeEnded = window.api?.meeting?.onCallEnded(({ key }) => {
+    const unsubscribeEnded = window.api.meeting.onCallEnded(({ key }) => {
       setDetection((current) => {
         if (!current || current.key !== key) {
           return current;
@@ -162,14 +158,14 @@ export function MeetingRecordingBanner() {
         return next;
       });
     });
-    const unsubscribeDismissed = window.api?.meeting?.onCallDismissed(({ key }) => {
+    const unsubscribeDismissed = window.api.meeting.onCallDismissed(({ key }) => {
       dismissMeeting(key);
     });
 
     return () => {
-      unsubscribeDetected?.();
-      unsubscribeEnded?.();
-      unsubscribeDismissed?.();
+      unsubscribeDetected();
+      unsubscribeEnded();
+      unsubscribeDismissed();
     };
   }, []);
 

--- a/apps/web/src/components/session/session-page.tsx
+++ b/apps/web/src/components/session/session-page.tsx
@@ -44,7 +44,7 @@ export function SessionPage({ sessionId }: SessionPageProps) {
   const timezone = settings?.['profile.timezone']?.trim() || LOCAL_TIMEZONE;
 
   const browserAppEnabled = appEnabledStates?.find((state) => state.appId === 'browser')?.enabled ?? true;
-  const hasBrowser = typeof window !== 'undefined' && Boolean(window.api?.browser) && browserAppEnabled;
+  const hasBrowser = browserAppEnabled;
 
   const rightPanel = requestedRightPanel === 'browser' && !hasBrowser ? 'closed' : requestedRightPanel;
   const rightPanelOpen = rightPanel !== 'closed';
@@ -58,7 +58,7 @@ export function SessionPage({ sessionId }: SessionPageProps) {
   };
 
   React.useEffect(() => {
-    return window.api?.browser.onShowRequested(() => {
+    return window.api.browser.onShowRequested(() => {
       if (browserAppEnabled) setRequestedRightPanel('browser');
     });
   }, [browserAppEnabled]);

--- a/apps/web/src/components/settings/general.tsx
+++ b/apps/web/src/components/settings/general.tsx
@@ -185,7 +185,7 @@ function AutoUpdatesContent() {
   function handleCheckUpdates() {
     setCheckPending(true);
     const startedAt = Date.now();
-    void window.api?.updater?.check().finally(() => {
+    void window.api.updater.check().finally(() => {
       const elapsedMs = Date.now() - startedAt;
       const remainingMs = Math.max(0, 700 - elapsedMs);
       window.setTimeout(() => setCheckPending(false), remainingMs);
@@ -195,7 +195,7 @@ function AutoUpdatesContent() {
   function handleInstallUpdate() {
     setInstallPending(true);
     setInstalling();
-    void window.api?.updater?.install().finally(() => {
+    void window.api.updater.install().finally(() => {
       setInstallPending(false);
     });
   }

--- a/apps/web/src/components/settings/permissions/permission-policy-editor.tsx
+++ b/apps/web/src/components/settings/permissions/permission-policy-editor.tsx
@@ -111,7 +111,7 @@ function ToolPermissionEditor({
   };
 
   const handleBrowse = () => {
-    void window.api?.files?.openPath?.().then((paths) => {
+    void window.api.files.openPath().then((paths) => {
       if (!paths || paths.length === 0) return;
       const picked = paths[0];
       if (!picked) return;

--- a/apps/web/src/components/settings/recordings.tsx
+++ b/apps/web/src/components/settings/recordings.tsx
@@ -92,14 +92,14 @@ function PermissionStatus() {
   const handleGrantPermissions = async () => {
     setRequesting(true);
     try {
-      if (micDenied && window.api?.permissions?.requestMicrophone) {
+      if (micDenied) {
         await window.api.permissions.requestMicrophone();
       }
       if (screenDenied) {
         // Prime triggers the native prompt; fall back to System Settings if still denied.
-        const status = await window.api?.recording?.primeSystemAudio?.();
-        if (status?.screenCapture !== 'granted') {
-          await window.api?.permissions?.openScreenCaptureSettings?.();
+        const status = await window.api.recording.primeSystemAudio();
+        if (status.screenCapture !== 'granted') {
+          await window.api.permissions.openScreenCaptureSettings();
         }
       }
       setTimeout(() => void refetch(), 2000);

--- a/apps/web/src/hooks/ui/use-fullscreen.ts
+++ b/apps/web/src/hooks/ui/use-fullscreen.ts
@@ -4,15 +4,7 @@ export function useFullScreen() {
   const [isFullScreen, setIsFullScreen] = useState(false);
 
   useEffect(() => {
-    const checkFullScreen = async () => {
-      if (!window.api?.window?.isFullScreen) {
-        return;
-      }
-
-      const fullScreen = await window.api.window.isFullScreen();
-      setIsFullScreen(fullScreen);
-    };
-    void checkFullScreen();
+    void window.api.window.isFullScreen().then(setIsFullScreen);
 
     const unsubscribe = window.electron?.subscribe('window:fullscreen-changed', (value) => {
       setIsFullScreen(value as boolean);

--- a/apps/web/src/hooks/ui/use-updater-sync.tsx
+++ b/apps/web/src/hooks/ui/use-updater-sync.tsx
@@ -39,7 +39,7 @@ export function UpdaterSync() {
             label: 'Restart to update',
             onClick: () => {
               setInstalling();
-              void window.api?.updater?.install();
+              void window.api.updater.install();
             },
           },
         });
@@ -52,7 +52,7 @@ export function UpdaterSync() {
       previousStatus.current = payload.status;
     });
 
-    void window.api?.updater?.getState?.().then((state) => {
+    void window.api.updater.getState().then((state) => {
       if (!isDesktopUpdaterState(state)) return;
       setUpdaterState(state);
       previousStatus.current = state.status;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -21,11 +21,9 @@ export type ServerConnectionConfig = { url: string; mode: ServerMode; remoteUrl:
 declare global {
   interface Window {
     electron?: ElectronBridge;
-    api?: DesktopBridge;
+    api: DesktopBridge;
   }
 }
-
-const DEV_FALLBACK_URL = 'http://localhost:3000';
 
 let cachedUrl: string | null = null;
 
@@ -40,13 +38,8 @@ export function resetServerUrlCache(url?: string): void {
 export async function getServerUrl(): Promise<string> {
   if (cachedUrl) return cachedUrl;
 
-  if (window.api?.getServerConfig) {
-    const config = await window.api.getServerConfig();
-    cachedUrl = config.url;
-    return cachedUrl;
-  }
-
-  cachedUrl = DEV_FALLBACK_URL;
+  const config = await window.api.getServerConfig();
+  cachedUrl = config.url;
   return cachedUrl;
 }
 

--- a/apps/web/src/lib/queries/connection.ts
+++ b/apps/web/src/lib/queries/connection.ts
@@ -8,22 +8,13 @@ const connectionKeys = { all: ['connection'] as const, config: () => [...connect
 
 export const serverConfigQueryOptions = queryOptions({
   queryKey: connectionKeys.config(),
-  queryFn: async (): Promise<ServerConnectionConfig> => {
-    if (!window.api?.getServerConfig) {
-      throw new Error('Server config is only available from the desktop app');
-    }
-    return window.api.getServerConfig();
-  },
+  queryFn: (): Promise<ServerConnectionConfig> => window.api.getServerConfig(),
 });
 
 export function useTestRemoteConnection() {
   return useMutation({
-    mutationFn: async (url: string): Promise<{ ok: boolean; url?: string; error?: string }> => {
-      if (!window.api?.server?.testRemote) {
-        throw new Error('Remote testing is only available from the desktop app');
-      }
-      return window.api.server.testRemote(url);
-    },
+    mutationFn: (url: string): Promise<{ ok: boolean; url?: string; error?: string }> =>
+      window.api.server.testRemote(url),
   });
 }
 
@@ -31,12 +22,8 @@ export function useSaveServerConfig() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: { mode: ServerMode; remoteUrl: string | null }): Promise<ServerConnectionConfig> => {
-      if (!window.api?.server?.setConfig) {
-        throw new Error('Server config is only available from the desktop app');
-      }
-      return window.api.server.setConfig(input);
-    },
+    mutationFn: (input: { mode: ServerMode; remoteUrl: string | null }): Promise<ServerConnectionConfig> =>
+      window.api.server.setConfig(input),
     onSuccess: (config) => {
       queryClient.setQueryData(connectionKeys.config(), config);
       toast.success('Server connection updated', { id: 'connection-update' });

--- a/apps/web/src/lib/queries/mcp.ts
+++ b/apps/web/src/lib/queries/mcp.ts
@@ -81,7 +81,7 @@ export function useRefreshMcpRegistry() {
 
 function openAuthUrl(authUrl: string): void {
   if (!authUrl) return;
-  void (window.api?.shell?.openExternal(authUrl) ?? window.open(authUrl, '_blank'));
+  void window.api.shell.openExternal(authUrl);
 }
 
 export function useStartMcpAuth() {

--- a/apps/web/src/lib/queries/recordings.ts
+++ b/apps/web/src/lib/queries/recordings.ts
@@ -129,87 +129,30 @@ type AudioPermissionsStatus = { microphone: PermissionState; screenCapture: Perm
 
 export const audioDevicesQueryOptions = queryOptions({
   queryKey: recordingsKeys.devices(),
-  queryFn: async (): Promise<AudioDeviceList> => {
-    if (!window.api?.recording?.listDevices) {
-      throw new Error('Audio devices are only available from the desktop app');
-    }
-
-    return window.api.recording.listDevices();
-  },
+  queryFn: (): Promise<AudioDeviceList> => window.api.recording.listDevices(),
   refetchInterval: 5_000,
   staleTime: 2_000,
 });
 
 export const audioPermissionsQueryOptions = queryOptions({
   queryKey: recordingsKeys.permissions(),
-  queryFn: async (): Promise<AudioPermissionsStatus> => {
-    if (!window.api?.recording?.checkPermissions) {
-      throw new Error('Audio permissions are only available from the desktop app');
-    }
-
-    return window.api.recording.checkPermissions();
-  },
+  queryFn: (): Promise<AudioPermissionsStatus> => window.api.recording.checkPermissions(),
   staleTime: 10_000,
 });
 
 async function preflightPermissionCheck(): Promise<void> {
   try {
     // Request microphone permission via Electron (triggers native macOS prompt)
-    if (window.api?.permissions?.requestMicrophone) {
-      await window.api.permissions.requestMicrophone();
-    }
+    await window.api.permissions.requestMicrophone();
 
     // Prime system audio: the kTCCServiceAudioCapture prompt only fires once IO
     // starts on a tap-backed device — there is no request-style API for it.
-    if (window.api?.recording?.primeSystemAudio) {
-      const status = await window.api.recording.primeSystemAudio();
-      if (status.screenCapture !== 'granted') {
-        if (window.api?.permissions?.openScreenCaptureSettings) {
-          void window.api.permissions.openScreenCaptureSettings();
-        }
-        throw new Error(
-          'Audio capture permission is needed. Allow "System Audio Recording" when prompted, or toggle on Stitch under "Screen & System Audio Recording" in System Settings, then click Start Recording again.',
-        );
-      }
-      return;
-    }
-
-    // Check screen capture permission from the Electron main process.
-    if (window.api?.permissions?.getScreenCaptureStatus) {
-      const status = await window.api.permissions.getScreenCaptureStatus();
-      if (status !== 'granted') {
-        if (window.api?.permissions?.openScreenCaptureSettings) {
-          void window.api.permissions.openScreenCaptureSettings();
-        }
-        throw new Error(
-          'Audio capture permission is needed. In the System Settings window, toggle on Stitch under "Screen & System Audio Recording", then click Start Recording again.',
-        );
-      }
-      return;
-    }
-
-    if (window.api?.recording?.checkPermissions) {
-      const permissions = await window.api.recording.checkPermissions();
-      if (permissions.microphone === 'granted' && permissions.screenCapture === 'granted') {
-        return;
-      }
-
-      const issues: string[] = [];
-
-      if (permissions.microphone !== 'granted') {
-        issues.push(
-          'Microphone access is denied. Grant microphone permission in System Settings > Privacy & Security > Microphone.',
-        );
-      }
-      if (permissions.screenCapture !== 'granted') {
-        issues.push(
-          'Audio capture permission is needed. Toggle on Stitch under "Screen & System Audio Recording" in System Settings > Privacy & Security.',
-        );
-      }
-
-      if (issues.length > 0) {
-        throw new Error(issues.join('\n'));
-      }
+    const status = await window.api.recording.primeSystemAudio();
+    if (status.screenCapture !== 'granted') {
+      void window.api.permissions.openScreenCaptureSettings();
+      throw new Error(
+        'Audio capture permission is needed. Allow "System Audio Recording" when prompted, or toggle on Stitch under "Screen & System Audio Recording" in System Settings, then click Start Recording again.',
+      );
     }
   } catch (error) {
     if (Error.isError(error) && error.message.includes('permission is needed')) {
@@ -227,16 +170,7 @@ export function useStartRecording() {
   return useMutation({
     mutationFn: async (input: StartRecordingInput): Promise<StartRecordingResponse> => {
       await preflightPermissionCheck();
-
-      if (window.api?.recording?.start) {
-        return window.api.recording.start(input);
-      }
-
-      return serverRequest<StartRecordingResponse>('/recordings/start', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(input),
-      });
+      return window.api.recording.start(input);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: recordingsKeys.lists() });
@@ -249,17 +183,7 @@ export function useStopRecording() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (): Promise<StopRecordingResponse> => {
-      if (window.api?.recording?.stop) {
-        return window.api.recording.stop();
-      }
-
-      return serverRequest<StopRecordingResponse>('/recordings/stop', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ durationMs: null, fileSizeBytes: null }),
-      });
-    },
+    mutationFn: (): Promise<StopRecordingResponse> => window.api.recording.stop(),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: recordingsKeys.lists() });
       void queryClient.invalidateQueries({ queryKey: recordingsKeys.active() });

--- a/apps/web/src/lib/telemetry/client.ts
+++ b/apps/web/src/lib/telemetry/client.ts
@@ -1,8 +1,6 @@
-import { createTelemetryClientId, ID_PREFIXES, isIdOfType } from '@stitch/shared/id';
 import { EVENT_SCHEMA_VERSION, type TelemetryEventName, type TelemetryEvents } from '@stitch/shared/telemetry/events';
 import { DEFAULT_POSTHOG_HOST, type TelemetryState } from '@stitch/shared/telemetry/types';
 
-const LOCALSTORAGE_KEY = 'stitch_telemetry_state';
 const APP_VERSION: string = typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : 'dev';
 
 let state: TelemetryState | null = null;
@@ -10,54 +8,11 @@ let posthogLoaded = false;
 let posthog: typeof import('posthog-js').default | null = null;
 
 // ---------------------------------------------------------------------------
-// State management (Electron IPC with localStorage fallback)
+// State management
 // ---------------------------------------------------------------------------
 
 async function loadState(): Promise<TelemetryState> {
-  // Prefer Electron IPC
-  if (window.api?.telemetry) {
-    return window.api.telemetry.getState();
-  }
-
-  // localStorage fallback for browser/dev
-  try {
-    const raw = localStorage.getItem(LOCALSTORAGE_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw) as Partial<TelemetryState>;
-      if (
-        typeof parsed.clientInstallationId === 'string' &&
-        isIdOfType(parsed.clientInstallationId, ID_PREFIXES.telemetryClient) &&
-        typeof parsed.enabled === 'boolean'
-      ) {
-        return {
-          clientInstallationId: parsed.clientInstallationId,
-          enabled: parsed.enabled,
-          lastActiveDate: typeof parsed.lastActiveDate === 'string' ? parsed.lastActiveDate : null,
-          lastMessageDate: typeof parsed.lastMessageDate === 'string' ? parsed.lastMessageDate : null,
-        };
-      }
-    }
-  } catch {
-    // ignore
-  }
-
-  // Generate new state
-  const newState: TelemetryState = {
-    clientInstallationId: createTelemetryClientId(),
-    enabled: true,
-    lastActiveDate: null,
-    lastMessageDate: null,
-  };
-  persistLocalState(newState);
-  return newState;
-}
-
-function persistLocalState(s: TelemetryState): void {
-  try {
-    localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(s));
-  } catch {
-    // quota or private browsing
-  }
+  return window.api.telemetry.getState();
 }
 
 // ---------------------------------------------------------------------------
@@ -85,15 +40,10 @@ export function getClientTelemetryState(): TelemetryState | null {
 }
 
 /**
- * Set telemetry enabled/disabled. Persists via Electron IPC or localStorage.
+ * Set telemetry enabled/disabled. Persists via Electron IPC.
  */
 export async function setClientTelemetryEnabled(enabled: boolean): Promise<TelemetryState> {
-  if (window.api?.telemetry) {
-    state = await window.api.telemetry.setEnabled(enabled);
-  } else if (state) {
-    state = { ...state, enabled };
-    persistLocalState(state);
-  }
+  state = await window.api.telemetry.setEnabled(enabled);
 
   if (!enabled) {
     if (posthog) {
@@ -108,7 +58,7 @@ export async function setClientTelemetryEnabled(enabled: boolean): Promise<Telem
     }
   }
 
-  return state as TelemetryState;
+  return state;
 }
 
 /**
@@ -186,11 +136,7 @@ function passesOncePerDay(field: 'lastActiveDate' | 'lastMessageDate'): boolean 
   if (state[field] === today) return false;
 
   state = { ...state, [field]: today };
-  if (window.api?.telemetry) {
-    void window.api.telemetry.setEnabled(state.enabled);
-  } else {
-    persistLocalState(state);
-  }
+  void window.api.telemetry.setEnabled(state.enabled);
   return true;
 }
 
@@ -206,5 +152,5 @@ function getReleaseChannel(): string {
 }
 
 function getClientType(): string {
-  return window.api ? 'desktop' : 'web';
+  return 'desktop';
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -12,6 +12,8 @@ import { applyAppearanceMode, applyTheme, DEFAULT_MODE, DEFAULT_THEME, getTheme 
 import { routeTree } from '@/routeTree.gen';
 import '@/styles/global.css';
 
+if (!('api' in window)) throw new Error('Desktop bridge (window.api) is not available');
+
 const queryClient = new QueryClient({ defaultOptions: { queries: { staleTime: Infinity } } });
 const isFileProtocol = window.location.protocol === 'file:';
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -93,7 +93,7 @@ function ServerConnectionSync() {
   const router = useRouter();
 
   React.useEffect(() => {
-    return window.api?.server?.onConfigChanged((config) => {
+    return window.api.server.onConfigChanged((config) => {
       resetServerUrlCache(config.url);
 
       void router.navigate({ to: '/settings/connection' }).then(async () => {

--- a/oxlint.json
+++ b/oxlint.json
@@ -18,6 +18,7 @@
     "eqeqeq": "error",
     "no-else-return": "error",
     "typescript/no-unnecessary-type-assertion": "error",
+    "typescript/no-unnecessary-condition": "error",
     "typescript/no-floating-promises": "error",
     "typescript/no-non-null-assertion": "error",
     "import/no-dynamic-require": ["error", { "esmodule": true }],


### PR DESCRIPTION
## Change Summary

Makes `window.api` (the Electron desktop bridge) non-optional in the TypeScript type system and removes all unnecessary nullish checks across the web app. The bridge is always injected by the preload script before the renderer process boots, so the optional typing was overly defensive and led to ~70 scattered `?.` chains that added noise without providing safety.

### New Features
- **Runtime assertion**: `main.tsx` now throws immediately if the bridge is somehow missing, providing a clear error instead of silent undefined behavior

### Improvements & Refactors
- **Non-optional `window.api`**: Changed from `api?: DesktopBridge` to `api: DesktopBridge` in the global Window interface declaration
- **Removed 70+ unnecessary optional chains**: All `window.api?.`, `window.api.subsystem?.`, and `window.api.subsystem.method?.()` patterns cleaned up across 22 files
- **Removed dead fallback code**: localStorage telemetry persistence, `DEV_FALLBACK_URL`, and `serverRequest` fallbacks in recording start/stop that could never be reached
- **Added `typescript/no-unnecessary-condition`** lint rule to oxlint to prevent regressions
