### PR TITLE
fix(web): clip chat input corners

### DIFF
--- a/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
+++ b/apps/web/src/components/chat/chat-input-parts/chat-input-inner.tsx
@@ -155,7 +155,7 @@ export function ChatInputInner({
   return (
     <div
       className={cn(
-        'relative flex flex-col rounded-2xl border border-border-subtle bg-card',
+        'relative flex flex-col overflow-hidden rounded-2xl border border-border-subtle bg-card',
         'transition-all focus-within:border-border focus-within:shadow-md',
         'shadow-sm',
         embedded && 'rounded-none border-0 bg-transparent shadow-none',

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -31,7 +31,7 @@ export function ChatInput({ className, hasDockAbove, embedded, ...props }: ChatI
         fallback={
           <div
             className={cn(
-              'relative flex flex-col rounded-2xl border border-border-subtle bg-card shadow-sm',
+              'relative flex flex-col overflow-hidden rounded-2xl border border-border-subtle bg-card shadow-sm',
               embedded && 'rounded-none border-0 bg-transparent shadow-none',
               hasDockAbove && !embedded && 'rounded-t-none border-t-0',
             )}>


### PR DESCRIPTION
## 🚀 Change Summary

Keeps the chat input's child backgrounds inside its rounded outline so square corners no longer protrude on the new session page.

### 🐛 Bug Fixes

- Clips both the loaded composer and its suspense fallback to their rounded containers.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
