### PR TITLE
feat(server): run durable background tasks

### DIFF
--- a/packages/server/src/background-tasks/repository.test.ts
+++ b/packages/server/src/background-tasks/repository.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { PrefixedString } from '@stitch/shared/id';
+
+import {
+  claimPendingBackgroundTasks,
+  completeBackgroundTask,
+  failBackgroundTask,
+  getBackgroundTask,
+  insertBackgroundTask,
+  interruptStaleBackgroundTasks,
+  listBackgroundTasks,
+  markBackgroundTaskCancelled,
+  markBackgroundTaskClaimsDelivered,
+  markBackgroundTaskInterrupted,
+  releaseBackgroundTaskClaims,
+} from '@/background-tasks/repository.js';
+import { getDb } from '@/db/client.js';
+import { messages, sessions } from '@/db/schema/sessions.js';
+import { setupTestDb } from '@/db/test-helpers.js';
+
+setupTestDb();
+
+const parentSessionId = 'ses_background_parent' as PrefixedString<'ses'>;
+const childSessionId = 'ses_background_child' as PrefixedString<'ses'>;
+const originMessageId = 'msg_background_origin' as PrefixedString<'msg'>;
+
+async function insertTask(): Promise<void> {
+  const now = Date.now();
+  await getDb()
+    .insert(sessions)
+    .values([
+      { id: parentSessionId, title: 'Parent', createdAt: now, updatedAt: now },
+      { id: childSessionId, title: 'Child', parentSessionId, createdAt: now, updatedAt: now },
+    ]);
+  await getDb()
+    .insert(messages)
+    .values({
+      id: originMessageId,
+      sessionId: parentSessionId,
+      role: 'assistant',
+      parts: [],
+      modelId: 'model',
+      providerId: 'provider',
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+      startedAt: now,
+      duration: null,
+    });
+  await insertBackgroundTask({
+    id: childSessionId,
+    parentSessionId,
+    childSessionId,
+    originMessageId,
+    originToolCallId: 'tool-call',
+    title: 'Child',
+    providerId: 'provider',
+    modelId: 'model',
+    activeToolsetIds: ['github'],
+    startedAt: now,
+  });
+}
+
+describe('background task repository', () => {
+  test('inserts and completes a running task once', async () => {
+    await insertTask();
+
+    const completed = await completeBackgroundTask(childSessionId, 'finished');
+    const secondSettlement = await failBackgroundTask(childSessionId, 'too late');
+
+    expect(completed?.status).toBe('completed');
+    expect(completed?.result).toBe('finished');
+    expect(completed?.completedAt).toBeNumber();
+    expect(secondSettlement).toBeNull();
+    expect((await getBackgroundTask(childSessionId))?.status).toBe('completed');
+    expect(await listBackgroundTasks(parentSessionId)).toHaveLength(1);
+  });
+
+  test('cancellation wins against later completion', async () => {
+    await insertTask();
+
+    const cancelled = await markBackgroundTaskCancelled(childSessionId);
+    const completion = await completeBackgroundTask(childSessionId, 'too late');
+
+    expect(cancelled?.status).toBe('cancelled');
+    expect(cancelled?.deliveryStatus).toBe('not-applicable');
+    expect(completion).toBeNull();
+  });
+
+  test('claims, releases, and delivers pending results conditionally', async () => {
+    await insertTask();
+    await completeBackgroundTask(childSessionId, 'finished');
+    const firstDeliveryId = 'msg_delivery_first' as PrefixedString<'msg'>;
+    const secondDeliveryId = 'msg_delivery_second' as PrefixedString<'msg'>;
+
+    expect(await claimPendingBackgroundTasks(parentSessionId, firstDeliveryId)).toHaveLength(1);
+    expect(await claimPendingBackgroundTasks(parentSessionId, secondDeliveryId)).toHaveLength(0);
+
+    await releaseBackgroundTaskClaims(firstDeliveryId);
+    expect(await claimPendingBackgroundTasks(parentSessionId, secondDeliveryId)).toHaveLength(1);
+
+    await markBackgroundTaskClaimsDelivered(secondDeliveryId);
+    expect(await claimPendingBackgroundTasks(parentSessionId, firstDeliveryId)).toHaveLength(0);
+    expect((await getBackgroundTask(childSessionId))?.deliveryStatus).toBe('delivered');
+  });
+
+  test('interrupts stale running tasks and prevents another terminal transition', async () => {
+    await insertTask();
+
+    const interrupted = await interruptStaleBackgroundTasks();
+
+    expect(interrupted).toHaveLength(1);
+    expect(interrupted[0].status).toBe('interrupted');
+    expect(interrupted[0].deliveryStatus).toBe('not-applicable');
+    expect(await markBackgroundTaskInterrupted(childSessionId)).toBeNull();
+  });
+});

