### PR TITLE
fix(web): stream tool call state updates

### DIFF
--- a/apps/web/src/stores/stream-store.test.ts
+++ b/apps/web/src/stores/stream-store.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+import { useStreamStore } from './stream-store.js';
+
+describe('stream store tool state', () => {
+  beforeEach(() => {
+    useStreamStore.setState({ sessions: {} });
+  });
+
+  test('adds and updates a tool call from streamed lifecycle events', () => {
+    const { applyStreamStart, applyToolState } = useStreamStore.getState();
+
+    applyStreamStart('ses_test', 'msg_test');
+    applyToolState('ses_test', 'msg_test', 'tool_test', 'bash', 'pending');
+
+    expect(useStreamStore.getState().sessions.ses_test.parts.tool_test).toMatchObject({
+      type: 'tool-call',
+      toolCallId: 'tool_test',
+      toolName: 'bash',
+      status: 'pending',
+    });
+
+    applyToolState('ses_test', 'msg_test', 'tool_test', 'bash', 'in-progress', { command: 'pwd' });
+
+    expect(useStreamStore.getState().sessions.ses_test.parts.tool_test).toMatchObject({
+      status: 'in-progress',
+      input: { command: 'pwd' },
+    });
+  });
+});

--- a/apps/web/src/stores/stream-store.ts
+++ b/apps/web/src/stores/stream-store.ts
@@ -163,7 +163,7 @@ function applyPartUpdateToSession(session: SessionStreamState, partId: string, p
 
     case 'tool-call': {
       const existing = session.parts[partId];
-      if (existing.type === 'tool-call') {
+      if (partId in session.parts && existing.type === 'tool-call') {
         return updatePart(session, partId, { ...existing, input: part.input });
       }
       return addPart(session, partId, {
@@ -276,7 +276,7 @@ export const useStreamStore = create<StreamStoreState & StreamStoreActions>()((s
 
       const existing = session.parts[toolCallId];
 
-      if (existing.type === 'tool-call') {
+      if (toolCallId in session.parts && existing.type === 'tool-call') {
         return {
           sessions: {
             ...state.sessions,


### PR DESCRIPTION
## 🚀 Change Summary

Fixes streamed MCP and core tool calls failing to enter or update their pending and in-progress UI states when no prior part exists.

### 🐛 Bug Fixes

- Check that a tool-call part exists before treating it as an existing streamed part.
- Preserve subsequent tool input and lifecycle updates after the initial tool-call state is created.
- Add regression coverage for adding and updating streamed tool calls.
