### PR TITLE
fix(telemetry): strip URL properties from PostHog events on desktop

### DIFF
--- a/apps/web/src/lib/telemetry/client.ts
+++ b/apps/web/src/lib/telemetry/client.ts
@@ -103,6 +103,7 @@ async function loadPostHog(key: string): Promise<void> {
       disable_session_recording: true,
       person_profiles: 'never',
       persistence: 'memory',
+      property_denylist: ['$current_url', '$pathname', '$session_entry_current_url', '$session_entry_pathname'],
       loaded: (ph) => {
         if (state) {
           ph.identify(state.clientInstallationId);


### PR DESCRIPTION
## 🚀 Change Summary

Prevents desktop telemetry events from including URL and pathname properties that can expose local application routes.

### 🐛 Bug Fixes

- Adds PostHog's current URL, pathname, session entry URL, and session entry pathname fields to the property denylist.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