--- a/packages/server/src/background-tasks/repository.ts
+++ b/packages/server/src/background-tasks/repository.ts
@@ -1,0 +1,170 @@
+import { and, desc, eq, inArray } from 'drizzle-orm';
+
+import type { BackgroundTask, BackgroundTaskStatus } from '@stitch/shared/background-tasks/types';
+import type { PrefixedString } from '@stitch/shared/id';
+
+import { getDb } from '@/db/client.js';
+import { backgroundTasks } from '@/db/schema/background-tasks.js';
+
+type BackgroundTaskRow = typeof backgroundTasks.$inferSelect;
+
+export type InsertBackgroundTaskInput = {
+  id: PrefixedString<'ses'>;
+  parentSessionId: PrefixedString<'ses'>;
+  childSessionId: PrefixedString<'ses'>;
+  originMessageId: PrefixedString<'msg'>;
+  originToolCallId: string;
+  title: string;
+  providerId: string;
+  modelId: string;
+  activeToolsetIds: string[];
+  startedAt?: number;
+};
+
+function toBackgroundTask(row: BackgroundTaskRow): BackgroundTask {
+  return {
+    id: row.id,
+    parentSessionId: row.parentSessionId,
+    childSessionId: row.childSessionId,
+    originMessageId: row.originMessageId,
+    originToolCallId: row.originToolCallId,
+    title: row.title,
+    status: row.status,
+    deliveryStatus: row.deliveryStatus,
+    result: row.result,
+    error: row.error,
+    providerId: row.providerId,
+    modelId: row.modelId,
+    activeToolsetIds: row.activeToolsetIds,
+    startedAt: row.startedAt,
+    completedAt: row.completedAt,
+    deliveredAt: row.deliveredAt,
+  };
+}
+
+export async function insertBackgroundTask(input: InsertBackgroundTaskInput): Promise<BackgroundTask> {
+  const now = input.startedAt ?? Date.now();
+  const [row] = await getDb()
+    .insert(backgroundTasks)
+    .values({ ...input, status: 'running', deliveryStatus: 'pending', startedAt: now, updatedAt: now })
+    .returning();
+  return toBackgroundTask(row);
+}
+
+export async function getBackgroundTask(taskId: PrefixedString<'ses'>): Promise<BackgroundTask | null> {
+  const row = (await getDb().select().from(backgroundTasks).where(eq(backgroundTasks.id, taskId))).at(0);
+  return row ? toBackgroundTask(row) : null;
+}
+
+export async function listBackgroundTasks(parentSessionId: PrefixedString<'ses'>): Promise<BackgroundTask[]> {
+  const rows = await getDb()
+    .select()
+    .from(backgroundTasks)
+    .where(eq(backgroundTasks.parentSessionId, parentSessionId))
+    .orderBy(desc(backgroundTasks.startedAt));
+  return rows.map(toBackgroundTask);
+}
+
+export async function listRunningBackgroundTasks(parentSessionId: PrefixedString<'ses'>): Promise<BackgroundTask[]> {
+  const rows = await getDb()
+    .select()
+    .from(backgroundTasks)
+    .where(and(eq(backgroundTasks.parentSessionId, parentSessionId), eq(backgroundTasks.status, 'running')));
+  return rows.map(toBackgroundTask);
+}
+
+async function settleBackgroundTask(
+  taskId: PrefixedString<'ses'>,
+  status: Exclude<BackgroundTaskStatus, 'running'>,
+  values: { result?: string | null; error?: string | null },
+): Promise<BackgroundTask | null> {
+  const now = Date.now();
+  const deliveryStatus = status === 'completed' || status === 'error' ? 'pending' : 'not-applicable';
+  const row = (
+    await getDb()
+      .update(backgroundTasks)
+      .set({ ...values, status, deliveryStatus, completedAt: now, updatedAt: now })
+      .where(and(eq(backgroundTasks.id, taskId), eq(backgroundTasks.status, 'running')))
+      .returning()
+  ).at(0);
+  return row ? toBackgroundTask(row) : null;
+}
+
+export function completeBackgroundTask(taskId: PrefixedString<'ses'>, result: string): Promise<BackgroundTask | null> {
+  return settleBackgroundTask(taskId, 'completed', { result, error: null });
+}
+
+export function failBackgroundTask(taskId: PrefixedString<'ses'>, error: string): Promise<BackgroundTask | null> {
+  return settleBackgroundTask(taskId, 'error', { result: null, error });
+}
+
+export function markBackgroundTaskCancelled(taskId: PrefixedString<'ses'>): Promise<BackgroundTask | null> {
+  return settleBackgroundTask(taskId, 'cancelled', { result: null, error: null });
+}
+
+export function markBackgroundTaskInterrupted(taskId: PrefixedString<'ses'>): Promise<BackgroundTask | null> {
+  return settleBackgroundTask(taskId, 'interrupted', { result: null, error: null });
+}
+
+export async function claimPendingBackgroundTasks(
+  parentSessionId: PrefixedString<'ses'>,
+  deliveryMessageId: PrefixedString<'msg'>,
+): Promise<BackgroundTask[]> {
+  return getDb().transaction(async (tx) => {
+    const pending = await tx
+      .select({ id: backgroundTasks.id })
+      .from(backgroundTasks)
+      .where(
+        and(
+          eq(backgroundTasks.parentSessionId, parentSessionId),
+          eq(backgroundTasks.deliveryStatus, 'pending'),
+          inArray(backgroundTasks.status, ['completed', 'error']),
+        ),
+      );
+    if (pending.length === 0) return [];
+
+    const rows = await tx
+      .update(backgroundTasks)
+      .set({ deliveryStatus: 'claimed', deliveryMessageId, updatedAt: Date.now() })
+      .where(
+        and(
+          inArray(
+            backgroundTasks.id,
+            pending.map((task) => task.id),
+          ),
+          eq(backgroundTasks.deliveryStatus, 'pending'),
+        ),
+      )
+      .returning();
+    return rows.map(toBackgroundTask);
+  });
+}
+
+export async function markBackgroundTaskClaimsDelivered(deliveryMessageId: PrefixedString<'msg'>): Promise<void> {
+  const now = Date.now();
+  await getDb()
+    .update(backgroundTasks)
+    .set({ deliveryStatus: 'delivered', deliveredAt: now, updatedAt: now })
+    .where(
+      and(eq(backgroundTasks.deliveryMessageId, deliveryMessageId), eq(backgroundTasks.deliveryStatus, 'claimed')),
+    );
+}
+
+export async function releaseBackgroundTaskClaims(deliveryMessageId: PrefixedString<'msg'>): Promise<void> {
+  await getDb()
+    .update(backgroundTasks)
+    .set({ deliveryStatus: 'pending', deliveryMessageId: null, updatedAt: Date.now() })
+    .where(
+      and(eq(backgroundTasks.deliveryMessageId, deliveryMessageId), eq(backgroundTasks.deliveryStatus, 'claimed')),
+    );
+}
+
+export async function interruptStaleBackgroundTasks(): Promise<BackgroundTask[]> {
+  const now = Date.now();
+  const rows = await getDb()
+    .update(backgroundTasks)
+    .set({ status: 'interrupted', deliveryStatus: 'not-applicable', completedAt: now, updatedAt: now })
+    .where(eq(backgroundTasks.status, 'running'))
+    .returning();
+  return rows.map(toBackgroundTask);
+}

