### PR TITLE
fix(server): crash in listProvidersWithCapabilities for providers without LLM registry entry

### DIFF
--- a/packages/server/src/provider/service.ts
+++ b/packages/server/src/provider/service.ts
@@ -66,7 +66,7 @@ export async function listProvidersWithCapabilities(): Promise<ServiceResult<Pro
     results.push({
       id,
       name: meta.displayName,
-      api: meta.api ?? llmProviders[id].api,
+      api: meta.api ?? llmProviders[id]?.api,
       enabled: enabledIds.has(id),
       capabilities: [...caps],
     });


### PR DESCRIPTION
## 🚀 Change Summary

Prevents startup crashes when provider capabilities include local providers that do not have an entry in the LLM registry.

### 🐛 Bug Fixes

- Safely reads provider API metadata when building the provider list, allowing providers such as `ollama_local` and `lmstudio_local` to load without throwing.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
