### PR TITLE
fix: resolve all no-unnecessary-condition lint errors

### DIFF
--- a/apps/desktop/src/main/browser/bridge.ts
+++ b/apps/desktop/src/main/browser/bridge.ts
@@ -27,7 +27,6 @@ export class BrowserBridge {
 
   private async handleSocketMessage(socket: WebSocket, raw: string): Promise<void> {
     const message = JSON.parse(raw) as ElectronBrowserCommandMessage;
-    if (message.type !== 'browser:command') return;
     try {
       const result = await this.handleCommand(message.sessionId, message.command);
       socket.send(JSON.stringify({ id: message.id, type: 'browser:result', ok: true, result }));

--- a/apps/desktop/src/main/browser/session-store.ts
+++ b/apps/desktop/src/main/browser/session-store.ts
@@ -148,7 +148,7 @@ export class SessionStore {
     }
 
     const remaining = Array.from(this.tabs.values());
-    const next = remaining[remaining.length - 1];
+    const next = remaining.at(-1);
     if (next) {
       this.activeTabId = next.id;
       this.broadcast();

--- a/apps/desktop/src/main/capture-restart.ts
+++ b/apps/desktop/src/main/capture-restart.ts
@@ -41,6 +41,10 @@ export function createCaptureRestarter(options: CaptureRestarterOptions): Captur
   let attempts = 0;
   let cancelled = false;
 
+  function isCancelled(): boolean {
+    return cancelled;
+  }
+
   function schedule(delayMs: number): void {
     if (cancelled || timer) {
       return;
@@ -66,7 +70,7 @@ export function createCaptureRestarter(options: CaptureRestarterOptions): Captur
     } catch (error) {
       retrigger = false;
       attempts += 1;
-      if (cancelled) {
+      if (isCancelled()) {
         return;
       }
       if (attempts >= maxAttempts) {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -111,9 +111,7 @@ function registerAllIpcHandlers(): void {
   registerUpdaterHandlers(updater, getWindow);
   registerTelemetryHandlers();
   registerNotificationHandlers((event) => {
-    if (event.type === 'meeting-detected') {
-      dismissMeetingCall(event.payload.key);
-    }
+    dismissMeetingCall(event.payload.key);
   });
   registerIpcHandler('meeting:call-dismiss', (_event, key) => {
     dismissMeetingCall(key);

--- a/apps/desktop/src/main/notifications.ts
+++ b/apps/desktop/src/main/notifications.ts
@@ -12,7 +12,6 @@ const NOTIFICATION_DEFAULT_HEIGHT = 92;
 const NOTIFICATION_MARGIN = 16;
 const NOTIFICATION_GAP = 8;
 const EXIT_ANIMATION_MS = 220;
-const FOLLOW_CURSOR_ENABLED = true;
 const FOLLOW_CURSOR_DWELL_MS = 1500;
 const FOLLOW_CURSOR_POLL_INTERVAL_MS = 250;
 
@@ -121,7 +120,7 @@ function pollCursorDisplay(): void {
 }
 
 function startFollowCursorPolling(): void {
-  if (!FOLLOW_CURSOR_ENABLED || followCursorInterval) return;
+  if (followCursorInterval) return;
 
   followCursorInterval = setInterval(pollCursorDisplay, FOLLOW_CURSOR_POLL_INTERVAL_MS);
 }
@@ -295,7 +294,7 @@ export function dismissDesktopNotification(id: string): void {
 
 export function destroyNotificationWindow(): void {
   while (orderedIds.length > 0) {
-    const id = orderedIds[0];
+    const id = orderedIds.at(0);
     if (!id) return;
     destroyNotification(id);
   }

--- a/apps/desktop/src/main/recording-capture.ts
+++ b/apps/desktop/src/main/recording-capture.ts
@@ -101,7 +101,7 @@ function attachCaptureEvents(ws: WebSocket, sttSessionId: string, getWindow: () 
     if (event.type === 'warning') {
       const payload: RecordingWarningPayload = { code: event.code, message: event.message };
       webContents.send('recording:warning', payload);
-    } else if (event.type === 'deviceChanged') {
+    } else {
       const payload: RecordingDeviceChangedPayload = { kind: event.kind, deviceName: event.deviceName };
       webContents.send('recording:device-changed', payload);
     }

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -83,7 +83,7 @@ function findStalePids(): number[] {
       if (!output) return [];
       return output
         .split('\n')
-        .map((line) => parseInt(line.split(',')[1]?.replace(/"/g, '') ?? '', 10))
+        .map((line) => parseInt(line.split(',').at(1)?.replace(/"/g, '') ?? '', 10))
         .filter(Number.isFinite);
     }
 

--- a/apps/web/src/components/agenda/agenda-page.tsx
+++ b/apps/web/src/components/agenda/agenda-page.tsx
@@ -516,7 +516,7 @@ export function AgendaPage({ listId }: { listId?: string }) {
                   </PaginationItem>
                   {pageNumbers.map((pageNumber, index) => {
                     const previousPage = pageNumbers[index - 1];
-                    const showGap = previousPage !== undefined && pageNumber - previousPage > 1;
+                    const showGap = pageNumber - previousPage > 1;
                     return (
                       <React.Fragment key={`page-${pageNumber}`}>
                         {showGap ? (

--- a/apps/web/src/components/automations/automation-dialog.tsx
+++ b/apps/web/src/components/automations/automation-dialog.tsx
@@ -65,7 +65,7 @@ const automationSchema = z
 type AutomationFormValues = z.infer<typeof automationSchema>;
 
 function getInitialSelection(providerModels: ProviderModels[]): { providerId: string; modelId: string } | null {
-  const provider = providerModels[0];
+  const provider = providerModels[0] as ProviderModels | undefined;
   const model = provider?.models[0];
   if (!provider || !model) return null;
   return { providerId: provider.providerId, modelId: model.id };

--- a/apps/web/src/components/automations/automations-table.tsx
+++ b/apps/web/src/components/automations/automations-table.tsx
@@ -229,7 +229,7 @@ export function AutomationsTable({
 
               {pageNumbers.map((pageNumber, index) => {
                 const previousPage = pageNumbers[index - 1];
-                const showGap = previousPage !== undefined && pageNumber - previousPage > 1;
+                const showGap = pageNumber - previousPage > 1;
                 return (
                   <React.Fragment key={`page-${pageNumber}`}>
                     {showGap ? (

--- a/apps/web/src/components/chat/chat-input-parts/model-selector-popover.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/model-selector-popover.tsx
@@ -76,7 +76,7 @@ export function ModelSelectorPopover({ selectedValue, onSelect, providerModels }
                 </div>
                 {provider.models.map((model) => {
                   const isSelected =
-                    selectedValue?.providerId === provider.providerId && selectedValue?.modelId === model.id;
+                    selectedValue?.providerId === provider.providerId && selectedValue.modelId === model.id;
                   return (
                     <PopoverClose
                       key={model.id}

--- a/apps/web/src/components/chat/chat-markdown.tsx
+++ b/apps/web/src/components/chat/chat-markdown.tsx
@@ -84,7 +84,7 @@ function MarkdownCodeBlock({ code, children }: { code: string; children: React.R
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleCopy = () => {
-    if (typeof navigator === 'undefined' || navigator.clipboard === null) {
+    if (typeof navigator === 'undefined') {
       return;
     }
     void navigator.clipboard
@@ -193,9 +193,8 @@ function splitLatexCommandSpans(node: MarkdownTextNode): MarkdownNode[] {
 
   for (const match of node.value.matchAll(LATEX_COMMAND_SPAN_REGEX)) {
     const index = match.index;
-    if (index === undefined) continue;
 
-    const streamingText = STREAMING_LATEX_TEXT[match[1] ?? ''];
+    const streamingText = STREAMING_LATEX_TEXT[match[1] ?? ''] as string | undefined;
     if (streamingText === undefined) continue;
 
     if (index > lastIndex) {

--- a/apps/web/src/components/chat/chat-sidebar.tsx
+++ b/apps/web/src/components/chat/chat-sidebar.tsx
@@ -96,7 +96,7 @@ export function ChatSidebarContent() {
     if (!node || !hasNextPage) return;
 
     const observer = new IntersectionObserver((entries) => {
-      if (entries[0]?.isIntersecting && !isFetchingNextPage) {
+      if (entries.at(0)?.isIntersecting && !isFetchingNextPage) {
         void fetchNextPage();
       }
     });

--- a/apps/web/src/components/chat/docks/question-dock.tsx
+++ b/apps/web/src/components/chat/docks/question-dock.tsx
@@ -77,7 +77,7 @@ export function QuestionDock({ request, onReply, onReject }: QuestionDockProps) 
 
   const isAnswered = (idx: number): boolean => {
     const hasOption = (answers[idx]?.length ?? 0) > 0;
-    const hasCustom = (customAnswers[idx]?.trim()?.length ?? 0) > 0;
+    const hasCustom = customAnswers[idx].trim().length > 0;
     return hasOption || hasCustom;
   };
 

--- a/apps/web/src/components/chat/liquid-ui/inline.ts
+++ b/apps/web/src/components/chat/liquid-ui/inline.ts
@@ -14,14 +14,14 @@ export function parseInlineLiquidUiText(text: string): InlineLiquidUiSegment[] |
   for (const match of text.matchAll(INLINE_LIQUID_UI_PATTERN)) {
     found = true;
     const [fullMatch, jsonText] = match;
-    const index = match.index ?? 0;
+    const index = match.index;
 
     if (index > lastIndex) {
       segments.push({ type: 'text', text: text.slice(lastIndex, index) });
     }
 
     try {
-      const spec = repairLiquidUiSpec(JSON.parse(jsonText ?? ''));
+      const spec = repairLiquidUiSpec(JSON.parse(jsonText));
       if (!spec) return null;
       segments.push({ type: 'liquid-ui', spec });
     } catch {

--- a/apps/web/src/components/chat/message-bubble/compaction-divider.tsx
+++ b/apps/web/src/components/chat/message-bubble/compaction-divider.tsx
@@ -12,7 +12,7 @@ type CompactionDividerProps = { summaryParts?: StoredPart[] };
 function stripOuterCodeFence(text: string): string {
   const trimmed = text.trim();
   const match = trimmed.match(/^```(?:\w*\n)?([\s\S]*?)```$/);
-  return match ? (match[1]?.trim() ?? trimmed) : trimmed;
+  return match ? (match.at(1)?.trim() ?? trimmed) : trimmed;
 }
 
 export function CompactionDivider({ summaryParts }: CompactionDividerProps) {

--- a/apps/web/src/components/chat/message-bubble/streaming-message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble/streaming-message-bubble.tsx
@@ -29,7 +29,6 @@ export function StreamingMessageBubble({ partIds, parts, onAbortTool }: Streamin
 
   const hasAnyContent = visibleIds.some((partId) => {
     const part = parts[partId];
-    if (!part) return false;
     if (part.type === 'text' || part.type === 'reasoning') {
       return part.hasContent;
     }
@@ -59,7 +58,6 @@ export function StreamingMessageBubble({ partIds, parts, onAbortTool }: Streamin
 
   for (const partId of visibleIds) {
     const part = parts[partId];
-    if (!part) continue;
 
     if (part.type === 'tool-call') {
       if (part.toolName === LIQUID_UI_TOOL_NAME) {

--- a/apps/web/src/components/chat/message-bubble/tool-call-display.ts
+++ b/apps/web/src/components/chat/message-bubble/tool-call-display.ts
@@ -80,7 +80,7 @@ export function buildStreamingToolCallDisplayItems(
 ): ToolCallDisplayItem[] {
   return partIds.flatMap((partId) => {
     const part = parts[partId];
-    if (!part || part.type !== 'tool-call' || isHiddenToolCall(part.toolName)) return [];
+    if (part.type !== 'tool-call' || isHiddenToolCall(part.toolName)) return [];
 
     return [
       {
@@ -154,7 +154,7 @@ function getToolLabel(toolName: string, displayName: string, kind: ToolSummaryKi
 }
 
 function getConnectorIconSlug(toolName: string): string | null {
-  const service = toolName.split('_', 1)[0];
+  const service = toolName.split('_', 1).at(0);
   if (!service) return null;
   return GOOGLE_SERVICE_ICON_SLUGS[service as keyof typeof GOOGLE_SERVICE_ICON_SLUGS] ?? null;
 }

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -280,25 +280,20 @@ function ToolCallRowStopButton({ onAbort }: { onAbort: () => void }) {
 }
 
 function ToolCallRowActions({ actions }: { actions: ToolCallAction[] }) {
-  return actions.map((action) => {
-    switch (action.type) {
-      case 'open-child-session':
-        return (
-          <Button
-            key={`${action.type}-${action.sessionId}`}
-            variant="quiet"
-            size="xs"
-            title="Open child session"
-            nativeButton={false}
-            render={<Link to="/session/$id" params={{ id: action.sessionId }} />}>
-            <Icon as={ExternalLinkIcon} size="xs" />
-            <Text as="span" variant="micro" tone="muted">
-              Open
-            </Text>
-          </Button>
-        );
-    }
-  });
+  return actions.map((action) => (
+    <Button
+      key={`${action.type}-${action.sessionId}`}
+      variant="quiet"
+      size="xs"
+      title="Open child session"
+      nativeButton={false}
+      render={<Link to="/session/$id" params={{ id: action.sessionId }} />}>
+      <Icon as={ExternalLinkIcon} size="xs" />
+      <Text as="span" variant="micro" tone="muted">
+        Open
+      </Text>
+    </Button>
+  ));
 }
 
 function useToolCallRow() {

--- a/apps/web/src/components/chat/message-list.tsx
+++ b/apps/web/src/components/chat/message-list.tsx
@@ -5,12 +5,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Message } from '@stitch/shared/chat/messages';
 
 import { RowContent } from '@/components/chat/message-list/row-content';
-import {
-  ALWAYS_UNVIRTUALIZED_TAIL_ROWS,
-  BASE_MESSAGE_HEIGHT_ESTIMATE,
-  buildRows,
-  estimateRowHeight,
-} from '@/components/chat/message-list/rows';
+import { ALWAYS_UNVIRTUALIZED_TAIL_ROWS, buildRows, estimateRowHeight } from '@/components/chat/message-list/rows';
 import { Stack } from '@/components/primitives/stack.js';
 import { Text } from '@/components/primitives/text.js';
 import type { SessionStreamState } from '@/stores/stream-store';
@@ -54,7 +49,7 @@ export function MessageList({
     const observer = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
-        if (entry?.isIntersecting) {
+        if (entry.isIntersecting) {
           onLoadMore();
         }
       },
@@ -80,7 +75,6 @@ export function MessageList({
     getItemKey: useCallback(
       (index: number) => {
         const row = rows[index];
-        if (!row) return index;
         if (row.kind === 'streaming') return 'streaming';
         if (row.kind === 'error') return 'error';
         if (row.kind === 'load-more') return 'load-more';
@@ -91,7 +85,7 @@ export function MessageList({
     estimateSize: useCallback(
       (index: number) => {
         const row = rows[index];
-        return row ? estimateRowHeight(row) : BASE_MESSAGE_HEIGHT_ESTIMATE;
+        return estimateRowHeight(row);
       },
       [rows],
     ),
@@ -107,7 +101,6 @@ export function MessageList({
         <div className="relative" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
           {virtualRows.map((virtualRow) => {
             const row = rows[virtualRow.index];
-            if (!row) return null;
 
             const rowKey =
               row.kind === 'streaming' || row.kind === 'error' || row.kind === 'load-more'

--- a/apps/web/src/components/chat/message-list/rows.ts
+++ b/apps/web/src/components/chat/message-list/rows.ts
@@ -4,7 +4,7 @@ import type { Message } from '@stitch/shared/chat/messages';
 import type { SessionStreamState } from '@/stores/stream-store';
 
 export const ALWAYS_UNVIRTUALIZED_TAIL_ROWS = 8;
-export const BASE_MESSAGE_HEIGHT_ESTIMATE = 200;
+const BASE_MESSAGE_HEIGHT_ESTIMATE = 200;
 const MESSAGE_HEIGHT_PER_CHAR = 20;
 
 export type RowData =
@@ -44,7 +44,7 @@ export function buildRows(
     if (message.role === 'user' && message.parts.some((part) => part.type === 'compaction')) {
       const next = messages[i + 1];
       let summaryParts: Message['parts'] | undefined;
-      if (next?.isSummary) {
+      if (next.isSummary) {
         summaryParts = next.parts;
         pairedSummaryIds.add(next.id);
       }
@@ -99,24 +99,20 @@ export function estimateRowHeight(row: RowData): number {
   if (row.kind === 'streaming') return 60;
   if (row.kind === 'error') return 80;
 
-  if (row.kind === 'message') {
-    const textContent = row.parts.reduce((acc, part) => {
-      if (part.type !== 'text-delta') return acc;
-      return acc + (part as { type: 'text-delta'; text: string }).text;
-    }, '');
+  const textContent = row.parts.reduce((acc, part) => {
+    if (part.type !== 'text-delta') return acc;
+    return acc + (part as { type: 'text-delta'; text: string }).text;
+  }, '');
 
-    const charCount = textContent.length;
-    const hasCodeBlocks = textContent.includes('```');
-    const hasReasoning = row.parts.some((part) => part.type === 'reasoning-delta');
-    const hasToolCalls = row.parts.some((part) => part.type === 'tool-call');
+  const charCount = textContent.length;
+  const hasCodeBlocks = textContent.includes('```');
+  const hasReasoning = row.parts.some((part) => part.type === 'reasoning-delta');
+  const hasToolCalls = row.parts.some((part) => part.type === 'tool-call');
 
-    let estimate = BASE_MESSAGE_HEIGHT_ESTIMATE + charCount * MESSAGE_HEIGHT_PER_CHAR;
-    if (hasCodeBlocks) estimate += 200;
-    if (hasReasoning) estimate += 100;
-    if (hasToolCalls) estimate += 50;
+  let estimate = BASE_MESSAGE_HEIGHT_ESTIMATE + charCount * MESSAGE_HEIGHT_PER_CHAR;
+  if (hasCodeBlocks) estimate += 200;
+  if (hasReasoning) estimate += 100;
+  if (hasToolCalls) estimate += 50;
 
-    return Math.min(Math.max(estimate, 80), 1500);
-  }
-
-  return BASE_MESSAGE_HEIGHT_ESTIMATE;
+  return Math.min(Math.max(estimate, 80), 1500);
 }

--- a/apps/web/src/components/connectors/setup-wizard.tsx
+++ b/apps/web/src/components/connectors/setup-wizard.tsx
@@ -90,7 +90,7 @@ export function SetupWizard({ definition, connectors, onClose }: Props) {
   const [label, setLabel] = useState('');
   const [setupError, setSetupError] = useState<string | null>(null);
   const [credentials, setCredentials] = useState<CredentialValues>({
-    selectedConnectorRefId: connectors[0]?.id ?? 'new',
+    selectedConnectorRefId: connectors.at(0)?.id ?? 'new',
     clientId: '',
     clientSecret: '',
     apiKey: '',

--- a/apps/web/src/components/cron-expression-builder.tsx
+++ b/apps/web/src/components/cron-expression-builder.tsx
@@ -161,9 +161,9 @@ export function CronExpressionBuilder({ value, onChange, timezone = 'UTC', class
         </TooltipProvider>
       </Stack>
       <ToggleGroup
-        value={[minutes[0]?.toString() ?? '0']}
+        value={[minutes.at(0)?.toString() ?? '0']}
         onValueChange={(vals) => {
-          const val = vals[0];
+          const val = vals.at(0);
           if (val) emit({ minutes: [Number.parseInt(val)] });
         }}
         className="flex flex-wrap justify-start gap-space-xs">
@@ -277,7 +277,7 @@ export function CronExpressionBuilder({ value, onChange, timezone = 'UTC', class
           <ToggleGroup
             value={[frequency]}
             onValueChange={(vals) => {
-              const val = vals[0];
+              const val = vals.at(0);
               if (val) {
                 const newFreq = val as Frequency;
                 setFrequency(newFreq);

--- a/apps/web/src/components/desktop-notifications/desktop-notification-root.tsx
+++ b/apps/web/src/components/desktop-notifications/desktop-notification-root.tsx
@@ -46,7 +46,7 @@ export function DesktopNotificationRoot() {
     if (!element) return;
 
     const observer = new ResizeObserver(([entry]) => {
-      const height = entry?.contentRect.height ?? 0;
+      const height = entry.contentRect.height;
       void window.api.notifications.setHeight(height);
     });
 

--- a/apps/web/src/components/mail/mail-page.tsx
+++ b/apps/web/src/components/mail/mail-page.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 
-import type { MailAccountId, MailLabelId, MailThreadId } from '@stitch/shared/mail/types';
+import type { MailAccountId, MailAccountView, MailLabelId, MailThreadId } from '@stitch/shared/mail/types';
 
 import { Composer } from '@/components/mail/composer';
 import { useMailStore } from '@/components/mail/mail-store';
@@ -17,7 +17,7 @@ import { getDefaultMailLabel, mailAccountsQueryOptions, mailLabelsQueryOptions }
 export function MailPage() {
   const { selectedAccountId, selectedLabelId } = useMailStore();
   const { data: accounts } = useSuspenseQuery(mailAccountsQueryOptions);
-  const accountId = selectedAccountId ?? accounts[0]?.id ?? null;
+  const accountId = selectedAccountId ?? (accounts[0] as MailAccountView | undefined)?.id ?? null;
 
   if (!accountId) return <NoMailAccounts />;
 

--- a/apps/web/src/components/mail/mail-sidebar.tsx
+++ b/apps/web/src/components/mail/mail-sidebar.tsx
@@ -14,7 +14,7 @@ import * as React from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 
-import type { MailAccountId, MailLabelView } from '@stitch/shared/mail/types';
+import type { MailAccountId, MailAccountView, MailLabelView } from '@stitch/shared/mail/types';
 
 import {
   getLabelDisplayName,
@@ -390,7 +390,8 @@ function MailLabelList({ accountId }: { accountId: MailAccountId }) {
 export function MailSidebarContent() {
   const { selectedAccountId, setSelectedAccountId } = useMailStore();
   const { data: accounts = [] } = useQuery(mailAccountsQueryOptions);
-  const selectedAccount = accounts.find((account) => account.id === selectedAccountId) ?? accounts[0];
+  const selectedAccount =
+    accounts.find((account) => account.id === selectedAccountId) ?? (accounts[0] as MailAccountView | undefined);
 
   React.useEffect(() => {
     if (!selectedAccountId && accounts[0]) setSelectedAccountId(accounts[0].id);

--- a/apps/web/src/components/mail/message-body.tsx
+++ b/apps/web/src/components/mail/message-body.tsx
@@ -75,7 +75,7 @@ function hasMeaningfulMailContent(node: Node): boolean {
 
 function hasMeaningfulContentBeside(node: Element, direction: 'previous' | 'next'): boolean {
   let current: Node | null = node;
-  while (current?.parentNode) {
+  while (current.parentNode) {
     let sibling = direction === 'previous' ? current.previousSibling : current.nextSibling;
     while (sibling) {
       if (hasMeaningfulMailContent(sibling)) return true;
@@ -92,7 +92,7 @@ function hasMeaningfulContentBeside(node: Element, direction: 'previous' | 'next
 function getTextBeside(node: Element, direction: 'previous' | 'next'): string {
   const text: string[] = [];
   let current: Node | null = node;
-  while (current?.parentNode) {
+  while (current.parentNode) {
     let sibling = direction === 'previous' ? current.previousSibling : current.nextSibling;
     while (sibling) {
       text.push(sibling.textContent ?? '');
@@ -151,7 +151,7 @@ function supportsDarkMode(doc: Document): boolean {
   if (content.includes('dark')) return true;
 
   return Array.from(doc.querySelectorAll('style')).some((style) =>
-    style.textContent?.toLowerCase().includes('prefers-color-scheme: dark'),
+    style.textContent.toLowerCase().includes('prefers-color-scheme: dark'),
   );
 }
 
@@ -201,7 +201,7 @@ function buildSandboxedMailHtml(input: {
 
   const emailStyles = Array.from(doc.querySelectorAll('head style, body style'))
     .flatMap((style) => {
-      const text = style.textContent ?? '';
+      const text = style.textContent;
       style.remove();
       return text ? [text] : [];
     })
@@ -218,7 +218,7 @@ function parseRgb(value: string): [number, number, number, number] | null {
 
   const parts = match[1].split(',').map((part) => Number(part.trim()));
   const [red, green, blue, alpha = 1] = parts;
-  if (red === undefined || green === undefined || blue === undefined || parts.some((part) => Number.isNaN(part))) {
+  if (parts.some((part) => Number.isNaN(part))) {
     return null;
   }
 
@@ -373,7 +373,7 @@ export function MessageBody({
 
   function handleFrameLoad() {
     const doc = iframeRef.current?.contentDocument;
-    if (!doc?.body?.innerHTML) return;
+    if (!doc?.body.innerHTML) return;
 
     resizeObserverRef.current?.disconnect();
     mutationObserverRef.current?.disconnect();

--- a/apps/web/src/components/mail/thread-list.tsx
+++ b/apps/web/src/components/mail/thread-list.tsx
@@ -89,7 +89,7 @@ export function ThreadList({ accountId, labelId, selectedThreadId, onSelectThrea
     if (!el || !hasNextPage || isFetchingNextPage) return;
 
     const observer = new IntersectionObserver((entries) => {
-      if (entries[0]?.isIntersecting) void fetchNextPage();
+      if (entries.at(0)?.isIntersecting) void fetchNextPage();
     });
     observer.observe(el);
     return () => observer.disconnect();
@@ -108,7 +108,6 @@ export function ThreadList({ accountId, labelId, selectedThreadId, onSelectThrea
       <div className="relative" style={{ height: `${rowVirtualizer.getTotalSize()}px` }}>
         {rowVirtualizer.getVirtualItems().map((virtualRow) => {
           const thread = threads[virtualRow.index];
-          if (!thread) return null;
 
           return (
             <div

--- a/apps/web/src/components/model-selectors/stt-model-selector-popover.tsx
+++ b/apps/web/src/components/model-selectors/stt-model-selector-popover.tsx
@@ -92,7 +92,7 @@ export function SttModelSelectorPopover({
                 </div>
                 {provider.models.map((model) => {
                   const isDefault =
-                    defaultValue?.providerId === provider.providerId && defaultValue?.modelId === model.id;
+                    defaultValue?.providerId === provider.providerId && defaultValue.modelId === model.id;
                   return (
                     <PopoverClose
                       key={model.id}

--- a/apps/web/src/components/onboarding/steps/profile-step.tsx
+++ b/apps/web/src/components/onboarding/steps/profile-step.tsx
@@ -14,7 +14,7 @@ function getDetectedTimezone(): string {
 
 function getTimezoneOptions(initialTimezone: string): string[] {
   const intlWithSupportedValues = Intl as typeof Intl & { supportedValuesOf?: (key: string) => string[] };
-  const listed = intlWithSupportedValues.supportedValuesOf?.('timeZone') ?? [];
+  const listed = intlWithSupportedValues.supportedValuesOf('timeZone');
   const preferred = [initialTimezone].filter((value) => value.length > 0);
 
   if (listed.length === 0) {

--- a/apps/web/src/components/onboarding/use-onboarding-state.ts
+++ b/apps/web/src/components/onboarding/use-onboarding-state.ts
@@ -49,7 +49,7 @@ export function useOnboardingState(): OnboardingState {
 
   const isOnboardingComplete =
     settings?.['onboarding.status'] === 'completed' &&
-    settings?.['onboarding.version'] === CURRENT_ONBOARDING_VERSION &&
+    settings['onboarding.version'] === CURRENT_ONBOARDING_VERSION &&
     profileName.length > 0 &&
     profileTimezone.length > 0 &&
     hasEnabledProvider;

--- a/apps/web/src/components/recordings/analysis/transcript-sidebar.tsx
+++ b/apps/web/src/components/recordings/analysis/transcript-sidebar.tsx
@@ -96,7 +96,7 @@ export function TranscriptSidebar({ analysis, isRunning, recordingId, isRecordin
               {rowVirtualizer.getVirtualItems().map((virtualRow) => {
                 const entry = entries[virtualRow.index];
 
-                return entry ? (
+                return (
                   <div
                     key={virtualRow.key}
                     data-index={virtualRow.index}
@@ -123,7 +123,7 @@ export function TranscriptSidebar({ analysis, isRunning, recordingId, isRecordin
                       )}
                     </div>
                   </div>
-                ) : null;
+                );
               })}
             </div>
           ) : (

--- a/apps/web/src/components/recordings/list/recordings-pagination.tsx
+++ b/apps/web/src/components/recordings/list/recordings-pagination.tsx
@@ -61,7 +61,7 @@ export function RecordingsPagination({
 
           {pageNumbers.map((pageNumber, index) => {
             const previousPage = pageNumbers[index - 1];
-            const showGap = previousPage !== undefined && pageNumber - previousPage > 1;
+            const showGap = pageNumber - previousPage > 1;
             return (
               <React.Fragment key={`page-${pageNumber}`}>
                 {showGap ? (

--- a/apps/web/src/components/recordings/recording-analysis-page.tsx
+++ b/apps/web/src/components/recordings/recording-analysis-page.tsx
@@ -4,6 +4,8 @@ import { toast } from 'sonner';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 
+import type { MeetingNoteTemplate } from '@stitch/shared/recordings/types';
+
 import { AnalysisHeader } from './analysis/analysis-header';
 import { TranscriptSidebar } from './analysis/transcript-sidebar';
 import { DeleteRecordingDialog } from './shared/delete-recording-dialog';
@@ -40,7 +42,8 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
   const isActiveRecording = recording.id === data.activeRecordingId;
   const defaultTemplateId = settings['recordings.analysis.defaultTemplateId'];
   const defaultTemplate =
-    templateData.templates.find((template) => template.id === defaultTemplateId) ?? templateData.templates[0];
+    templateData.templates.find((template) => template.id === defaultTemplateId) ??
+    (templateData.templates[0] as MeetingNoteTemplate | undefined);
   const [selectedTemplateId, setSelectedTemplateId] = React.useState<string>(defaultTemplate?.id ?? '');
   const selectedTemplate =
     templateData.templates.find((template) => template.id === selectedTemplateId) ?? defaultTemplate;
@@ -106,7 +109,6 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
             );
           }}
           onDelete={() => {
-            if (!recording) return;
             setShowDeleteConfirm(true);
           }}
         />
@@ -144,7 +146,7 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
               analysis={analysis}
               isRunning={isRunning}
               recordingId={recordingId}
-              isRecording={recording?.status === 'recording'}
+              isRecording={recording.status === 'recording'}
             />
           </div>
         </div>

--- a/apps/web/src/components/recordings/recordings-sidebar.tsx
+++ b/apps/web/src/components/recordings/recordings-sidebar.tsx
@@ -32,7 +32,7 @@ export function RecordingsSidebarContent() {
     if (!node || !hasNextPage) return;
 
     const observer = new IntersectionObserver((entries) => {
-      if (entries[0]?.isIntersecting && !isFetchingNextPage) {
+      if (entries.at(0)?.isIntersecting && !isFetchingNextPage) {
         void fetchNextPage();
       }
     });

--- a/apps/web/src/components/session/session-chat-pane/session-message-context.ts
+++ b/apps/web/src/components/session/session-chat-pane/session-message-context.ts
@@ -15,7 +15,7 @@ function shouldSkipMessage(message: SessionMessageContext): boolean {
 export function findLastUsedModel(messages: SessionMessageContext[]): ModelSpec | null {
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
-    if (!message || shouldSkipMessage(message)) continue;
+    if (shouldSkipMessage(message)) continue;
     return { providerId: message.providerId, modelId: message.modelId };
   }
 

--- a/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
+++ b/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
@@ -51,11 +51,11 @@ export function InstallRegistryMcpServer({
     label: index === 0 ? `Default (${describeAuthConfig(config)})` : describeAuthConfig(config),
   }));
 
-  const [selectedAuthId, setSelectedAuthId] = React.useState(authOptions[0]?.id ?? '0');
+  const [selectedAuthId, setSelectedAuthId] = React.useState(authOptions.at(0)?.id ?? '0');
   const form = useForm({
     defaultValues: applyAuthConfigToForm(
       { ...EMPTY_ADD_FORM, name: server.install.name, url: server.install.url, transport: server.install.transport },
-      authOptions[0]?.config ?? server.install.authConfig,
+      authOptions.at(0)?.config ?? server.install.authConfig,
     ),
     validators: { onMount: addMcpServerSchema, onChange: addMcpServerSchema },
     onSubmit: async ({ value }) => {
@@ -152,7 +152,7 @@ export function InstallRegistryMcpServer({
               <Label className="text-xs font-medium text-muted-foreground">Auth preset</Label>
               <Select value={selectedAuthId} onValueChange={handleAuthPresetChange}>
                 <SelectTrigger className="w-full">
-                  <SelectValue>{selectedAuthOption?.label ?? 'Select auth preset'}</SelectValue>
+                  <SelectValue>{selectedAuthOption.label}</SelectValue>
                 </SelectTrigger>
                 <SelectContent>
                   {authOptions.map((option) => (

--- a/apps/web/src/components/settings/permissions/permission-policy-editor.tsx
+++ b/apps/web/src/components/settings/permissions/permission-policy-editor.tsx
@@ -112,8 +112,8 @@ function ToolPermissionEditor({
 
   const handleBrowse = () => {
     void window.api.files.openPath().then((paths) => {
-      if (!paths || paths.length === 0) return;
-      const picked = paths[0];
+      if (paths.length === 0) return;
+      const picked = paths.at(0);
       if (!picked) return;
       const lastSegment = picked.split(/[/\\]/).at(-1) ?? '';
       const isLikelyDir = !lastSegment.includes('.');

--- a/apps/web/src/components/settings/providers/provider-config.tsx
+++ b/apps/web/src/components/settings/providers/provider-config.tsx
@@ -247,7 +247,7 @@ export function ProviderConfig({ provider, onBack, saveLabel = 'Save', onSaved, 
                     ) : null}
                   </Label>
                   {fieldDef.type === 'select' ? (
-                    <Select value={field.state.value ?? ''} onValueChange={(value) => field.handleChange(value || '')}>
+                    <Select value={field.state.value} onValueChange={(value) => field.handleChange(value || '')}>
                       <SelectTrigger
                         id={`${providerId}-${fieldDef.key}`}
                         className="w-full"
@@ -270,7 +270,7 @@ export function ProviderConfig({ provider, onBack, saveLabel = 'Save', onSaved, 
                       id={`${providerId}-${fieldDef.key}`}
                       type={fieldDef.secret ? 'password' : fieldDef.format === 'url' ? 'url' : 'text'}
                       placeholder={fieldDef.placeholder}
-                      value={field.state.value ?? ''}
+                      value={field.state.value}
                       aria-invalid={!!fieldErrorMessage(field.state.meta)}
                       onBlur={field.handleBlur}
                       onChange={(event) => field.handleChange(event.target.value)}

--- a/apps/web/src/components/settings/providers/utils.ts
+++ b/apps/web/src/components/settings/providers/utils.ts
@@ -15,7 +15,7 @@ export function resolveDefaultAuthMethod(
     return existingMethod;
   }
 
-  return enabledAuthMethods[0]?.method ?? '';
+  return enabledAuthMethods.at(0)?.method ?? '';
 }
 
 export function hydrateProviderConfigState(

--- a/apps/web/src/components/settings/recordings.tsx
+++ b/apps/web/src/components/settings/recordings.tsx
@@ -5,6 +5,8 @@ import { z } from 'zod';
 import { useForm, useStore } from '@tanstack/react-form';
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 
+import type { MeetingNoteTemplate } from '@stitch/shared/recordings/types';
+
 import ChatMarkdown from '@/components/chat/chat-markdown';
 import { Stack } from '@/components/primitives/stack';
 import { Text } from '@/components/primitives/text';
@@ -227,7 +229,8 @@ function RecordingsContent() {
   const autoAnalyzeEnabled = settings['recordings.autoAnalyze'] === 'true';
   const defaultTemplateId = settings['recordings.analysis.defaultTemplateId'];
   const defaultTemplate =
-    templateData.templates.find((template) => template.id === defaultTemplateId) ?? templateData.templates[0];
+    templateData.templates.find((template) => template.id === defaultTemplateId) ??
+    (templateData.templates[0] as MeetingNoteTemplate | undefined);
   const hasTranscriptionModel =
     !!settings['recordings.transcription.providerId'] && !!settings['recordings.transcription.modelId'];
   const hasAnalysisModel = !!settings['recordings.analysis.providerId'] && !!settings['recordings.analysis.modelId'];
@@ -371,7 +374,7 @@ function MeetingNoteTemplatesSettings() {
   const createMutation = useCreateMeetingNoteTemplate();
   const updateMutation = useUpdateMeetingNoteTemplate();
   const deleteMutation = useDeleteMeetingNoteTemplate();
-  const [selectedId, setSelectedId] = React.useState<string | null>(data.templates[0]?.id ?? null);
+  const [selectedId, setSelectedId] = React.useState<string | null>(data.templates.at(0)?.id ?? null);
   const [deleteOpen, setDeleteOpen] = React.useState(false);
 
   const selectedTemplate = data.templates.find((template) => template.id === selectedId) ?? null;

--- a/apps/web/src/components/settings/shortcuts.tsx
+++ b/apps/web/src/components/settings/shortcuts.tsx
@@ -312,7 +312,7 @@ function ShortcutsContent() {
         </SettingRows>
       </SettingSection>
 
-      <Tabs defaultValue={SHORTCUT_CATEGORIES[0]} className="gap-space-xl">
+      <Tabs defaultValue={SHORTCUT_CATEGORIES.at(0)} className="gap-space-xl">
         <TabsList variant="line">
           {SHORTCUT_CATEGORIES.map((category) => (
             <TabsTrigger key={category} value={category}>

--- a/apps/web/src/components/usage/charts/stt-usage-cost-chart.tsx
+++ b/apps/web/src/components/usage/charts/stt-usage-cost-chart.tsx
@@ -1,7 +1,7 @@
 import type { SttUsageDashboardResponse } from '@stitch/shared/usage/types';
 
 import { StackedBarChart } from '@/components/usage/charts/stacked-bar-chart';
-import { getChartColor, getChartColorForKey } from '@/lib/chart-colors';
+import { getChartColor } from '@/lib/chart-colors';
 
 const SERVICE_COLOR_INDEX: Record<string, number> = { 'chat-input': 0, 'meeting-recording': 1 };
 
@@ -9,8 +9,7 @@ const SERVICE_LABELS: Record<string, string> = { 'chat-input': 'Chat Input', 'me
 
 function getServiceColor(service: string): string {
   const index = SERVICE_COLOR_INDEX[service];
-  if (index !== undefined) return getChartColor(index);
-  return getChartColorForKey(service);
+  return getChartColor(index);
 }
 
 function getServiceLabel(service: string): string {

--- a/apps/web/src/components/usage/charts/usage-dashboard-cost-chart.tsx
+++ b/apps/web/src/components/usage/charts/usage-dashboard-cost-chart.tsx
@@ -2,7 +2,7 @@ import type { UsageDashboardResponse } from '@stitch/shared/usage/types';
 
 import { StackedBarChart } from '@/components/usage/charts/stacked-bar-chart';
 import { getSourceLabel, useSourceOrder } from '@/components/usage/utils/usage-dashboard-utils';
-import { getChartColor, getChartColorForKey } from '@/lib/chart-colors';
+import { getChartColor } from '@/lib/chart-colors';
 
 const SOURCE_COLOR_INDEX: Record<string, number> = {
   chat: 0,
@@ -15,8 +15,7 @@ const SOURCE_COLOR_INDEX: Record<string, number> = {
 
 function getSourceColor(source: string): string {
   const index = SOURCE_COLOR_INDEX[source];
-  if (index !== undefined) return getChartColor(index);
-  return getChartColorForKey(source);
+  return getChartColor(index);
 }
 
 type UsageDashboardCostChartProps = { usageData: UsageDashboardResponse | undefined };

--- a/apps/web/src/hooks/session/use-session-docks.tsx
+++ b/apps/web/src/hooks/session/use-session-docks.tsx
@@ -92,97 +92,93 @@ export function useSessionDocks({
 
   if (pendingQuestions.length > 0) {
     const request = pendingQuestions[0];
-    if (request) {
-      items.push({
-        id: 'questions',
-        title: 'Questions',
-        defaultExpanded: true,
-        variant: 'primary',
-        children: (
-          <QuestionDock
-            request={request}
-            onReply={async (questionId, answers) => {
-              await runMutation(
-                () => replyQuestion.mutateAsync({ sessionId, questionId, answers }),
-                'Failed to reply to question:',
-              );
-            }}
-            onReject={async (questionId) => {
-              await runMutation(
-                () => rejectQuestion.mutateAsync({ sessionId, questionId }),
-                'Failed to reject question:',
-              );
-            }}
-          />
-        ),
-      });
-    }
+    items.push({
+      id: 'questions',
+      title: 'Questions',
+      defaultExpanded: true,
+      variant: 'primary',
+      children: (
+        <QuestionDock
+          request={request}
+          onReply={async (questionId, answers) => {
+            await runMutation(
+              () => replyQuestion.mutateAsync({ sessionId, questionId, answers }),
+              'Failed to reply to question:',
+            );
+          }}
+          onReject={async (questionId) => {
+            await runMutation(
+              () => rejectQuestion.mutateAsync({ sessionId, questionId }),
+              'Failed to reject question:',
+            );
+          }}
+        />
+      ),
+    });
   }
 
   if (pendingPermissionResponses.length > 0) {
     const permissionResponse = pendingPermissionResponses[0];
-    if (permissionResponse) {
-      const parsedTool = parseMcpToolName(permissionResponse.toolName);
-      const toolLabel = parsedTool?.toolName ?? permissionResponse.toolName;
+    const parsedTool = parseMcpToolName(permissionResponse.toolName);
+    const toolLabel = parsedTool?.toolName ?? permissionResponse.toolName;
 
-      items.push({
-        id: 'permission-response',
-        title: `Allow ${toolLabel}?`,
-        defaultExpanded: true,
-        variant: 'primary',
-        children: (
-          <PermissionResponseDock
-            permissionResponse={permissionResponse}
-            toolLabel={toolLabel}
-            isPending={
-              allowPermissionResponse.isPending ||
-              rejectPermissionResponse.isPending ||
-              alternativePermissionResponse.isPending
-            }
-            onAllow={async (permissionResponseId) => {
-              await runMutation(
-                () => allowPermissionResponse.mutateAsync({ sessionId, permissionResponseId }),
-                'Failed to allow tool:',
-              );
-            }}
-            onAlwaysAllow={async (permissionResponseId) => {
-              await runMutation(
-                () =>
-                  allowPermissionResponse.mutateAsync({
-                    sessionId,
-                    permissionResponseId,
-                    setPermission: { permission: 'allow', pattern: null },
-                  }),
-                'Failed to always allow tool:',
-              );
-            }}
-            onReject={async (permissionResponseId) => {
-              await runMutation(
-                () => rejectPermissionResponse.mutateAsync({ sessionId, permissionResponseId }),
-                'Failed to reject tool:',
-              );
-            }}
-            onAlternative={async (permissionResponseId, entry) => {
-              await runMutation(
-                () => alternativePermissionResponse.mutateAsync({ sessionId, permissionResponseId, entry }),
-                'Failed to submit alternative action:',
-              );
-            }}
-            onApplySuggestion={async (permissionResponseId, pattern) => {
-              await runMutation(
-                () =>
-                  allowPermissionResponse.mutateAsync({
-                    sessionId,
-                    permissionResponseId,
-                    setPermission: { permission: 'allow', pattern },
-                  }),
-                'Failed to apply permission suggestion:',
-              );
-            }}
-          />
-        ),
-      });
-    }
+    items.push({
+      id: 'permission-response',
+      title: `Allow ${toolLabel}?`,
+      defaultExpanded: true,
+      variant: 'primary',
+      children: (
+        <PermissionResponseDock
+          permissionResponse={permissionResponse}
+          toolLabel={toolLabel}
+          isPending={
+            allowPermissionResponse.isPending ||
+            rejectPermissionResponse.isPending ||
+            alternativePermissionResponse.isPending
+          }
+          onAllow={async (permissionResponseId) => {
+            await runMutation(
+              () => allowPermissionResponse.mutateAsync({ sessionId, permissionResponseId }),
+              'Failed to allow tool:',
+            );
+          }}
+          onAlwaysAllow={async (permissionResponseId) => {
+            await runMutation(
+              () =>
+                allowPermissionResponse.mutateAsync({
+                  sessionId,
+                  permissionResponseId,
+                  setPermission: { permission: 'allow', pattern: null },
+                }),
+              'Failed to always allow tool:',
+            );
+          }}
+          onReject={async (permissionResponseId) => {
+            await runMutation(
+              () => rejectPermissionResponse.mutateAsync({ sessionId, permissionResponseId }),
+              'Failed to reject tool:',
+            );
+          }}
+          onAlternative={async (permissionResponseId, entry) => {
+            await runMutation(
+              () => alternativePermissionResponse.mutateAsync({ sessionId, permissionResponseId, entry }),
+              'Failed to submit alternative action:',
+            );
+          }}
+          onApplySuggestion={async (permissionResponseId, pattern) => {
+            await runMutation(
+              () =>
+                allowPermissionResponse.mutateAsync({
+                  sessionId,
+                  permissionResponseId,
+                  setPermission: { permission: 'allow', pattern },
+                }),
+              'Failed to apply permission suggestion:',
+            );
+          }}
+        />
+      ),
+    });
   }
 
   const activeCount = todos.filter((todo) => todo.status === 'pending' || todo.status === 'in_progress').length;

--- a/apps/web/src/hooks/use-actions.ts
+++ b/apps/web/src/hooks/use-actions.ts
@@ -15,7 +15,7 @@ export interface Action {
 export function useActions(): Action[] {
   const navigate = useNavigate();
   const params = useParams({ strict: false });
-  const sessionId = params?.id;
+  const sessionId = params.id;
   const { commandPaletteOpen, setCommandPaletteOpen, renameSessionOpen, setRenameSessionOpen } = useDialogContext();
   const abortStream = useStreamStore((s) => s.abortStream);
 

--- a/apps/web/src/lib/chart-colors.ts
+++ b/apps/web/src/lib/chart-colors.ts
@@ -13,20 +13,7 @@ export const CHART_THEME = {
 export const CHART_CLASS_NAME = 'stitch-chart';
 export const CHART_TOOLTIP_CLASS_NAME = 'stitch-chart-tooltip';
 
-function hashString(str: string): number {
-  let hash = 0;
-  for (let i = 0; i < str.length; i += 1) {
-    hash = (hash * 31 + str.charCodeAt(i)) >>> 0;
-  }
-  return hash;
-}
-
 /** Resolves the color for series `index`, cycling through `--chart-1`..`--chart-6`. */
 export function getChartColor(index: number): string {
   return `var(--chart-${(index % PALETTE_SIZE) + 1})`;
-}
-
-/** Resolves a chart color for an arbitrary series key by hashing it onto the chart palette. */
-export function getChartColorForKey(key: string): string {
-  return getChartColor(hashString(key));
 }

--- a/apps/web/src/lib/markdown/code-highlighting.test.ts
+++ b/apps/web/src/lib/markdown/code-highlighting.test.ts
@@ -9,7 +9,7 @@ const DRACULA = getTheme('dracula').code;
 
 function rootPre(hast: ReturnType<typeof highlightToHast>) {
   const pre = hast.children[0];
-  if (pre === undefined || pre.type !== 'element') throw new Error('expected a root pre element');
+  if (pre.type !== 'element') throw new Error('expected a root pre element');
   return pre;
 }
 

--- a/apps/web/src/lib/markdown/markdown-callouts.ts
+++ b/apps/web/src/lib/markdown/markdown-callouts.ts
@@ -1,6 +1,6 @@
 import { visit } from 'unist-util-visit';
 
-import type { Blockquote, Paragraph, Root } from 'mdast';
+import type { BlockContent, Blockquote, DefinitionContent, Paragraph, PhrasingContent, Root } from 'mdast';
 
 /**
  * GitHub alerts: a blockquote whose first line opens with `[!NOTE]`. GitHub requires
@@ -28,17 +28,17 @@ function calloutTitle(label: string): Paragraph {
 }
 
 function transformCallout(node: Blockquote): void {
-  const firstBlock = node.children[0];
-  if (firstBlock?.type !== 'paragraph') return;
+  const firstBlock = node.children[0] as BlockContent | DefinitionContent | undefined;
+  if (!firstBlock || firstBlock.type !== 'paragraph') return;
 
-  const firstInline = firstBlock.children[0];
-  if (firstInline?.type !== 'text') return;
+  const firstInline = firstBlock.children[0] as PhrasingContent | undefined;
+  if (!firstInline || firstInline.type !== 'text') return;
 
   const match = CALLOUT_MARKER.exec(firstInline.value);
   if (!match) return;
 
   const kind = match[1]?.toLowerCase() ?? '';
-  const label = CALLOUT_LABELS[kind];
+  const label = CALLOUT_LABELS[kind] as string | undefined;
   if (label === undefined) return;
 
   firstInline.value = firstInline.value.slice(match[0].length);

--- a/apps/web/src/lib/markdown/markdown-sanitize-schema.ts
+++ b/apps/web/src/lib/markdown/markdown-sanitize-schema.ts
@@ -16,9 +16,12 @@ export const markdownSanitizeSchema: SanitizeSchema = {
   tagNames: [...(defaultSchema.tagNames ?? []), 'abbr', 'mark', 'small', 'u'],
   attributes: {
     ...defaultAttributes,
-    blockquote: [...(defaultAttributes.blockquote ?? []), ['className', /^markdown-callout(?:-|$)/]],
+    blockquote: [...defaultAttributes.blockquote, ['className', /^markdown-callout(?:-|$)/]],
     // `math-inline`/`math-display` are how rehype-katex finds math to render.
     code: [['className', /^language-./, 'math-inline', 'math-display']],
-    p: [...(defaultAttributes.p ?? []), ['className', 'markdown-callout-title']],
+    p: [
+      ...((defaultAttributes.p as typeof defaultAttributes.blockquote | undefined) ?? []),
+      ['className', 'markdown-callout-title'],
+    ],
   },
 };

--- a/apps/web/src/lib/queries/chat.ts
+++ b/apps/web/src/lib/queries/chat.ts
@@ -116,7 +116,6 @@ export const sessionMessagesInfiniteQueryOptions = (id: string) =>
       // The cursor is the createdAt of the oldest message in this page
       // (messages are returned chronologically, so oldest is first)
       const oldest = lastPage.messages[0];
-      if (!oldest) return undefined;
       // Guard against infinite loops: if cursor hasn't changed, stop
       if (lastPageParam !== undefined && oldest.createdAt === lastPageParam) return undefined;
       return oldest.createdAt;
@@ -367,7 +366,7 @@ export function useSendMessage() {
 
         // Append the optimistic message to the first page (most recent)
         const updatedPages = [...previous.pages];
-        const firstPage = updatedPages[0];
+        const firstPage = updatedPages[0] as MessagesPage | undefined;
         if (firstPage) {
           updatedPages[0] = { ...firstPage, messages: [...firstPage.messages, optimisticMessage] };
         }

--- a/apps/web/src/lib/queries/mail.ts
+++ b/apps/web/src/lib/queries/mail.ts
@@ -69,7 +69,7 @@ export const mailDataKeys = {
 };
 
 export function getDefaultMailLabel(labels: MailLabelView[]): MailLabelView | undefined {
-  return labels.find((label) => label.providerLabelId.toUpperCase() === 'INBOX') ?? labels[0];
+  return labels.find((label) => label.providerLabelId.toUpperCase() === 'INBOX') ?? labels.at(0);
 }
 
 export function mailLabelsQueryOptions(accountId: MailAccountId) {

--- a/apps/web/src/lib/telemetry/client.ts
+++ b/apps/web/src/lib/telemetry/client.ts
@@ -141,7 +141,7 @@ function passesOncePerDay(field: 'lastActiveDate' | 'lastMessageDate'): boolean 
 }
 
 function getPlatform(): string {
-  return window.electron?.platform ?? navigator.platform ?? 'unknown';
+  return window.electron?.platform ?? navigator.platform;
 }
 
 function getReleaseChannel(): string {

--- a/apps/web/src/routes/mail/index.tsx
+++ b/apps/web/src/routes/mail/index.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 
 import { createFileRoute } from '@tanstack/react-router';
 
+import type { MailAccountView } from '@stitch/shared/mail/types';
+
 import { MailPage } from '@/components/mail/mail-page';
 import { Text } from '@/components/primitives/text';
 import {
@@ -14,7 +16,7 @@ import {
 export const Route = createFileRoute('/mail/')({
   loader: async ({ context }) => {
     const accounts = await context.queryClient.ensureQueryData(mailAccountsQueryOptions);
-    const account = accounts[0];
+    const account = accounts[0] as MailAccountView | undefined;
     if (!account) return;
 
     const labels = await context.queryClient.ensureQueryData(mailLabelsQueryOptions(account.id));

--- a/apps/web/src/stores/stream-store.ts
+++ b/apps/web/src/stores/stream-store.ts
@@ -148,7 +148,7 @@ function applyPartUpdateToSession(session: SessionStreamState, partId: string, p
 
     case 'text-end': {
       const existing = session.parts[partId];
-      if (!existing || existing.type !== 'text') return session;
+      if (existing.type !== 'text') return session;
       return updatePart(session, partId, { ...existing, status: 'complete', endedAt: Date.now() });
     }
 
@@ -157,13 +157,13 @@ function applyPartUpdateToSession(session: SessionStreamState, partId: string, p
 
     case 'reasoning-end': {
       const existing = session.parts[partId];
-      if (!existing || existing.type !== 'reasoning') return session;
+      if (existing.type !== 'reasoning') return session;
       return updatePart(session, partId, { ...existing, status: 'complete', endedAt: Date.now() });
     }
 
     case 'tool-call': {
       const existing = session.parts[partId];
-      if (existing && existing.type === 'tool-call') {
+      if (existing.type === 'tool-call') {
         return updatePart(session, partId, { ...existing, input: part.input });
       }
       return addPart(session, partId, {
@@ -211,7 +211,6 @@ function applyPartUpdateToSession(session: SessionStreamState, partId: string, p
 
 function applyPartDeltaToSession(session: SessionStreamState, partId: string, delta: PartDelta): SessionStreamState {
   const existing = session.parts[partId];
-  if (!existing) return session;
 
   if (delta.type === 'text-delta' && existing.type === 'text') {
     return updatePart(session, partId, { ...existing, text: existing.text + delta.text, hasContent: true });
@@ -277,7 +276,7 @@ export const useStreamStore = create<StreamStoreState & StreamStoreActions>()((s
 
       const existing = session.parts[toolCallId];
 
-      if (existing && existing.type === 'tool-call') {
+      if (existing.type === 'tool-call') {
         return {
           sessions: {
             ...state.sessions,

--- a/connectors/google/src/client.ts
+++ b/connectors/google/src/client.ts
@@ -219,12 +219,10 @@ function mergeRateLimitConfig(overrides: Partial<GoogleRateLimitConfig> | undefi
   const services = { ...DEFAULT_GOOGLE_RATE_LIMIT_CONFIG.services };
   if (overrides.services) {
     for (const key of Object.keys(services) as (keyof typeof services)[]) {
-      if (overrides.services[key]) {
-        services[key] = {
-          project: overrides.services[key]?.project ?? services[key].project,
-          account: overrides.services[key]?.account ?? services[key].account,
-        };
-      }
+      services[key] = {
+        project: overrides.services[key]?.project ?? services[key].project,
+        account: overrides.services[key]?.account ?? services[key].account,
+      };
     }
   }
 
@@ -255,7 +253,7 @@ async function parseGoogleApiError(response: Response): Promise<ParsedApiError> 
       ...(parsed.error?.errors?.flatMap((item) => (item.reason ? [item.reason] : [])) ?? []),
       ...(parsed.error?.details?.flatMap((item) => (item.reason ? [item.reason] : [])) ?? []),
     ];
-    const reason = reasons[0];
+    const reason = reasons.at(0);
     return { message, code, reason, reasons, authChallenge, retryAfterMs };
   } catch {
     return { message: fallbackMessage, code: undefined, reason: undefined, reasons: [], authChallenge, retryAfterMs };

--- a/connectors/google/src/docs/api.ts
+++ b/connectors/google/src/docs/api.ts
@@ -74,7 +74,7 @@ function getBodyEndIndex(document: DocsDocumentRaw): number {
     return 1;
   }
 
-  const last = content[content.length - 1];
+  const last = content.at(-1);
   if (!last?.endIndex || last.endIndex <= 1) {
     return 1;
   }

--- a/connectors/google/src/docs/tools.test.ts
+++ b/connectors/google/src/docs/tools.test.ts
@@ -56,7 +56,7 @@ describe('createDocsTools docs_edit', () => {
     const result = await docsEdit.execute({ documentId: 'doc-1', oldString: 'beta', newString: 'gamma' });
 
     expect(batchUpdates).toHaveLength(1);
-    expect(batchUpdates[0]).toEqual(
+    expect(batchUpdates.at(0)).toEqual(
       expect.objectContaining({
         requests: expect.arrayContaining([
           expect.objectContaining({ insertText: { location: { index: 1 }, text: 'alpha gamma alpha' } }),
@@ -101,7 +101,7 @@ describe('createDocsTools docs_edit', () => {
     await docsEdit.execute({ documentId: 'doc-4', oldString: 'task', newString: 'item', replaceAll: true });
 
     expect(batchUpdates).toHaveLength(1);
-    expect(batchUpdates[0]).toEqual(
+    expect(batchUpdates.at(0)).toEqual(
       expect.objectContaining({
         requests: expect.arrayContaining([
           expect.objectContaining({ insertText: { location: { index: 1 }, text: 'item item done' } }),

--- a/connectors/google/src/docs/tools.ts
+++ b/connectors/google/src/docs/tools.ts
@@ -72,7 +72,7 @@ function countOccurrences(content: string, oldString: string): number {
   let count = 0;
   let startIndex = 0;
 
-  while (true) {
+  for (;;) {
     const index = content.indexOf(oldString, startIndex);
     if (index === -1) {
       return count;

--- a/connectors/google/src/gmail/api.test.ts
+++ b/connectors/google/src/gmail/api.test.ts
@@ -56,13 +56,13 @@ describe('gmail api', () => {
     const result = await downloadAttachments(client, 'msg-1', root);
 
     expect(result.attachments).toHaveLength(1);
-    expect(result.attachments[0]).toMatchObject({
+    expect(result.attachments.at(0)).toMatchObject({
       attachmentId: 'att-1',
       filename: 'report.pdf',
       mimeType: 'application/pdf',
       size: 11,
     });
-    expect(result.attachments[0]?.path).toBe(path.join(root, 'gmail-attachments', 'msg-1', 'report.pdf'));
-    expect(fs.readFile(result.attachments[0]?.path ?? '', 'utf8')).resolves.toBe('hello world');
+    expect(result.attachments.at(0)?.path).toBe(path.join(root, 'gmail-attachments', 'msg-1', 'report.pdf'));
+    expect(fs.readFile(result.attachments.at(0)?.path ?? '', 'utf8')).resolves.toBe('hello world');
   });
 });

--- a/connectors/google/src/gmail/api.ts
+++ b/connectors/google/src/gmail/api.ts
@@ -79,8 +79,13 @@ function extractAttachments(payload: GmailMessagePart | undefined): GmailAttachm
   const attachments: GmailAttachment[] = [];
   for (const part of payload.parts) {
     const filename =
-      extractHeader(part.headers, 'Content-Disposition')?.match(/filename="?([^";]+)"?/i)?.[1] ??
-      part.headers?.find((h) => h.name.toLowerCase() === 'content-type')?.value.match(/name="?([^";]+)"?/i)?.[1];
+      extractHeader(part.headers, 'Content-Disposition')
+        ?.match(/filename="?([^";]+)"?/i)
+        ?.at(1) ??
+      part.headers
+        ?.find((h) => h.name.toLowerCase() === 'content-type')
+        ?.value.match(/name="?([^";]+)"?/i)
+        ?.at(1);
 
     if (filename && part.body?.size) {
       attachments.push({
@@ -552,7 +557,7 @@ export async function getFilter(client: GoogleClient, filterId: string): Promise
 export async function createFilter(client: GoogleClient, input: GmailFilterInput): Promise<GmailFilter> {
   const criteria = input.criteria ?? {};
 
-  const hasCriteria = Object.values(criteria).some((v) => v !== undefined);
+  const hasCriteria = Object.values(criteria).length > 0;
   if (!hasCriteria) {
     throw new GmailFilterNoCriteriaError();
   }

--- a/connectors/google/src/rate-limit.ts
+++ b/connectors/google/src/rate-limit.ts
@@ -239,7 +239,7 @@ class SlidingWindowLimiter {
   private async acquireInternal(weight: number, options: AcquireOptions): Promise<number> {
     let waitedMs = 0;
 
-    while (true) {
+    for (;;) {
       const now = Date.now();
       this.pruneExpired(now);
 
@@ -249,7 +249,7 @@ class SlidingWindowLimiter {
         return waitedMs;
       }
 
-      const oldest = this.events[0];
+      const oldest = this.events.at(0);
       if (!oldest) {
         this.events.push({ timestamp: now, weight });
         return waitedMs;

--- a/connectors/google/src/scopes.ts
+++ b/connectors/google/src/scopes.ts
@@ -66,10 +66,7 @@ export function hasWriteAccess(grantedScopes: string[], service: GoogleService):
   if (service === 'calendar') {
     return grantedScopes.some((s) => s === GOOGLE_SCOPE_CALENDAR_EVENTS || s === GOOGLE_SCOPE_CALENDAR);
   }
-  if (service === 'docs') {
-    return grantedScopes.some((s) => s === GOOGLE_SCOPE_DOCS);
-  }
-  return false;
+  return grantedScopes.some((s) => s === GOOGLE_SCOPE_DOCS);
 }
 
 /** Check if granted scopes can send Gmail messages. */

--- a/connectors/sdk/src/upgrade.ts
+++ b/connectors/sdk/src/upgrade.ts
@@ -58,15 +58,16 @@ export function buildUpgradeState(input: {
   const currentCapabilities = new Set(input.capabilities);
   const newCapabilities = targetCapabilities.filter((capability) => !currentCapabilities.has(capability));
 
-  const latestVersion = pendingVersions[pendingVersions.length - 1];
+  const latestVersion = pendingVersions.at(-1);
+  if (!latestVersion) return null;
 
   return {
     available: true,
     fromVersion,
     toVersion,
     actions: [...actionSet],
-    title: latestVersion?.title ?? `Upgrade ${input.definition.name}`,
-    description: latestVersion?.description ?? 'A connector upgrade is available.',
+    title: latestVersion.title,
+    description: latestVersion.description,
     missingScopes,
     newCapabilities,
   };

--- a/packages/mail/src/db/queries.test.ts
+++ b/packages/mail/src/db/queries.test.ts
@@ -95,7 +95,7 @@ describe('listThreads', () => {
     const trashedThreads = await listThreads({ accountId, isTrashed: true, db });
 
     expect(inboxThreads.threads.map((thread) => thread.id)).toEqual([inboxThreadId]);
-    expect(inboxThreads.threads[0]?.labels.map((label) => label.id)).toEqual([inboxLabelId]);
+    expect(inboxThreads.threads.at(0)?.labels.map((label) => label.id)).toEqual([inboxLabelId]);
     expect(trashedThreads.threads.map((thread) => thread.id)).toEqual([trashThreadId]);
   });
 
@@ -168,8 +168,8 @@ describe('listThreads', () => {
     expect(accounts.map((item) => item.id)).toEqual([accountId]);
     expect(labels.map((label) => label.id)).toEqual([labelId]);
     expect(drafts.map((draft) => draft.id)).toEqual([draftId]);
-    expect(threadList.threads[0]?.from).toEqual({ name: 'A', email: 'a@example.com' });
+    expect(threadList.threads.at(0)?.from).toEqual({ name: 'A', email: 'a@example.com' });
     expect(thread?.from).toEqual({ name: 'A', email: 'a@example.com' });
-    expect(thread?.messages[0]?.attachments[0]?.id).toBe(attachmentId);
+    expect(thread?.messages.at(0)?.attachments[0]?.id).toBe(attachmentId);
   });
 });

--- a/packages/mail/src/db/queries.ts
+++ b/packages/mail/src/db/queries.ts
@@ -190,7 +190,7 @@ export async function listThreads(options: ListThreadsOptions): Promise<ListThre
 
 export async function getThread(threadId: MailThreadId, dbOption?: MailDb): Promise<MailThreadDetail | null> {
   const db = dbOrDefault(dbOption);
-  const [thread] = await db.select().from(mailThreads).where(eq(mailThreads.id, threadId)).limit(1);
+  const thread = (await db.select().from(mailThreads).where(eq(mailThreads.id, threadId)).limit(1)).at(0);
   if (!thread) return null;
 
   const messages = await db
@@ -278,7 +278,7 @@ export async function listAccounts(dbOption?: MailDb): Promise<MailAccountView[]
 
 export async function getAccount(accountId: MailAccountId, dbOption?: MailDb): Promise<MailAccountView | null> {
   const db = dbOrDefault(dbOption);
-  const [account] = await db.select().from(mailAccounts).where(eq(mailAccounts.id, accountId)).limit(1);
+  const account = (await db.select().from(mailAccounts).where(eq(mailAccounts.id, accountId)).limit(1)).at(0);
   return account ? getAccountView(db, account) : null;
 }
 
@@ -314,10 +314,10 @@ async function getAccountView(db: MailDb, account: typeof mailAccounts.$inferSel
   return {
     ...account,
     counts: {
-      threads: threadCount?.value ?? 0,
-      unreadThreads: unreadThreadCount?.value ?? 0,
-      drafts: draftCount?.value ?? 0,
-      outboxPending: outboxPendingCount?.value ?? 0,
+      threads: threadCount.value,
+      unreadThreads: unreadThreadCount.value,
+      drafts: draftCount.value,
+      outboxPending: outboxPendingCount.value,
     },
   };
 }

--- a/packages/mail/src/ops/operations.ts
+++ b/packages/mail/src/ops/operations.ts
@@ -40,7 +40,7 @@ function stringifyAddresses(addresses: SyncAddress[]): string {
 }
 
 async function getAccount(accountId: MailAccountId): Promise<MailAccountRecord> {
-  const [account] = await getMailDb().select().from(mailAccounts).where(eq(mailAccounts.id, accountId)).limit(1);
+  const account = (await getMailDb().select().from(mailAccounts).where(eq(mailAccounts.id, accountId)).limit(1)).at(0);
   if (!account) throw new MailNotFoundError(`Mail account not found: ${accountId}`);
   return account;
 }
@@ -58,9 +58,11 @@ async function toOutgoingDraft(input: DraftInput): Promise<OutgoingDraft> {
       inReplyTo: null,
     };
   }
-  const [message] = await db.select().from(mailMessages).where(eq(mailMessages.id, input.inReplyToMessageId)).limit(1);
+  const message = (
+    await db.select().from(mailMessages).where(eq(mailMessages.id, input.inReplyToMessageId)).limit(1)
+  ).at(0);
   if (!message) throw new MailNotFoundError(`Reply message not found: ${input.inReplyToMessageId}`);
-  const [thread] = await db.select().from(mailThreads).where(eq(mailThreads.id, message.threadId)).limit(1);
+  const thread = (await db.select().from(mailThreads).where(eq(mailThreads.id, message.threadId)).limit(1)).at(0);
   if (!thread) throw new MailNotFoundError(`Reply thread not found: ${message.threadId}`);
   return {
     to: input.to,
@@ -86,7 +88,7 @@ export function createOperations(deps: OperationsDeps) {
       input: { addLabelIds?: MailLabelId[]; removeLabelIds?: MailLabelId[]; markRead?: boolean },
     ): Promise<void> {
       const db = getMailDb();
-      const [message] = await db.select().from(mailMessages).where(eq(mailMessages.id, messageId)).limit(1);
+      const message = (await db.select().from(mailMessages).where(eq(mailMessages.id, messageId)).limit(1)).at(0);
       if (!message) throw new MailNotFoundError(`Mail message not found: ${messageId}`);
       const addProviderIds = [...(await labelsById(input.addLabelIds ?? [])).values()];
       const removeProviderIds = [...(await labelsById(input.removeLabelIds ?? [])).values()];
@@ -168,7 +170,7 @@ export function createOperations(deps: OperationsDeps) {
 
     async updateDraft(draftId: MailDraftId, input: Partial<DraftInput>): Promise<void> {
       const db = getMailDb();
-      const [draft] = await db.select().from(mailDrafts).where(eq(mailDrafts.id, draftId)).limit(1);
+      const draft = (await db.select().from(mailDrafts).where(eq(mailDrafts.id, draftId)).limit(1)).at(0);
       if (!draft) throw new MailNotFoundError(`Mail draft not found: ${draftId}`);
       const next = {
         accountId: input.accountId ?? draft.accountId,
@@ -203,7 +205,7 @@ export function createOperations(deps: OperationsDeps) {
 
     async deleteDraft(draftId: MailDraftId): Promise<void> {
       const db = getMailDb();
-      const [draft] = await db.select().from(mailDrafts).where(eq(mailDrafts.id, draftId)).limit(1);
+      const draft = (await db.select().from(mailDrafts).where(eq(mailDrafts.id, draftId)).limit(1)).at(0);
       if (!draft) return;
       await db.delete(mailDrafts).where(eq(mailDrafts.id, draft.id));
       if (draft.providerDraftId)
@@ -212,7 +214,7 @@ export function createOperations(deps: OperationsDeps) {
 
     async sendDraft(draftId: MailDraftId): Promise<void> {
       const db = getMailDb();
-      const [draft] = await db.select().from(mailDrafts).where(eq(mailDrafts.id, draftId)).limit(1);
+      const draft = (await db.select().from(mailDrafts).where(eq(mailDrafts.id, draftId)).limit(1)).at(0);
       if (!draft) throw new MailNotFoundError(`Mail draft not found: ${draftId}`);
       const input: DraftInput = {
         accountId: draft.accountId,
@@ -238,7 +240,7 @@ export function createOperations(deps: OperationsDeps) {
 
     async hydrateThread(threadId: MailThreadId): Promise<void> {
       const db = getMailDb();
-      const [thread] = await db.select().from(mailThreads).where(eq(mailThreads.id, threadId)).limit(1);
+      const thread = (await db.select().from(mailThreads).where(eq(mailThreads.id, threadId)).limit(1)).at(0);
       if (!thread) throw new MailNotFoundError(`Mail thread not found: ${threadId}`);
       const messages = await db.select().from(mailMessages).where(eq(mailMessages.threadId, threadId));
       if (messages.length > 0 && messages.every((message) => message.hydration === 'full')) return;
@@ -252,12 +254,14 @@ export function createOperations(deps: OperationsDeps) {
 
     async fetchAttachment(attachmentId: MailAttachmentId): Promise<string> {
       const db = getMailDb();
-      const [row] = await db
-        .select({ attachment: mailAttachments, message: mailMessages })
-        .from(mailAttachments)
-        .innerJoin(mailMessages, eq(mailMessages.id, mailAttachments.messageId))
-        .where(eq(mailAttachments.id, attachmentId))
-        .limit(1);
+      const row = (
+        await db
+          .select({ attachment: mailAttachments, message: mailMessages })
+          .from(mailAttachments)
+          .innerJoin(mailMessages, eq(mailMessages.id, mailAttachments.messageId))
+          .where(eq(mailAttachments.id, attachmentId))
+          .limit(1)
+      ).at(0);
       if (!row) throw new MailNotFoundError(`Mail attachment not found: ${attachmentId}`);
       if (row.attachment.localPath) return row.attachment.localPath;
       const account = await getAccount(row.message.accountId);
@@ -282,14 +286,14 @@ export function createOperations(deps: OperationsDeps) {
 
 async function setThreadTrash(threadId: MailThreadId, isTrashed: boolean, deps: OperationsDeps): Promise<void> {
   const db = getMailDb();
-  const [thread] = await db.select().from(mailThreads).where(eq(mailThreads.id, threadId)).limit(1);
+  const thread = (await db.select().from(mailThreads).where(eq(mailThreads.id, threadId)).limit(1)).at(0);
   if (!thread) throw new MailNotFoundError(`Mail thread not found: ${threadId}`);
   const messages = await db.select().from(mailMessages).where(eq(mailMessages.threadId, thread.id));
   const trashLabels = await db
     .select()
     .from(mailLabels)
     .where(and(eq(mailLabels.accountId, thread.accountId), eq(mailLabels.providerLabelId, MAIL_SYSTEM_LABELS.trash)));
-  const trashLabel = trashLabels[0];
+  const trashLabel = trashLabels.at(0);
   for (const message of messages) {
     await db.update(mailMessages).set({ isTrashed, updatedAt: Date.now() }).where(eq(mailMessages.id, message.id));
     if (trashLabel && isTrashed)

--- a/packages/mail/src/ops/outbox.ts
+++ b/packages/mail/src/ops/outbox.ts
@@ -84,7 +84,7 @@ async function processSentMessage(
 
 async function processOutboxRow(deps: OutboxDeps, row: typeof mailOutbox.$inferSelect): Promise<void> {
   const db = getMailDb();
-  const [account] = await db.select().from(mailAccounts).where(eq(mailAccounts.id, row.accountId)).limit(1);
+  const account = (await db.select().from(mailAccounts).where(eq(mailAccounts.id, row.accountId)).limit(1)).at(0);
   if (!account) return;
   const ctx = deps.createContext(account);
   const provider = getMailProvider(account.provider);
@@ -165,7 +165,7 @@ export function createOutbox(deps: OutboxDeps): OutboxController {
     if (flushPromise) return flushPromise;
     flushPromise = (async () => {
       const db = getMailDb();
-      while (true) {
+      for (;;) {
         const now = Date.now();
         const rows = await db
           .select()

--- a/packages/mail/src/providers/gmail/batch.ts
+++ b/packages/mail/src/providers/gmail/batch.ts
@@ -31,10 +31,10 @@ function parsePart(part: string): GmailBatchResult | null {
   const httpStart = part.search(/HTTP\/\d(?:\.\d)?\s+\d{3}/);
   if (httpStart === -1) return null;
 
-  const contentId = part.match(/Content-ID:\s*<?([^>\r\n]+)>?/i)?.[1] ?? '';
+  const contentId = part.match(/Content-ID:\s*<?([^>\r\n]+)>?/i)?.at(1) ?? '';
   const httpResponse = part.slice(httpStart).trim();
   const [statusLine = '', ...rest] = httpResponse.split(/\r?\n/);
-  const status = Number(statusLine.match(/\s(\d{3})\s/)?.[1] ?? 0);
+  const status = Number(statusLine.match(/\s(\d{3})\s/)?.at(1) ?? 0);
   const separator = rest.findIndex((line) => line.trim() === '');
   const headerLines = separator === -1 ? rest : rest.slice(0, separator);
   const bodyLines = separator === -1 ? [] : rest.slice(separator + 1);
@@ -49,8 +49,8 @@ function parsePart(part: string): GmailBatchResult | null {
 
 export function parseGmailBatchResponse(contentType: string | null, body: string): GmailBatchResult[] {
   const boundary =
-    contentType?.match(/boundary=(?:"([^"]+)"|([^;]+))/i)?.[1] ??
-    contentType?.match(/boundary=(?:"([^"]+)"|([^;]+))/i)?.[2];
+    contentType?.match(/boundary=(?:"([^"]+)"|([^;]+))/i)?.at(1) ??
+    contentType?.match(/boundary=(?:"([^"]+)"|([^;]+))/i)?.at(2);
   if (!boundary) throw new GmailBatchError('Gmail batch response did not include a multipart boundary');
 
   return body

--- a/packages/mail/src/providers/gmail/parse.ts
+++ b/packages/mail/src/providers/gmail/parse.ts
@@ -101,8 +101,8 @@ function findFilename(part: GmailMessagePart): string | null {
   const disposition = extractHeader(part.headers, 'Content-Disposition');
   const contentType = extractHeader(part.headers, 'Content-Type');
   return (
-    disposition?.match(/filename\*?=(?:UTF-8''|")?([^";]+)/i)?.[1] ??
-    contentType?.match(/name\*?=(?:UTF-8''|")?([^";]+)/i)?.[1] ??
+    disposition?.match(/filename\*?=(?:UTF-8''|")?([^";]+)/i)?.at(1) ??
+    contentType?.match(/name\*?=(?:UTF-8''|")?([^";]+)/i)?.at(1) ??
     null
   );
 }

--- a/packages/mail/src/providers/gmail/provider.ts
+++ b/packages/mail/src/providers/gmail/provider.ts
@@ -246,7 +246,7 @@ export const gmailSyncProvider: MailSyncProvider = {
   },
 
   async getThread(ctx, providerThreadId, hydration) {
-    return (await batchGetParsedThreads(ctx, [providerThreadId], hydration))[0] ?? null;
+    return (await batchGetParsedThreads(ctx, [providerThreadId], hydration)).at(0) ?? null;
   },
 
   async fetchAttachment(ctx, providerMessageId, providerAttachmentId) {

--- a/packages/mail/src/registry.ts
+++ b/packages/mail/src/registry.ts
@@ -6,7 +6,6 @@ import type { MailProviderId } from './db/schema.js';
 const providers = new Map<MailProviderId, MailProviderModule>();
 
 export function registerMailProvider(module: MailProviderModule): void {
-  if (module.sync.id !== module.ops.id) throw new MailConfigurationError('Mail provider sync and ops ids must match');
   providers.set(module.sync.id, module);
 }
 

--- a/packages/mail/src/sync/engine.ts
+++ b/packages/mail/src/sync/engine.ts
@@ -104,7 +104,7 @@ function isAbortError(error: unknown): boolean {
 
 async function readAccount(accountId: MailAccountId): Promise<MailAccountRecord | null> {
   const [account] = await getMailDb().select().from(mailAccounts).where(eq(mailAccounts.id, accountId)).limit(1);
-  return account ?? null;
+  return account;
 }
 
 export function createMailEngine(deps: MailEngineDeps): MailEngine {

--- a/packages/mail/src/sync/persist.ts
+++ b/packages/mail/src/sync/persist.ts
@@ -85,11 +85,13 @@ async function ensureLabels(
 }
 
 async function getOrCreateThread(accountId: MailAccountId, thread: SyncThread, db: MailDb): Promise<MailThreadId> {
-  const [existing] = await db
-    .select()
-    .from(mailThreads)
-    .where(and(eq(mailThreads.accountId, accountId), eq(mailThreads.providerThreadId, thread.providerThreadId)))
-    .limit(1);
+  const existing = (
+    await db
+      .select()
+      .from(mailThreads)
+      .where(and(eq(mailThreads.accountId, accountId), eq(mailThreads.providerThreadId, thread.providerThreadId)))
+      .limit(1)
+  ).at(0);
   if (existing) return existing.id;
 
   const latest = latestMessage(thread.messages);
@@ -127,11 +129,13 @@ async function upsertMessage(
   message: SyncMessage,
   db: MailDb,
 ): Promise<void> {
-  const [existing] = await db
-    .select()
-    .from(mailMessages)
-    .where(and(eq(mailMessages.accountId, accountId), eq(mailMessages.providerMessageId, message.providerMessageId)))
-    .limit(1);
+  const existing = (
+    await db
+      .select()
+      .from(mailMessages)
+      .where(and(eq(mailMessages.accountId, accountId), eq(mailMessages.providerMessageId, message.providerMessageId)))
+      .limit(1)
+  ).at(0);
   const now = Date.now();
   const keepExistingBody = existing?.hydration === 'full' && message.hydration === 'metadata';
   const values = {
@@ -207,11 +211,13 @@ async function deleteThread(
   providerThreadId: string,
   db: MailDb,
 ): Promise<MailThreadId | null> {
-  const [thread] = await db
-    .select()
-    .from(mailThreads)
-    .where(and(eq(mailThreads.accountId, accountId), eq(mailThreads.providerThreadId, providerThreadId)))
-    .limit(1);
+  const thread = (
+    await db
+      .select()
+      .from(mailThreads)
+      .where(and(eq(mailThreads.accountId, accountId), eq(mailThreads.providerThreadId, providerThreadId)))
+      .limit(1)
+  ).at(0);
   if (!thread) return null;
   await db.delete(mailThreads).where(eq(mailThreads.id, thread.id));
   return thread.id;
@@ -244,7 +250,7 @@ export async function recomputeThreads(threadIds: MailThreadId[], dbOption?: Mai
         lastMessageAt: latest.internalDate,
         messageCount: messages.length,
         hasUnread: messages.some((message) => message.isUnread),
-        hasAttachments: (attachmentCount ?? 0) > 0,
+        hasAttachments: attachmentCount > 0,
         isTrashed: messages.some((message) => message.isTrashed),
         updatedAt: Date.now(),
       })
@@ -274,7 +280,7 @@ export async function refreshLabelCounts(accountId: MailAccountId, dbOption?: Ma
       );
     await db
       .update(mailLabels)
-      .set({ totalCount: total?.value ?? 0, unreadCount: unread?.value ?? 0 })
+      .set({ totalCount: total.value, unreadCount: unread.value })
       .where(eq(mailLabels.id, label.id));
   }
 }

--- a/packages/meeting-detection/src/meeting-detection/engine.test.ts
+++ b/packages/meeting-detection/src/meeting-detection/engine.test.ts
@@ -30,11 +30,11 @@ describe('createMeetingDetectionEngine', () => {
 
     engine.ingest([observation], now + 400);
     expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({ type: 'detected' });
+    expect(events.at(0)).toMatchObject({ type: 'detected' });
 
     engine.ingest([], now + 700);
     expect(events).toHaveLength(2);
-    expect(events[1]).toMatchObject({ type: 'ended', key: 'desktop:zoom' });
+    expect(events.at(1)).toMatchObject({ type: 'ended', key: 'desktop:zoom' });
   });
 
   test('does not re-emit detected while in cooldown', () => {
@@ -94,7 +94,7 @@ describe('createMeetingDetectionEngine', () => {
     engine.ingest([observation], now);
     engine.ingest([observation], now + 400);
     expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({ type: 'detected' });
+    expect(events.at(0)).toMatchObject({ type: 'detected' });
   });
 
   test('throws when staleCandidateThresholdMs < activationThresholdMs', () => {

--- a/packages/meeting-detection/src/meeting-detection/engine.ts
+++ b/packages/meeting-detection/src/meeting-detection/engine.ts
@@ -123,7 +123,7 @@ export function createMeetingDetectionEngine(options: MeetingEngineOptions = {})
       return null;
     }
     eligible.sort((a, b) => compareObservations(a.observation, b.observation));
-    return eligible[0] ?? null;
+    return eligible.at(0) ?? null;
   }
 
   function endActiveMeeting(now: number): void {

--- a/packages/sandbox/src/fixtures/sample-library.ts
+++ b/packages/sandbox/src/fixtures/sample-library.ts
@@ -5,7 +5,7 @@ export function double(value: number): number {
 }
 
 export function canReadFunctionPrototype(): boolean {
-  return typeof globalThis.Function?.prototype === 'function';
+  return typeof globalThis.Function.prototype === 'function';
 }
 
 export function hasGlobalSampleWorker(): boolean {

--- a/packages/sandbox/src/hardening.ts
+++ b/packages/sandbox/src/hardening.ts
@@ -56,9 +56,9 @@ function assertSafeDynamicImports(code: string): void {
   const dynamicImports = code.matchAll(/\bimport\s*\(([^)]*)\)/g);
 
   for (const match of dynamicImports) {
-    const specifier = match[1]?.trim();
+    const specifier = match.at(1)?.trim();
     const literal = specifier?.match(/^['"]([^'"]+)['"]$/);
-    if (!literal || !ALLOWED_DYNAMIC_IMPORTS.has(literal[1])) {
+    if (!literal || !ALLOWED_DYNAMIC_IMPORTS.has(literal.at(1) ?? '')) {
       throw new SandboxSecurityError('dynamic import is only available for node:fs and node:fs/promises');
     }
   }

--- a/packages/sandbox/src/process-driver.ts
+++ b/packages/sandbox/src/process-driver.ts
@@ -83,7 +83,7 @@ async function dispatchToolCall(
 
     assertMessageSize(message, ctx.maxMessageBytes);
 
-    const binding = ctx.bindings[message.name];
+    const binding = ctx.bindings[message.name] as ToolBinding | undefined;
     if (!binding) {
       ctx.proc.send({ type: 'tool_error', id: message.id, error: new SandboxUnknownToolError(message.name).message });
       return;

--- a/packages/sandbox/src/process-runtime.ts
+++ b/packages/sandbox/src/process-runtime.ts
@@ -91,7 +91,7 @@ export function startProcessRuntime(preloadedModules: Record<string, Record<stri
     const entries: Array<readonly [string, unknown]> = [];
     await Promise.all(
       Object.entries(libraries).map(async ([name, library]) => {
-        const preloaded = preloadedModules[library.specifier];
+        const preloaded = preloadedModules[library.specifier] as Record<string, unknown> | undefined;
         const moduleNamespace = preloaded ?? (await importLibrary(library.specifier));
         const exposedLibrary = Object.freeze({ ...moduleNamespace });
         if (library.globalName !== undefined) {
@@ -177,7 +177,7 @@ export function startProcessRuntime(preloadedModules: Record<string, Record<stri
   }
 
   function handleToolError(msg: Extract<HostMessage, { type: 'tool_error' }>): void {
-    pendingCalls.get(msg.id)?.reject(new SandboxToolError(msg.error ?? 'Tool call failed'));
+    pendingCalls.get(msg.id)?.reject(new SandboxToolError(msg.error));
     pendingCalls.delete(msg.id);
   }
 

--- a/packages/server/src/adapters/sse.test.ts
+++ b/packages/server/src/adapters/sse.test.ts
@@ -49,11 +49,11 @@ describe('sse adapter', () => {
 
     const events = parseCaptured(captured, 'stream.started');
     expect(events).toHaveLength(1);
-    expect(events[0]).toEqual({ sessionId, messageId });
+    expect(events.at(0)).toEqual({ sessionId, messageId });
     // Internal-only fields must NOT leak
-    expect(events[0]).not.toHaveProperty('modelId');
-    expect(events[0]).not.toHaveProperty('providerId');
-    expect(events[0]).not.toHaveProperty('streamRunId');
+    expect(events.at(0)).not.toHaveProperty('modelId');
+    expect(events.at(0)).not.toHaveProperty('providerId');
+    expect(events.at(0)).not.toHaveProperty('streamRunId');
 
     unregisterSseConnection(stream);
   });
@@ -77,9 +77,9 @@ describe('sse adapter', () => {
 
     const events = parseCaptured(captured, 'stream.error');
     expect(events).toHaveLength(1);
-    expect(events[0]).toEqual({ sessionId, messageId, error: 'rate_limit', details });
-    expect(events[0]).not.toHaveProperty('streamRunId');
-    expect(events[0]).not.toHaveProperty('modelId');
+    expect(events.at(0)).toEqual({ sessionId, messageId, error: 'rate_limit', details });
+    expect(events.at(0)).not.toHaveProperty('streamRunId');
+    expect(events.at(0)).not.toHaveProperty('modelId');
 
     unregisterSseConnection(stream);
   });
@@ -104,7 +104,7 @@ describe('sse adapter', () => {
 
     const events = parseCaptured(captured, 'question.asked');
     expect(events).toHaveLength(1);
-    expect(events[0]).toEqual({ question });
+    expect(events.at(0)).toEqual({ question });
 
     unregisterSseConnection(stream);
   });
@@ -132,8 +132,8 @@ describe('sse adapter', () => {
     const events = parseCaptured(captured, 'tool.state');
     expect(events).toHaveLength(5);
 
-    expect(events[0]).toEqual({ sessionId, messageId, toolCallId, toolName, status: 'pending' });
-    expect(events[1]).toEqual({
+    expect(events.at(0)).toEqual({ sessionId, messageId, toolCallId, toolName, status: 'pending' });
+    expect(events.at(1)).toEqual({
       sessionId,
       messageId,
       toolCallId,
@@ -141,7 +141,7 @@ describe('sse adapter', () => {
       status: 'in-progress',
       input: { path: '/a' },
     });
-    expect(events[2]).toEqual({
+    expect(events.at(2)).toEqual({
       sessionId,
       messageId,
       toolCallId,
@@ -149,7 +149,7 @@ describe('sse adapter', () => {
       status: 'in-progress',
       output: 'partial...',
     });
-    expect(events[3]).toEqual({
+    expect(events.at(3)).toEqual({
       sessionId,
       messageId,
       toolCallId,
@@ -158,7 +158,7 @@ describe('sse adapter', () => {
       input: { path: '/a' },
       output: 'done',
     });
-    expect(events[4]).toEqual({ sessionId, messageId, toolCallId, toolName, status: 'error', error: 'ENOENT' });
+    expect(events.at(4)).toEqual({ sessionId, messageId, toolCallId, toolName, status: 'error', error: 'ENOENT' });
 
     unregisterSseConnection(stream);
   });
@@ -187,9 +187,9 @@ describe('sse adapter', () => {
 
     const events = parseCaptured(captured, 'stream.finish');
     expect(events).toHaveLength(1);
-    expect(events[0]).toEqual({ sessionId, messageId, finishReason: 'stop', usage });
-    expect(events[0]).not.toHaveProperty('modelId');
-    expect(events[0]).not.toHaveProperty('costUsd');
+    expect(events.at(0)).toEqual({ sessionId, messageId, finishReason: 'stop', usage });
+    expect(events.at(0)).not.toHaveProperty('modelId');
+    expect(events.at(0)).not.toHaveProperty('costUsd');
 
     unregisterSseConnection(stream);
   });
@@ -221,9 +221,9 @@ describe('sse adapter', () => {
     const started = parseCaptured(captured, 'recording.started');
     const stopped = parseCaptured(captured, 'recording.stopped');
     expect(started).toHaveLength(1);
-    expect(started[0]).toEqual({ recordingId });
+    expect(started.at(0)).toEqual({ recordingId });
     expect(stopped).toHaveLength(1);
-    expect(stopped[0]).toEqual({ recordingId });
+    expect(stopped.at(0)).toEqual({ recordingId });
 
     unregisterSseConnection(stream);
   });

--- a/packages/server/src/adapters/title-generation.test.ts
+++ b/packages/server/src/adapters/title-generation.test.ts
@@ -103,7 +103,7 @@ describe('title generation adapter', () => {
 
     await waitFor(async () => {
       const [session] = await getDb().select().from(sessions).where(eq(sessions.id, sessionId));
-      return session?.title === 'Title: Chat Content';
+      return session.title === 'Title: Chat Content';
     });
 
     const titleMessages = await getDb().select().from(messages).where(eq(messages.sessionId, sessionId));
@@ -140,7 +140,7 @@ describe('title generation adapter', () => {
 
     await waitFor(async () => {
       const [analysis] = await getDb().select().from(recordingAnalyses).where(eq(recordingAnalyses.id, analysisId));
-      return analysis?.title === 'Generated Recording Title';
+      return analysis.title === 'Generated Recording Title';
     });
 
     const [analysis] = await getDb().select().from(recordingAnalyses).where(eq(recordingAnalyses.id, analysisId));
@@ -174,7 +174,7 @@ describe('title generation adapter', () => {
 
     await waitFor(async () => {
       const [analysis] = await getDb().select().from(recordingAnalyses).where(eq(recordingAnalyses.id, analysisId));
-      return analysis?.costUsd === 1.25;
+      return analysis.costUsd === 1.25;
     });
 
     const [analysis] = await getDb().select().from(recordingAnalyses).where(eq(recordingAnalyses.id, analysisId));

--- a/packages/server/src/adapters/title-generation.ts
+++ b/packages/server/src/adapters/title-generation.ts
@@ -109,15 +109,17 @@ export function registerTitleGenerationAdapter(deps: TitleGenerationAdapterDeps 
       });
 
       const db = getDb();
-      const [updated] = await db
-        .update(recordingAnalyses)
-        .set({
-          title: generatedTitle.title,
-          costUsd: sql`${recordingAnalyses.costUsd} + ${costUsd}`,
-          updatedAt: Date.now(),
-        })
-        .where(and(eq(recordingAnalyses.id, event.analysisId), eq(recordingAnalyses.recordingId, event.recordingId)))
-        .returning({ id: recordingAnalyses.id });
+      const updated = (
+        await db
+          .update(recordingAnalyses)
+          .set({
+            title: generatedTitle.title,
+            costUsd: sql`${recordingAnalyses.costUsd} + ${costUsd}`,
+            updatedAt: Date.now(),
+          })
+          .where(and(eq(recordingAnalyses.id, event.analysisId), eq(recordingAnalyses.recordingId, event.recordingId)))
+          .returning({ id: recordingAnalyses.id })
+      ).at(0);
       if (!updated) return;
 
       internalBus.emit('recording.analysis.updated', {

--- a/packages/server/src/automations/generation.ts
+++ b/packages/server/src/automations/generation.ts
@@ -36,7 +36,7 @@ function isHiddenFromHistory(message: GenerationMessageContext): boolean {
 function findLastUsedModel(messageList: GenerationMessageContext[]): { providerId: string; modelId: string } | null {
   for (let index = messageList.length - 1; index >= 0; index--) {
     const message = messageList[index];
-    if (!message || message.isSummary || isHiddenFromHistory(message)) continue;
+    if (message.isSummary || isHiddenFromHistory(message)) continue;
     if (!message.providerId || !message.modelId) continue;
     return { providerId: message.providerId, modelId: message.modelId };
   }
@@ -153,9 +153,6 @@ export async function generateAutomationDraft(sessionId: string): Promise<Servic
     .select()
     .from(sessions)
     .where(eq(sessions.id, sessionId as PrefixedString<'ses'>));
-  if (!session) {
-    return err('Session not found', 404);
-  }
 
   const messageList = await db
     .select()
@@ -212,7 +209,7 @@ export async function generateAutomationDraft(sessionId: string): Promise<Servic
     toolsetContext.inferredToolsets,
   );
 
-  const usage = result.usage ?? null;
+  const usage = result.usage;
 
   const { costUsd } = await recordLlmUsage({
     source: 'automation_generation',
@@ -248,7 +245,7 @@ export async function generateAutomationDraft(sessionId: string): Promise<Servic
       parts: [generationPart],
       modelId: resolved.modelId,
       providerId: resolved.providerId,
-      usage: usage ?? undefined,
+      usage,
       costUsd,
       finishReason: 'stop',
       isSummary: false,

--- a/packages/server/src/automations/scheduler.ts
+++ b/packages/server/src/automations/scheduler.ts
@@ -78,7 +78,7 @@ export async function syncAllAutomationSchedules(): Promise<void> {
   const timezone = await resolveUserTimezone();
   let page = 1;
 
-  while (true) {
+  for (;;) {
     const result = await listAutomations({ page, pageSize });
     if (result.error) throw new AutomationSyncError(result.error.message);
 

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -56,7 +56,6 @@ function serializeAutomationSchedule(schedule: AutomationSchedule | null): Autom
 
 function deserializeAutomationSchedule(blob: AutomationScheduleBlob | null): AutomationSchedule | null {
   if (blob === null) return null;
-  if (blob.version !== 1) return null;
   return blob.schedule;
 }
 
@@ -83,10 +82,12 @@ export async function listAutomations(input: {
 
 export async function getAutomation(automationId: string): Promise<ServiceResult<AutomationRow>> {
   const db = getDb();
-  const [automation] = await db
-    .select()
-    .from(automations)
-    .where(eq(automations.id, automationId as PrefixedString<'auto'>));
+  const automation = (
+    await db
+      .select()
+      .from(automations)
+      .where(eq(automations.id, automationId as PrefixedString<'auto'>))
+  ).at(0);
 
   if (!automation) {
     return err('Automation not found', 404);
@@ -154,10 +155,12 @@ async function updateAutomation(
   input: UpdateAutomationInput,
 ): Promise<ServiceResult<AutomationRow>> {
   const db = getDb();
-  const [existing] = await db
-    .select()
-    .from(automations)
-    .where(eq(automations.id, automationId as PrefixedString<'auto'>));
+  const existing = (
+    await db
+      .select()
+      .from(automations)
+      .where(eq(automations.id, automationId as PrefixedString<'auto'>))
+  ).at(0);
   if (!existing) {
     return err('Automation not found', 404);
   }
@@ -184,18 +187,20 @@ async function updateAutomation(
     return validation;
   }
 
-  const [updated] = await db
-    .update(automations)
-    .set({
-      providerId,
-      modelId,
-      title,
-      initialMessage,
-      schedule: serializeAutomationSchedule(scheduleResult.data),
-      updatedAt: Date.now(),
-    })
-    .where(eq(automations.id, automationId as PrefixedString<'auto'>))
-    .returning();
+  const updated = (
+    await db
+      .update(automations)
+      .set({
+        providerId,
+        modelId,
+        title,
+        initialMessage,
+        schedule: serializeAutomationSchedule(scheduleResult.data),
+        updatedAt: Date.now(),
+      })
+      .where(eq(automations.id, automationId as PrefixedString<'auto'>))
+      .returning()
+  ).at(0);
 
   if (!updated) {
     return err('Automation not found', 404);
@@ -277,10 +282,12 @@ export async function deleteAutomation(
 
 export async function listAutomationSessions(automationId: string): Promise<ServiceResult<Session[]>> {
   const db = getDb();
-  const [existing] = await db
-    .select({ id: automations.id })
-    .from(automations)
-    .where(eq(automations.id, automationId as PrefixedString<'auto'>));
+  const existing = (
+    await db
+      .select({ id: automations.id })
+      .from(automations)
+      .where(eq(automations.id, automationId as PrefixedString<'auto'>))
+  ).at(0);
   if (!existing) {
     return err('Automation not found', 404);
   }
@@ -303,10 +310,12 @@ export async function listAutomationSessions(automationId: string): Promise<Serv
 export async function runAutomation(automationId: string): Promise<ServiceResult<RunAutomationResponse>> {
   const db = getDb();
 
-  const [automation] = await db
-    .select()
-    .from(automations)
-    .where(eq(automations.id, automationId as PrefixedString<'auto'>));
+  const automation = (
+    await db
+      .select()
+      .from(automations)
+      .where(eq(automations.id, automationId as PrefixedString<'auto'>))
+  ).at(0);
   if (!automation) {
     return err('Automation not found', 404);
   }
@@ -336,11 +345,12 @@ export async function runAutomation(automationId: string): Promise<ServiceResult
   }
 
   const [updatedAutomation] = await db.transaction(async (tx) => {
-    const [updated] = await tx
+    const rows = await tx
       .update(automations)
       .set({ runCount: sql`${automations.runCount} + 1`, updatedAt: Date.now() })
       .where(eq(automations.id, automation.id))
       .returning({ runCount: automations.runCount });
+    const updated = rows[0] as { runCount: number } | undefined;
 
     if (!updated) return [];
 

--- a/packages/server/src/chat/history-search-service.ts
+++ b/packages/server/src/chat/history-search-service.ts
@@ -192,7 +192,7 @@ export async function searchSessionHistory(
     }
 
     if (!query) {
-      const firstText = extractMessageText(sessionMessages[0]?.parts);
+      const firstText = extractMessageText(sessionMessages.at(0)?.parts);
       hits.push({
         sessionId: sessionRow.id,
         title: sessionRow.title,
@@ -262,10 +262,9 @@ export async function getSessionHistoryMessages(input: {
 }): Promise<{ title: string | null; messages: SessionMessageView[] } | null> {
   const db = getDb();
 
-  const [session] = await db
-    .select({ id: sessions.id, title: sessions.title })
-    .from(sessions)
-    .where(eq(sessions.id, input.sessionId));
+  const session = (
+    await db.select({ id: sessions.id, title: sessions.title }).from(sessions).where(eq(sessions.id, input.sessionId))
+  ).at(0);
 
   if (!session) {
     return null;

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -156,12 +156,12 @@ async function loadTurnContext(
 ): Promise<ServiceResult<{ session: TurnSession; config: LlmTurnConfig }>> {
   const db = getDb();
 
-  const [session] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+  const session = (await db.select().from(sessions).where(eq(sessions.id, sessionId))).at(0);
   if (!session) {
     return err('Session not found', 404);
   }
 
-  const [config] = await db.select().from(providerConfig).where(eq(providerConfig.providerId, providerId));
+  const config = (await db.select().from(providerConfig).where(eq(providerConfig.providerId, providerId))).at(0);
   if (!config) {
     return err(`Provider "${providerId}" is not configured`, 400);
   }
@@ -264,12 +264,18 @@ export async function redoMessage(
   const context = await loadTurnContext(input.sessionId, input.providerId);
   if (context.error) return context;
 
-  const [editedMessage] = await db
-    .select()
-    .from(messages)
-    .where(
-      and(eq(messages.id, input.editedMessageId), eq(messages.sessionId, input.sessionId), isNull(messages.archivedAt)),
-    );
+  const editedMessage = (
+    await db
+      .select()
+      .from(messages)
+      .where(
+        and(
+          eq(messages.id, input.editedMessageId),
+          eq(messages.sessionId, input.sessionId),
+          isNull(messages.archivedAt),
+        ),
+      )
+  ).at(0);
   if (!editedMessage) return err('Message not found', 404);
   if (editedMessage.role !== 'user') return err('Can only redo from user messages', 400);
 
@@ -377,13 +383,15 @@ export async function splitSession(
 ): Promise<ServiceResult<{ session: typeof sessions.$inferSelect; prefillText: string }>> {
   const db = getDb();
 
-  const [session] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+  const session = (await db.select().from(sessions).where(eq(sessions.id, sessionId))).at(0);
   if (!session) return err('Session not found', 404);
 
-  const [splitMsg] = await db
-    .select()
-    .from(messages)
-    .where(and(eq(messages.id, msgId), eq(messages.sessionId, sessionId), isNull(messages.archivedAt)));
+  const splitMsg = (
+    await db
+      .select()
+      .from(messages)
+      .where(and(eq(messages.id, msgId), eq(messages.sessionId, sessionId), isNull(messages.archivedAt)))
+  ).at(0);
   if (!splitMsg) return err('Message not found', 404);
   if (splitMsg.role !== 'user') return err('Can only split from user messages', 400);
 
@@ -447,7 +455,7 @@ export async function splitSession(
 export async function requestCompaction(sessionId: PrefixedString<'ses'>): Promise<ServiceResult<{ ok: true }>> {
   const db = getDb();
 
-  const [session] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+  const session = (await db.select().from(sessions).where(eq(sessions.id, sessionId))).at(0);
   if (!session) {
     return err('Session not found', 404);
   }
@@ -458,7 +466,7 @@ export async function requestCompaction(sessionId: PrefixedString<'ses'>): Promi
     .where(eq(messages.sessionId, sessionId))
     .orderBy(desc(messages.createdAt))
     .limit(1)
-    .then((rows) => rows[0]);
+    .then((rows) => rows.at(0));
 
   if (!lastMessage) {
     return err('Session has no messages to compact', 400);
@@ -475,7 +483,7 @@ export async function getSessionStats(sessionId: PrefixedString<'ses'>): Promise
   const getMessageTokens = (usage: (typeof messages.$inferSelect)['usage']): number =>
     normalizeUsage(usage).totalTokens;
 
-  const [session] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+  const session = (await db.select().from(sessions).where(eq(sessions.id, sessionId))).at(0);
   if (!session) {
     return err('Session not found', 404);
   }
@@ -496,7 +504,7 @@ export async function getSessionStats(sessionId: PrefixedString<'ses'>): Promise
     db.select({ id: sessions.id }).from(sessions).where(eq(sessions.parentSessionId, sessionId)),
   ]);
 
-  const currentSessionCostUsd = sessionMessages.reduce((acc, m) => acc + (m.costUsd ?? 0), 0);
+  const currentSessionCostUsd = sessionMessages.reduce((acc, m) => acc + m.costUsd, 0);
   const currentSessionTokens = sessionMessages.reduce((acc, m) => acc + getMessageTokens(m.usage), 0);
   const userMessageCount = sessionMessages.filter((m) => m.role === 'user').length;
   const assistantMessageCount = sessionMessages.filter((m) => m.role === 'assistant').length;
@@ -510,7 +518,7 @@ export async function getSessionStats(sessionId: PrefixedString<'ses'>): Promise
       .from(messages)
       .where(and(inArray(messages.sessionId, childIds), isNull(messages.archivedAt)));
 
-    childSessionsCostUsd = childMsgs.reduce((acc, m) => acc + (m.costUsd ?? 0), 0);
+    childSessionsCostUsd = childMsgs.reduce((acc, m) => acc + m.costUsd, 0);
     childSessionsTokens = childMsgs.reduce((acc, m) => acc + getMessageTokens(m.usage), 0);
   }
 
@@ -518,8 +526,8 @@ export async function getSessionStats(sessionId: PrefixedString<'ses'>): Promise
   let latestAssistantWithTokens: (typeof sessionMessages)[number] | null = null;
   for (let i = sessionMessages.length - 1; i >= 0; i--) {
     const msg = sessionMessages[i];
-    if (!msg || msg.role !== 'assistant') continue;
-    if (msg.parts?.some((p) => p.type === 'session-title')) continue;
+    if (msg.role !== 'assistant') continue;
+    if (msg.parts.some((p) => p.type === 'session-title')) continue;
     const tokenSum = normalizeUsage(msg.usage).totalTokens;
     if (tokenSum > 0) {
       latestAssistantWithTokens = msg;
@@ -540,8 +548,8 @@ export async function getSessionStats(sessionId: PrefixedString<'ses'>): Promise
   let latestRealMessage: (typeof sessionMessages)[number] | null = null;
   for (let i = sessionMessages.length - 1; i >= 0; i--) {
     const msg = sessionMessages[i];
-    if (!msg || msg.role !== 'assistant') continue;
-    if (msg.parts?.some((p) => BACKGROUND_PART_TYPES.has(p.type))) continue;
+    if (msg.role !== 'assistant') continue;
+    if (msg.parts.some((p) => BACKGROUND_PART_TYPES.has(p.type))) continue;
     latestRealMessage = msg;
     break;
   }
@@ -562,8 +570,8 @@ export async function getSessionStats(sessionId: PrefixedString<'ses'>): Promise
       modelLabel = localModel.error ? latestRealMessage.modelId : localModel.data.name;
     } else {
       const providerModels = modelCatalog[latestRealMessage.providerId];
-      const model = providerModels?.models[latestRealMessage.modelId];
-      modelLabel = model?.name ?? latestRealMessage.modelId;
+      const model = providerModels.models[latestRealMessage.modelId];
+      modelLabel = model.name;
     }
   }
 
@@ -576,8 +584,8 @@ export async function getSessionStats(sessionId: PrefixedString<'ses'>): Promise
       contextLimit = localModel.error ? null : localModel.data.contextWindow;
     } else {
       const providerModels = modelCatalog[latestAssistantWithTokens.providerId];
-      const model = providerModels?.models[latestAssistantWithTokens.modelId];
-      contextLimit = model?.limit?.context ?? null;
+      const model = providerModels.models[latestAssistantWithTokens.modelId];
+      contextLimit = model.limit.context;
     }
   }
 

--- a/packages/server/src/chat/session-crud.ts
+++ b/packages/server/src/chat/session-crud.ts
@@ -76,7 +76,7 @@ export async function getSessionById(
   sessionId: PrefixedString<'ses'>,
 ): Promise<ServiceResult<typeof sessions.$inferSelect>> {
   const db = getDb();
-  const [session] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
+  const session = (await db.select().from(sessions).where(eq(sessions.id, sessionId))).at(0);
   if (!session) return err('Session not found', 404);
   return ok(session);
 }
@@ -119,11 +119,13 @@ export async function archiveSession(
 ): Promise<ServiceResult<typeof sessions.$inferSelect>> {
   const db = getDb();
   const now = Date.now();
-  const [updated] = await db
-    .update(sessions)
-    .set({ archivedAt: now, archivedReason: ARCHIVE_REASONS.archiveSession, updatedAt: now })
-    .where(eq(sessions.id, sessionId))
-    .returning();
+  const updated = (
+    await db
+      .update(sessions)
+      .set({ archivedAt: now, archivedReason: ARCHIVE_REASONS.archiveSession, updatedAt: now })
+      .where(eq(sessions.id, sessionId))
+      .returning()
+  ).at(0);
   if (!updated) return err('Session not found', 404);
   return ok(updated);
 }
@@ -133,11 +135,9 @@ export async function renameSession(
   title: string,
 ): Promise<ServiceResult<typeof sessions.$inferSelect>> {
   const db = getDb();
-  const [updated] = await db
-    .update(sessions)
-    .set({ title, updatedAt: Date.now() })
-    .where(eq(sessions.id, sessionId))
-    .returning();
+  const updated = (
+    await db.update(sessions).set({ title, updatedAt: Date.now() }).where(eq(sessions.id, sessionId)).returning()
+  ).at(0);
   if (!updated) return err('Session not found', 404);
   return ok(updated);
 }
@@ -146,11 +146,13 @@ export async function markSessionRead(
   sessionId: PrefixedString<'ses'>,
 ): Promise<ServiceResult<typeof sessions.$inferSelect>> {
   const db = getDb();
-  const [updated] = await db
-    .update(sessions)
-    .set({ isUnread: false, updatedAt: Date.now() })
-    .where(eq(sessions.id, sessionId))
-    .returning();
+  const updated = (
+    await db
+      .update(sessions)
+      .set({ isUnread: false, updatedAt: Date.now() })
+      .where(eq(sessions.id, sessionId))
+      .returning()
+  ).at(0);
   if (!updated) return err('Session not found', 404);
   return ok(updated);
 }

--- a/packages/server/src/code-mode/bindings/type-generator.ts
+++ b/packages/server/src/code-mode/bindings/type-generator.ts
@@ -3,7 +3,7 @@ import type { ToolTypeInfo } from '@/code-mode/bindings/tool-binding.js';
 type JsonSchema = Record<string, unknown>;
 
 function jsonSchemaToTypeScript(schema: JsonSchema, indent = 0): string {
-  if (!schema || typeof schema !== 'object') return 'unknown';
+  if (typeof schema !== 'object') return 'unknown';
 
   const pad = '  '.repeat(indent);
 

--- a/packages/server/src/connectors/auth/oauth-credentials.ts
+++ b/packages/server/src/connectors/auth/oauth-credentials.ts
@@ -11,7 +11,7 @@ export async function resolveOAuthCredentials(
   instance: OAuthCredentialCarrier,
 ): Promise<{ clientId: string; clientSecret: string } | null> {
   const db = getDb();
-  const [connector] = await db.select().from(connectors).where(eq(connectors.id, instance.connectorRefId));
+  const connector = (await db.select().from(connectors).where(eq(connectors.id, instance.connectorRefId))).at(0);
   if (connector?.clientId && connector.clientSecret) {
     return { clientId: connector.clientId, clientSecret: connector.clientSecret };
   }

--- a/packages/server/src/connectors/auth/token-vault.test.ts
+++ b/packages/server/src/connectors/auth/token-vault.test.ts
@@ -87,8 +87,8 @@ describe('refreshExpiringTokens', () => {
       .select()
       .from(connectorInstances)
       .where(eq(connectorInstances.id, 'conn_refresh_1' as never));
-    expect(row?.status).toBe('connected');
-    expect(row?.authIssue).toBeNull();
+    expect(row.status).toBe('connected');
+    expect(row.authIssue).toBeNull();
   });
 
   test('marks connector errored when refresh token is revoked', async () => {
@@ -107,8 +107,8 @@ describe('refreshExpiringTokens', () => {
       .select()
       .from(connectorInstances)
       .where(eq(connectorInstances.id, 'conn_refresh_2' as never));
-    expect(row?.status).toBe('error');
-    expect(row?.authIssue).toBe('reauthorization_required');
+    expect(row.status).toBe('error');
+    expect(row.authIssue).toBe('reauthorization_required');
   });
 
   test('recovers after a transient refresh failure by retrying', async () => {
@@ -129,9 +129,9 @@ describe('refreshExpiringTokens', () => {
       .select()
       .from(connectorInstances)
       .where(eq(connectorInstances.id, 'conn_refresh_retry' as never));
-    expect(row?.status).toBe('connected');
-    expect(row?.accessToken).toBe('refreshed-access');
-    expect(row?.refreshToken).toBe('rotated-refresh');
+    expect(row.status).toBe('connected');
+    expect(row.accessToken).toBe('refreshed-access');
+    expect(row.refreshToken).toBe('rotated-refresh');
   });
 
   test('does not retry permanent invalid_grant failures', async () => {
@@ -151,7 +151,7 @@ describe('refreshExpiringTokens', () => {
       .select()
       .from(connectorInstances)
       .where(eq(connectorInstances.id, 'conn_refresh_no_retry' as never));
-    expect(row?.status).toBe('error');
-    expect(row?.authIssue).toBe('reauthorization_required');
+    expect(row.status).toBe('error');
+    expect(row.authIssue).toBe('reauthorization_required');
   });
 });

--- a/packages/server/src/connectors/auth/token-vault.ts
+++ b/packages/server/src/connectors/auth/token-vault.ts
@@ -146,7 +146,6 @@ export async function ensureFreshAccessToken(
     .select()
     .from(connectorInstances)
     .where(eq(connectorInstances.id, instanceId as never));
-  if (!row) return null;
 
   const now = Date.now();
   const shouldRefresh =

--- a/packages/server/src/connectors/google-toolsets.ts
+++ b/packages/server/src/connectors/google-toolsets.ts
@@ -80,13 +80,13 @@ function toServerToolset(def: GoogleToolsetDefinition): Toolset {
               const id = row.id.toLowerCase();
               return email === normalized || label === normalized || id === normalized;
             })
-          : connected[0];
+          : connected.at(0);
 
         if (!chosen) {
           throw new GoogleAccountNotFoundError('google', account ?? undefined);
         }
 
-        if (!canActivateToolset(def.id, (chosen.scopes as string[]) ?? [], chosen.capabilities ?? [])) {
+        if (!canActivateToolset(def.id, chosen.scopes ?? [], chosen.capabilities)) {
           throw new GoogleAccountInsufficientScopesError('google', chosen.accountEmail ?? chosen.label, def.name);
         }
 
@@ -139,7 +139,7 @@ export async function registerGoogleToolsets(): Promise<void> {
     return;
   }
 
-  const scopes = [...new Set(connected.flatMap((instance) => (instance.scopes as string[]) ?? []))];
+  const scopes = [...new Set(connected.flatMap((instance) => instance.scopes ?? []))];
   const capabilities = [...new Set(connected.flatMap((instance) => (instance.capabilities as string[] | null) ?? []))];
   const appliedVersion = Math.max(
     ...connected.map((instance) => (Number.isFinite(instance.appliedVersion) ? instance.appliedVersion : 1)),

--- a/packages/server/src/connectors/service.test.ts
+++ b/packages/server/src/connectors/service.test.ts
@@ -113,7 +113,7 @@ describe('connector service', () => {
 
     // Row should be unchanged
     const [row] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId));
-    expect(row?.appliedVersion).toBe(1);
+    expect(row.appliedVersion).toBe(1);
   });
 
   test('upgrade handles mixed rotate + reauthorize actions', async () => {
@@ -176,8 +176,8 @@ describe('connector service', () => {
       .from(connectors)
       .where(eq(connectors.id, connectorRefId as never));
     // After token exchange the instance should be connected with the new key and merged scopes
-    expect(connector?.apiKey).toBe('new-key');
-    expect((row?.scopes as string[])?.includes('scope:admin')).toBe(true);
+    expect(connector.apiKey).toBe('new-key');
+    expect((row.scopes as string[]).includes('scope:admin')).toBe(true);
     expect(requestedScopes).toEqual(['scope:read', 'scope:admin']);
   });
 
@@ -246,7 +246,7 @@ describe('connector service', () => {
     await new Promise((r) => setTimeout(r, 50));
 
     const [row] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId));
-    expect(row?.scopes).toEqual(['scope:read', 'scope:admin']);
+    expect(row.scopes).toEqual(['scope:read', 'scope:admin']);
   });
 
   test('disabled connectors cannot be created', async () => {
@@ -340,7 +340,7 @@ describe('connector service', () => {
     expect(threw).toBe(true);
 
     const [row] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId));
-    expect(row?.status).toBe('error');
+    expect(row.status).toBe('error');
   });
 
   test('authorizeOAuthInstance stores tokens and marks connector connected on success', async () => {
@@ -387,12 +387,12 @@ describe('connector service', () => {
     await result.data.waitForTokens();
 
     const [row] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId));
-    expect(row?.status).toBe('connected');
-    expect(row?.accessToken).toBe('access-token-123');
-    expect(row?.refreshToken).toBe('refresh-token-123');
-    expect(row?.appliedVersion).toBe(definition.currentVersion);
-    expect(row?.capabilities).toEqual(['example.read', 'example.write', 'example.admin']);
-    expect(typeof row?.tokenExpiresAt).toBe('number');
+    expect(row.status).toBe('connected');
+    expect(row.accessToken).toBe('access-token-123');
+    expect(row.refreshToken).toBe('refresh-token-123');
+    expect(row.appliedVersion).toBe(definition.currentVersion);
+    expect(row.capabilities).toEqual(['example.read', 'example.write', 'example.admin']);
+    expect(typeof row.tokenExpiresAt).toBe('number');
   });
 
   test('authorizeOAuthInstance uses default scopes for connected incremental oauth reauth', async () => {
@@ -494,8 +494,8 @@ describe('connector service', () => {
     await result.data.waitForTokens();
 
     const [row] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId));
-    expect(row?.status).toBe('connected');
-    expect(row?.accessToken).toBe('new-access-token');
-    expect(row?.refreshToken).toBe('existing-refresh-token');
+    expect(row.status).toBe('connected');
+    expect(row.accessToken).toBe('new-access-token');
+    expect(row.refreshToken).toBe('existing-refresh-token');
   });
 });

--- a/packages/server/src/connectors/service.ts
+++ b/packages/server/src/connectors/service.ts
@@ -144,7 +144,7 @@ export async function createOAuthConnector(input: {
 export async function deleteConnector(connectorRefId: string): Promise<ServiceResult<null>> {
   const db = getDb();
   const typedConnectorRefId = connectorRefId as PrefixedString<'cnr'>;
-  const [existing] = await db.select().from(connectors).where(eq(connectors.id, typedConnectorRefId));
+  const existing = (await db.select().from(connectors).where(eq(connectors.id, typedConnectorRefId))).at(0);
 
   if (!existing) return err('Connector not found', 404);
 
@@ -172,10 +172,12 @@ export async function listConnectorInstances(): Promise<ServiceResult<ConnectorI
 
 export async function getConnectorInstance(id: string): Promise<ServiceResult<ConnectorInstanceSafe>> {
   const db = getDb();
-  const [row] = await db
-    .select()
-    .from(connectorInstances)
-    .where(eq(connectorInstances.id, id as PrefixedString<'conn'>));
+  const row = (
+    await db
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, id as PrefixedString<'conn'>))
+  ).at(0);
 
   if (!row) return err('Connector instance not found', 404);
   const instance = row as ConnectorInstance;
@@ -188,10 +190,12 @@ export async function createOAuthConnectorInstance(input: {
   scopes: string[];
 }): Promise<ServiceResult<ConnectorInstanceSafe>> {
   const db = getDb();
-  const [connector] = await db
-    .select()
-    .from(connectors)
-    .where(eq(connectors.id, input.connectorRefId as PrefixedString<'cnr'>));
+  const connector = (
+    await db
+      .select()
+      .from(connectors)
+      .where(eq(connectors.id, input.connectorRefId as PrefixedString<'cnr'>))
+  ).at(0);
 
   if (!connector) return err('Connector not found', 404);
 
@@ -296,10 +300,12 @@ export async function authorizeOAuthInstance(
   options?: { scopes?: string[]; additionalParams?: Record<string, string> },
 ): Promise<ServiceResult<{ authUrl: string; waitForTokens: () => Promise<void> }>> {
   const db = getDb();
-  const [instance] = await db
-    .select()
-    .from(connectorInstances)
-    .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+  const instance = (
+    await db
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>))
+  ).at(0);
 
   if (!instance) return err('Connector instance not found', 404);
 
@@ -316,9 +322,7 @@ export async function authorizeOAuthInstance(
   const config = definition.authConfig as OAuthConfig;
   const useIncrementalRefresh =
     options?.scopes === undefined && config.incrementalAuth?.enabled === true && instance.status === 'connected';
-  const scopes =
-    options?.scopes ??
-    (useIncrementalRefresh ? config.defaultScopes : (instance.scopes as string[]) || config.defaultScopes);
+  const scopes = options?.scopes ?? (useIncrementalRefresh ? config.defaultScopes : (instance.scopes as string[]));
   const additionalParams =
     options?.additionalParams ?? (useIncrementalRefresh ? config.incrementalAuth?.params : undefined);
 
@@ -382,10 +386,12 @@ export async function updateConnectorInstance(
   updates: { label?: string; scopes?: string[] },
 ): Promise<ServiceResult<ConnectorInstanceSafe>> {
   const db = getDb();
-  const [existing] = await db
-    .select()
-    .from(connectorInstances)
-    .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+  const existing = (
+    await db
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>))
+  ).at(0);
 
   if (!existing) return err('Connector instance not found', 404);
 
@@ -414,7 +420,7 @@ export async function upgradeConnectorInstance(
 ): Promise<ServiceResult<{ type: 'reauthorize'; authUrl: string } | { type: 'updated' }>> {
   const db = getDb();
   const typedInstanceId = instanceId as PrefixedString<'conn'>;
-  const [instance] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, typedInstanceId));
+  const instance = (await db.select().from(connectorInstances).where(eq(connectorInstances.id, typedInstanceId))).at(0);
 
   if (!instance) return err('Connector instance not found', 404);
 
@@ -525,10 +531,12 @@ export async function upgradeConnectorInstance(
 
 export async function deleteConnectorInstance(instanceId: string): Promise<ServiceResult<null>> {
   const db = getDb();
-  const [existing] = await db
-    .select()
-    .from(connectorInstances)
-    .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+  const existing = (
+    await db
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>))
+  ).at(0);
 
   if (!existing) return err('Connector instance not found', 404);
 
@@ -547,10 +555,12 @@ export async function deleteConnectorInstance(instanceId: string): Promise<Servi
 
 export async function testConnectorInstance(instanceId: string): Promise<ServiceResult<boolean>> {
   const db = getDb();
-  const [instance] = await db
-    .select()
-    .from(connectorInstances)
-    .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+  const instance = (
+    await db
+      .select()
+      .from(connectorInstances)
+      .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>))
+  ).at(0);
 
   if (!instance) return err('Connector instance not found', 404);
 
@@ -605,7 +615,7 @@ export async function testConnectorInstance(instanceId: string): Promise<Service
     if (definition.authType === 'oauth2' && testedInstance.accessToken) {
       return ok(true);
     } else if (definition.authType === 'api_key') {
-      const [connector] = await db.select().from(connectors).where(eq(connectors.id, instance.connectorRefId));
+      const connector = (await db.select().from(connectors).where(eq(connectors.id, instance.connectorRefId))).at(0);
       if (!connector?.apiKey) return err('Connector has no credentials to test', 400);
       return err('Connector test is not supported for this connector type', 400);
     }

--- a/packages/server/src/lib/icon-cache.ts
+++ b/packages/server/src/lib/icon-cache.ts
@@ -16,5 +16,5 @@ export async function writeCachedText(filePath: string, value: string): Promise<
 }
 
 export function isSvgResponse(response: Response): boolean {
-  return response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() === 'image/svg+xml';
+  return response.headers.get('content-type')?.split(';').at(0)?.trim().toLowerCase() === 'image/svg+xml';
 }

--- a/packages/server/src/lib/log.ts
+++ b/packages/server/src/lib/log.ts
@@ -132,7 +132,7 @@ export function create(tags?: Record<string, unknown>, { skipCache = false } = {
     const diff = next.getTime() - last;
     last = next.getTime();
 
-    return [next.toISOString().split('.')[0], `+${diff}ms`, prefix, message].filter(Boolean).join(' ');
+    return [next.toISOString().split('.').at(0), `+${diff}ms`, prefix, message].filter(Boolean).join(' ');
   }
 
   function emit(lvl: Level, extraOrMessage: Record<string, unknown> | string, message?: string) {

--- a/packages/server/src/lib/paginated-query.ts
+++ b/packages/server/src/lib/paginated-query.ts
@@ -29,7 +29,7 @@ export async function paginatedQuery<TRow, TOut = TRow>(input: {
 
   const [rows, countRows] = await Promise.all([input.dataQuery.limit(input.pageSize).offset(offset), input.countQuery]);
 
-  const total = Number(countRows[0]?.total ?? 0);
+  const total = Number(countRows.at(0)?.total ?? 0);
   const transform = input.transform ?? ((row: TRow) => row as unknown as TOut);
 
   return {

--- a/packages/server/src/lib/registry-cache.ts
+++ b/packages/server/src/lib/registry-cache.ts
@@ -42,7 +42,7 @@ function userAgentToken(value: string | undefined, fallback: string): string {
 }
 
 function runtimeToken(): string {
-  const bunVersion = (globalThis as BunGlobal).Bun?.version;
+  const bunVersion = (globalThis as BunGlobal).Bun.version;
   if (bunVersion) return `Bun/${userAgentToken(bunVersion, 'unknown')}`;
   return `Node/${userAgentToken(process.versions.node, 'unknown')}`;
 }

--- a/packages/server/src/llm/attachment-transform.ts
+++ b/packages/server/src/llm/attachment-transform.ts
@@ -44,7 +44,7 @@ export async function transformAttachmentsForModel(
   modelId: string,
 ): Promise<ModelMessage[]> {
   const providers = await Models.get();
-  const model = providers[providerId]?.models[modelId];
+  const model = providers[providerId]?.models[modelId] as Models.RawModel | undefined;
   const supportedInputModalities: string[] = model?.modalities?.input ?? [];
 
   return messages.map((msg): ModelMessage => {

--- a/packages/server/src/llm/context-budget.test.ts
+++ b/packages/server/src/llm/context-budget.test.ts
@@ -36,8 +36,8 @@ describe('conversation compactor', () => {
     const compacted = compactConversationForStep(conversation, { preserveRecentToolResults: 1 });
     const toolMessage = compacted[1];
 
-    expect(toolMessage?.role).toBe('tool');
-    if (toolMessage?.role !== 'tool' || !Array.isArray(toolMessage.content)) {
+    expect(toolMessage.role).toBe('tool');
+    if (toolMessage.role !== 'tool' || !Array.isArray(toolMessage.content)) {
       throw new Error('expected tool message content');
     }
 
@@ -74,8 +74,8 @@ describe('conversation compactor', () => {
     const compacted = compactConversationForStep(conversation, { preserveRecentToolResults: 3 });
     const toolMessage = compacted[1];
 
-    expect(toolMessage?.role).toBe('tool');
-    if (toolMessage?.role !== 'tool' || !Array.isArray(toolMessage.content)) {
+    expect(toolMessage.role).toBe('tool');
+    if (toolMessage.role !== 'tool' || !Array.isArray(toolMessage.content)) {
       throw new Error('expected tool message content');
     }
 
@@ -108,8 +108,8 @@ describe('conversation compactor', () => {
     const compacted = compactConversationForStep(conversation, { preserveRecentToolResults: 0 });
     const toolMessage = compacted[1];
 
-    expect(toolMessage?.role).toBe('tool');
-    if (toolMessage?.role !== 'tool' || !Array.isArray(toolMessage.content)) {
+    expect(toolMessage.role).toBe('tool');
+    if (toolMessage.role !== 'tool' || !Array.isArray(toolMessage.content)) {
       throw new Error('expected tool message content');
     }
 

--- a/packages/server/src/llm/context-budget.ts
+++ b/packages/server/src/llm/context-budget.ts
@@ -2,7 +2,7 @@ import { estimate } from '@/utils/token.js';
 import type { ModelMessage } from 'ai';
 
 const DEFAULT_TOOL_RESULT_BUDGET_TOKENS = 1_000;
-const TOOL_RESULT_BUDGET_TOKENS: Record<string, number> = { browser: 600, webfetch: 700, bash: 900 };
+const TOOL_RESULT_BUDGET_TOKENS: Record<string, number | undefined> = { browser: 600, webfetch: 700, bash: 900 };
 
 const TOOL_RESULT_PREVIEW_CHARS = 1_600;
 const PRESERVE_RECENT_TOOL_RESULTS = 3;
@@ -25,13 +25,15 @@ export function isToolResultError(output: unknown): boolean {
 }
 
 export function getToolResultBudget(toolName: string): number {
-  if (TOOL_RESULT_BUDGET_TOKENS[toolName] !== undefined) {
-    return TOOL_RESULT_BUDGET_TOKENS[toolName];
+  const exactBudget = TOOL_RESULT_BUDGET_TOKENS[toolName];
+  if (exactBudget !== undefined) {
+    return exactBudget;
   }
 
-  const prefix = toolName.split('_')[0];
-  if (prefix && TOOL_RESULT_BUDGET_TOKENS[prefix] !== undefined) {
-    return TOOL_RESULT_BUDGET_TOKENS[prefix];
+  const prefix = toolName.split('_').at(0);
+  const prefixBudget = prefix ? TOOL_RESULT_BUDGET_TOKENS[prefix] : undefined;
+  if (prefixBudget !== undefined) {
+    return prefixBudget;
   }
 
   return DEFAULT_TOOL_RESULT_BUDGET_TOKENS;
@@ -153,22 +155,13 @@ export function compactConversationForStep(
   let remainingProtectedToolResults = preserveRecentToolResults;
   let remainingToolResults = countToolResults(conversation);
   let remainingBrowserToolResults = countBrowserToolResults(conversation);
-  let changed = false;
 
   const compacted = conversation.map((message, messageIndex): ModelMessage => {
     if (message.role === 'user' && Array.isArray(message.content) && messageIndex !== lastUserMessageIndex) {
-      let contentChanged = false;
-      const content = message.content.map((part) => {
-        if (!isMediaContentPart(part)) {
-          return part;
-        }
-
-        contentChanged = true;
-        return stripMediaPart(part);
-      });
+      const content = message.content.map((part) => (isMediaContentPart(part) ? stripMediaPart(part) : part));
+      const contentChanged = content.some((part, i) => part !== message.content[i]);
 
       if (contentChanged) {
-        changed = true;
         return { ...message, content } as ModelMessage;
       }
     }
@@ -177,7 +170,6 @@ export function compactConversationForStep(
       return message;
     }
 
-    let contentChanged = false;
     const content = message.content.map((part) => {
       if (!isToolResultContentPart(part)) {
         return part;
@@ -198,7 +190,6 @@ export function compactConversationForStep(
             RECENT_BROWSER_TOOL_RESULT_BUDGET_TOKENS,
           );
           if (compactedOutput !== part.output.value) {
-            contentChanged = true;
             return { ...part, output: toToolResultOutput(compactedOutput) };
           }
         }
@@ -210,17 +201,16 @@ export function compactConversationForStep(
         return part;
       }
 
-      contentChanged = true;
       return { ...part, output: toToolResultOutput(compactedOutput) };
     });
 
-    if (contentChanged) {
-      changed = true;
+    if (content.some((part, i) => part !== message.content[i])) {
       return { ...message, content } as ModelMessage;
     }
 
     return message;
   });
 
+  const changed = compacted.some((message, i) => message !== conversation[i]);
   return changed ? compacted : conversation;
 }

--- a/packages/server/src/llm/history-messages.ts
+++ b/packages/server/src/llm/history-messages.ts
@@ -208,7 +208,7 @@ export function buildHistoryMessages(
     }
   }
 
-  if (llmMessages[0]?.role !== 'system') {
+  if (llmMessages.at(0)?.role !== 'system') {
     const layers = buildSystemPromptLayers(promptConfig);
     const parts = [layers.static, layers.semiStatic];
     if (layers.dynamic) {

--- a/packages/server/src/llm/provider-schema.ts
+++ b/packages/server/src/llm/provider-schema.ts
@@ -54,7 +54,7 @@ function sanitizeGemini(node: unknown): unknown {
     if (nonNull.length === 0) {
       result.type = 'null';
     } else if (nonNull.length === 1) {
-      result.type = nonNull[0];
+      result.type = nonNull.at(0);
       if (types.includes('null')) result.nullable = true;
     } else {
       delete result.type;
@@ -161,7 +161,7 @@ function sanitizeOpenAI(value: unknown): unknown {
   const inferredTypes = inferType();
   if (inferredTypes.length === 0) return {};
 
-  result.type = inferredTypes.length === 1 ? inferredTypes[0] : inferredTypes;
+  result.type = inferredTypes.length === 1 ? inferredTypes.at(0) : inferredTypes;
   if (inferredTypes.includes('object') && !('properties' in result)) result.properties = {};
   if (inferredTypes.includes('array') && !('items' in result)) result.items = { type: 'string' };
   return result;

--- a/packages/server/src/llm/provider/service.ts
+++ b/packages/server/src/llm/provider/service.ts
@@ -54,7 +54,7 @@ async function resolveProvider(providerId: string): Promise<ServiceResult<Models
   }
 
   const providers = await Models.get();
-  const provider = providers[providerId];
+  const provider = providers[providerId] as Models.RawProvider | undefined;
   if (!provider) {
     return err('Provider not found', 404);
   }
@@ -71,29 +71,31 @@ export async function getProvider(providerId: string): Promise<ServiceResult<Pro
   if (isLocalProviderId(providerId)) {
     const meta = LOCAL_PROVIDER_META[providerId];
     const db = getDb();
-    const [[config], modelCount] = await Promise.all([
+    const [configRows, modelCount] = await Promise.all([
       db
         .select({ providerId: providerConfig.providerId, credentials: providerConfig.credentials })
         .from(providerConfig)
         .where(eq(providerConfig.providerId, providerId)),
       db.select({ value: count() }).from(localModels).where(eq(localModels.provider, providerId)),
     ]);
+    const config = configRows.at(0);
     const storedBaseURL = (config?.credentials as { baseURL?: string } | undefined)?.baseURL;
     return ok({
       id: providerId,
       name: meta.name,
       api: storedBaseURL,
-      model_count: modelCount[0]?.value ?? 0,
+      model_count: modelCount.at(0)?.value ?? 0,
       enabled: config !== undefined,
     });
   }
 
   if (providerId === 'elevenlabs') {
     const db = getDb();
-    const [config] = await db
+    const configRows = await db
       .select({ providerId: providerConfig.providerId })
       .from(providerConfig)
       .where(eq(providerConfig.providerId, 'elevenlabs'));
+    const config = configRows.at(0);
     return ok({
       id: 'elevenlabs',
       name: 'ElevenLabs',
@@ -109,10 +111,11 @@ export async function getProvider(providerId: string): Promise<ServiceResult<Pro
   }
 
   const db = getDb();
-  const [config] = await db
+  const configRows = await db
     .select({ providerId: providerConfig.providerId })
     .from(providerConfig)
     .where(eq(providerConfig.providerId, providerId));
+  const config = configRows.at(0);
 
   return ok(toProviderSummary(providerResult.data, config !== undefined));
 }
@@ -174,7 +177,7 @@ export async function listEnabledProviderEmbeddingModels(): Promise<ServiceResul
 /** @knipignore Reserved for embedding consumers. */
 export async function getEmbeddingModelDimensions(providerId: string, modelId: string): Promise<number | undefined> {
   const providers = await EmbeddingModels.getEmbeddingModels();
-  const model = providers[providerId]?.models[modelId];
+  const model = providers[providerId]?.models[modelId] as ResolvedEmbeddingModel | undefined;
   if (!model) return undefined;
   return EmbeddingModels.getEmbeddingDimensions(model);
 }

--- a/packages/server/src/llm/resolve-model.ts
+++ b/packages/server/src/llm/resolve-model.ts
@@ -52,8 +52,8 @@ export async function resolveModel(input: ResolveModelInput): Promise<ServiceRes
     Models.get(),
   ]);
 
-  const configuredProviderId = (settingsMap[input.providerIdKey] as string)?.trim();
-  const configuredModelId = (settingsMap[input.modelIdKey] as string)?.trim();
+  const configuredProviderId = (settingsMap[input.providerIdKey] as string).trim();
+  const configuredModelId = (settingsMap[input.modelIdKey] as string).trim();
 
   let targetProviderId: string | undefined;
   let targetModelId: string | undefined;
@@ -68,7 +68,8 @@ export async function resolveModel(input: ResolveModelInput): Promise<ServiceRes
     const enabledProviderIds = new Set(configs.map((c) => c.providerId));
     for (const modelId of input.priorityModelIds) {
       for (const providerId of enabledProviderIds) {
-        if (providers[providerId]?.models[modelId]) {
+        const provider = providers[providerId] as Models.RawProvider | undefined;
+        if (provider?.models[modelId]) {
           targetProviderId = providerId;
           targetModelId = modelId;
           break;
@@ -92,10 +93,10 @@ export async function resolveModel(input: ResolveModelInput): Promise<ServiceRes
     return err('Provider not found', 404);
   }
 
-  const provider = providers[targetProviderId];
+  const provider = providers[targetProviderId] as Models.RawProvider | undefined;
   if (!provider) return err('Provider not found', 404);
 
-  const model = provider.models[targetModelId];
+  const model = provider.models[targetModelId] as Models.RawModel | undefined;
   if (!model) return err('Model not found for provider', 400);
 
   if (input.modelFilter && !input.modelFilter(model)) {
@@ -131,10 +132,10 @@ export async function validateProviderModel(providerId: string, modelId: string)
       .get(),
   ]);
 
-  const provider = providers[providerId];
+  const provider = providers[providerId] as Models.RawProvider | undefined;
   if (!provider) return err('Provider not found', 404);
 
-  const model = provider.models[modelId];
+  const model = provider.models[modelId] as Models.RawModel | undefined;
   if (!model) return err('Model not found for provider', 400);
 
   if (!config) return err('Provider is not configured', 400);

--- a/packages/server/src/llm/session-summary.ts
+++ b/packages/server/src/llm/session-summary.ts
@@ -121,7 +121,7 @@ async function prune(msgs: StoredMessage[]): Promise<number> {
           const updatedParts = [...msg.parts];
           for (const partIndex of partIndices) {
             const part = updatedParts[partIndex];
-            if (part?.type === 'tool-result') {
+            if (part.type === 'tool-result') {
               updatedParts[partIndex] = { ...part, output: '[Old tool result content cleared]' } as StoredPart;
             }
           }
@@ -209,7 +209,7 @@ async function resolveCompactionModel(
   }
 
   const providers = await Models.get();
-  const provider = providers[resolved.providerId];
+  const provider = providers[resolved.providerId] as Models.RawProvider | undefined;
   const model = provider?.models[resolved.modelId];
   const limits: ModelLimits = model?.limit ?? { context: 200_000, output: 8_192 };
 
@@ -468,7 +468,7 @@ export async function getModelLimits(providerId: string, modelId: string): Promi
   }
 
   const providers = await Models.get();
-  const provider = providers[providerId];
+  const provider = providers[providerId] as Models.RawProvider | undefined;
   const model = provider?.models[modelId];
   return model?.limit ?? { context: 200_000, output: 8_192 };
 }

--- a/packages/server/src/llm/stream/ai-error-mapper.ts
+++ b/packages/server/src/llm/stream/ai-error-mapper.ts
@@ -98,7 +98,7 @@ function normalizeHeaders(input: unknown): Record<string, string> | undefined {
     return headers;
   }
 
-  if (typeof input === 'object' && input !== null) {
+  if (typeof input === 'object') {
     const headers: Record<string, string> = {};
     for (const [key, value] of Object.entries(input as Record<string, unknown>)) {
       headers[key.toLowerCase()] = String(value);

--- a/packages/server/src/llm/stream/runner.test.ts
+++ b/packages/server/src/llm/stream/runner.test.ts
@@ -88,8 +88,8 @@ describe('runStream integration', () => {
     });
 
     expect(savedMessages).toHaveLength(1);
-    expect(savedMessages[0]?.finishReason).toBe('stop');
-    expect(savedMessages[0]?.parts).toEqual(
+    expect(savedMessages.at(0)?.finishReason).toBe('stop');
+    expect(savedMessages.at(0)?.parts).toEqual(
       expect.arrayContaining([expect.objectContaining({ type: 'text-delta', text: 'Hello from integration' })]),
     );
 
@@ -121,6 +121,6 @@ describe('runStream integration', () => {
     });
 
     expect(savedMessages).toHaveLength(1);
-    expect(savedMessages[0]?.finishReason).toBe('aborted');
+    expect(savedMessages.at(0)?.finishReason).toBe('aborted');
   });
 });

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -259,7 +259,7 @@ class StreamRunner {
   private getLastUserText(maxLength?: number): string | null {
     for (let i = this.state.conversation.length - 1; i >= 0; i--) {
       const message = this.state.conversation[i];
-      if (message?.role !== 'user') {
+      if (message.role !== 'user') {
         continue;
       }
 
@@ -269,7 +269,7 @@ class StreamRunner {
       }
 
       if (Array.isArray(content)) {
-        const textPart = content.find((part) => typeof part === 'object' && part !== null && part.type === 'text');
+        const textPart = content.find((part) => typeof part === 'object' && part.type === 'text');
         if (textPart && typeof textPart === 'object' && 'text' in textPart && typeof textPart.text === 'string') {
           return maxLength ? textPart.text.slice(0, maxLength) : textPart.text;
         }
@@ -629,7 +629,7 @@ class StreamRunner {
 
     for (let i = this.state.accumulatedParts.length - 1; i >= 0; i--) {
       const type = this.state.accumulatedParts[i]?.type;
-      if (type && TRANSIENT_PART_TYPES.has(type)) {
+      if (TRANSIENT_PART_TYPES.has(type)) {
         this.state.accumulatedParts.splice(i, 1);
       }
     }
@@ -945,7 +945,7 @@ class StreamRunner {
 
     for (let i = lastToolResultIndex + 1; i < this.state.accumulatedParts.length; i++) {
       const part = this.state.accumulatedParts[i];
-      if (part?.type === 'text-delta' && typeof part.text === 'string' && part.text.trim().length > 0) {
+      if (part.type === 'text-delta' && typeof part.text === 'string' && part.text.trim().length > 0) {
         return true;
       }
     }

--- a/packages/server/src/llm/stream/session-toolsets.test.ts
+++ b/packages/server/src/llm/stream/session-toolsets.test.ts
@@ -26,7 +26,7 @@ describe('session toolset state persistence', () => {
 
     const state = getSessionToolsetState(sessionId);
     state.active.push({ id: 'mutated', scope: 'until_deactivated' });
-    state.expired[0]?.toolNames.push('mutated_tool');
+    state.expired.at(0)?.toolNames.push('mutated_tool');
 
     expect(getSessionToolsetState(sessionId)).toEqual({
       turnCounter: 2,

--- a/packages/server/src/llm/stream/step-executor.ts
+++ b/packages/server/src/llm/stream/step-executor.ts
@@ -83,7 +83,7 @@ async function executeStep(opts: StepOptions): Promise<StepResult> {
     tools: cachedTools,
     providerOptions,
     experimental_repairToolCall: async (failed) => {
-      const toolName = String(failed.toolCall.toolName ?? '');
+      const toolName = String(failed.toolCall.toolName);
       const normalizedToolName = toolName.toLowerCase();
       if (normalizedToolName !== toolName && normalizedToolName in tools) {
         log.info(
@@ -143,7 +143,7 @@ async function executeStep(opts: StepOptions): Promise<StepResult> {
 
     for (let i = initialPartCount; i < accumulatedParts.length; i++) {
       const part = accumulatedParts[i];
-      if (part?.type === 'tool-call' || part?.type === 'tool-result') {
+      if (part.type === 'tool-call' || part.type === 'tool-result') {
         return true;
       }
     }
@@ -182,7 +182,7 @@ async function executeStep(opts: StepOptions): Promise<StepResult> {
     if (hasStepSideEffects()) {
       const sideEffectPartTypes = accumulatedParts
         .slice(initialPartCount)
-        .filter((part) => part?.type === 'tool-call' || part?.type === 'tool-result')
+        .filter((part) => part.type === 'tool-call' || part.type === 'tool-result')
         .map((part) => part.type);
 
       log.warn(
@@ -242,7 +242,7 @@ async function executeStep(opts: StepOptions): Promise<StepResult> {
 export async function executeStepWithRetry(opts: StepOptions): Promise<StepResult> {
   let attempt = 0;
 
-  while (true) {
+  for (;;) {
     try {
       const result = await executeStep(opts);
       return { ...result, attemptCount: attempt + 1 };

--- a/packages/server/src/llm/stream/stream-accumulator.test.ts
+++ b/packages/server/src/llm/stream/stream-accumulator.test.ts
@@ -69,7 +69,7 @@ describe('StreamAccumulator', () => {
       acc.handlePart(part({ type: 'text-end', id: 'id1' }));
 
       expect(parts).toHaveLength(1);
-      expect(parts[0]).toMatchObject({ type: 'text-delta', text: 'Hello, world!' });
+      expect(parts.at(0)).toMatchObject({ type: 'text-delta', text: 'Hello, world!' });
 
       expect(getEmittedCalls('part.update')).toHaveLength(2);
       expect(getEmittedCalls('part.delta')).toHaveLength(2);
@@ -84,12 +84,12 @@ describe('StreamAccumulator', () => {
       acc.flush();
 
       expect(parts).toHaveLength(1);
-      expect(parts[0]).toMatchObject({ type: 'text-delta', text: 'Incomplete' });
+      expect(parts.at(0)).toMatchObject({ type: 'text-delta', text: 'Incomplete' });
 
       const updateCalls = getEmittedCalls('part.update');
       // text-start + text-end (from flush)
       expect(updateCalls).toHaveLength(2);
-      expect(updateCalls[1]).toMatchObject({ part: { type: 'text-end' } });
+      expect(updateCalls.at(1)).toMatchObject({ part: { type: 'text-end' } });
     });
 
     test('flush() does nothing when text buffer is empty', () => {
@@ -124,7 +124,7 @@ describe('StreamAccumulator', () => {
       acc.handlePart(part({ type: 'reasoning-end', id: 'id1' }));
 
       expect(parts).toHaveLength(1);
-      expect(parts[0]).toMatchObject({ type: 'reasoning-delta', text: 'Thinking step 1. Thinking step 2' });
+      expect(parts.at(0)).toMatchObject({ type: 'reasoning-delta', text: 'Thinking step 1. Thinking step 2' });
     });
 
     test('reasoning-delta without reasoning-start increments protocol violation', () => {
@@ -144,12 +144,12 @@ describe('StreamAccumulator', () => {
       acc.flush();
 
       expect(parts).toHaveLength(1);
-      expect(parts[0]).toMatchObject({ type: 'reasoning-delta', text: 'Partial reasoning' });
+      expect(parts.at(0)).toMatchObject({ type: 'reasoning-delta', text: 'Partial reasoning' });
 
       const updateCalls = getEmittedCalls('part.update');
       // reasoning-start + reasoning-end (from flush)
       expect(updateCalls).toHaveLength(2);
-      expect(updateCalls[1]).toMatchObject({ part: { type: 'reasoning-end' } });
+      expect(updateCalls.at(1)).toMatchObject({ part: { type: 'reasoning-end' } });
     });
   });
 
@@ -174,8 +174,8 @@ describe('StreamAccumulator', () => {
 
       expect(toolCalls).toEqual([expect.objectContaining({ toolName: 'bash' })]);
       expect(parts).toHaveLength(2);
-      expect(parts[0]).toMatchObject({ type: 'tool-call', toolCallId: 'call_1', toolName: 'bash' });
-      expect(parts[1]).toMatchObject({
+      expect(parts.at(0)).toMatchObject({ type: 'tool-call', toolCallId: 'call_1', toolName: 'bash' });
+      expect(parts.at(1)).toMatchObject({
         type: 'tool-result',
         toolCallId: 'call_1',
         toolName: 'bash',
@@ -187,8 +187,8 @@ describe('StreamAccumulator', () => {
       const completedCalls = getEmittedCalls('tool.completed');
       expect(startedCalls).toHaveLength(1);
       expect(completedCalls).toHaveLength(1);
-      expect(startedCalls[0]).toMatchObject({ toolName: 'bash' });
-      expect(completedCalls[0]).toMatchObject({ toolName: 'bash' });
+      expect(startedCalls.at(0)).toMatchObject({ toolName: 'bash' });
+      expect(completedCalls.at(0)).toMatchObject({ toolName: 'bash' });
     });
 
     test('broadcasts tool.failed when a tool-result contains an error payload', () => {
@@ -206,7 +206,7 @@ describe('StreamAccumulator', () => {
 
       const failedCalls = getEmittedCalls('tool.failed');
       expect(failedCalls).toHaveLength(1);
-      expect(failedCalls[0]).toMatchObject({ toolName: 'browser', error: 'Navigation failed' });
+      expect(failedCalls.at(0)).toMatchObject({ toolName: 'browser', error: 'Navigation failed' });
     });
 
     test('broadcasts tool.pending for tool-input-start', () => {
@@ -216,7 +216,7 @@ describe('StreamAccumulator', () => {
 
       const pendingCalls = getEmittedCalls('tool.pending');
       expect(pendingCalls).toHaveLength(1);
-      expect(pendingCalls[0]).toMatchObject({ toolName: 'bash' });
+      expect(pendingCalls.at(0)).toMatchObject({ toolName: 'bash' });
     });
   });
 
@@ -238,7 +238,7 @@ describe('StreamAccumulator', () => {
       );
 
       expect(parts).toHaveLength(1);
-      expect(parts[0]).toMatchObject({
+      expect(parts.at(0)).toMatchObject({
         type: 'tool-result',
         toolCallId: 'call_1',
         toolName: 'webfetch',
@@ -247,7 +247,7 @@ describe('StreamAccumulator', () => {
 
       const failedCalls = getEmittedCalls('tool.failed');
       expect(failedCalls).toHaveLength(1);
-      expect(failedCalls[0]).toMatchObject({ toolName: 'webfetch', error: 'connection refused' });
+      expect(failedCalls.at(0)).toMatchObject({ toolName: 'webfetch', error: 'connection refused' });
     });
 
     test('captures PermissionRejectedError from tool-error', () => {
@@ -288,7 +288,7 @@ describe('StreamAccumulator', () => {
 
       const errorCalls = getEmittedCalls('stream.failed');
       expect(errorCalls).toHaveLength(1);
-      expect(errorCalls[0]).toMatchObject({ sessionId: 'ses_1', messageId: 'msg_1' });
+      expect(errorCalls.at(0)).toMatchObject({ sessionId: 'ses_1', messageId: 'msg_1' });
     });
 
     test('throws StreamPartError for non-Error error parts', () => {
@@ -320,7 +320,7 @@ describe('StreamAccumulator', () => {
       );
 
       expect(parts).toHaveLength(1);
-      expect(parts[0]).toMatchObject({ type: 'source', url: 'https://example.com' });
+      expect(parts.at(0)).toMatchObject({ type: 'source', url: 'https://example.com' });
     });
 
     test('stores file parts', () => {
@@ -332,7 +332,7 @@ describe('StreamAccumulator', () => {
       );
 
       expect(parts).toHaveLength(1);
-      expect(parts[0]).toMatchObject({ type: 'file' });
+      expect(parts.at(0)).toMatchObject({ type: 'file' });
     });
   });
 
@@ -404,10 +404,10 @@ describe('StreamAccumulator', () => {
       );
 
       expect(parts).toHaveLength(4);
-      expect(parts[0]).toMatchObject({ type: 'reasoning-delta', text: 'Analyzing...' });
-      expect(parts[1]).toMatchObject({ type: 'text-delta', text: 'Let me check.' });
-      expect(parts[2]).toMatchObject({ type: 'tool-call', toolName: 'bash' });
-      expect(parts[3]).toMatchObject({ type: 'tool-result', toolName: 'bash' });
+      expect(parts.at(0)).toMatchObject({ type: 'reasoning-delta', text: 'Analyzing...' });
+      expect(parts.at(1)).toMatchObject({ type: 'text-delta', text: 'Let me check.' });
+      expect(parts.at(2)).toMatchObject({ type: 'tool-call', toolName: 'bash' });
+      expect(parts.at(3)).toMatchObject({ type: 'tool-result', toolName: 'bash' });
       expect(toolCalls).toHaveLength(1);
     });
   });

--- a/packages/server/src/llm/stream/stream-accumulator.ts
+++ b/packages/server/src/llm/stream/stream-accumulator.ts
@@ -151,7 +151,7 @@ export class StreamAccumulator {
         sessionId: this.sessionId,
         messageId: this.messageId,
         step: this.step,
-        partType: String(part?.type ?? 'unknown'),
+        partType: String(part.type),
       },
       'stream.part.received',
     );
@@ -321,7 +321,7 @@ export class StreamAccumulator {
         } as StoredPart);
 
         if (isPermissionRejectedError(part.error)) {
-          this.permissionRejected = new PermissionRejectedError(part.toolName ?? 'unknown');
+          this.permissionRejected = new PermissionRejectedError(part.toolName);
         }
         break;
       }

--- a/packages/server/src/mail/read-model.ts
+++ b/packages/server/src/mail/read-model.ts
@@ -46,7 +46,7 @@ export async function getDraftView(draftId: string): Promise<MailDraftView | nul
     .from(mailDrafts)
     .where(eq(mailDrafts.id, draftId as MailDraftId))
     .limit(1);
-  return draft ? toDraftView(draft) : null;
+  return toDraftView(draft);
 }
 
 export async function getAttachmentRecord(attachmentId: string): Promise<typeof mailAttachments.$inferSelect | null> {
@@ -56,7 +56,7 @@ export async function getAttachmentRecord(attachmentId: string): Promise<typeof 
     .from(mailAttachments)
     .where(eq(mailAttachments.id, attachmentId as MailAttachmentId))
     .limit(1);
-  return attachment ?? null;
+  return attachment;
 }
 
 export async function getMessageView(messageId: string): Promise<MailMessageView | null> {
@@ -66,7 +66,6 @@ export async function getMessageView(messageId: string): Promise<MailMessageView
     .from(mailMessages)
     .where(eq(mailMessages.id, messageId as MailMessageId))
     .limit(1);
-  if (!message) return null;
 
   const [labelRows, attachments] = await Promise.all([
     db

--- a/packages/server/src/mcp/icons.ts
+++ b/packages/server/src/mcp/icons.ts
@@ -30,7 +30,7 @@ function parseDataUri(uri: string): { mimeType: string; data: Uint8Array } | nul
   const header = uri.slice(5, commaIndex);
   const dataPart = uri.slice(commaIndex + 1);
   const parts = header.split(';').map((part) => part.trim().toLowerCase());
-  const mimeType = parts[0] || 'text/plain';
+  const mimeType = parts.at(0) || 'text/plain';
   const isBase64 = parts.includes('base64');
   if (!ALLOWED_MIME_TYPES.has(mimeType)) return null;
 
@@ -46,7 +46,7 @@ function parseDataUri(uri: string): { mimeType: string; data: Uint8Array } | nul
 
 function normalizeMimeType(raw?: string): string | undefined {
   if (!raw) return undefined;
-  const normalized = raw.split(';')[0]?.trim().toLowerCase();
+  const normalized = raw.split(';').at(0)?.trim().toLowerCase();
   if (!normalized) return undefined;
   if (normalized === 'image/jpg') return 'image/jpeg';
   return normalized;
@@ -91,7 +91,7 @@ export async function cacheMcpIcon(input: {
 }): Promise<{ key: string } | null> {
   const { serverUrl, scope, icon } = input;
   const cacheDir = input.cacheDir ?? PATHS.dirPaths.mcpIcons;
-  if (!icon?.src) return null;
+  if (!icon.src) return null;
 
   const key = buildKey(scope, icon.src);
   const existing = await readCachedIcon(key, cacheDir);

--- a/packages/server/src/mcp/oauth-callback.ts
+++ b/packages/server/src/mcp/oauth-callback.ts
@@ -106,7 +106,7 @@ export function registerPendingAuth(input: { state: string; serverId: string }):
       pending.delete(input.state);
       reject(new Error('MCP OAuth flow timed out after 5 minutes'));
     }, AUTH_TIMEOUT_MS);
-    timeout.unref?.();
+    timeout.unref();
 
     pending.set(input.state, { serverId: input.serverId, resolve, reject, timeout });
   });

--- a/packages/server/src/mcp/oauth-provider.test.ts
+++ b/packages/server/src/mcp/oauth-provider.test.ts
@@ -89,7 +89,7 @@ describe('McpOAuthProvider', () => {
     expect(await provider.tokens()).toBeUndefined();
     expect(await provider.clientInformation()).toEqual({ client_id: 'dcr-id' });
     const [server] = await getDb().select().from(mcpServers).where(eq(mcpServers.id, serverId));
-    expect(server?.authStatus).toBe('reauthorization_required');
+    expect(server.authStatus).toBe('reauthorization_required');
   });
 
   test('invalidateCredentials("client") clears only client information', async () => {

--- a/packages/server/src/mcp/oauth-provider.ts
+++ b/packages/server/src/mcp/oauth-provider.ts
@@ -73,7 +73,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   private async getSession() {
     const db = getDb();
-    const [row] = await db.select().from(mcpOAuthSessions).where(eq(mcpOAuthSessions.serverId, this.serverId));
+    const rows = await db.select().from(mcpOAuthSessions).where(eq(mcpOAuthSessions.serverId, this.serverId));
+    const row = rows.at(0);
     return row ?? null;
   }
 

--- a/packages/server/src/mcp/presentation.ts
+++ b/packages/server/src/mcp/presentation.ts
@@ -25,7 +25,7 @@ export type McpServerPresentation = {
 
 function pickDisplayIcon(icons?: McpIcon[]): McpIcon | undefined {
   if (!icons || icons.length === 0) return undefined;
-  return icons[0];
+  return icons.at(0);
 }
 
 async function resolveIconPath(input: {
@@ -59,7 +59,7 @@ export async function buildServerPresentation(
 
   return {
     serverId: server.id,
-    name: registryServer?.name ?? server.name ?? liveInfo?.name,
+    name: registryServer?.name ?? server.name,
     title: registryServer?.name ?? liveInfo?.title,
     description: liveInfo?.description ?? registryServer?.description,
     instructions: liveInfo?.instructions,

--- a/packages/server/src/mcp/registry-logos.ts
+++ b/packages/server/src/mcp/registry-logos.ts
@@ -73,10 +73,11 @@ export async function getMcpRegistryLogo(
 
 export async function getMcpInstalledServerRegistryLogo(serverId: string): Promise<string | undefined> {
   const db = getDb();
-  const [server] = await db
+  const serverRows = await db
     .select()
     .from(mcpServers)
     .where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  const server = serverRows.at(0);
   if (!server) return undefined;
 
   const registryServer = await findMcpRegistryServerForInstall({ name: server.name, url: server.url });

--- a/packages/server/src/mcp/registry-service.test.ts
+++ b/packages/server/src/mcp/registry-service.test.ts
@@ -144,7 +144,7 @@ describe('mcp registry service', () => {
     const result = await refreshMcpRegistryCache({ cacheFilePath, fetchImpl, force: true });
     expect(result.error).toBeNull();
     if (result.error) return;
-    expect(result.data.servers[0]?.install.authConfig).toEqual({ type: 'oauth', scopes: ['read'] });
+    expect(result.data.servers.at(0)?.install.authConfig).toEqual({ type: 'oauth', scopes: ['read'] });
   });
 
   test('rejects an oauth authConfig with a non-string scope', async () => {

--- a/packages/server/src/mcp/service.test.ts
+++ b/packages/server/src/mcp/service.test.ts
@@ -51,6 +51,6 @@ describe('mcp auth service', () => {
     expect(sessions).toHaveLength(0);
 
     const [server] = await db.select().from(mcpServers).where(eq(mcpServers.id, id));
-    expect(server?.authStatus).toBe('none');
+    expect(server.authStatus).toBe('none');
   });
 });

--- a/packages/server/src/mcp/service.ts
+++ b/packages/server/src/mcp/service.ts
@@ -51,10 +51,11 @@ export async function deleteMcpServer(serverId: string): Promise<ServiceResult<n
   const toolsetId = `mcp:${serverId}`;
   const mcpToolPrefix = `${serverId}_%`;
 
-  const [existing] = await db
+  const existingRows = await db
     .select()
     .from(mcpServers)
     .where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  const existing = existingRows.at(0);
   if (!existing) {
     return err('MCP server not found', 404);
   }
@@ -75,10 +76,11 @@ export async function deleteMcpServer(serverId: string): Promise<ServiceResult<n
 
 export async function fetchMcpTools(serverId: string): Promise<ServiceResult<McpTool[]>> {
   const db = getDb();
-  const [server] = await db
+  const serverRows = await db
     .select()
     .from(mcpServers)
     .where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  const server = serverRows.at(0);
   if (!server) {
     return err('MCP server not found', 404);
   }
@@ -153,10 +155,11 @@ async function loadOAuthServer(
   serverId: string,
 ): Promise<ServiceResult<{ id: PrefixedString<'mcp'>; url: string; authConfig: OAuthAuth }>> {
   const db = getDb();
-  const [server] = await db
+  const serverRows = await db
     .select()
     .from(mcpServers)
     .where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  const server = serverRows.at(0);
   if (!server) {
     return err('MCP server not found', 404);
   }
@@ -259,10 +262,11 @@ export async function getMcpAuthStatus(
   serverId: string,
 ): Promise<ServiceResult<{ authStatus: McpServerRow['authStatus'] }>> {
   const db = getDb();
-  const [server] = await db
+  const serverRows = await db
     .select({ authStatus: mcpServers.authStatus })
     .from(mcpServers)
     .where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  const server = serverRows.at(0);
   if (!server) {
     return err('MCP server not found', 404);
   }
@@ -292,7 +296,7 @@ export async function refreshExpiringMcpTokens(): Promise<void> {
       .select({ updatedAt: mcpServers.updatedAt })
       .from(mcpServers)
       .where(eq(mcpServers.id, server.id));
-    const issuedAt = session[0]?.updatedAt ?? now;
+    const issuedAt = session.at(0)?.updatedAt ?? now;
     const expiresAt = issuedAt + tokens.expires_in * 1000;
     if (expiresAt - now > TOKEN_REFRESH_BUFFER_MS) continue;
 

--- a/packages/server/src/mcp/tool-executor.ts
+++ b/packages/server/src/mcp/tool-executor.ts
@@ -118,7 +118,7 @@ async function fetchServerPrompts(server: McpServerWithTools): Promise<ToolsetPr
   try {
     const client = await getMcpClient(server);
     const result = await client.listPrompts();
-    return (result.prompts ?? []).map((prompt) => ({
+    return result.prompts.map((prompt) => ({
       name: prompt.name,
       description: prompt.description,
       arguments: prompt.arguments?.map((arg) => ({
@@ -193,7 +193,7 @@ function createMcpToolset(
 ): Toolset {
   const toolsetId = buildMcpToolsetId(server.id);
   const cachedTools = server.tools ?? [];
-  const displayName = registryServer?.name ?? server.name ?? liveInfo?.title ?? liveInfo?.name;
+  const displayName = registryServer?.name ?? server.name;
   const description = buildToolsetDescription(server, liveInfo, registryServer);
 
   return {

--- a/packages/server/src/memory/consolidation.test.ts
+++ b/packages/server/src/memory/consolidation.test.ts
@@ -89,7 +89,7 @@ describe('consolidation validation', () => {
       },
     });
 
-    expect(result.user[0]).toMatchObject({ id: candidate.id, source: 'ses_new' });
+    expect(result.user.at(0)).toMatchObject({ id: candidate.id, source: 'ses_new' });
     expect(result.promotedCount).toBe(1);
   });
 
@@ -138,7 +138,7 @@ describe('file consolidation', () => {
     const daily = await store.appendDaily([
       { content: 'Uses Google Calendar.', origin: 'user', source: 'ses_1', target: 'memory' },
     ]);
-    const candidate = daily.entries[0];
+    const candidate = daily.entries[0] as ManagedMemoryEntry | undefined;
     if (!candidate) throw new Error('Missing test candidate');
 
     const first = await consolidateMemories({
@@ -188,7 +188,6 @@ describe('file consolidation', () => {
       { content: 'Uses Outlook for work.', origin: 'user', source: 'ses_1', target: 'memory' },
     ]);
     const [firstCandidate, secondCandidate] = daily.entries;
-    if (!firstCandidate || !secondCandidate) throw new Error('Missing test candidates');
 
     const propose = (candidate: ManagedMemoryEntry) => async () => ({
       memory: [{ ...candidate, candidateId: candidate.id }],

--- a/packages/server/src/memory/consolidation.ts
+++ b/packages/server/src/memory/consolidation.ts
@@ -279,17 +279,14 @@ export async function consolidateMemories(
         output: Output.object({ schema: consolidationSchema }),
         messages: [{ role: 'user', content: prompt }],
       });
-      if (generated.usage) {
-        internalBus.emit('usage.memory.completed', {
-          providerId: resolved.providerId,
-          modelId: resolved.modelId,
-          usage: generated.usage,
-          phase: 'consolidation',
-          startedAt,
-          endedAt: Date.now(),
-        });
-      }
-      if (!generated.output) throw new Error('Consolidation model returned no proposal');
+      internalBus.emit('usage.memory.completed', {
+        providerId: resolved.providerId,
+        modelId: resolved.modelId,
+        usage: generated.usage,
+        phase: 'consolidation',
+        startedAt,
+        endedAt: Date.now(),
+      });
       proposal = generated.output;
     }
 

--- a/packages/server/src/memory/file-store.test.ts
+++ b/packages/server/src/memory/file-store.test.ts
@@ -40,7 +40,7 @@ describe('MemoryFileStore', () => {
 
     const snapshot = await store.readCurated('memory');
 
-    expect(snapshot.entries[0]).toMatchObject({
+    expect(snapshot.entries.at(0)).toMatchObject({
       id: 'mem_one',
       content: 'Uses TypeScript.\nAvoids JavaScript.',
       lineStart: 3,
@@ -66,8 +66,8 @@ describe('MemoryFileStore', () => {
     );
 
     expect(replaced.rawContent).toStartWith(manual.trimEnd());
-    expect(replaced.entries[0]?.content).toBe('The calendar uses Google Calendar.');
-    expect(replaced.entries[0]?.id).toBe(added.entries[0]?.id);
+    expect(replaced.entries.at(0)?.content).toBe('The calendar uses Google Calendar.');
+    expect(replaced.entries.at(0)?.id).toBe(added.entries.at(0)?.id);
   });
 
   test('rejects duplicate ids and malformed managed blocks', async () => {
@@ -146,7 +146,7 @@ describe('MemoryFileStore', () => {
 
     expect(snapshot.name).toBe('daily/2026-08-04.md');
     expect(snapshot.entries).toHaveLength(1);
-    expect(snapshot.entries[0]?.target).toBe('user');
+    expect(snapshot.entries.at(0)?.target).toBe('user');
     expect(await store.listDailyFiles()).toEqual(['daily/2026-08-04.md']);
   });
 
@@ -189,11 +189,11 @@ describe('MemoryFileStore', () => {
   test('updates and deletes managed entries by stable id with hash guards', async () => {
     const store = await createStore();
     const added = await store.mutate('memory', [{ type: 'add', content: 'Original fact.' }]);
-    const id = added.entries[0]?.id;
+    const id = added.entries.at(0)?.id;
     if (!id) throw new Error('Missing test entry');
 
     const updated = await store.updateEntry(id, 'Updated fact.', added.contentHash);
-    expect(updated.entries[0]?.content).toBe('Updated fact.');
+    expect(updated.entries.at(0)?.content).toBe('Updated fact.');
     expect(store.deleteEntry(id, added.contentHash)).rejects.toThrow('changed outside Stitch');
     expect((await store.deleteEntry(id, updated.contentHash)).entries).toEqual([]);
   });

--- a/packages/server/src/memory/file-store.ts
+++ b/packages/server/src/memory/file-store.ts
@@ -86,7 +86,7 @@ function parseDocument(content: string, filePath: string, defaultTarget: MemoryT
     if (!line.startsWith('<!-- stitch-memory ')) continue;
 
     const metadata = METADATA_PATTERN.exec(line);
-    const item = lines[index + 1];
+    const item = lines[index + 1] as string | undefined;
     if (!metadata || !item?.startsWith('- ')) {
       throw new MemoryParseError(`Managed memory block is malformed at ${filePath}:${index + 1}`);
     }
@@ -235,7 +235,7 @@ export class MemoryFileStore {
               : 'oldText matches multiple memory entries',
           );
         }
-        const match = matches[0];
+        const match = matches.at(0);
         if (!match) throw new MemoryConflictError('No memory entry uniquely matches oldText');
         if (operation.type === 'remove') {
           raw = replaceEntryBlock(raw, match, '').replace(/\n{3,}/g, '\n\n');
@@ -474,7 +474,7 @@ export class MemoryFileStore {
     if (matches.length !== 1) {
       throw new MemoryConflictError(`Memory entry id is ${matches.length === 0 ? 'missing' : 'not unique'}: ${id}`);
     }
-    const match = matches[0];
+    const match = matches.at(0);
     if (!match) throw new MemoryConflictError(`Memory entry id is missing: ${id}`);
 
     return this.withFileLock(match.snapshot.name, async () => {

--- a/packages/server/src/memory/processor.ts
+++ b/packages/server/src/memory/processor.ts
@@ -102,23 +102,17 @@ export async function processMemories(input: {
       output: Output.object({ schema: extractionSchema }),
       messages: [{ role: 'user', content: buildExtractionPrompt(input.userMessage, input.assistantMessage) }],
     });
-    if (result.usage) {
-      internalBus.emit('usage.memory.completed', {
-        providerId: resolved.providerId,
-        modelId: resolved.modelId,
-        usage: result.usage,
-        phase: 'extraction',
-        startedAt,
-        endedAt: Date.now(),
-      });
-    }
+    internalBus.emit('usage.memory.completed', {
+      providerId: resolved.providerId,
+      modelId: resolved.modelId,
+      usage: result.usage,
+      phase: 'extraction',
+      startedAt,
+      endedAt: Date.now(),
+    });
 
     const remaining = Math.min(config.maxFactsPerTurn, config.maxFactsPerSession - state.factsWritten);
-    const candidates = filterCaptureCandidates(
-      result.output?.candidates ?? [],
-      await existingCandidateKeys(),
-      remaining,
-    );
+    const candidates = filterCaptureCandidates(result.output.candidates, await existingCandidateKeys(), remaining);
     if (candidates.length === 0) return;
     await memoryFileStore.appendDaily(
       candidates.map((candidate) => ({
@@ -138,10 +132,12 @@ export async function processMemories(input: {
 
 async function resolveMemorySource(sessionId: string, override: MemorySource | undefined): Promise<MemorySource> {
   if (override) return override;
-  const [session] = await getDb()
-    .select({ type: sessions.type })
-    .from(sessions)
-    .where(eq(sessions.id, sessionId as PrefixedString<'ses'>))
-    .limit(1);
+  const session = (
+    await getDb()
+      .select({ type: sessions.type })
+      .from(sessions)
+      .where(eq(sessions.id, sessionId as PrefixedString<'ses'>))
+      .limit(1)
+  ).at(0);
   return session?.type === 'automation' ? 'automation' : 'chat';
 }

--- a/packages/server/src/models/embedding/provider-embedder.ts
+++ b/packages/server/src/models/embedding/provider-embedder.ts
@@ -28,11 +28,11 @@ export class ProviderEmbedder implements Embedder {
 
   async embed(text: string): Promise<EmbedResult> {
     const result = await embed({ model: this.model, value: text });
-    return { embedding: result.embedding, tokens: result.usage?.tokens ?? 0 };
+    return { embedding: result.embedding, tokens: result.usage.tokens };
   }
 
   async embedMany(texts: string[]): Promise<EmbedManyResult> {
     const result = await embedMany({ model: this.model, values: texts });
-    return { embeddings: result.embeddings, tokens: result.usage?.tokens ?? 0 };
+    return { embeddings: result.embeddings, tokens: result.usage.tokens };
   }
 }

--- a/packages/server/src/models/llm/local.ts
+++ b/packages/server/src/models/llm/local.ts
@@ -44,10 +44,12 @@ export type DiscoveredModel = {
 
 export async function getStoredBaseURL(provider: LocalProviderId): Promise<string | null> {
   const db = getDb();
-  const [config] = await db
-    .select({ credentials: providerConfig.credentials })
-    .from(providerConfig)
-    .where(eq(providerConfig.providerId, provider));
+  const config = (
+    await db
+      .select({ credentials: providerConfig.credentials })
+      .from(providerConfig)
+      .where(eq(providerConfig.providerId, provider))
+  ).at(0);
   return (config?.credentials as { baseURL?: string } | undefined)?.baseURL ?? null;
 }
 
@@ -58,10 +60,12 @@ export async function listLocalModels(provider: LocalProviderId): Promise<LocalM
 
 export async function getLocalModel(provider: LocalProviderId, id: string): Promise<ServiceResult<LocalModel>> {
   const db = getDb();
-  const [model] = await db
-    .select()
-    .from(localModels)
-    .where(and(eq(localModels.provider, provider), eq(localModels.id, id)));
+  const model = (
+    await db
+      .select()
+      .from(localModels)
+      .where(and(eq(localModels.provider, provider), eq(localModels.id, id)))
+  ).at(0);
   if (!model) {
     return err('Model not found', 404);
   }
@@ -79,29 +83,31 @@ export async function upsertLocalModel(
 
   const db = getDb();
   const now = Date.now();
-  const [model] = await db
-    .insert(localModels)
-    .values({ ...parsed.data, provider, createdAt: now, updatedAt: now })
-    .onConflictDoUpdate({
-      target: [localModels.provider, localModels.id],
-      set: {
-        name: parsed.data.name,
-        contextWindow: parsed.data.contextWindow,
-        inputLimit: parsed.data.inputLimit,
-        outputLimit: parsed.data.outputLimit,
-        inputCostPerMillion: parsed.data.inputCostPerMillion,
-        outputCostPerMillion: parsed.data.outputCostPerMillion,
-        cacheReadCostPerMillion: parsed.data.cacheReadCostPerMillion,
-        cacheWriteCostPerMillion: parsed.data.cacheWriteCostPerMillion,
-        supportsToolCalls: parsed.data.supportsToolCalls,
-        supportsVision: parsed.data.supportsVision,
-        supportsReasoning: parsed.data.supportsReasoning,
-        inputModalities: parsed.data.inputModalities,
-        outputModalities: parsed.data.outputModalities,
-        updatedAt: now,
-      },
-    })
-    .returning();
+  const model = (
+    await db
+      .insert(localModels)
+      .values({ ...parsed.data, provider, createdAt: now, updatedAt: now })
+      .onConflictDoUpdate({
+        target: [localModels.provider, localModels.id],
+        set: {
+          name: parsed.data.name,
+          contextWindow: parsed.data.contextWindow,
+          inputLimit: parsed.data.inputLimit,
+          outputLimit: parsed.data.outputLimit,
+          inputCostPerMillion: parsed.data.inputCostPerMillion,
+          outputCostPerMillion: parsed.data.outputCostPerMillion,
+          cacheReadCostPerMillion: parsed.data.cacheReadCostPerMillion,
+          cacheWriteCostPerMillion: parsed.data.cacheWriteCostPerMillion,
+          supportsToolCalls: parsed.data.supportsToolCalls,
+          supportsVision: parsed.data.supportsVision,
+          supportsReasoning: parsed.data.supportsReasoning,
+          inputModalities: parsed.data.inputModalities,
+          outputModalities: parsed.data.outputModalities,
+          updatedAt: now,
+        },
+      })
+      .returning()
+  ).at(0);
 
   if (!model) {
     return err('Failed to save model', 500);

--- a/packages/server/src/permission/policy.ts
+++ b/packages/server/src/permission/policy.ts
@@ -31,7 +31,7 @@ export function resolvePermissionFromRules(
     .filter((row) => wildcardPatternMatches(row.pattern, patternTargets))
     .toSorted((a, b) => b.pattern.length - a.pattern.length);
 
-  const firstMatch = patternMatchesBySpecificity[0];
+  const firstMatch = patternMatchesBySpecificity.at(0);
   if (!firstMatch) return 'ask';
   return firstMatch.permission;
 }

--- a/packages/server/src/provider/config/service.ts
+++ b/packages/server/src/provider/config/service.ts
@@ -15,7 +15,7 @@ export async function getProviderCredentials(providerId: string): Promise<Servic
   }
 
   const db = getDb();
-  const [config] = await db.select().from(providerConfig).where(eq(providerConfig.providerId, providerId));
+  const config = (await db.select().from(providerConfig).where(eq(providerConfig.providerId, providerId))).at(0);
   if (!config) {
     return err('Provider not configured', 404);
   }

--- a/packages/server/src/provider/service.ts
+++ b/packages/server/src/provider/service.ts
@@ -65,8 +65,8 @@ export async function listProvidersWithCapabilities(): Promise<ServiceResult<Pro
     const meta = PROVIDER_META[id as keyof typeof PROVIDER_META];
     results.push({
       id,
-      name: meta?.displayName ?? llmProviders[id]?.name ?? id,
-      api: meta?.api ?? llmProviders[id]?.api,
+      name: meta.displayName,
+      api: meta.api ?? llmProviders[id].api,
       enabled: enabledIds.has(id),
       capabilities: [...caps],
     });
@@ -92,7 +92,7 @@ export async function listEnabledSttModels(): Promise<ServiceResult<SttProviderM
   for (const entry of sttCatalog) {
     if (!enabledIds.has(entry.providerId)) continue;
     const meta = PROVIDER_META[entry.providerId as keyof typeof PROVIDER_META];
-    const providerName = meta?.displayName ?? entry.providerName;
+    const providerName = meta.displayName;
     results.push({
       providerId: entry.providerId,
       providerName,

--- a/packages/server/src/question/service.test.ts
+++ b/packages/server/src/question/service.test.ts
@@ -83,8 +83,8 @@ describe('question service interactions', () => {
 
     const db = getDb();
     const [row] = await db.select().from(questions).where(eq(questions.id, questionId));
-    expect(row?.status).toBe('answered');
-    expect(row?.answers).toEqual([['A']]);
+    expect(row.status).toBe('answered');
+    expect(row.answers).toEqual([['A']]);
   });
 
   test('rejectQuestion rejects a pending askQuestion promise', async () => {
@@ -114,7 +114,7 @@ describe('question service interactions', () => {
 
     const db = getDb();
     const [row] = await db.select().from(questions).where(eq(questions.id, questionId));
-    expect(row?.status).toBe('rejected');
+    expect(row.status).toBe('rejected');
   });
 
   test('replyQuestion accepts custom answers by default', async () => {
@@ -137,8 +137,8 @@ describe('question service interactions', () => {
 
     const db = getDb();
     const [row] = await db.select().from(questions).where(eq(questions.id, question.id));
-    expect(row?.status).toBe('answered');
-    expect(row?.answers).toEqual([['Something else']]);
+    expect(row.status).toBe('answered');
+    expect(row.answers).toEqual([['Something else']]);
   });
 
   test('replyQuestion rejects invalid answers without resolving the question', async () => {
@@ -177,8 +177,8 @@ describe('question service interactions', () => {
 
     const db = getDb();
     const [row] = await db.select().from(questions).where(eq(questions.id, question.id));
-    expect(row?.status).toBe('pending');
-    expect(row?.answers).toBeNull();
+    expect(row.status).toBe('pending');
+    expect(row.answers).toBeNull();
   });
 
   test('abortQuestions rejects pending questions for the session', async () => {

--- a/packages/server/src/question/service.ts
+++ b/packages/server/src/question/service.ts
@@ -104,18 +104,20 @@ export async function askQuestion(opts: {
     'asking question',
   );
 
-  const [row] = await db
-    .insert(questions)
-    .values({
-      id,
-      sessionId: opts.sessionId,
-      questions: opts.questions,
-      status: 'pending',
-      toolCallId: opts.toolCallId,
-      messageId: opts.messageId,
-      createdAt: now,
-    })
-    .returning();
+  const row = (
+    await db
+      .insert(questions)
+      .values({
+        id,
+        sessionId: opts.sessionId,
+        questions: opts.questions,
+        status: 'pending',
+        toolCallId: opts.toolCallId,
+        messageId: opts.messageId,
+        createdAt: now,
+      })
+      .returning()
+  ).at(0);
 
   if (!row) {
     throw new QuestionNotFoundAfterCreateError(id);
@@ -140,7 +142,7 @@ export async function replyQuestion(
   const db = getDb();
   const now = Date.now();
 
-  const [existingQuestion] = await db.select().from(questions).where(eq(questions.id, questionId));
+  const existingQuestion = (await db.select().from(questions).where(eq(questions.id, questionId))).at(0);
   if (!existingQuestion) {
     return err(`Question not found: ${questionId}`, 404);
   }
@@ -178,7 +180,7 @@ export async function rejectQuestion(questionId: PrefixedString<'quest'>): Promi
   const db = getDb();
   const now = Date.now();
 
-  const [question] = await db.select().from(questions).where(eq(questions.id, questionId));
+  const question = (await db.select().from(questions).where(eq(questions.id, questionId))).at(0);
   if (!question) {
     return err(`Question not found: ${questionId}`, 404);
   }

--- a/packages/server/src/recordings/analysis-service.ts
+++ b/packages/server/src/recordings/analysis-service.ts
@@ -109,12 +109,16 @@ export async function getRecordingAnalysis(
 ): Promise<ServiceResult<RecordingAnalysisResponse>> {
   const db = getDb();
 
-  const [recording] = await db.select({ id: recordings.id }).from(recordings).where(eq(recordings.id, recordingId));
+  const recording = (await db.select({ id: recordings.id }).from(recordings).where(eq(recordings.id, recordingId))).at(
+    0,
+  );
   if (!recording) {
     return err('Recording not found', 404);
   }
 
-  const [analysis] = await db.select().from(recordingAnalyses).where(eq(recordingAnalyses.recordingId, recordingId));
+  const analysis = (await db.select().from(recordingAnalyses).where(eq(recordingAnalyses.recordingId, recordingId))).at(
+    0,
+  );
 
   return ok({ analysis: analysis ? await toRecordingAnalysis(analysis) : null });
 }
@@ -126,7 +130,7 @@ export async function startRecordingAnalysis(
 ): Promise<ServiceResult<StartRecordingAnalysisResponse>> {
   const db = getDb();
 
-  const [recording] = await db.select().from(recordings).where(eq(recordings.id, recordingId));
+  const recording = (await db.select().from(recordings).where(eq(recordings.id, recordingId))).at(0);
   if (!recording) {
     return err('Recording not found', 404);
   }
@@ -134,7 +138,9 @@ export async function startRecordingAnalysis(
     return err('Recording must be completed before analysis', 400);
   }
 
-  const [existing] = await db.select().from(recordingAnalyses).where(eq(recordingAnalyses.recordingId, recordingId));
+  const existing = (await db.select().from(recordingAnalyses).where(eq(recordingAnalyses.recordingId, recordingId))).at(
+    0,
+  );
 
   if (existing && existing.status !== 'failed' && existing.status !== 'pending' && !input.force) {
     return ok({ analysis: await toRecordingAnalysis(existing) });
@@ -225,7 +231,7 @@ export async function startRecordingAnalysis(
     deps,
   );
 
-  const [created] = await db.select().from(recordingAnalyses).where(eq(recordingAnalyses.id, id));
+  const created = (await db.select().from(recordingAnalyses).where(eq(recordingAnalyses.id, id))).at(0);
   if (!created) {
     return err('Failed to create recording analysis', 400);
   }
@@ -236,12 +242,16 @@ export async function startRecordingAnalysis(
 export async function cancelRecordingAnalysis(recordingId: PrefixedString<'rec'>): Promise<ServiceResult<null>> {
   const db = getDb();
 
-  const [recording] = await db.select({ id: recordings.id }).from(recordings).where(eq(recordings.id, recordingId));
+  const recording = (await db.select({ id: recordings.id }).from(recordings).where(eq(recordings.id, recordingId))).at(
+    0,
+  );
   if (!recording) {
     return err('Recording not found', 404);
   }
 
-  const [existing] = await db.select().from(recordingAnalyses).where(eq(recordingAnalyses.recordingId, recordingId));
+  const existing = (await db.select().from(recordingAnalyses).where(eq(recordingAnalyses.recordingId, recordingId))).at(
+    0,
+  );
   if (!existing) {
     return err('Recording analysis not found', 404);
   }
@@ -261,17 +271,19 @@ export async function cancelRecordingAnalysis(recordingId: PrefixedString<'rec'>
   }
 
   const endedAt = Date.now();
-  const [updated] = await db
-    .update(recordingAnalyses)
-    .set({
-      status: 'failed',
-      error: null,
-      endedAt,
-      durationMs: existing.startedAt ? endedAt - existing.startedAt : null,
-      updatedAt: endedAt,
-    })
-    .where(eq(recordingAnalyses.id, existing.id))
-    .returning();
+  const updated = (
+    await db
+      .update(recordingAnalyses)
+      .set({
+        status: 'failed',
+        error: null,
+        endedAt,
+        durationMs: existing.startedAt ? endedAt - existing.startedAt : null,
+        updatedAt: endedAt,
+      })
+      .where(eq(recordingAnalyses.id, existing.id))
+      .returning()
+  ).at(0);
 
   internalBus.emit('recording.analysis.failed', { recordingId });
 
@@ -330,7 +342,7 @@ async function runRecordingAnalysis(
       throw new RecordingAnalysisEmptyResponseError();
     }
 
-    const analysisUsage = analysisResult.usage ?? ZERO_USAGE;
+    const analysisUsage = analysisResult.usage;
 
     const { costUsd: analysisCost } = await recordLlmUsage({
       source: 'recording_analysis',
@@ -351,10 +363,12 @@ async function runRecordingAnalysis(
     }
 
     // Read existing transcription cost so we can add analysis cost on top
-    const [currentRow] = await db
-      .select({ costUsd: recordingAnalyses.costUsd })
-      .from(recordingAnalyses)
-      .where(eq(recordingAnalyses.id, analysisId));
+    const currentRow = (
+      await db
+        .select({ costUsd: recordingAnalyses.costUsd })
+        .from(recordingAnalyses)
+        .where(eq(recordingAnalyses.id, analysisId))
+    ).at(0);
     const transcriptionCost = currentRow?.costUsd ?? 0;
 
     await writeRecordingAnalysis(input.recordingId, summary);

--- a/packages/server/src/recordings/meeting-note-templates.ts
+++ b/packages/server/src/recordings/meeting-note-templates.ts
@@ -67,7 +67,7 @@ export async function getMeetingNoteTemplate(
   id: MeetingNoteTemplate['id'],
 ): Promise<ServiceResult<MeetingNoteTemplateResponse>> {
   const db = getDb();
-  const [row] = await db.select().from(meetingNoteTemplates).where(eq(meetingNoteTemplates.id, id));
+  const row = (await db.select().from(meetingNoteTemplates).where(eq(meetingNoteTemplates.id, id))).at(0);
 
   if (!row) return err('Meeting note template not found', 404);
 
@@ -80,10 +80,12 @@ export async function createMeetingNoteTemplate(
   const db = getDb();
   const now = Date.now();
   const id = createMeetingNoteTemplateId();
-  const [row] = await db
-    .insert(meetingNoteTemplates)
-    .values({ id, name: input.name.trim(), content: input.content, createdAt: now, updatedAt: now })
-    .returning();
+  const row = (
+    await db
+      .insert(meetingNoteTemplates)
+      .values({ id, name: input.name.trim(), content: input.content, createdAt: now, updatedAt: now })
+      .returning()
+  ).at(0);
 
   if (!row) return err('Failed to create meeting note template', 500);
 
@@ -95,11 +97,13 @@ export async function updateMeetingNoteTemplate(
   input: MeetingNoteTemplateInput,
 ): Promise<ServiceResult<MeetingNoteTemplateResponse>> {
   const db = getDb();
-  const [row] = await db
-    .update(meetingNoteTemplates)
-    .set({ name: input.name.trim(), content: input.content, updatedAt: Date.now() })
-    .where(eq(meetingNoteTemplates.id, id))
-    .returning();
+  const row = (
+    await db
+      .update(meetingNoteTemplates)
+      .set({ name: input.name.trim(), content: input.content, updatedAt: Date.now() })
+      .where(eq(meetingNoteTemplates.id, id))
+      .returning()
+  ).at(0);
 
   if (!row) return err('Meeting note template not found', 404);
 

--- a/packages/server/src/recordings/service.ts
+++ b/packages/server/src/recordings/service.ts
@@ -48,7 +48,7 @@ async function resolveSttConfig(override?: { providerId: string; modelId: string
   let providerId: string;
   let modelId: string;
 
-  if (override?.providerId && override?.modelId) {
+  if (override?.providerId && override.modelId) {
     providerId = override.providerId;
     modelId = override.modelId;
   } else {
@@ -63,7 +63,7 @@ async function resolveSttConfig(override?: { providerId: string; modelId: string
   }
 
   const db = getDb();
-  const [config] = await db.select().from(providerConfig).where(eq(providerConfig.providerId, providerId));
+  const config = (await db.select().from(providerConfig).where(eq(providerConfig.providerId, providerId))).at(0);
 
   if (!config) {
     log.warn({ providerId }, 'no provider config found for transcription provider');
@@ -130,7 +130,7 @@ export async function listRecordings(input: {
       .offset(offset),
     db.select({ total: sql<number>`count(*)` }).from(recordings),
   ]);
-  const total = Number(countRows[0]?.total ?? 0);
+  const total = Number(countRows.at(0)?.total ?? 0);
   const totalPages = computeTotalPages(total, input.pageSize);
 
   return ok({
@@ -147,16 +147,18 @@ export async function getRecordingDetails(
   recordingId: Recording['id'],
 ): Promise<ServiceResult<RecordingDetailsResponse>> {
   const db = getDb();
-  const [row] = await db
-    .select({
-      recording: recordings,
-      analysis: recordingAnalyses,
-      analysisTitle: recordingAnalyses.title,
-      analysisCostUsd: recordingAnalyses.costUsd,
-    })
-    .from(recordings)
-    .leftJoin(recordingAnalyses, eq(recordingAnalyses.recordingId, recordings.id))
-    .where(eq(recordings.id, recordingId));
+  const row = (
+    await db
+      .select({
+        recording: recordings,
+        analysis: recordingAnalyses,
+        analysisTitle: recordingAnalyses.title,
+        analysisCostUsd: recordingAnalyses.costUsd,
+      })
+      .from(recordings)
+      .leftJoin(recordingAnalyses, eq(recordingAnalyses.recordingId, recordings.id))
+      .where(eq(recordings.id, recordingId))
+  ).at(0);
 
   if (!row) {
     return err('Recording not found', 404);
@@ -251,7 +253,7 @@ export async function startRecording(input: StartRecordingInput): Promise<Servic
     return err(message, 400);
   }
 
-  const [row] = await db.select().from(recordings).where(eq(recordings.id, id));
+  const row = (await db.select().from(recordings).where(eq(recordings.id, id))).at(0);
   if (!row) {
     return err('Recording not found', 404);
   }
@@ -318,7 +320,7 @@ export async function stopRecording(input: StopRecordingInput): Promise<ServiceR
     return err(message, 400);
   }
 
-  const [row] = await db.select().from(recordings).where(eq(recordings.id, current.id));
+  const row = (await db.select().from(recordings).where(eq(recordings.id, current.id))).at(0);
   if (!row) {
     return err('Recording not found', 404);
   }
@@ -334,7 +336,7 @@ export async function deleteRecording(recordingId: Recording['id']): Promise<Ser
   }
 
   const db = getDb();
-  const [row] = await db.select().from(recordings).where(eq(recordings.id, recordingId));
+  const row = (await db.select().from(recordings).where(eq(recordings.id, recordingId))).at(0);
 
   if (!row) {
     return err('Recording not found', 404);

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -20,15 +20,17 @@ eventsRouter.get('/', (c) => {
         unregisterSseConnection(stream);
       });
 
+      const isAborted = () => stream.aborted;
+
       await stream.writeSSE({
         event: 'connected',
         data: JSON.stringify({ ts: Date.now() }),
         retry: RECONNECT_DELAY_MS,
       });
 
-      while (!stream.aborted) {
+      while (!isAborted()) {
         await stream.sleep(HEARTBEAT_INTERVAL_MS);
-        if (!stream.aborted) {
+        if (!isAborted()) {
           await stream.writeSSE({ event: 'heartbeat', data: JSON.stringify({ ts: Date.now() }) });
         }
       }

--- a/packages/server/src/routes/memory.ts
+++ b/packages/server/src/routes/memory.ts
@@ -80,7 +80,7 @@ memoryRouter.get('/files', async (c) => {
 
 memoryRouter.get('/files/:name', async (c) => {
   const name = c.req.param('name') as keyof typeof fileNames;
-  const fileName = fileNames[name];
+  const fileName = fileNames[name] as (typeof fileNames)[keyof typeof fileNames] | undefined;
   if (!fileName) return c.json({ error: 'Unknown memory file.' }, 404);
   return c.json(await memoryFileStore.readFile(fileName));
 });

--- a/packages/server/src/scheduler/store.ts
+++ b/packages/server/src/scheduler/store.ts
@@ -36,7 +36,8 @@ export function createSchedulerStore(): SchedulerStore {
             })
             .where(eq(scheduledJobs.key, input.key))
             .returning()
-            .get();
+            .all()
+            .at(0);
 
           if (!updated) throw new SchedulerJobUpsertError(input.key);
           return updated;
@@ -61,7 +62,8 @@ export function createSchedulerStore(): SchedulerStore {
           updatedAt: input.now,
         })
         .returning()
-        .get();
+        .all()
+        .at(0);
 
       if (!inserted) throw new SchedulerJobUpsertError(input.key);
       return inserted;
@@ -106,7 +108,8 @@ export function createSchedulerStore(): SchedulerStore {
             createdAt: input.now,
           })
           .returning()
-          .get();
+          .all()
+          .at(0);
 
         if (!inserted) return null;
 

--- a/packages/server/src/settings/service.ts
+++ b/packages/server/src/settings/service.ts
@@ -55,7 +55,7 @@ export async function listSettings(): Promise<ServiceResult<Record<string, strin
 }
 
 export async function saveSetting(key: string, value: string): Promise<ServiceResult<null>> {
-  const schema = SETTINGS_SCHEMAS[key as SettingsKey];
+  const schema = SETTINGS_SCHEMAS[key as SettingsKey] as (typeof SETTINGS_SCHEMAS)[SettingsKey] | undefined;
   if (!schema) {
     return err('Invalid setting key', 400);
   }

--- a/packages/server/src/skills/built-in-skills.test.ts
+++ b/packages/server/src/skills/built-in-skills.test.ts
@@ -10,7 +10,7 @@ describe('loadBuiltInSkills', () => {
     const skills = await loadBuiltInSkills(TEST_BUILT_INS_DIR);
 
     expect(skills).toHaveLength(1);
-    expect(skills[0]).toMatchObject({
+    expect(skills.at(0)).toMatchObject({
       name: 'test-skill',
       description: 'Use this test skill in loader tests.',
       content: 'These are test skill instructions.',

--- a/packages/server/src/skills/built-in-skills.ts
+++ b/packages/server/src/skills/built-in-skills.ts
@@ -42,7 +42,7 @@ export async function loadBuiltInSkills(builtInsDir?: string): Promise<BuiltInSk
       const result = createSkillSchema.safeParse(parsed);
       if (!result.success) {
         throw new SkillInvalidError(
-          `Invalid built-in skill ${skillDirEntry.name}: ${result.error.issues[0]?.message ?? 'validation failed'}`,
+          `Invalid built-in skill ${skillDirEntry.name}: ${result.error.issues.at(0)?.message ?? 'validation failed'}`,
         );
       }
 

--- a/packages/server/src/skills/parse-skill-markdown.ts
+++ b/packages/server/src/skills/parse-skill-markdown.ts
@@ -15,8 +15,8 @@ export function parseSkillMarkdown(markdown: string): SkillCreateInput | null {
   const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(markdown);
   if (!match) return null;
 
-  const frontmatter = match[1] ?? '';
-  const content = (match[2] ?? '').replace(/^\n/, '');
+  const frontmatter = match.at(1) ?? '';
+  const content = (match.at(2) ?? '').replace(/^\n/, '');
 
   const nameMatch =
     /^name:\s*"((?:[^"\\]|\\.)*)"\s*$/m.exec(frontmatter) ??

--- a/packages/server/src/skills/service.ts
+++ b/packages/server/src/skills/service.ts
@@ -89,7 +89,7 @@ export async function getSkillByName(name: string): Promise<ServiceResult<Skill>
 
 export async function createSkill(input: SkillCreateInput): Promise<ServiceResult<Skill>> {
   const parsed = createSkillSchema.safeParse(input);
-  if (!parsed.success) return err(parsed.error.issues[0]?.message ?? 'Invalid skill', 400);
+  if (!parsed.success) return err(parsed.error.issues.at(0)?.message ?? 'Invalid skill', 400);
 
   const value = parsed.data;
   await ensureSkillsDir();
@@ -129,7 +129,7 @@ export async function syncBuiltInSkills(builtInSkills: BuiltInSkill[]): Promise<
 
 export async function updateSkill(name: string, input: SkillUpdateInput): Promise<ServiceResult<Skill>> {
   const parsed = updateSkillSchema.safeParse(input);
-  if (!parsed.success) return err(parsed.error.issues[0]?.message ?? 'Invalid skill', 400);
+  if (!parsed.success) return err(parsed.error.issues.at(0)?.message ?? 'Invalid skill', 400);
 
   const value = parsed.data;
   await ensureSkillsDir();
@@ -219,7 +219,7 @@ export async function searchSkillsDirectory(query: string): Promise<ServiceResul
 
 export async function importSkillFromDirectory(input: SkillImportInput): Promise<ServiceResult<Skill>> {
   const parsed = importSkillSchema.safeParse(input);
-  if (!parsed.success) return err(parsed.error.issues[0]?.message ?? 'Invalid skill import', 400);
+  if (!parsed.success) return err(parsed.error.issues.at(0)?.message ?? 'Invalid skill import', 400);
 
   const { source, slug } = parsed.data;
   if (!source.includes('/')) return err('Skill source must be an owner/repo value', 400);
@@ -258,7 +258,7 @@ export async function importSkillFromDirectory(input: SkillImportInput): Promise
     if (!createParsed.success) {
       log.error({ source, slug, issues: createParsed.error.issues }, 'downloaded skill failed schema validation');
       return err(
-        new SkillInvalidError(createParsed.error.issues[0]?.message ?? 'Downloaded skill is invalid').message,
+        new SkillInvalidError(createParsed.error.issues.at(0)?.message ?? 'Downloaded skill is invalid').message,
         422,
       );
     }

--- a/packages/server/src/stt/adapters/assemblyai.ts
+++ b/packages/server/src/stt/adapters/assemblyai.ts
@@ -47,7 +47,7 @@ export function createAssemblyAIMessageParser(sessionStartMs: number) {
         if (!('transcript' in msg)) return null;
 
         const words =
-          'words' in msg && msg.words
+          'words' in msg
             ? msg.words.map((w) => ({ text: w.text, startMs: Math.round(w.start), endMs: Math.round(w.end) }))
             : undefined;
 

--- a/packages/server/src/stt/auth.ts
+++ b/packages/server/src/stt/auth.ts
@@ -12,7 +12,7 @@ import type { ProviderAuth } from '@/stt/types.js';
  */
 export async function resolveSttAuth(providerId: string): Promise<ProviderAuth | null> {
   const db = getDb();
-  const [config] = await db.select().from(providerConfig).where(eq(providerConfig.providerId, providerId));
+  const config = (await db.select().from(providerConfig).where(eq(providerConfig.providerId, providerId))).at(0);
 
   if (!config) return null;
 

--- a/packages/server/src/stt/base-adapter.ts
+++ b/packages/server/src/stt/base-adapter.ts
@@ -69,6 +69,7 @@ export async function createManagedConnection(config: ManagedConnectionConfig): 
 
   let transport: STTTransport | null = null;
   let closed = false;
+  const isClosed = () => closed;
   let rotating = false;
   let reconnecting = false;
   let recoveryQueued = false;
@@ -258,7 +259,7 @@ export async function createManagedConnection(config: ManagedConnectionConfig): 
     } finally {
       rotating = false;
       scheduleRotation();
-      if (recoveryQueued && !closed) {
+      if (recoveryQueued && !isClosed()) {
         recoveryQueued = false;
         void reactiveReconnect();
       }
@@ -310,7 +311,7 @@ export async function createManagedConnection(config: ManagedConnectionConfig): 
       );
 
       await new Promise((r) => setTimeout(r, delay));
-      if (closed) break;
+      if (isClosed()) break;
 
       try {
         const newTransport = await openConnection();

--- a/packages/server/src/stt/route.ts
+++ b/packages/server/src/stt/route.ts
@@ -123,7 +123,7 @@ async function handleStart(
   }
 
   state.inputEncoding = message.audioChunkConfig.encoding;
-  state.recordingId = message.recordingId ?? null;
+  state.recordingId = message.recordingId;
 
   try {
     const session = await createSTTSession({

--- a/packages/server/src/stt/ws-transport.test.ts
+++ b/packages/server/src/stt/ws-transport.test.ts
@@ -105,8 +105,8 @@ describe('createWsTransport', () => {
 
     await sleep(20);
 
-    expect(errors[0]?.message).toBe('Test WebSocket missing pong');
-    expect((errors[0] as Error & { code?: string })?.code).toBe('missing-pong');
+    expect(errors.at(0)?.message).toBe('Test WebSocket missing pong');
+    expect((errors.at(0) as Error & { code?: string }).code).toBe('missing-pong');
     expect(FakeWebSocket.last?.closeCode).toBe(4000);
   });
 

--- a/packages/server/src/stt/ws-transport.ts
+++ b/packages/server/src/stt/ws-transport.ts
@@ -19,7 +19,7 @@ type WsTransportConfig = {
   keepAliveMessage?: string;
 };
 
-type PingableWebSocket = WebSocket & { ping?: () => void };
+type PingableWebSocket = Omit<WebSocket, 'ping'> & { ping?: () => void };
 
 export type WsMessageResult = { transcript?: TranscriptEvent; usage?: STTUsage; error?: Error };
 
@@ -219,7 +219,7 @@ export function createWsTransport(
     }
 
     function handleError(event: Event): void {
-      const message = (event as ErrorEvent).message ?? 'unknown';
+      const message = (event as { message?: string }).message ?? 'unknown';
       const err = new Error(`${config.label} WebSocket error: ${message}`);
       if (!opened) {
         reject(err);

--- a/packages/server/src/title-generation/generator.ts
+++ b/packages/server/src/title-generation/generator.ts
@@ -37,7 +37,7 @@ export async function generateTitleFromContent(
     const title = result.text.trim().replace(/^["']|["']$/g, '');
     if (!title) return null;
 
-    return { title, usage: result.usage ?? null, providerId: resolved.providerId, modelId: resolved.modelId };
+    return { title, usage: result.usage, providerId: resolved.providerId, modelId: resolved.modelId };
   } catch (error) {
     const mappedError = mapAIError(error, resolved.providerId);
     log.error(

--- a/packages/server/src/todos/service.ts
+++ b/packages/server/src/todos/service.ts
@@ -26,11 +26,9 @@ export async function replaceSessionTodos(input: {
   broadcastUpdate?: boolean;
 }): Promise<ServiceResult<SessionTodo[]>> {
   const db = getDb();
-  const [session] = await db
-    .select({ id: sessions.id })
-    .from(sessions)
-    .where(eq(sessions.id, input.sessionId))
-    .limit(1);
+  const session = (
+    await db.select({ id: sessions.id }).from(sessions).where(eq(sessions.id, input.sessionId)).limit(1)
+  ).at(0);
   if (!session) return err(`Session not found: ${input.sessionId}`, 404);
 
   const now = Date.now();

--- a/packages/server/src/tools/core/bash.ts
+++ b/packages/server/src/tools/core/bash.ts
@@ -128,7 +128,7 @@ Parameter sourcing:
       proc.stdout?.on('data', append);
       proc.stderr?.on('data', append);
 
-      let timedOut = false;
+      const timedOutState = { value: false };
       let aborted = false;
       let exited = false;
 
@@ -147,7 +147,7 @@ Parameter sourcing:
       abortSignal?.addEventListener('abort', abortHandler, { once: true });
 
       const timeoutId = setTimeout(() => {
-        timedOut = true;
+        timedOutState.value = true;
         void kill();
       }, timeout + 100);
 
@@ -174,7 +174,7 @@ Parameter sourcing:
       });
 
       const runtimeNotes: string[] = [];
-      if (timedOut) runtimeNotes.push(`Command timed out after ${timeout} ms`);
+      if (timedOutState.value) runtimeNotes.push(`Command timed out after ${timeout} ms`);
       if (aborted) runtimeNotes.push('Command was aborted');
 
       if (runtimeNotes.length > 0) {
@@ -183,7 +183,7 @@ Parameter sourcing:
 
       const cleanedOutput = stripAnsi(output);
       const exitCode = proc.exitCode ?? 0;
-      const failed = exitCode !== 0 && !timedOut && !aborted;
+      const failed = exitCode !== 0 && !timedOutState.value && !aborted;
 
       return {
         title: input.description,
@@ -203,13 +203,13 @@ Parameter sourcing:
 }
 
 function getPatternTargets(input: unknown): string[] {
-  const command = (input as { command?: unknown })?.command;
+  const command = (input as { command?: unknown }).command;
   if (typeof command !== 'string' || command.trim().length === 0) return [];
   return deriveCommandFamilies(command).map((family) => family.pattern);
 }
 
 function getSuggestion(input: unknown): PermissionSuggestion | null {
-  const command = (input as { command?: unknown })?.command;
+  const command = (input as { command?: unknown }).command;
   if (typeof command !== 'string' || command.trim().length === 0) return null;
   return getCommandFamilySuggestion(command);
 }

--- a/packages/server/src/tools/core/edit.ts
+++ b/packages/server/src/tools/core/edit.ts
@@ -26,7 +26,7 @@ function countOccurrences(content: string, oldString: string): number {
   let count = 0;
   let startIndex = 0;
 
-  while (true) {
+  for (;;) {
     const index = content.indexOf(oldString, startIndex);
     if (index === -1) return count;
     count += 1;

--- a/packages/server/src/tools/core/glob.ts
+++ b/packages/server/src/tools/core/glob.ts
@@ -71,7 +71,7 @@ function createGlobTool() {
 }
 
 function getPatternTargets(input: unknown): string[] {
-  const target = (input as { path?: unknown })?.path;
+  const target = (input as { path?: unknown }).path;
   return typeof target === 'string' && target.length > 0 ? [target] : [];
 }
 

--- a/packages/server/src/tools/core/grep.ts
+++ b/packages/server/src/tools/core/grep.ts
@@ -163,7 +163,7 @@ function createGrepTool() {
 }
 
 function getPatternTargets(input: unknown): string[] {
-  const target = (input as { path?: unknown })?.path;
+  const target = (input as { path?: unknown }).path;
   return typeof target === 'string' && target.length > 0 ? [target] : [];
 }
 

--- a/packages/server/src/tools/core/inspect-image.ts
+++ b/packages/server/src/tools/core/inspect-image.ts
@@ -182,7 +182,7 @@ export function createInspectImageTool(context: ToolContext, deps: InspectImageT
           .from(messages)
           .where(and(eq(messages.sessionId, childSessionId), eq(messages.id, assistantMessageId)));
 
-        const assistantMessage = childMessages[0];
+        const assistantMessage = childMessages.at(0);
         let summary = 'Image inspection completed.';
 
         if (assistantMessage?.parts) {

--- a/packages/server/src/tools/core/task.ts
+++ b/packages/server/src/tools/core/task.ts
@@ -149,7 +149,7 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
           .from(messages)
           .where(and(eq(messages.sessionId, childSessionId), eq(messages.id, assistantMessageId)));
 
-        const assistantMessage = childMessages[0];
+        const assistantMessage = childMessages.at(0);
         let summary = 'Task completed.';
 
         if (assistantMessage?.parts) {

--- a/packages/server/src/tools/core/webfetch.ts
+++ b/packages/server/src/tools/core/webfetch.ts
@@ -54,7 +54,7 @@ function toSafeTimeoutMs(timeoutSeconds: number | undefined): number {
 
 function parseContentType(contentType: string | null): { mime: string; full: string } {
   const full = contentType ?? '';
-  const mime = full.split(';')[0]?.trim().toLowerCase() ?? '';
+  const mime = full.split(';').at(0)?.trim().toLowerCase() ?? '';
   return { mime, full };
 }
 
@@ -96,9 +96,9 @@ function normalizeHostForSuggestion(hostname: string): string {
   if (labels.length < 2) return host;
 
   const secondLevelTlds = new Set(['co.uk', 'org.uk', 'ac.uk', 'gov.uk', 'com.au', 'co.jp']);
-  const lastTwo = `${labels[labels.length - 2]}.${labels[labels.length - 1]}`;
+  const lastTwo = `${labels.at(-2)}.${labels.at(-1)}`;
   if (secondLevelTlds.has(lastTwo) && labels.length >= 3) {
-    return `${labels[labels.length - 3]}.${lastTwo}`;
+    return `${labels.at(-3)}.${lastTwo}`;
   }
 
   return lastTwo;
@@ -215,14 +215,14 @@ Parameter sourcing:
 }
 
 function getPatternTargets(input: unknown): string[] {
-  const url = (input as { url?: unknown })?.url;
+  const url = (input as { url?: unknown }).url;
   if (typeof url !== 'string' || url.length === 0) return [];
   const domain = extractDomainForPermission(url);
   return domain ? [domain] : [];
 }
 
 function getSuggestion(input: unknown) {
-  const url = (input as { url?: unknown })?.url;
+  const url = (input as { url?: unknown }).url;
   if (typeof url !== 'string' || url.length === 0) return null;
   const domain = extractDomainForPermission(url);
   if (!domain) return null;

--- a/packages/server/src/tools/enabled-service.ts
+++ b/packages/server/src/tools/enabled-service.ts
@@ -41,10 +41,11 @@ export async function isToolEnabled(opts: { scope: ToolEnabledScope; identifier:
   }
 
   const db = getDb();
-  const [row] = await db
+  const rows = await db
     .select({ enabled: toolEnabled.enabled })
     .from(toolEnabled)
     .where(and(eq(toolEnabled.scope, opts.scope), eq(toolEnabled.identifier, opts.identifier)));
+  const row = rows.at(0);
 
   return row?.enabled ?? true;
 }

--- a/packages/server/src/tools/runtime/bash-families.ts
+++ b/packages/server/src/tools/runtime/bash-families.ts
@@ -149,7 +149,8 @@ export function deriveCommandFamilies(command: string): CommandFamily[] {
 }
 
 export function getCommandFamilySuggestion(command: string): PermissionSuggestion | null {
-  const firstFamily = deriveCommandFamilies(command)[0];
+  const families = deriveCommandFamilies(command);
+  const firstFamily = families.at(0);
   if (!firstFamily) return null;
 
   return { message: `Always allow: ${firstFamily.description}`, pattern: firstFamily.pattern };

--- a/packages/server/src/tools/runtime/file-permissions.ts
+++ b/packages/server/src/tools/runtime/file-permissions.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { PermissionSuggestion } from '@stitch/shared/permissions/types';
 
 function resolveAbsoluteFilePath(input: unknown): string | null {
-  const filePath = (input as { filePath?: unknown })?.filePath;
+  const filePath = (input as { filePath?: unknown }).filePath;
   if (typeof filePath !== 'string' || filePath.length === 0) return null;
   if (!path.isAbsolute(filePath)) return null;
   return path.resolve(filePath);

--- a/packages/server/src/tools/runtime/middleware.ts
+++ b/packages/server/src/tools/runtime/middleware.ts
@@ -126,7 +126,7 @@ export function permissionMiddleware(): ToolMiddleware {
       systemReminder: 'Tool execution requires user approval',
       suggestion: behavior.getSuggestion(input.args),
       dedupeKey: createPermissionDedupeKey(input, patternTargets),
-      abortSignal: meta?.abortSignal,
+      abortSignal: meta.abortSignal,
     });
 
     if (decision.decision === 'allow') {

--- a/packages/server/src/tools/runtime/runtime.test.ts
+++ b/packages/server/src/tools/runtime/runtime.test.ts
@@ -49,6 +49,6 @@ describe('tool runtime', () => {
     ]);
 
     expect(Object.keys(tools)).toEqual(['example']);
-    expect(tools.example?.execute?.({}, {} as never)).resolves.toBe('ok');
+    expect(tools.example.execute?.({}, {} as never)).resolves.toBe('ok');
   });
 });

--- a/packages/server/src/tools/runtime/runtime.ts
+++ b/packages/server/src/tools/runtime/runtime.ts
@@ -74,7 +74,7 @@ export function createToolRuntime(context: ToolRuntimeContext): ToolRuntime {
       return {
         ...tool,
         execute: async (...args: Parameters<typeof originalExecute>) =>
-          executor({ toolName: name, args: args[0], executeOptions: args[1], tool, context, metadata }),
+          executor({ toolName: name, args: args.at(0), executeOptions: args.at(1), tool, context, metadata }),
       } as T;
     },
 

--- a/packages/server/src/tools/runtime/shared.ts
+++ b/packages/server/src/tools/runtime/shared.ts
@@ -69,8 +69,8 @@ function detectTextEncoding(buffer: Buffer): TextEncoding | null {
   if (buffer.length === 0) return 'utf-8';
 
   if (buffer.length >= 2) {
-    if (buffer[0] === 0xff && buffer[1] === 0xfe) return 'utf-16le';
-    if (buffer[0] === 0xfe && buffer[1] === 0xff) return 'utf-16be';
+    if (buffer.at(0) === 0xff && buffer.at(1) === 0xfe) return 'utf-16le';
+    if (buffer.at(0) === 0xfe && buffer.at(1) === 0xff) return 'utf-16be';
   }
 
   let evenNulCount = 0;

--- a/packages/server/src/tools/toolsets/browser/index.ts
+++ b/packages/server/src/tools/toolsets/browser/index.ts
@@ -246,7 +246,7 @@ function createBatchTool(context: ToolContext) {
           ? `Batch executed ${executed}/${total} action(s). ${stoppedReason}`
           : `Batch executed ${executed}/${total} action(s) successfully.`;
         const resultLines = results.map((result) => {
-          const action = input.actions[result.index - 1];
+          const action = input.actions[result.index - 1] as (typeof input.actions)[number] | undefined;
           const label = action
             ? `${result.index}. ${action.tool}${action.op ? `.${action.op}` : ''}`
             : `${result.index}. action`;

--- a/packages/server/src/tools/toolsets/browser/operations.ts
+++ b/packages/server/src/tools/toolsets/browser/operations.ts
@@ -1,6 +1,5 @@
 import { getBrowserManager } from '@/lib/browser/browser-manager.js';
 import type { ScrollDirection } from '@/lib/browser/types.js';
-import { ToolError } from '@/tools/errors.js';
 import { BrowserInvalidOpError, BrowserMissingFieldError } from '@/tools/toolsets/browser/errors.js';
 import {
   formatDropdownOptionsSummary,
@@ -207,52 +206,48 @@ export async function executeOperation(input: OperationInput, signal?: AbortSign
     throw new BrowserInvalidOpError('dialog', op);
   }
 
-  if (input.tool === 'content') {
-    const op = getRequiredOp(input);
-    switch (op) {
-      case 'extract': {
-        const content = await browser.extractPageContent(signal, {
-          selector: input.selector,
-          query: input.query,
-          includeLinks: input.includeLinks,
-          includeImages: input.includeImages,
-          outputSchema: input.outputSchema,
-        });
-        const selectorNote = input.selector ? `\n**Selector:** ${input.selector}` : '';
-        return { output: `${formatExtractContent(input.query, content)}${selectorNote}` };
-      }
-      case 'search_page': {
-        if (!input.pattern) throw new BrowserMissingFieldError('content', 'pattern');
-        const result = await browser.searchPage(
-          {
-            pattern: input.pattern,
-            regex: input.regex,
-            caseSensitive: input.caseSensitive,
-            contextChars: input.contextChars,
-            cssScope: input.cssScope,
-            maxResults: input.maxResults,
-          },
-          signal,
-        );
-        return { output: formatSearchPageSummary(input.pattern, result) };
-      }
-      case 'find_elements': {
-        if (!input.selector) throw new BrowserMissingFieldError('content', 'selector');
-        const result = await browser.findElements(
-          {
-            selector: input.selector,
-            attributes: input.attributes,
-            maxResults: input.maxResults,
-            includeText: input.includeText,
-          },
-          signal,
-        );
-        return { output: formatFindElementsSummary(input.selector, result) };
-      }
-      default:
-        throw new BrowserInvalidOpError('content', op);
+  const op = getRequiredOp(input);
+  switch (op) {
+    case 'extract': {
+      const content = await browser.extractPageContent(signal, {
+        selector: input.selector,
+        query: input.query,
+        includeLinks: input.includeLinks,
+        includeImages: input.includeImages,
+        outputSchema: input.outputSchema,
+      });
+      const selectorNote = input.selector ? `\n**Selector:** ${input.selector}` : '';
+      return { output: `${formatExtractContent(input.query, content)}${selectorNote}` };
     }
+    case 'search_page': {
+      if (!input.pattern) throw new BrowserMissingFieldError('content', 'pattern');
+      const result = await browser.searchPage(
+        {
+          pattern: input.pattern,
+          regex: input.regex,
+          caseSensitive: input.caseSensitive,
+          contextChars: input.contextChars,
+          cssScope: input.cssScope,
+          maxResults: input.maxResults,
+        },
+        signal,
+      );
+      return { output: formatSearchPageSummary(input.pattern, result) };
+    }
+    case 'find_elements': {
+      if (!input.selector) throw new BrowserMissingFieldError('content', 'selector');
+      const result = await browser.findElements(
+        {
+          selector: input.selector,
+          attributes: input.attributes,
+          maxResults: input.maxResults,
+          includeText: input.includeText,
+        },
+        signal,
+      );
+      return { output: formatFindElementsSummary(input.selector, result) };
+    }
+    default:
+      throw new BrowserInvalidOpError('content', op);
   }
-
-  throw new ToolError('Unsupported batch tool.');
 }

--- a/packages/server/src/usage/cost.ts
+++ b/packages/server/src/usage/cost.ts
@@ -1,3 +1,4 @@
+import { ResolvedEmbeddingProvider } from '@/models/embedding/schema';
 import * as EmbeddingModels from '@/models/embedding/service.js';
 import * as Models from '@/models/llm/registry.js';
 import { normalizeUsage } from '@/utils/usage.js';
@@ -22,7 +23,8 @@ export async function calculateMessageCostUsd(input: {
   providers?: Awaited<ReturnType<typeof Models.get>>;
 }): Promise<number> {
   const providers = input.providers ?? (await Models.get());
-  const model = providers[input.providerId]?.models[input.modelId];
+  const provider = providers[input.providerId] as Models.RawProvider | undefined;
+  const model = provider?.models[input.modelId];
   const modelCost = model?.cost;
   if (!modelCost) {
     return 0;
@@ -47,7 +49,8 @@ export async function calculateEmbeddingCostUsd(input: {
   tokens: number;
 }): Promise<number> {
   const providers = await EmbeddingModels.getEmbeddingModels();
-  const model = providers[input.providerId]?.models[input.modelId];
+  const provider = providers[input.providerId] as ResolvedEmbeddingProvider | undefined;
+  const model = provider?.models[input.modelId];
   if (!model) return 0;
 
   const costUsd = (input.tokens * model.cost.input) / TOKENS_PER_MILLION;

--- a/packages/server/src/usage/ledger.test.ts
+++ b/packages/server/src/usage/ledger.test.ts
@@ -85,9 +85,9 @@ describe('recordLlmUsage', () => {
     const events = await db.select().from(llmUsageEvents).where(eq(llmUsageEvents.source, 'compaction'));
 
     expect(events.length).toBe(1);
-    expect(events[0]?.source).toBe('compaction');
-    expect(events[0]?.inputTokens).toBe(100);
-    expect(events[0]?.outputTokens).toBe(50);
+    expect(events.at(0)?.source).toBe('compaction');
+    expect(events.at(0)?.inputTokens).toBe(100);
+    expect(events.at(0)?.outputTokens).toBe(50);
   });
 
   test('writes correct status and metadata fields', async () => {
@@ -116,8 +116,8 @@ describe('recordLlmUsage', () => {
     const events = await db.select().from(llmUsageEvents).where(eq(llmUsageEvents.source, 'title_generation'));
 
     expect(events.length).toBe(1);
-    expect(events[0]?.status).toBe('failed');
-    expect(events[0]?.errorCode).toBe('rate_limit');
-    expect(events[0]?.durationMs).toBe(100);
+    expect(events.at(0)?.status).toBe('failed');
+    expect(events.at(0)?.errorCode).toBe('rate_limit');
+    expect(events.at(0)?.durationMs).toBe(100);
   });
 });

--- a/packages/server/src/usage/service.ts
+++ b/packages/server/src/usage/service.ts
@@ -223,7 +223,7 @@ async function getEarliestUsageTimestamp(): Promise<number | null> {
     .orderBy(asc(recordingAnalyses.startedAt))
     .limit(1);
 
-  const timestamps = [firstEvent[0]?.createdAt, firstRecordingAnalysis[0]?.createdAt].filter(
+  const timestamps = [firstEvent.at(0)?.createdAt, firstRecordingAnalysis.at(0)?.createdAt].filter(
     (value): value is number => typeof value === 'number',
   );
 
@@ -353,7 +353,6 @@ export async function getUsageDashboard(input: GetUsageDashboardInput): Promise<
     if (bucketIndex === undefined) return;
 
     const bucket = buckets[bucketIndex];
-    if (!bucket) return;
 
     bucket.costUsdBySource[args.source] = (bucket.costUsdBySource[args.source] ?? 0) + costUsd;
   };
@@ -448,7 +447,7 @@ export async function getSttUsageDashboard(
     usedModelKeys.add(`${row.providerId}::${row.modelId}`);
 
     const service = row.service;
-    const costUsd = row.costUsd ?? 0;
+    const costUsd = row.costUsd;
     const durationMs = row.rawData?.durationMs ?? 0;
 
     serviceSet.add(service);
@@ -460,7 +459,6 @@ export async function getSttUsageDashboard(
     if (bucketIndex === undefined) continue;
 
     const bucket = buckets[bucketIndex];
-    if (!bucket) continue;
 
     bucket.costUsdByService[service] = (bucket.costUsdByService[service] ?? 0) + costUsd;
     bucket.durationMsByService[service] = (bucket.durationMsByService[service] ?? 0) + durationMs;

--- a/packages/server/src/utils/usage.ts
+++ b/packages/server/src/utils/usage.ts
@@ -21,11 +21,11 @@ function safe(value: number | null | undefined): number {
 export function normalizeUsage(usage: LanguageModelUsage | null | undefined): NormalizedUsage {
   const inputTokens = safe(usage?.inputTokens);
   const outputTokens = safe(usage?.outputTokens);
-  const reasoningTokens = safe(usage?.outputTokenDetails?.reasoningTokens);
-  const cacheReadTokens = safe(usage?.inputTokenDetails?.cacheReadTokens);
-  const cacheWriteTokens = safe(usage?.inputTokenDetails?.cacheWriteTokens);
+  const reasoningTokens = safe(usage?.outputTokenDetails.reasoningTokens);
+  const cacheReadTokens = safe(usage?.inputTokenDetails.cacheReadTokens);
+  const cacheWriteTokens = safe(usage?.inputTokenDetails.cacheWriteTokens);
   const noCacheTokens =
-    usage?.inputTokenDetails?.noCacheTokens !== undefined
+    usage?.inputTokenDetails.noCacheTokens !== undefined
       ? safe(usage.inputTokenDetails.noCacheTokens)
       : Math.max(0, inputTokens - cacheReadTokens - cacheWriteTokens);
   const providedTotalTokens = safe(usage?.totalTokens);
@@ -51,7 +51,7 @@ export function addUsage(a: LanguageModelUsage, b: LanguageModelUsage): Language
       cacheWriteTokens: usageA.cacheWriteTokens + usageB.cacheWriteTokens,
     },
     outputTokenDetails: {
-      textTokens: safe(a.outputTokenDetails?.textTokens) + safe(b.outputTokenDetails?.textTokens),
+      textTokens: safe(a.outputTokenDetails.textTokens) + safe(b.outputTokenDetails.textTokens),
       reasoningTokens: usageA.reasoningTokens + usageB.reasoningTokens,
     },
   };

--- a/packages/shared/src/providers/model-visibility.ts
+++ b/packages/shared/src/providers/model-visibility.ts
@@ -49,7 +49,7 @@ export function buildDefaultVisibleSet(providers: ProviderModelGroup[]): Set<str
           if (!m.release_date) return best;
           const t = Date.parse(m.release_date);
           if (isNaN(t)) return best;
-          const bestT = best.release_date ? (Date.parse(best.release_date) ?? 0) : 0;
+          const bestT = best.release_date ? Date.parse(best.release_date) : 0;
           return t > bestT ? m : best;
         });
 

--- a/scripts/check-design-system.ts
+++ b/scripts/check-design-system.ts
@@ -41,7 +41,7 @@ const normalizedSpacing = new Map(
 );
 
 function matches(source: string, pattern: RegExp) {
-  return new Set([...source.matchAll(pattern)].map((match) => match[1]));
+  return new Set([...source.matchAll(pattern)].map((match) => match.at(1)));
 }
 
 function collectDrift(files: string[]) {
@@ -71,7 +71,11 @@ function collectDrift(files: string[]) {
     for (const value of matches(source, new RegExp(String.raw`\b((?:duration|ease)-${UTILITY})`, 'g')))
       axes.motion.add(value);
     for (const element of source.matchAll(/<(?:p|span)\b[^>]*>/gs)) {
-      const tokens = element[0].match(/[^\s"'`{}]+/g)?.filter((token) => typographyTokens.test(token)) ?? [];
+      const tokens =
+        element
+          .at(0)
+          .match(/[^\s"'`{}]+/g)
+          ?.filter((token) => typographyTokens.test(token)) ?? [];
       if (tokens.length > 0) axes.typography.add([...new Set(tokens)].toSorted().join(' '));
     }
   }

--- a/scripts/format-changed.ts
+++ b/scripts/format-changed.ts
@@ -18,4 +18,4 @@ const cmd = checkOnly
   : ['oxfmt', 'write', '--no-error-on-unmatched-pattern', ...files];
 
 const fmt = spawnSync(cmd, { stdout: 'inherit', stderr: 'inherit' });
-process.exit(fmt.exitCode ?? 0);
+process.exit(fmt.exitCode);

--- a/scripts/stats.ts
+++ b/scripts/stats.ts
@@ -36,7 +36,7 @@ async function fetchReleases(): Promise<Release[]> {
   let page = 1;
   const per = 100;
 
-  while (true) {
+  for (;;) {
     const url = `https://api.github.com/repos/UseStitch/stitch/releases?page=${page}&per_page=${per}`;
     const response = await fetch(url);
 
@@ -176,7 +176,7 @@ async function fetchCloudflareRegistryStats(): Promise<RegistryStats | null> {
     throw new Error(`Cloudflare GraphQL error: ${payload.errors.map((error) => error.message).join(', ')}`);
   }
 
-  const groups = payload.data?.viewer.zones[0]?.httpRequestsAdaptiveGroups ?? [];
+  const groups = payload.data?.viewer.zones.at(0)?.httpRequestsAdaptiveGroups ?? [];
   return aggregateRegistryStats(groups, since.toISOString(), until.toISOString());
 }
 


### PR DESCRIPTION
## Change Summary

Makes `window.api` (the Electron desktop bridge) non-optional in the TypeScript type system and removes all unnecessary nullish checks across the web app. The bridge is always injected by the preload script before the renderer process boots, so the optional typing was overly defensive and led to ~70 scattered `?.` chains that added noise without providing safety.

### New Features
- **Runtime assertion**: `main.tsx` now throws immediately if the bridge is somehow missing, providing a clear error instead of silent undefined behavior

### Improvements & Refactors
- **Non-optional `window.api`**: Changed from `api?: DesktopBridge` to `api: DesktopBridge` in the global Window interface declaration
- **Removed 70+ unnecessary optional chains**: All `window.api?.`, `window.api.subsystem?.`, and `window.api.subsystem.method?.()` patterns cleaned up across 22 files
- **Removed dead fallback code**: localStorage telemetry persistence, `DEV_FALLBACK_URL`, and `serverRequest` fallbacks in recording start/stop that could never be reached
- **Added `typescript/no-unnecessary-condition`** lint rule to oxlint to prevent regressions
