### PR TITLE
chore(server): upgrade MCP SDK

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/desktop": {
       "name": "@stitch/desktop",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "dependencies": {
         "@stitch/audio-capture": "workspace:*",
         "@stitch/meeting-detection": "workspace:*",
@@ -40,7 +40,7 @@
     },
     "apps/web": {
       "name": "@stitch/web",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@stitch/scheduler": "workspace:*",
@@ -207,7 +207,7 @@
         "@hono/node-ws": "^1.3.1",
         "@hono/zod-validator": "^0.7.6",
         "@libpdf/core": "^0.3.6",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@openrouter/ai-sdk-provider": "catalog:ai",
         "@stitch-connectors/google": "workspace:*",
         "@stitch-connectors/sdk": "workspace:*",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,7 +22,7 @@
     "@hono/node-ws": "^1.3.1",
     "@hono/zod-validator": "^0.7.6",
     "@libpdf/core": "^0.3.6",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@openrouter/ai-sdk-provider": "catalog:ai",
     "@stitch-connectors/google": "workspace:*",
     "@stitch-connectors/sdk": "workspace:*",


### PR DESCRIPTION
## 🚀 Change Summary

Updates the backend Model Context Protocol SDK to `1.30.0`, providing the elicitation APIs and protocol types required by later changes in this stack.

### 🛠 Improvements & Refactors

- Upgrade `@modelcontextprotocol/sdk` from `1.29.0` to `1.30.0`.
- Refresh the Bun lockfile and workspace package metadata.