--- a/packages/server/src/background-tasks/service.test.ts
+++ b/packages/server/src/background-tasks/service.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { StoredPart } from '@stitch/shared/chat/messages';
+import type { PrefixedString } from '@stitch/shared/id';
+
+import { getBackgroundTask } from '@/background-tasks/repository.js';
+import { cancelBackgroundTask, startBackgroundTask } from '@/background-tasks/service.js';
+import { getDb } from '@/db/client.js';
+import { messages, sessions } from '@/db/schema/sessions.js';
+import { setupTestDb } from '@/db/test-helpers.js';
+import { internalBus } from '@/lib/internal-bus.js';
+import type { LlmProviderCredentials } from '@/provider/config/schema.js';
+
+setupTestDb();
+
+const parentSessionId = 'ses_service_parent' as PrefixedString<'ses'>;
+const childSessionId = 'ses_service_child' as PrefixedString<'ses'>;
+const originMessageId = 'msg_service_origin' as PrefixedString<'msg'>;
+const assistantMessageId = 'msg_service_assistant' as PrefixedString<'msg'>;
+
+async function setupSessions(): Promise<void> {
+  const now = Date.now();
+  await getDb()
+    .insert(sessions)
+    .values([
+      { id: parentSessionId, title: 'Parent', createdAt: now, updatedAt: now },
+      { id: childSessionId, title: 'Child', parentSessionId, createdAt: now, updatedAt: now },
+    ]);
+  await getDb()
+    .insert(messages)
+    .values({
+      id: originMessageId,
+      sessionId: parentSessionId,
+      role: 'assistant',
+      parts: [],
+      modelId: 'model',
+      providerId: 'openai',
+      costUsd: 0,
+      createdAt: now,
+      updatedAt: now,
+      startedAt: now,
+      duration: null,
+    });
+}
+
+function input(
+  run: Parameters<typeof startBackgroundTask>[0]['run'],
+  scheduleResult?: (parentId: PrefixedString<'ses'>) => void,
+) {
+  return {
+    taskId: childSessionId,
+    parentSessionId,
+    childSessionId,
+    childAssistantMessageId: assistantMessageId,
+    originMessageId,
+    originToolCallId: 'tool-call',
+    title: 'Child',
+    providerId: 'openai' as const,
+    modelId: 'model',
+    credentials: { providerId: 'openai', auth: { method: 'api-key', apiKey: 'test' } } as LlmProviderCredentials,
+    activeToolsetIds: ['github'],
+    llmMessages: [],
+    run,
+    scheduleResult,
+  };
+}
+
+describe('background task service', () => {
+  test('returns after durable start and settles completion in the detached execution', async () => {
+    await setupSessions();
+    const streamGate = Promise.withResolvers<void>();
+    const completedEvent = Promise.withResolvers<void>();
+    const scheduled: PrefixedString<'ses'>[] = [];
+    const unsubscribe = internalBus.on('background-task.completed', async ({ task }) => {
+      expect((await getBackgroundTask(task.id))?.status).toBe('completed');
+      completedEvent.resolve();
+    });
+
+    await startBackgroundTask(
+      input(
+        async () => {
+          await streamGate.promise;
+          const now = Date.now();
+          const part: StoredPart = {
+            type: 'text-delta',
+            id: 'prt_service_result',
+            text: 'child result',
+            startedAt: now,
+            endedAt: now,
+          };
+          await getDb()
+            .insert(messages)
+            .values({
+              id: assistantMessageId,
+              sessionId: childSessionId,
+              role: 'assistant',
+              parts: [part],
+              modelId: 'model',
+              providerId: 'openai',
+              costUsd: 0,
+              createdAt: now,
+              updatedAt: now,
+              startedAt: now,
+              duration: 0,
+            });
+        },
+        (parentId) => scheduled.push(parentId),
+      ),
+      { registerAbort: () => new AbortController().signal, cleanupAbort: () => undefined },
+    );
+
+    expect((await getBackgroundTask(childSessionId))?.status).toBe('running');
+    streamGate.resolve();
+    await completedEvent.promise;
+    unsubscribe();
+
+    expect((await getBackgroundTask(childSessionId))?.result).toBe('child result');
+    expect(scheduled).toEqual([parentSessionId]);
+  });
+
+  test('cancellation remains terminal when detached execution finishes later', async () => {
+    await setupSessions();
+    const streamGate = Promise.withResolvers<void>();
+
+    await startBackgroundTask(
+      input(async () => streamGate.promise),
+      { registerAbort: () => new AbortController().signal, cleanupAbort: () => undefined },
+    );
+    const cancelled = await cancelBackgroundTask(childSessionId);
+    streamGate.resolve();
+    await Bun.sleep(0);
+
+    expect(cancelled?.status).toBe('cancelled');
+    expect((await getBackgroundTask(childSessionId))?.status).toBe('cancelled');
+  });
+
+  test('persists a stream failure before emitting the failed event', async () => {
+    await setupSessions();
+    const failedEvent = Promise.withResolvers<void>();
+    const unsubscribe = internalBus.on('background-task.failed', async ({ task }) => {
+      expect((await getBackgroundTask(task.id))?.error).toBe('stream failed');
+      failedEvent.resolve();
+    });
+
+    await startBackgroundTask(
+      input(async () => {
+        throw new Error('stream failed');
+      }),
+      { registerAbort: () => new AbortController().signal, cleanupAbort: () => undefined },
+    );
+    await failedEvent.promise;
+    unsubscribe();
+
+    expect((await getBackgroundTask(childSessionId))?.status).toBe('error');
+  });
+});

