### PR TITLE
fix(web): space reasoning disclosure caret

### DIFF
--- a/apps/web/src/components/chat/message-bubble/reasoning-block.tsx
+++ b/apps/web/src/components/chat/message-bubble/reasoning-block.tsx
@@ -15,7 +15,7 @@ export function ReasoningBlock({ text, isStreaming }: ReasoningBlockProps) {
     <div className="my-space-m overflow-hidden rounded-lg border border-border-subtle bg-surface-sunken">
       <Button
         variant="quiet"
-        size="inline"
+        size="xs"
         width="full"
         align="start"
         onClick={() => setOpen((o) => !o)}


### PR DESCRIPTION
## 🚀 Change Summary

Gives the reasoning disclosure caret more space from the edge of its container.

### 🛠 Improvements & Refactors

- Uses the design system's extra-small button size to add balanced horizontal padding while preserving the existing full-width disclosure layout.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
