### PR TITLE
chore(lint): enable typescript/no-deprecated rule and fix violations

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, dialog, session, type BrowserWindow } from 'electron';
 
 import { ElectronBrowserManager } from './browser/browser-manager.js';
 import { registerBrowserHandlers } from './ipc/browser.js';
+import { registerClipboardHandlers } from './ipc/clipboard.js';
 import { registerDevtoolsHandlers } from './ipc/devtools.js';
 import { registerFilesHandlers } from './ipc/files.js';
 import { registerPermissionsHandlers } from './ipc/permissions.js';
@@ -102,6 +103,7 @@ function registerAllIpcHandlers(): void {
   registerWindowHandlers(getWindow);
   if (browserManager) registerBrowserHandlers(browserManager);
   registerDevtoolsHandlers(getWindow);
+  registerClipboardHandlers(getWindow);
   registerSpellcheckHandlers(getWindow);
   registerShellHandlers();
   registerFilesHandlers();

--- a/apps/desktop/src/main/ipc/clipboard.ts
+++ b/apps/desktop/src/main/ipc/clipboard.ts
@@ -1,0 +1,17 @@
+import { registerIpcHandler } from './register.js';
+
+import type { BrowserWindow } from 'electron';
+
+export function registerClipboardHandlers(getWindow: () => BrowserWindow | null): void {
+  registerIpcHandler('clipboard:cut', () => {
+    getWindow()?.webContents.cut();
+  });
+
+  registerIpcHandler('clipboard:copy', () => {
+    getWindow()?.webContents.copy();
+  });
+
+  registerIpcHandler('clipboard:paste', () => {
+    getWindow()?.webContents.paste();
+  });
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -64,6 +64,11 @@ const api = {
     toggle: () => invokeIpc('devtools:toggle'),
     inspect: (x: number, y: number) => invokeIpc('devtools:inspect', x, y),
   },
+  clipboard: {
+    cut: () => invokeIpc('clipboard:cut'),
+    copy: () => invokeIpc('clipboard:copy'),
+    paste: () => invokeIpc('clipboard:paste'),
+  },
   shell: { openExternal: (url: string) => invokeIpc('shell:openExternal', url) },
   files: {
     writeTmp: (data: ArrayBuffer, ext: string) => invokeIpc('files:writeTmp', data, ext),

--- a/apps/web/src/components/automations/automation-dialog.tsx
+++ b/apps/web/src/components/automations/automation-dialog.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { z } from 'zod';
 
-import { useForm, useStore } from '@tanstack/react-form';
+import { useForm, useSelector } from '@tanstack/react-form';
 
 import type { Automation, AutomationSchedule, GeneratedAutomationDraft } from '@stitch/shared/automations/types';
 
@@ -172,7 +172,7 @@ function AutomationForm({
     if (form.getFieldValue('modelId') !== modelId) form.setFieldValue('modelId', modelId);
   }, [form, providerModels]);
 
-  const values = useStore(form.store, (state) => state.values);
+  const values = useSelector(form.store, (state) => state.values);
 
   const selectedProvider = providerModels.find((provider) => provider.providerId === values.providerId) ?? null;
   const availableModels = selectedProvider?.models ?? [];

--- a/apps/web/src/components/browser/browser-panel.tsx
+++ b/apps/web/src/components/browser/browser-panel.tsx
@@ -79,7 +79,7 @@ export function BrowserPanel({ sessionId, onClose }: BrowserPanelProps) {
     };
   }, [registerWebview]);
 
-  const submitAddress = (event: React.FormEvent<HTMLFormElement>) => {
+  const submitAddress = (event: React.SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
     void window.api.browser.userNavigate(address);
   };

--- a/apps/web/src/components/chat/docks/mcp-elicitation-dock.tsx
+++ b/apps/web/src/components/chat/docks/mcp-elicitation-dock.tsx
@@ -129,7 +129,7 @@ export function McpElicitationDock({ request, isPending, onRespond }: McpElicita
     setValues((current) => ({ ...current, [name]: value }));
   }
 
-  function submit(event: React.FormEvent<HTMLFormElement>) {
+  function submit(event: React.SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
     const content = Object.fromEntries(
       Object.entries(values).filter(

--- a/apps/web/src/components/chat/docks/question-dock.tsx
+++ b/apps/web/src/components/chat/docks/question-dock.tsx
@@ -63,7 +63,7 @@ export function QuestionDock({ request, onReply, onReject }: QuestionDockProps) 
     setCustomAnswers(newCustomAnswers);
   }
 
-  function handleSubmit(event?: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(event?: React.SubmitEvent<HTMLFormElement>) {
     event?.preventDefault();
     const finalAnswers = answers.map((a, i) => {
       const customAnswer = customAnswers[i]?.trim();

--- a/apps/web/src/components/connectors/setup-wizard.tsx
+++ b/apps/web/src/components/connectors/setup-wizard.tsx
@@ -3,7 +3,7 @@ import { useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { z } from 'zod';
 
-import { useForm, useStore } from '@tanstack/react-form';
+import { useForm, useSelector } from '@tanstack/react-form';
 
 import type {
   ConnectorDefinition,
@@ -390,7 +390,7 @@ function ConnectorCredentialsStep({
     },
     onSubmit: ({ value }) => onNext(value),
   });
-  const values = useStore(form.store, (state) => state.values);
+  const values = useSelector(form.store, (state) => state.values);
   const isCreatingConnector = values.selectedConnectorRefId === 'new';
 
   return (
@@ -621,7 +621,7 @@ function ScopesStep({
     validators: { onMount: scopesSchema(config), onChange: scopesSchema(config) },
     onSubmit: ({ value }) => onNext({ ...value, selectedScopes: getComputedScopes(config, value) }),
   });
-  const values = useStore(form.store, (state) => state.values);
+  const values = useSelector(form.store, (state) => state.values);
   const { selectedScopes, serviceAccess } = values;
   const selectedScopeSet = useMemo(() => new Set(selectedScopes), [selectedScopes]);
   const computedScopes = getComputedScopes(config, values);

--- a/apps/web/src/components/mail/composer.tsx
+++ b/apps/web/src/components/mail/composer.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { toast } from 'sonner';
 import { z } from 'zod';
 
-import { useForm, useStore } from '@tanstack/react-form';
+import { useForm, useSelector } from '@tanstack/react-form';
 
 import type {
   MailAccountId,
@@ -136,7 +136,7 @@ export function Composer({ accountId, draft, replyTo, onClose }: ComposerProps) 
     },
   });
 
-  const values = useStore(form.store, (state) => state.values);
+  const values = useSelector(form.store, (state) => state.values);
   const autosaveDraft = React.useEffectEvent((nextValues: ComposerValues) => {
     void persistDraft(nextValues).catch(() => undefined);
   });

--- a/apps/web/src/components/navigation/right-click-menu.tsx
+++ b/apps/web/src/components/navigation/right-click-menu.tsx
@@ -188,15 +188,15 @@ export function RightClickMenu({ children }: RightClickMenuProps) {
   };
 
   const handleCut = () => {
-    document.execCommand('cut');
+    void window.api.clipboard.cut();
     close();
   };
   const handleCopy = () => {
-    document.execCommand('copy');
+    void window.api.clipboard.copy();
     close();
   };
   const handlePaste = () => {
-    document.execCommand('paste');
+    void window.api.clipboard.paste();
     close();
   };
   const handleOpenDevTools = () => {

--- a/apps/web/src/components/onboarding/steps/profile-step.tsx
+++ b/apps/web/src/components/onboarding/steps/profile-step.tsx
@@ -43,7 +43,7 @@ export function ProfileStep({ initialName, initialTimezone, isSaving, onContinue
   const hasError = touched && trimmed.length === 0;
   const hasTimezoneError = touched && trimmedTimezone.length === 0;
 
-  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+  function handleSubmit(event: React.SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
     setTouched(true);
     if (trimmed.length === 0 || trimmedTimezone.length === 0) return;

--- a/apps/web/src/components/settings/mcp-servers/add-custom-mcp-server.tsx
+++ b/apps/web/src/components/settings/mcp-servers/add-custom-mcp-server.tsx
@@ -1,6 +1,6 @@
 import { toast } from 'sonner';
 
-import { useForm, useStore } from '@tanstack/react-form';
+import { useForm, useSelector } from '@tanstack/react-form';
 
 import { MCP_AUTH_TYPES } from '@stitch/shared/mcp/types';
 
@@ -54,7 +54,7 @@ export function AddCustomMcpServer({ onBack }: { onBack: () => void }) {
     },
   });
 
-  const values = useStore(form.store, (state) => state.values);
+  const values = useSelector(form.store, (state) => state.values);
   const set = (key: 'oauthScopes' | 'oauthClientId' | 'oauthClientSecret', value: string) => {
     form.setFieldValue(key, value);
   };

--- a/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
+++ b/apps/web/src/components/settings/mcp-servers/install-registry-mcp-server.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { toast } from 'sonner';
 
-import { useForm, useStore } from '@tanstack/react-form';
+import { useForm, useSelector } from '@tanstack/react-form';
 
 import { MCP_AUTH_TYPES } from '@stitch/shared/mcp/types';
 import type { McpRegistryServer } from '@stitch/shared/mcp/types';
@@ -88,7 +88,7 @@ export function InstallRegistryMcpServer({
     },
   });
 
-  const values = useStore(form.store, (state) => state.values);
+  const values = useSelector(form.store, (state) => state.values);
   const set = (key: 'oauthScopes' | 'oauthClientId' | 'oauthClientSecret', value: string) => {
     form.setFieldValue(key, value);
   };

--- a/apps/web/src/components/settings/providers/local-models-panel.tsx
+++ b/apps/web/src/components/settings/providers/local-models-panel.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { toast } from 'sonner';
 import { z } from 'zod';
 
-import { useForm, useStore } from '@tanstack/react-form';
+import { useForm, useSelector } from '@tanstack/react-form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { LocalProviderId } from '@stitch/shared/providers/types';
@@ -171,7 +171,7 @@ function ModelForm({
     validators: { onMount: modelFormSchema, onChange: modelFormSchema },
     onSubmit: ({ value }) => onSave(formToInput(value)),
   });
-  const values = useStore(form.store, (state) => state.values);
+  const values = useSelector(form.store, (state) => state.values);
 
   return (
     <div className="rounded-md border p-space-xl">

--- a/apps/web/src/components/settings/recordings.tsx
+++ b/apps/web/src/components/settings/recordings.tsx
@@ -2,7 +2,7 @@ import { HelpCircleIcon, PlusIcon, SaveIcon, TrashIcon } from 'lucide-react';
 import * as React from 'react';
 import { z } from 'zod';
 
-import { useForm, useStore } from '@tanstack/react-form';
+import { useForm, useSelector } from '@tanstack/react-form';
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 
 import type { MeetingNoteTemplate } from '@stitch/shared/recordings/types';
@@ -386,7 +386,7 @@ function MeetingNoteTemplatesSettings() {
       updateMutation.mutate({ id: selectedTemplate.id, template: value });
     },
   });
-  const content = useStore(form.store, (state) => state.values.content);
+  const content = useSelector(form.store, (state) => state.values.content);
 
   if (!selectedId && data.templates[0]) {
     setSelectedId(data.templates[0].id);

--- a/oxlint.json
+++ b/oxlint.json
@@ -17,6 +17,7 @@
     "no-unused-vars": "error",
     "eqeqeq": "error",
     "no-else-return": "error",
+    "typescript/no-deprecated": "error",
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unnecessary-condition": "error",
     "typescript/no-floating-promises": "error",

--- a/packages/server/src/db/schema/agenda.ts
+++ b/packages/server/src/db/schema/agenda.ts
@@ -4,7 +4,7 @@ import { check, index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-o
 import type { AgendaItemPriority, AgendaItemStatus } from '@stitch/shared/agenda/types';
 import type { PrefixedString } from '@stitch/shared/id';
 
-/** @deprecated Type field is no longer used but kept for DB compatibility */
+// Type field is no longer used but kept for DB compatibility
 type AgendaItemType = 'todo' | 'reminder' | 'checkup';
 
 export const agendaLists = sqliteTable(

--- a/packages/server/src/mcp/registry-service.ts
+++ b/packages/server/src/mcp/registry-service.ts
@@ -36,14 +36,14 @@ const mcpRegistryServerSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
   description: z.string().min(1),
-  homepageUrl: z.string().url().optional(),
-  docsUrl: z.string().url(),
-  logoUrl: z.string().url().optional(),
+  homepageUrl: z.url().optional(),
+  docsUrl: z.url(),
+  logoUrl: z.url().optional(),
   tags: z.array(z.string().min(1)).min(1),
   install: z.object({
     name: z.string().min(1),
     transport: z.enum(['stdio', 'http']),
-    url: z.string().url(),
+    url: z.url(),
     authConfig: authConfigSchema,
     optionalAuthConfigs: z.array(authConfigSchema).optional(),
   }),
@@ -51,7 +51,7 @@ const mcpRegistryServerSchema = z.object({
 
 const mcpRegistryPayloadSchema = z.object({
   version: z.number().int().positive(),
-  generatedAt: z.string().datetime({ offset: true }),
+  generatedAt: z.iso.datetime({ offset: true }),
   servers: z.array(mcpRegistryServerSchema),
 });
 

--- a/packages/server/src/models/embedding/schema.ts
+++ b/packages/server/src/models/embedding/schema.ts
@@ -36,7 +36,7 @@ const EmbeddingProviderSchema = z.object({
 
 export const EmbeddingRegistryPayloadSchema = z.object({
   version: z.number().int().positive(),
-  generatedAt: z.string().datetime({ offset: true }),
+  generatedAt: z.iso.datetime({ offset: true }),
   providers: z.array(EmbeddingProviderSchema).min(1),
 });
 

--- a/packages/server/src/models/llm/local.ts
+++ b/packages/server/src/models/llm/local.ts
@@ -78,7 +78,7 @@ export async function upsertLocalModel(
 ): Promise<ServiceResult<LocalModel>> {
   const parsed = LocalModelInputSchema.safeParse(input);
   if (!parsed.success) {
-    return err('Invalid model data', 400, parsed.error.flatten());
+    return err('Invalid model data', 400, z.treeifyError(parsed.error));
   }
 
   const db = getDb();

--- a/packages/server/src/models/stt/schema.ts
+++ b/packages/server/src/models/stt/schema.ts
@@ -68,7 +68,7 @@ const SttProviderSchema = z.object({
 
 export const SttRegistryPayloadSchema = z.object({
   version: z.number().int().positive(),
-  generatedAt: z.string().datetime({ offset: true }),
+  generatedAt: z.iso.datetime({ offset: true }),
   providers: z.array(SttProviderSchema).min(1),
 });
 

--- a/packages/server/src/provider/config/service.ts
+++ b/packages/server/src/provider/config/service.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import { z } from 'zod';
 
 import { isLocalProviderId } from '@stitch/shared/providers/types';
 
@@ -30,7 +31,7 @@ export async function upsertProviderCredentials(providerId: string, body: unknow
 
   const parsed = ProviderCredentialsSchema.safeParse({ ...(body as Record<string, unknown>), providerId });
   if (!parsed.success) {
-    return err('Invalid credentials', 400, parsed.error.flatten());
+    return err('Invalid credentials', 400, z.treeifyError(parsed.error));
   }
 
   const db = getDb();

--- a/packages/server/src/routes/mail.ts
+++ b/packages/server/src/routes/mail.ts
@@ -47,7 +47,7 @@ const modifyMessageSchema = z.object({
   markRead: z.boolean().optional(),
 });
 
-const addressSchema = z.object({ name: z.string().nullable(), email: z.string().email() });
+const addressSchema = z.object({ name: z.string().nullable(), email: z.email() });
 
 const draftSchema = z.object({
   accountId: routeSchemas.mailAccountId,

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -43,7 +43,7 @@ const authConfigSchema = z.discriminatedUnion('type', [
 const createMcpServerSchema = z.object({
   name: z.string().trim().min(1),
   transport: z.enum(MCP_TRANSPORT_TYPES),
-  url: z.string().url(),
+  url: z.url(),
   authConfig: authConfigSchema,
 });
 

--- a/packages/shared/src/desktop/bridge.ts
+++ b/packages/shared/src/desktop/bridge.ts
@@ -35,6 +35,7 @@ export type DesktopBridge = {
     isFullScreen: () => Promise<boolean>;
   };
   devtools: { toggle: () => Promise<void>; inspect: (x: number, y: number) => Promise<void> };
+  clipboard: { cut: () => Promise<void>; copy: () => Promise<void>; paste: () => Promise<void> };
   shell: { openExternal: (url: string) => Promise<void> };
   files: { writeTmp: (data: ArrayBuffer, ext: string) => Promise<string>; openPath: () => Promise<string[]> };
   updater: {

--- a/packages/shared/src/ipc/types.ts
+++ b/packages/shared/src/ipc/types.ts
@@ -61,6 +61,9 @@ export interface IpcContract {
   'window:isFullScreen': { args: []; return: boolean };
   'devtools:toggle': { args: []; return: void };
   'devtools:inspect': { args: [x: number, y: number]; return: void };
+  'clipboard:cut': { args: []; return: void };
+  'clipboard:copy': { args: []; return: void };
+  'clipboard:paste': { args: []; return: void };
   'shell:openExternal': { args: [url: string]; return: void };
   'files:writeTmp': { args: [data: ArrayBuffer, ext: string]; return: string };
   'dialog:openPath': { args: []; return: string[] };


### PR DESCRIPTION
## Change Summary

Enables the `typescript/no-deprecated` lint rule and fixes all resulting violations across the codebase.

### Bug Fixes
- **desktop**: Replace deprecated `document.execCommand('cut'|'copy'|'paste')` with an IPC clipboard bridge that calls `webContents.cut()/copy()/paste()` in the main process, matching the existing devtools/spellcheck bridge pattern.
- **web**: Replace deprecated TanStack `useStore` with `useSelector`.
- **web**: Replace deprecated `React.FormEvent` with `React.SubmitEvent` for `onSubmit` handlers.
- **server**: Replace deprecated Zod APIs (`z.string().datetime()/.url()/.email()`, `error.flatten()`) with their v4 equivalents (`z.iso.datetime()`, `z.url()`, `z.email()`, `z.treeifyError()`).
- **server**: Remove a stray `@deprecated` marker from `AgendaItemType`; the field is intentionally kept for DB compatibility, not a deprecated API usage.

### Chores
- Enable `typescript/no-deprecated` in the lint config to catch future deprecated API usage.