--- a/packages/server/src/background-tasks/service.ts
+++ b/packages/server/src/background-tasks/service.ts
@@ -1,0 +1,172 @@
+import { and, eq } from 'drizzle-orm';
+
+import type { StoredPart } from '@stitch/shared/chat/messages';
+import type { PrefixedString } from '@stitch/shared/id';
+import type { LlmProviderId } from '@stitch/shared/providers/types';
+
+import {
+  completeBackgroundTask,
+  failBackgroundTask,
+  getBackgroundTask,
+  insertBackgroundTask,
+  listRunningBackgroundTasks,
+  markBackgroundTaskCancelled,
+} from '@/background-tasks/repository.js';
+import { getDb } from '@/db/client.js';
+import { messages } from '@/db/schema/sessions.js';
+import * as AbortRegistry from '@/lib/abort-registry.js';
+import { internalBus } from '@/lib/internal-bus.js';
+import * as Log from '@/lib/log.js';
+import { cancelDecision } from '@/llm/stream/doom-loop.js';
+import type { runStream } from '@/llm/stream/runner.js';
+import { abortMcpElicitations } from '@/mcp/elicitation-service.js';
+import { abortPermissionResponses } from '@/permission/service.js';
+import type { LlmProviderCredentials } from '@/provider/config/schema.js';
+import { abortQuestions } from '@/question/service.js';
+import type { ModelMessage } from 'ai';
+
+const log = Log.create({ service: 'background-task-service' });
+
+type StartBackgroundTaskInput = {
+  taskId: PrefixedString<'ses'>;
+  parentSessionId: PrefixedString<'ses'>;
+  childSessionId: PrefixedString<'ses'>;
+  childAssistantMessageId: PrefixedString<'msg'>;
+  originMessageId: PrefixedString<'msg'>;
+  originToolCallId: string;
+  title: string;
+  providerId: LlmProviderId;
+  modelId: string;
+  credentials: LlmProviderCredentials;
+  activeToolsetIds: string[];
+  llmMessages: ModelMessage[];
+  run: typeof runStream;
+  scheduleResult?: (parentSessionId: PrefixedString<'ses'>) => void | Promise<void>;
+};
+
+type BackgroundTaskServiceDependencies = {
+  registerAbort: typeof AbortRegistry.register;
+  cleanupAbort: typeof AbortRegistry.cleanup;
+};
+
+const defaultDependencies: BackgroundTaskServiceDependencies = {
+  registerAbort: AbortRegistry.register,
+  cleanupAbort: AbortRegistry.cleanup,
+};
+
+function extractAssistantText(parts: StoredPart[] | undefined): string {
+  const text = parts
+    ?.filter(
+      (part): part is StoredPart & { type: 'text-delta'; text: string } =>
+        part.type === 'text-delta' && typeof (part as { text?: unknown }).text === 'string',
+    )
+    .map((part) => part.text)
+    .join('');
+  return text || 'Task completed.';
+}
+
+async function scheduleResult(input: StartBackgroundTaskInput): Promise<void> {
+  if (!input.scheduleResult) return;
+  try {
+    await input.scheduleResult(input.parentSessionId);
+  } catch (error) {
+    log.error({ event: 'background_task.delivery.failed', taskId: input.taskId, error }, 'result scheduling failed');
+  }
+}
+
+async function executeBackgroundTask(
+  input: StartBackgroundTaskInput,
+  abortSignal: AbortSignal,
+  deps: BackgroundTaskServiceDependencies,
+): Promise<void> {
+  try {
+    await input.run({
+      sessionId: input.childSessionId,
+      assistantMessageId: input.childAssistantMessageId,
+      modelId: input.modelId,
+      llmMessages: input.llmMessages,
+      credentials: input.credentials,
+      abortSignal,
+      activeToolsetIds: input.activeToolsetIds,
+      allowTaskTool: false,
+      excludedToolsetIds: ['browser'],
+    });
+
+    const assistantMessage = (
+      await getDb()
+        .select({ parts: messages.parts })
+        .from(messages)
+        .where(and(eq(messages.sessionId, input.childSessionId), eq(messages.id, input.childAssistantMessageId)))
+    ).at(0);
+    const settled = await completeBackgroundTask(input.taskId, extractAssistantText(assistantMessage?.parts));
+    if (!settled) return;
+
+    internalBus.emit('background-task.completed', { task: settled });
+    await scheduleResult(input);
+  } catch (error) {
+    const message = Error.isError(error) ? error.message : 'Unknown error';
+    const settled = await failBackgroundTask(input.taskId, message);
+    if (!settled) return;
+
+    internalBus.emit('background-task.failed', { task: settled });
+    await scheduleResult(input);
+  } finally {
+    deps.cleanupAbort(input.childSessionId);
+  }
+}
+
+export async function startBackgroundTask(
+  input: StartBackgroundTaskInput,
+  dependencies: BackgroundTaskServiceDependencies = defaultDependencies,
+): Promise<void> {
+  const task = await insertBackgroundTask({
+    id: input.taskId,
+    parentSessionId: input.parentSessionId,
+    childSessionId: input.childSessionId,
+    originMessageId: input.originMessageId,
+    originToolCallId: input.originToolCallId,
+    title: input.title,
+    providerId: input.providerId,
+    modelId: input.modelId,
+    activeToolsetIds: input.activeToolsetIds,
+  });
+  internalBus.emit('background-task.started', { task });
+
+  const abortSignal = dependencies.registerAbort(input.childSessionId);
+  const execution = executeBackgroundTask(input, abortSignal, dependencies);
+  void execution.catch((error) => {
+    log.error(
+      { event: 'background_task.execution.unhandled', taskId: input.taskId, error },
+      'detached execution failed',
+    );
+  });
+}
+
+export async function cancelBackgroundTask(taskId: PrefixedString<'ses'>) {
+  const existing = await getBackgroundTask(taskId);
+  if (!existing || existing.status !== 'running') return existing;
+
+  const cancelled = await markBackgroundTaskCancelled(taskId);
+  if (!cancelled) return getBackgroundTask(taskId);
+
+  AbortRegistry.abort(cancelled.childSessionId);
+  cancelDecision(cancelled.childSessionId);
+  await Promise.all([
+    abortQuestions(cancelled.childSessionId),
+    abortPermissionResponses(cancelled.childSessionId),
+    abortMcpElicitations(cancelled.childSessionId),
+  ]);
+  internalBus.emit('background-task.cancelled', { task: cancelled });
+  return cancelled;
+}
+
+export async function cancelBackgroundTasksForParent(parentSessionId: PrefixedString<'ses'>): Promise<void> {
+  const pendingParents = [parentSessionId];
+  while (pendingParents.length > 0) {
+    const parentId = pendingParents.shift();
+    if (!parentId) break;
+    const tasks = await listRunningBackgroundTasks(parentId);
+    pendingParents.push(...tasks.map((task) => task.childSessionId));
+    await Promise.all(tasks.map((task) => cancelBackgroundTask(task.id)));
+  }
+}

