### PR TITLE
feat(server): serialize session runs

### DIFF
--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -21,6 +21,11 @@ import { buildSessionLlmMessages } from '@/llm/session-history.js';
 import { compact } from '@/llm/session-summary.js';
 import { cancelDecision, resolveDecision, type DoomLoopResponse } from '@/llm/stream/doom-loop.js';
 import { runStream } from '@/llm/stream/runner.js';
+import {
+  abortActiveSessionRun,
+  cancelQueuedSessionRuns,
+  enqueueSessionRun,
+} from '@/llm/stream/session-run-coordinator.js';
 import { abortMcpElicitations } from '@/mcp/elicitation-service.js';
 import * as LocalModels from '@/models/llm/local.js';
 import * as Models from '@/models/llm/registry.js';
@@ -174,38 +179,33 @@ async function loadTurnContext(
   return ok({ session, config: config as LlmTurnConfig });
 }
 
-async function runTurn(input: {
+function runTurn(input: {
   sessionId: PrefixedString<'ses'>;
   assistantMessageId: string;
   session: TurnSession;
   config: LlmTurnConfig;
   modelId: string;
-}): Promise<void> {
-  const llmMessages = await buildSessionLlmMessages(input.sessionId, { useBasePrompt: true, systemPrompt: null });
-
-  const abortSignal = AbortRegistry.register(input.sessionId);
-
+}): void {
   const isChildSession = input.session.parentSessionId !== null;
 
-  void runStream({
-    sessionId: input.sessionId,
-    assistantMessageId: input.assistantMessageId as PrefixedString<'msg'>,
-    modelId: input.modelId,
-    llmMessages,
-    credentials: input.config.credentials,
-    abortSignal,
-    allowTaskTool: !isChildSession,
-    excludedToolsetIds: isChildSession ? ['browser'] : undefined,
-  })
-    .catch((error) => {
-      log.error(
-        { event: 'stream.failed', sessionId: input.sessionId, messageId: input.assistantMessageId, error },
-        'stream run failed',
-      );
-    })
-    .finally(() => {
-      AbortRegistry.cleanup(input.sessionId);
+  void enqueueSessionRun(input.sessionId, async (abortSignal) => {
+    const llmMessages = await buildSessionLlmMessages(input.sessionId, { useBasePrompt: true, systemPrompt: null });
+    await runStream({
+      sessionId: input.sessionId,
+      assistantMessageId: input.assistantMessageId as PrefixedString<'msg'>,
+      modelId: input.modelId,
+      llmMessages,
+      credentials: input.config.credentials,
+      abortSignal,
+      allowTaskTool: !isChildSession,
+      excludedToolsetIds: isChildSession ? ['browser'] : undefined,
     });
+  }).catch((error) => {
+    log.error(
+      { event: 'stream.failed', sessionId: input.sessionId, messageId: input.assistantMessageId, error },
+      'stream run failed',
+    );
+  });
 }
 
 export async function sendMessage(
@@ -246,7 +246,7 @@ export async function sendMessage(
 
   await db.update(sessions).set({ updatedAt: Date.now() }).where(eq(sessions.id, input.sessionId));
 
-  await runTurn({
+  runTurn({
     sessionId: input.sessionId,
     assistantMessageId: input.assistantMessageId,
     session: context.data.session,
@@ -321,7 +321,7 @@ export async function redoMessage(
     await tx.update(sessions).set({ updatedAt: now }).where(eq(sessions.id, input.sessionId));
   });
 
-  await runTurn({
+  runTurn({
     sessionId: input.sessionId,
     assistantMessageId: input.assistantMessageId,
     session: context.data.session,
@@ -346,7 +346,8 @@ export function resolveDoomLoop(
 
 export async function abortSessionRun(sessionId: PrefixedString<'ses'>): Promise<ServiceResult<null>> {
   log.info({ event: 'stream.abort.requested', sessionId }, 'stream abort requested');
-  AbortRegistry.abort(sessionId);
+  abortActiveSessionRun(sessionId);
+  cancelQueuedSessionRuns(sessionId);
   cancelDecision(sessionId);
 
   const db = getDb();

--- a/packages/server/src/llm/stream/session-run-coordinator.test.ts
+++ b/packages/server/src/llm/stream/session-run-coordinator.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { PrefixedString } from '@stitch/shared/id';
+
+import {
+  abortActiveSessionRun,
+  cancelQueuedSessionRuns,
+  enqueueSessionRun,
+  isSessionRunActive,
+} from '@/llm/stream/session-run-coordinator.js';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('session run coordinator', () => {
+  test('runs same-session work in FIFO order without overlap', async () => {
+    const sessionId = 'ses_fifo' as PrefixedString<'ses'>;
+    const firstRelease = deferred();
+    const events: string[] = [];
+
+    const first = enqueueSessionRun(sessionId, async () => {
+      events.push('first-start');
+      await firstRelease.promise;
+      events.push('first-end');
+    });
+    const second = enqueueSessionRun(sessionId, () => {
+      events.push('second');
+      return Promise.resolve();
+    });
+
+    await Promise.resolve();
+    expect(events).toEqual(['first-start']);
+    firstRelease.resolve();
+    await Promise.all([first, second]);
+    expect(events).toEqual(['first-start', 'first-end', 'second']);
+  });
+
+  test('runs different sessions concurrently', async () => {
+    const firstRelease = deferred();
+    const secondRelease = deferred();
+    const started: string[] = [];
+
+    const first = enqueueSessionRun('ses_one' as PrefixedString<'ses'>, async () => {
+      started.push('one');
+      await firstRelease.promise;
+    });
+    const second = enqueueSessionRun('ses_two' as PrefixedString<'ses'>, async () => {
+      started.push('two');
+      await secondRelease.promise;
+    });
+
+    await Promise.resolve();
+    expect(started).toEqual(['one', 'two']);
+    firstRelease.resolve();
+    secondRelease.resolve();
+    await Promise.all([first, second]);
+  });
+
+  test('continues after a rejected run', async () => {
+    const sessionId = 'ses_rejection' as PrefixedString<'ses'>;
+    const events: string[] = [];
+
+    const first = enqueueSessionRun(sessionId, () => Promise.reject(new Error('failed')));
+    const second = enqueueSessionRun(sessionId, () => {
+      events.push('second');
+      return Promise.resolve();
+    });
+
+     expect(first).rejects.toThrow('failed');
+    await second;
+    expect(events).toEqual(['second']);
+  });
+
+  test('aborts only the active run and allows queued work to continue', async () => {
+    const sessionId = 'ses_abort' as PrefixedString<'ses'>;
+    let activeSignal: AbortSignal | undefined;
+    let secondRan = false;
+
+    const first = enqueueSessionRun(sessionId, (signal) => {
+      activeSignal = signal;
+      return new Promise<void>((resolve) => signal.addEventListener('abort', () => resolve(), { once: true }));
+    });
+    const second = enqueueSessionRun(sessionId, () => {
+      secondRan = true;
+      return Promise.resolve();
+    });
+
+    await Promise.resolve();
+    expect(isSessionRunActive(sessionId)).toBe(true);
+    abortActiveSessionRun(sessionId);
+    await Promise.all([first, second]);
+    expect(activeSignal?.aborted).toBe(true);
+    expect(secondRan).toBe(true);
+    expect(isSessionRunActive(sessionId)).toBe(false);
+  });
+
+  test('cancels queued work without stopping the active run', async () => {
+    const sessionId = 'ses_cancel_queue' as PrefixedString<'ses'>;
+    const release = deferred();
+    let queuedRan = false;
+
+    const active = enqueueSessionRun(sessionId, () => release.promise);
+    const queued = enqueueSessionRun(sessionId, () => {
+      queuedRan = true;
+      return Promise.resolve();
+    });
+
+    await Promise.resolve();
+    cancelQueuedSessionRuns(sessionId);
+    release.resolve();
+    await Promise.all([active, queued]);
+    expect(queuedRan).toBe(false);
+  });
+});

--- a/packages/server/src/llm/stream/session-run-coordinator.ts
+++ b/packages/server/src/llm/stream/session-run-coordinator.ts
@@ -1,0 +1,68 @@
+import type { PrefixedString } from '@stitch/shared/id';
+
+type SessionRun = (abortSignal: AbortSignal) => Promise<void>;
+
+type QueuedRun = {
+  run: SessionRun;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+};
+
+type SessionQueue = {
+  runs: QueuedRun[];
+  activeController: AbortController | null;
+};
+
+const queues = new Map<PrefixedString<'ses'>, SessionQueue>();
+
+async function runNext(sessionId: PrefixedString<'ses'>, queue: SessionQueue): Promise<void> {
+  const queued = queue.runs.shift();
+  if (!queued) {
+    if (queues.get(sessionId) === queue) queues.delete(sessionId);
+    return;
+  }
+
+  const controller = new AbortController();
+  queue.activeController = controller;
+
+  try {
+    await queued.run(controller.signal);
+    queued.resolve();
+  } catch (error) {
+    queued.reject(error);
+  } finally {
+    queue.activeController = null;
+    void runNext(sessionId, queue);
+  }
+}
+
+export function enqueueSessionRun(sessionId: PrefixedString<'ses'>, run: SessionRun): Promise<void> {
+  let queue = queues.get(sessionId);
+  if (!queue) {
+    queue = { runs: [], activeController: null };
+    queues.set(sessionId, queue);
+  }
+
+  const promise = new Promise<void>((resolve, reject) => {
+    queue.runs.push({ run, resolve, reject });
+  });
+
+  if (!queue.activeController) void runNext(sessionId, queue);
+  return promise;
+}
+
+export function abortActiveSessionRun(sessionId: PrefixedString<'ses'>): void {
+  queues.get(sessionId)?.activeController?.abort();
+}
+
+export function cancelQueuedSessionRuns(sessionId: PrefixedString<'ses'>): void {
+  const queue = queues.get(sessionId);
+  if (!queue) return;
+
+  for (const queued of queue.runs.splice(0)) queued.resolve();
+  if (!queue.activeController) queues.delete(sessionId);
+}
+
+export function isSessionRunActive(sessionId: PrefixedString<'ses'>): boolean {
+  return queues.get(sessionId)?.activeController !== null && queues.has(sessionId);
+}


### PR DESCRIPTION
## Change Summary

Serializes model runs per session so delayed task delivery cannot interrupt or race an active user turn.

### New Features
- Adds a FIFO session run coordinator with independent queues per session.
- Supports aborting active work and cancelling queued work without affecting other sessions.

### Improvements
- Routes foreground chat turns through the same session-level concurrency boundary.