--- a/packages/server/src/chat/message-store.test.ts
+++ b/packages/server/src/chat/message-store.test.ts
@@ -64,6 +64,48 @@ describe('saveAssistantMessage', () => {
     expect(emitted).toHaveLength(1);
     expect(emitted[0]).toMatchObject({ sessionId, messageId: assistantMessageId, finishReason: 'stop' });
   });
+
+  test('fills an existing placeholder used by a background task foreign key', async () => {
+    const sessionId = 'ses_test_save_placeholder' as never;
+    const assistantMessageId = 'msg_test_save_placeholder' as never;
+    const startedAt = Date.now() - 100;
+    await seedSession(sessionId);
+    await getDb()
+      .insert(messages)
+      .values({
+        id: assistantMessageId,
+        sessionId,
+        role: 'assistant',
+        parts: [],
+        modelId: 'test-model',
+        providerId: 'test-provider',
+        costUsd: 0,
+        createdAt: startedAt,
+        updatedAt: startedAt,
+        startedAt,
+        duration: null,
+      });
+
+    await saveAssistantMessage({
+      sessionId,
+      assistantMessageId,
+      modelId: 'test-model',
+      providerId: 'test-provider',
+      accumulatedParts: [
+        { type: 'text-delta', id: 'prt_test_placeholder', text: 'Finished', startedAt, endedAt: startedAt },
+      ],
+      totalUsage: ZERO_USAGE,
+      finalFinishReason: 'stop',
+      startedAt,
+    });
+
+    const rows = await getDb().select().from(messages).where(eq(messages.id, assistantMessageId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].parts).toEqual([
+      { type: 'text-delta', id: 'prt_test_placeholder', text: 'Finished', startedAt, endedAt: startedAt },
+    ]);
+    expect(rows[0].finishReason).toBe('stop');
+  });
 });
 
 describe('markSessionUnread', () => {

--- a/packages/server/src/chat/message-store.ts
+++ b/packages/server/src/chat/message-store.ts
@@ -62,6 +62,18 @@ export async function saveAssistantMessage(opts: SaveAssistantMessageOpts): Prom
       createdAt: startedAt,
       startedAt,
       duration: finishedAt - startedAt,
+    })
+    .onConflictDoUpdate({
+      target: messages.id,
+      set: {
+        parts: accumulatedParts,
+        usage: totalUsage,
+        costUsd,
+        finishReason: finalFinishReason,
+        updatedAt: finishedAt,
+        startedAt,
+        duration: finishedAt - startedAt,
+      },
     });
 
   internalBus.emit('session.message.saved', {

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -9,6 +9,7 @@ import { createMessageId, createPartId, createSessionId } from '@stitch/shared/i
 import type { PrefixedString } from '@stitch/shared/id';
 import { isLocalProviderId } from '@stitch/shared/providers/types';
 
+import { cancelBackgroundTasksForParent } from '@/background-tasks/service.js';
 import { getDb } from '@/db/client.js';
 import { providerConfig } from '@/db/schema/providers.js';
 import { messages, sessions } from '@/db/schema/sessions.js';
@@ -357,6 +358,7 @@ export async function abortSessionRun(sessionId: PrefixedString<'ses'>): Promise
     .where(eq(sessions.parentSessionId, sessionId));
 
   await Promise.all([
+    cancelBackgroundTasksForParent(sessionId),
     abortQuestions(sessionId),
     abortPermissionResponses(sessionId),
     abortMcpElicitations(sessionId),

--- a/packages/server/src/chat/session-crud.ts
+++ b/packages/server/src/chat/session-crud.ts
@@ -4,6 +4,7 @@ import { ARCHIVE_REASONS } from '@stitch/shared/chat/messages';
 import type { PrefixedString } from '@stitch/shared/id';
 import { createSessionId } from '@stitch/shared/id';
 
+import { cancelBackgroundTasksForParent } from '@/background-tasks/service.js';
 import { getDb } from '@/db/client.js';
 import { messages, sessions } from '@/db/schema/sessions.js';
 import { err, ok } from '@/lib/service-result.js';
@@ -108,6 +109,7 @@ export async function listSessionMessages(
 }
 
 export async function deleteSession(sessionId: PrefixedString<'ses'>): Promise<ServiceResult<{ id: string }>> {
+  await cancelBackgroundTasksForParent(sessionId);
   const db = getDb();
   const result = await db.delete(sessions).where(eq(sessions.id, sessionId)).returning({ id: sessions.id });
   if (result.length === 0) return err('Session not found', 404);
@@ -117,6 +119,7 @@ export async function deleteSession(sessionId: PrefixedString<'ses'>): Promise<S
 export async function archiveSession(
   sessionId: PrefixedString<'ses'>,
 ): Promise<ServiceResult<typeof sessions.$inferSelect>> {
+  await cancelBackgroundTasksForParent(sessionId);
   const db = getDb();
   const now = Date.now();
   const updated = (

--- a/packages/server/src/tools/core/task.test.ts
+++ b/packages/server/src/tools/core/task.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import type { PrefixedString } from '@stitch/shared/id';
+
+import { TASK_DESCRIPTION, createTaskTool } from '@/tools/core/task.js';
+import type { ToolsetManager } from '@/tools/toolsets/manager.js';
+
+describe('task tool background contract', () => {
+  test('documents automatic notification and prohibits polling', () => {
+    expect(TASK_DESCRIPTION).toContain('Background mode returns immediately');
+    expect(TASK_DESCRIPTION).toContain('result arrives automatically');
+    expect(TASK_DESCRIPTION).toContain('Do not poll');
+    expect(TASK_DESCRIPTION).toContain('non-overlapping work');
+  });
+
+  test('accepts background as optional and preserves the foreground default', () => {
+    const tool = createTaskTool(
+      {
+        sessionId: 'ses_parent' as PrefixedString<'ses'>,
+        messageId: 'msg_parent' as PrefixedString<'msg'>,
+        streamRunId: 'run',
+      },
+      {
+        parentSessionId: 'ses_parent' as PrefixedString<'ses'>,
+        parentAbortSignal: new AbortController().signal,
+        credentials: { providerId: 'openai', auth: { method: 'api-key', apiKey: 'test' } },
+        modelId: 'model',
+        providerId: 'openai',
+        toolsetManager: { getActiveIds: () => new Set<string>() } as ToolsetManager,
+      },
+    );
+
+    const schema = tool.inputSchema as z.ZodType;
+    expect(schema.safeParse({ title: 'Task', task: 'Do work' }).success).toBeTrue();
+    expect(schema.safeParse({ title: 'Task', task: 'Do work', background: true }).success).toBeTrue();
+  });
+});

--- a/packages/server/src/tools/core/task.ts
+++ b/packages/server/src/tools/core/task.ts
@@ -7,6 +7,7 @@ import { createMessageId, createPartId } from '@stitch/shared/id';
 import type { PrefixedString } from '@stitch/shared/id';
 import type { LlmProviderId } from '@stitch/shared/providers/types';
 
+import { cancelBackgroundTask, startBackgroundTask } from '@/background-tasks/service.js';
 import { createSession } from '@/chat/session-crud.js';
 import { getDb } from '@/db/client.js';
 import { messages } from '@/db/schema/sessions.js';
@@ -22,7 +23,7 @@ import type { ToolsetManager } from '@/tools/toolsets/manager.js';
 const log = Log.create({ service: 'task-tool' });
 const CHILD_SESSION_EXCLUDED_TOOLSETS = ['browser'];
 
-const TASK_DESCRIPTION = `Spawn a child session to handle a task independently with its own context window.
+export const TASK_DESCRIPTION = `Spawn a child session to handle a task independently with its own context window.
 
 Use this tool for:
 - Context-heavy work (research, comparison, planning, or multi-step execution)
@@ -32,6 +33,10 @@ Use this tool for:
 The child session inherits your active toolsets and permissions.
 Provide a concise title (30 chars max) and a detailed task description - the child session starts fresh with only what you provide.
 The child session can ask questions and request permissions from the user, just like you can.
+
+Set background to true only for independent work. Background mode returns immediately and the result arrives automatically.
+Do not poll, sleep, ask for status, duplicate delegated work, or modify overlapping files. Continue only with non-overlapping work.
+The child starts with only the supplied task and inherited tools. Its output is not directly shown to the user; summarize it after notification.
 
 Returns a summary of the completed work. You can also link the user to the child session for full details.`;
 
@@ -50,12 +55,16 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
     inputSchema: z.object({
       title: z.string().trim().min(1).max(30).describe('Short task title for the child session (30 chars max)'),
       task: z.string().describe('Detailed description of the task to accomplish'),
+      background: z
+        .boolean()
+        .optional()
+        .describe('Run independently and report back automatically. Do not poll for status.'),
       toolsets: z
         .array(z.string())
         .optional()
         .describe('Additional toolset IDs to activate in the child session beyond inherited ones'),
     }),
-    execute: async ({ title, task, toolsets: additionalToolsets }, { toolCallId }) => {
+    execute: async ({ title, task, background, toolsets: additionalToolsets }, { toolCallId }) => {
       const sessionResult = await createSession({ title, parentSessionId: deps.parentSessionId });
       if (sessionResult.error) {
         return {
@@ -77,12 +86,7 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
       });
 
       log.info(
-        {
-          event: 'task.child_session.created',
-          parentSessionId: deps.parentSessionId,
-          childSessionId,
-          taskPreview: task.slice(0, 200),
-        },
+        { event: 'task.child_session.created', parentSessionId: deps.parentSessionId, childSessionId },
         'child session created for task tool',
       );
 
@@ -111,6 +115,60 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
       // Build history (just the system prompt + user message)
       const llmMessages = await buildSessionLlmMessages(childSessionId, { useBasePrompt: true, systemPrompt: null });
       const assistantMessageId = createMessageId();
+
+      if (background) {
+        const inheritedToolsetIds = [...deps.toolsetManager.getActiveIds()];
+        const allToolsetIds = [...new Set([...inheritedToolsetIds, ...(additionalToolsets ?? [])])];
+        try {
+          await db
+            .insert(messages)
+            .values({
+              id: context.messageId,
+              sessionId: deps.parentSessionId,
+              role: 'assistant',
+              parts: [],
+              modelId: deps.modelId,
+              providerId: deps.providerId,
+              costUsd: 0,
+              createdAt: now,
+              updatedAt: now,
+              startedAt: now,
+              duration: null,
+            })
+            .onConflictDoNothing();
+
+          await startBackgroundTask({
+            taskId: childSessionId,
+            parentSessionId: deps.parentSessionId,
+            childSessionId,
+            childAssistantMessageId: assistantMessageId,
+            originMessageId: context.messageId,
+            originToolCallId: toolCallId,
+            title,
+            providerId: deps.providerId,
+            modelId: deps.modelId,
+            credentials: deps.credentials,
+            activeToolsetIds: allToolsetIds,
+            llmMessages,
+            run: runStream,
+          });
+          if (deps.parentAbortSignal.aborted) await cancelBackgroundTask(childSessionId);
+
+          return {
+            taskId: childSessionId,
+            childSessionId,
+            childSessionName: childSession.title,
+            status: 'running' as const,
+            summary: 'Background task started. You will be notified automatically when it finishes.',
+          };
+        } catch (error) {
+          return {
+            childSessionId,
+            childSessionName: childSession.title,
+            summary: `Task failed: ${Error.isError(error) ? error.message : 'Unknown error'}`,
+          };
+        }
+      }
 
       // Create a child abort controller linked to the parent
       const childAbortSignal = AbortRegistry.register(childSessionId);


### PR DESCRIPTION
## Change Summary

Adds durable detached execution for task-tool calls launched with `background: true` while preserving foreground behavior.

### New Features
- Persists task state before acknowledging a background launch.
- Runs child sessions independently with inherited toolsets and cancellation support.
- Emits lifecycle events only after terminal state is durable.

### Improvements
- Prevents nested task spawning and browser activation in detached child runs.
