### PR TITLE
feat(web): manage background tasks

### DIFF
--- a/apps/web/src/components/chat/message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble.tsx
@@ -1,6 +1,7 @@
 import type { StoredPart } from '@stitch/shared/chat/messages';
 
 import { AssistantMessageBubble } from '@/components/chat/message-bubble/assistant-message-bubble';
+import { BackgroundTaskResultBubble } from '@/components/chat/message-bubble/background-task-result-bubble';
 import { UserMessageBubble } from '@/components/chat/message-bubble/user-message-bubble';
 
 type MessageBubbleProps = {
@@ -13,6 +14,13 @@ type MessageBubbleProps = {
 };
 
 export function MessageBubble({ role, parts, finishReason, onAbortTool, onSplit, onEdit }: MessageBubbleProps) {
+  const backgroundTaskResults = parts.filter(
+    (part): part is Extract<StoredPart, { type: 'background-task-result' }> => part.type === 'background-task-result',
+  );
+  if (backgroundTaskResults.length > 0) {
+    return <BackgroundTaskResultBubble parts={backgroundTaskResults} />;
+  }
+
   if (role === 'user') {
     return <UserMessageBubble parts={parts} onSplit={onSplit} onEdit={onEdit} />;
   }

--- a/apps/web/src/components/chat/message-bubble/background-task-result-bubble.test.tsx
+++ b/apps/web/src/components/chat/message-bubble/background-task-result-bubble.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import type { StoredPart } from '@stitch/shared/chat/messages';
+
+import { MessageBubble } from '../message-bubble.js';
+
+describe('background task result message', () => {
+  test('renders a compact marker without user message actions', () => {
+    const part: StoredPart = {
+      type: 'background-task-result',
+      id: 'prt_result',
+      startedAt: 1,
+      endedAt: 1,
+      tasks: [
+        { taskId: 'ses_child', childSessionId: 'ses_child', title: 'Task', state: 'completed', text: 'done' },
+      ],
+    };
+    const messageRole = 'user';
+    const html = renderToStaticMarkup(
+      <MessageBubble role={messageRole} parts={[part]} onEdit={() => undefined} onSplit={() => undefined} />,
+    );
+
+    expect(html).toContain('Background task result received');
+    expect(html).not.toContain('Edit');
+    expect(html).not.toContain('Split');
+    expect(html).not.toContain('done');
+  });
+});

--- a/apps/web/src/components/chat/message-bubble/background-task-result-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble/background-task-result-bubble.tsx
@@ -1,0 +1,20 @@
+import { CheckCircleIcon } from 'lucide-react';
+
+import type { StoredPart } from '@stitch/shared/chat/messages';
+
+import { Icon } from '@/components/primitives/icon.js';
+import { Text } from '@/components/primitives/text.js';
+
+type BackgroundTaskResultPart = Extract<StoredPart, { type: 'background-task-result' }>;
+
+export function BackgroundTaskResultBubble({ parts }: { parts: BackgroundTaskResultPart[] }) {
+  const count = parts.reduce((total, part) => total + part.tasks.length, 0);
+  return (
+    <div className="flex items-center justify-center gap-space-s py-space-xs">
+      <Icon as={CheckCircleIcon} size="s" color="var(--muted-foreground)" />
+      <Text as="span" variant="caption" tone="muted">
+        {count === 1 ? 'Background task result received' : `${count} background task results received`}
+      </Text>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/message-bubble/tool-call-display.ts
+++ b/apps/web/src/components/chat/message-bubble/tool-call-display.ts
@@ -128,7 +128,7 @@ function isToolResultError(output: unknown): boolean {
   );
 }
 
-function getChildSessionId(result: unknown): string | null {
+export function getChildSessionId(result: unknown): string | null {
   if (!result || typeof result !== 'object') return null;
   const id = (result as Record<string, unknown>).childSessionId;
   return typeof id === 'string' ? id : null;

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -2,18 +2,21 @@ import { cn } from 'cnfast';
 import { ChevronDownIcon, ClockIcon, ExternalLinkIcon, SquareIcon } from 'lucide-react';
 import * as React from 'react';
 
-import { Link } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { Link, useParams } from '@tanstack/react-router';
 
+import type { BackgroundTask, BackgroundTaskStatus } from '@stitch/shared/background-tasks/types';
 import type { ToolCallStatus } from '@stitch/shared/chat/stream-events';
 
 import {
   getToolCallActions,
+  getChildSessionId,
   getToolSummary,
   type ToolCallAction,
   type ToolCallDisplayItem,
   type ToolCallSummary,
 } from './tool-call-display';
-import { useStitchToolDisplayName } from './tool-call/card-primitives';
+import { truncateText, useStitchToolDisplayName } from './tool-call/card-primitives';
 
 import { ConnectorIcon } from '@/components/connectors/connector-icon';
 import { McpServerLogo } from '@/components/mcp/mcp-server-logo';
@@ -24,6 +27,7 @@ import { Button } from '@/components/ui/button';
 import { CopyButton } from '@/components/ui/copy-button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Spinner } from '@/components/ui/spinner';
+import { backgroundTasksQueryOptions, useCancelBackgroundTask } from '@/lib/queries/background-tasks';
 
 const VISIBLE_TOOL_COUNT = 4;
 
@@ -45,10 +49,27 @@ const STATUS_LABEL: Record<ToolCallStatus, string> = {
   error: 'Error',
 };
 
+const BACKGROUND_STATUS_LABEL: Record<BackgroundTaskStatus, string> = {
+  running: 'Running',
+  completed: 'Completed',
+  error: 'Failed',
+  cancelled: 'Cancelled',
+  interrupted: 'Interrupted',
+};
+
+const BACKGROUND_STATUS_TONE = {
+  running: 'primary',
+  completed: 'success',
+  error: 'destructive',
+  cancelled: 'muted',
+  interrupted: 'muted',
+} as const;
+
 type ToolCallRowContextValue = {
   call: ToolCallDisplayItem;
   summary: ToolCallSummary;
   errorDetails: ToolErrorDetails | null;
+  backgroundTask: BackgroundTask | undefined;
   onViewErrorDetails: (details: ToolErrorDetails) => void;
 };
 
@@ -116,10 +137,26 @@ function ToolCallDisplayRow({
   animateIn: boolean;
 }) {
   const displayName = useStitchToolDisplayName(call.toolName);
-  const summary = getToolSummary(call, displayName);
+  const params = useParams({ strict: false });
+  const childSessionId = getChildSessionId(call.result);
+  const isBackgroundTask = call.toolName === 'task' && Boolean(params.id && childSessionId);
+  const { data: backgroundTasks } = useQuery({
+    ...backgroundTasksQueryOptions(params.id ?? ''),
+    enabled: isBackgroundTask,
+  });
+  const backgroundTask = backgroundTasks?.find((task) => task.childSessionId === childSessionId);
+  const baseSummary = getToolSummary(call, displayName);
+  const summary =
+    backgroundTask?.status === 'error' && backgroundTask.error
+      ? { ...baseSummary, preview: truncateText(backgroundTask.error, 96) }
+      : baseSummary;
   const isActive = call.status === 'pending' || call.status === 'in-progress';
   const errorDetails =
-    call.status === 'error' && call.error ? { toolName: call.toolName, label: summary.label, error: call.error } : null;
+    backgroundTask?.status === 'error' && backgroundTask.error
+      ? { toolName: call.toolName, label: summary.label, error: backgroundTask.error }
+      : call.status === 'error' && call.error
+        ? { toolName: call.toolName, label: summary.label, error: call.error }
+        : null;
   const actions = getToolCallActions(call);
 
   return (
@@ -127,6 +164,7 @@ function ToolCallDisplayRow({
       call={call}
       summary={summary}
       errorDetails={errorDetails}
+      backgroundTask={backgroundTask}
       onViewErrorDetails={onViewErrorDetails}
       animateIn={animateIn && isActive}>
       <ToolCallRow.Icon />
@@ -135,6 +173,7 @@ function ToolCallDisplayRow({
       <ToolCallRow.Meta />
       <ToolCallRow.Status />
       {isActive && onAbort ? <ToolCallRow.StopButton onAbort={onAbort} /> : null}
+      {backgroundTask?.status === 'running' ? <BackgroundTaskCancelButton task={backgroundTask} /> : null}
       <ToolCallRow.Actions actions={actions} />
     </ToolCallRow.Root>
   );
@@ -155,6 +194,7 @@ function ToolCallRowRoot({
   call,
   summary,
   errorDetails,
+  backgroundTask,
   onViewErrorDetails,
   animateIn,
   children,
@@ -162,13 +202,14 @@ function ToolCallRowRoot({
   call: ToolCallDisplayItem;
   summary: ToolCallSummary;
   errorDetails: ToolErrorDetails | null;
+  backgroundTask: BackgroundTask | undefined;
   onViewErrorDetails: (details: ToolErrorDetails) => void;
   animateIn: boolean;
   children: React.ReactNode;
 }) {
   const contextValue = React.useMemo(
-    () => ({ call, summary, errorDetails, onViewErrorDetails }),
-    [call, summary, errorDetails, onViewErrorDetails],
+    () => ({ call, summary, errorDetails, backgroundTask, onViewErrorDetails }),
+    [call, summary, errorDetails, backgroundTask, onViewErrorDetails],
   );
 
   return (
@@ -185,8 +226,8 @@ function ToolCallRowRoot({
 }
 
 function ToolCallRowIcon() {
-  const { call, summary } = useToolCallRow();
-  return <ToolStatusIcon status={call.status} summary={summary} />;
+  const { call, summary, backgroundTask } = useToolCallRow();
+  return <ToolStatusIcon status={call.status} summary={summary} backgroundStatus={backgroundTask?.status} />;
 }
 
 function ToolCallRowLabel() {
@@ -241,7 +282,17 @@ function ToolCallRowMeta() {
 }
 
 function ToolCallRowStatus() {
-  const { call, errorDetails, onViewErrorDetails } = useToolCallRow();
+  const { call, errorDetails, backgroundTask, onViewErrorDetails } = useToolCallRow();
+
+  if (backgroundTask && !errorDetails) {
+    return (
+      <span className="flex h-5 w-16 shrink-0 items-center justify-end">
+        <Text as="span" variant="micro" tone={BACKGROUND_STATUS_TONE[backgroundTask.status]} align="right">
+          {BACKGROUND_STATUS_LABEL[backgroundTask.status]}
+        </Text>
+      </span>
+    );
+  }
 
   if (!errorDetails) {
     return (
@@ -262,7 +313,7 @@ function ToolCallRowStatus() {
         onClick={() => onViewErrorDetails(errorDetails)}
         className="hover:underline"
         title="View full error">
-        {STATUS_LABEL[call.status]}
+        {backgroundTask?.status === 'error' ? BACKGROUND_STATUS_LABEL.error : STATUS_LABEL[call.status]}
       </Button>
     </span>
   );
@@ -274,6 +325,24 @@ function ToolCallRowStopButton({ onAbort }: { onAbort: () => void }) {
       <Icon as={SquareIcon} size="xs" />
       <Text as="span" variant="micro" tone="destructive">
         Stop
+      </Text>
+    </Button>
+  );
+}
+
+function BackgroundTaskCancelButton({ task }: { task: BackgroundTask }) {
+  const cancel = useCancelBackgroundTask();
+  return (
+    <Button
+      type="button"
+      variant="destructive-quiet"
+      size="xs"
+      disabled={cancel.isPending}
+      onClick={() => cancel.mutate(task.id)}
+      title="Cancel background task">
+      <Icon as={SquareIcon} size="xs" />
+      <Text as="span" variant="micro" tone="destructive">
+        Cancel
       </Text>
     </Button>
   );
@@ -333,7 +402,19 @@ function ToolErrorDetailsDialog({
   );
 }
 
-function ToolStatusIcon({ status, summary }: { status: ToolCallStatus; summary: ToolCallSummary }) {
+function ToolStatusIcon({
+  status,
+  summary,
+  backgroundStatus,
+}: {
+  status: ToolCallStatus;
+  summary: ToolCallSummary;
+  backgroundStatus?: BackgroundTaskStatus;
+}) {
+  if (backgroundStatus === 'running') {
+    return <Spinner size="sm" tone="primary" className="shrink-0" />;
+  }
+
   if (status === 'pending') {
     return <Icon as={ClockIcon} size="s" color="var(--muted-foreground)" />;
   }
@@ -346,7 +427,14 @@ function ToolStatusIcon({ status, summary }: { status: ToolCallStatus; summary: 
     return (
       <ConnectorIcon
         icon={{ type: 'simpleIcons', slug: summary.connectorIconSlug }}
-        className={cn('size-3.5 shrink-0', status === 'error' ? 'bg-destructive' : 'bg-success')}
+        className={cn(
+          'size-3.5 shrink-0',
+          backgroundStatus === 'cancelled' || backgroundStatus === 'interrupted'
+            ? 'bg-muted-foreground'
+            : status === 'error' || backgroundStatus === 'error'
+              ? 'bg-destructive'
+              : 'bg-success',
+        )}
       />
     );
   }
@@ -358,7 +446,14 @@ function ToolStatusIcon({ status, summary }: { status: ToolCallStatus; summary: 
   return (
     <ToolKindIcon
       kind={summary.kind}
-      className={cn('size-3.5 shrink-0', status === 'error' ? 'text-destructive' : 'text-success')}
+      className={cn(
+        'size-3.5 shrink-0',
+        backgroundStatus === 'cancelled' || backgroundStatus === 'interrupted'
+          ? 'text-muted-foreground'
+          : status === 'error' || backgroundStatus === 'error'
+            ? 'text-destructive'
+            : 'text-success',
+      )}
     />
   );
 }

--- a/apps/web/src/hooks/sse/server-event-sync.test.ts
+++ b/apps/web/src/hooks/sse/server-event-sync.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+
+import { QueryClient } from '@tanstack/react-query';
+
+import type { BackgroundTask } from '@stitch/shared/background-tasks/types';
+import type { Session, SessionsPage } from '@stitch/shared/chat/messages';
+
+import { syncBackgroundTaskEvent } from './server-event-sync.js';
+
+import { backgroundTaskKeys } from '@/lib/queries/background-tasks';
+import { sessionKeys } from '@/lib/queries/chat';
+
+function completedTask(): BackgroundTask {
+  return {
+    id: 'ses_child',
+    parentSessionId: 'ses_parent',
+    childSessionId: 'ses_child',
+    originMessageId: 'msg_origin',
+    originToolCallId: 'call-task',
+    title: 'Task',
+    status: 'completed',
+    deliveryStatus: 'pending',
+    result: 'done',
+    error: null,
+    providerId: 'provider',
+    modelId: 'model',
+    activeToolsetIds: [],
+    startedAt: 1,
+    completedAt: 2,
+    deliveredAt: null,
+  };
+}
+
+describe('background task SSE synchronization', () => {
+  test('marks an inactive parent unread and only sounds for the first terminal event', () => {
+    const queryClient = new QueryClient();
+    const parent: Session = {
+      id: 'ses_parent',
+      title: 'Parent',
+      type: 'chat',
+      automationId: null,
+      parentSessionId: null,
+      isUnread: false,
+      archivedAt: null,
+      archivedReason: null,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    queryClient.setQueryData(backgroundTaskKeys.list('ses_parent'), [
+      { ...completedTask(), status: 'running', completedAt: null },
+    ]);
+    queryClient.setQueryData(sessionKeys.infiniteList(''), {
+      pages: [{ sessions: [parent], hasMore: false }],
+      pageParams: [undefined],
+    });
+    let sounds = 0;
+
+    syncBackgroundTaskEvent(queryClient, completedTask(), 'ses_other', () => sounds++);
+    syncBackgroundTaskEvent(queryClient, completedTask(), 'ses_other', () => sounds++);
+
+    const sessions = queryClient.getQueryData<{ pages: SessionsPage[] }>(sessionKeys.infiniteList(''));
+    expect(sessions?.pages[0].sessions[0].isUnread).toBe(true);
+    expect(sounds).toBe(1);
+  });
+
+  test('respects disabled sound settings', () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(backgroundTaskKeys.list('ses_parent'), []);
+    queryClient.setQueryData(['settings', 'list'], { 'notifications.sound.enabled': 'false' });
+    let sounds = 0;
+
+    syncBackgroundTaskEvent(queryClient, completedTask(), 'ses_parent', () => sounds++);
+
+    expect(sounds).toBe(0);
+  });
+});

--- a/apps/web/src/hooks/sse/server-event-sync.ts
+++ b/apps/web/src/hooks/sse/server-event-sync.ts
@@ -4,10 +4,12 @@ import { useQueryClient } from '@tanstack/react-query';
 import type { InfiniteData, QueryClient } from '@tanstack/react-query';
 import { useParams } from '@tanstack/react-router';
 
+import type { BackgroundTask } from '@stitch/shared/background-tasks/types';
 import type { Session, SessionsPage } from '@stitch/shared/chat/messages';
 import type { PartDelta } from '@stitch/shared/chat/stream-events';
 
 import { useSSE } from '@/hooks/sse/sse-context';
+import { updateBackgroundTaskCache } from '@/lib/queries/background-tasks';
 import { sessionKeys } from '@/lib/queries/chat';
 import { connectorKeys } from '@/lib/queries/connectors';
 import { mcpKeys } from '@/lib/queries/mcp';
@@ -48,6 +50,22 @@ function markSessionUnread(queryClient: QueryClient, sessionId: string, currentS
 function isSoundEnabled(queryClient: QueryClient): boolean {
   const settings = queryClient.getQueryData<Record<string, string>>(settingsQueryOptions.queryKey);
   return settings?.['notifications.sound.enabled'] !== 'false';
+}
+
+const TERMINAL_BACKGROUND_TASK_STATUSES = new Set(['completed', 'error', 'cancelled', 'interrupted']);
+
+export function syncBackgroundTaskEvent(
+  queryClient: QueryClient,
+  task: BackgroundTask,
+  currentSessionId: string | undefined,
+  notify: () => void = playNotificationSound,
+): void {
+  const previous = updateBackgroundTaskCache(queryClient, task);
+  if (task.status !== 'completed' && task.status !== 'error') return;
+
+  markSessionUnread(queryClient, task.parentSessionId, currentSessionId);
+  const wasTerminal = previous && TERMINAL_BACKGROUND_TASK_STATUSES.has(previous.status);
+  if (!wasTerminal && isSoundEnabled(queryClient)) notify();
 }
 
 function useServerEventSync(): void {
@@ -233,6 +251,13 @@ function useServerEventSync(): void {
     'session.compaction.completed': ({ sessionId }) => {
       void queryClient.resetQueries({ queryKey: sessionKeys.messages(sessionId) });
     },
+
+    // Background Task Events
+    'background-task.started': ({ task }) => syncBackgroundTaskEvent(queryClient, task, currentSessionId),
+    'background-task.completed': ({ task }) => syncBackgroundTaskEvent(queryClient, task, currentSessionId),
+    'background-task.failed': ({ task }) => syncBackgroundTaskEvent(queryClient, task, currentSessionId),
+    'background-task.cancelled': ({ task }) => syncBackgroundTaskEvent(queryClient, task, currentSessionId),
+    'background-task.interrupted': ({ task }) => syncBackgroundTaskEvent(queryClient, task, currentSessionId),
 
     // Question Events
     'question.asked': ({ question }) => {

--- a/apps/web/src/lib/queries/background-tasks.test.ts
+++ b/apps/web/src/lib/queries/background-tasks.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+
+import { QueryClient } from '@tanstack/react-query';
+
+import type { BackgroundTask } from '@stitch/shared/background-tasks/types';
+
+import { backgroundTaskKeys, updateBackgroundTaskCache } from './background-tasks.js';
+
+function task(id: string, startedAt: number, status: BackgroundTask['status'] = 'running'): BackgroundTask {
+  return {
+    id: id as BackgroundTask['id'],
+    parentSessionId: 'ses_parent',
+    childSessionId: id as BackgroundTask['childSessionId'],
+    originMessageId: 'msg_origin',
+    originToolCallId: `call-${id}`,
+    title: id,
+    status,
+    deliveryStatus: 'pending',
+    result: null,
+    error: null,
+    providerId: 'provider',
+    modelId: 'model',
+    activeToolsetIds: [],
+    startedAt,
+    completedAt: null,
+    deliveredAt: null,
+  };
+}
+
+describe('background task cache', () => {
+  test('upserts events while preserving newest-first order and returns prior state', () => {
+    const queryClient = new QueryClient();
+    const older = task('ses_older', 1);
+    queryClient.setQueryData(backgroundTaskKeys.list('ses_parent'), [older]);
+
+    expect(updateBackgroundTaskCache(queryClient, task('ses_newer', 2))).toBeUndefined();
+    const completed = { ...older, status: 'completed' as const };
+    expect(updateBackgroundTaskCache(queryClient, completed)?.status).toBe('running');
+    expect(queryClient.getQueryData<BackgroundTask[]>(backgroundTaskKeys.list('ses_parent'))).toEqual([
+      task('ses_newer', 2),
+      completed,
+    ]);
+  });
+});

--- a/apps/web/src/lib/queries/background-tasks.ts
+++ b/apps/web/src/lib/queries/background-tasks.ts
@@ -1,0 +1,40 @@
+import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { QueryClient } from '@tanstack/react-query';
+
+import type { BackgroundTask } from '@stitch/shared/background-tasks/types';
+import type { PrefixedString } from '@stitch/shared/id';
+
+import { serverRequest } from '@/lib/api';
+
+export const backgroundTaskKeys = {
+  all: ['background-tasks'] as const,
+  lists: () => [...backgroundTaskKeys.all, 'list'] as const,
+  list: (parentSessionId: string) => [...backgroundTaskKeys.lists(), parentSessionId] as const,
+};
+
+export const backgroundTasksQueryOptions = (parentSessionId: string) =>
+  queryOptions({
+    queryKey: backgroundTaskKeys.list(parentSessionId),
+    queryFn: () => serverRequest<BackgroundTask[]>(`/chat/sessions/${parentSessionId}/background-tasks`),
+  });
+
+export function updateBackgroundTaskCache(queryClient: QueryClient, task: BackgroundTask): BackgroundTask | undefined {
+  const queryKey = backgroundTaskKeys.list(task.parentSessionId);
+  const previous = queryClient.getQueryData<BackgroundTask[]>(queryKey);
+  const previousTask = previous?.find((item) => item.id === task.id);
+
+  const next = previousTask ? previous?.map((item) => (item.id === task.id ? task : item)) : [task, ...(previous ?? [])];
+  queryClient.setQueryData(queryKey, next?.toSorted((a, b) => b.startedAt - a.startedAt));
+
+  void queryClient.invalidateQueries({ queryKey });
+  return previousTask;
+}
+
+export function useCancelBackgroundTask() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (taskId: PrefixedString<'ses'>) =>
+      serverRequest<BackgroundTask>(`/chat/background-tasks/${taskId}/cancel`, { method: 'POST' }),
+    onSuccess: (task) => updateBackgroundTaskCache(queryClient, task),
+  });
+}

--- a/packages/server/src/background-tasks/service.ts
+++ b/packages/server/src/background-tasks/service.ts
@@ -1,5 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 
+import type { BackgroundTask } from '@stitch/shared/background-tasks/types';
 import type { StoredPart } from '@stitch/shared/chat/messages';
 import type { PrefixedString } from '@stitch/shared/id';
 import type { LlmProviderId } from '@stitch/shared/providers/types';
@@ -9,6 +10,7 @@ import {
   failBackgroundTask,
   getBackgroundTask,
   insertBackgroundTask,
+  listBackgroundTasks,
   listRunningBackgroundTasks,
   markBackgroundTaskCancelled,
 } from '@/background-tasks/repository.js';
@@ -18,6 +20,7 @@ import { messages } from '@/db/schema/sessions.js';
 import * as AbortRegistry from '@/lib/abort-registry.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
+import { err, ok, type ServiceResult } from '@/lib/service-result.js';
 import { cancelDecision } from '@/llm/stream/doom-loop.js';
 import type { runStream } from '@/llm/stream/runner.js';
 import { abortMcpElicitations } from '@/mcp/elicitation-service.js';
@@ -169,4 +172,15 @@ export async function cancelBackgroundTasksForParent(parentSessionId: PrefixedSt
     pendingParents.push(...tasks.map((task) => task.childSessionId));
     await Promise.all(tasks.map((task) => cancelBackgroundTask(task.id)));
   }
+}
+
+export async function listBackgroundTasksForParent(
+  parentSessionId: PrefixedString<'ses'>,
+): Promise<ServiceResult<BackgroundTask[]>> {
+  return ok(await listBackgroundTasks(parentSessionId));
+}
+
+export async function cancelBackgroundTaskById(taskId: PrefixedString<'ses'>): Promise<ServiceResult<BackgroundTask>> {
+  const task = await cancelBackgroundTask(taskId);
+  return task ? ok(task) : err('Background task not found', 404);
 }

--- a/packages/server/src/routes/chat.test.ts
+++ b/packages/server/src/routes/chat.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { PrefixedString } from '@stitch/shared/id';
+
+import { completeBackgroundTask, insertBackgroundTask } from '@/background-tasks/repository.js';
+import { getDb } from '@/db/client.js';
+import { messages, sessions } from '@/db/schema/sessions.js';
+import { setupTestDb } from '@/db/test-helpers.js';
+import { chatRouter } from '@/routes/chat.js';
+
+setupTestDb();
+
+const parentSessionId = 'ses_route_parent' as PrefixedString<'ses'>;
+const originMessageId = 'msg_route_origin' as PrefixedString<'msg'>;
+
+async function setupTasks(): Promise<[PrefixedString<'ses'>, PrefixedString<'ses'>]> {
+  const olderId = 'ses_route_older' as PrefixedString<'ses'>;
+  const newerId = 'ses_route_newer' as PrefixedString<'ses'>;
+  await getDb()
+    .insert(sessions)
+    .values([
+      { id: parentSessionId, title: 'Parent', createdAt: 1, updatedAt: 1 },
+      { id: olderId, title: 'Older', parentSessionId, createdAt: 1, updatedAt: 1 },
+      { id: newerId, title: 'Newer', parentSessionId, createdAt: 2, updatedAt: 2 },
+    ]);
+  await getDb().insert(messages).values({
+    id: originMessageId,
+    sessionId: parentSessionId,
+    role: 'assistant',
+    parts: [],
+    modelId: 'model',
+    providerId: 'provider',
+    costUsd: 0,
+    createdAt: 1,
+    updatedAt: 1,
+    startedAt: 1,
+    duration: null,
+  });
+
+  for (const [id, startedAt] of [
+    [olderId, 1],
+    [newerId, 2],
+  ] as const) {
+    await insertBackgroundTask({
+      id,
+      parentSessionId,
+      childSessionId: id,
+      originMessageId,
+      originToolCallId: `call-${id}`,
+      title: id,
+      providerId: 'provider',
+      modelId: 'model',
+      activeToolsetIds: [],
+      startedAt,
+    });
+  }
+  return [olderId, newerId];
+}
+
+describe('background task chat routes', () => {
+  test('lists newest first and cancelling a terminal task is idempotent', async () => {
+    const [olderId, newerId] = await setupTasks();
+    await completeBackgroundTask(olderId, 'done');
+
+    const listResponse = await chatRouter.request(`/sessions/${parentSessionId}/background-tasks`);
+    expect(listResponse.status).toBe(200);
+    const listed = (await listResponse.json()) as { id: string }[];
+    expect(listed.map((task) => task.id)).toEqual([newerId, olderId]);
+
+    const cancelResponse = await chatRouter.request(`/background-tasks/${olderId}/cancel`, { method: 'POST' });
+    expect(cancelResponse.status).toBe(200);
+    expect(((await cancelResponse.json()) as { status: string }).status).toBe('completed');
+  });
+
+  test('returns 404 when cancelling an unknown task', async () => {
+    const response = await chatRouter.request('/background-tasks/ses_route_missing/cancel', { method: 'POST' });
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 
 import { generateAutomationDraft } from '@/automations/generation.js';
+import { cancelBackgroundTaskById, listBackgroundTasksForParent } from '@/background-tasks/service.js';
 import {
   abortSessionRun,
   getSessionStats,
@@ -92,6 +93,16 @@ chatRouter.get('/sessions/:id/todos', zValidator('param', sessionIdParamSchema),
   const { id } = c.req.valid('param');
   const result = await listSessionTodos(id);
   return unwrapResult(c, result);
+});
+
+chatRouter.get('/sessions/:id/background-tasks', zValidator('param', sessionIdParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  return unwrapResult(c, await listBackgroundTasksForParent(id));
+});
+
+chatRouter.post('/background-tasks/:id/cancel', zValidator('param', sessionIdParamSchema), async (c) => {
+  const { id } = c.req.valid('param');
+  return unwrapResult(c, await cancelBackgroundTaskById(id));
 });
 
 chatRouter.get(


### PR DESCRIPTION
## Change Summary

Adds live background-task controls and status presentation to the chat UI.

### New Features
- Lists and cancels background tasks through typed chat APIs.
- Synchronizes task state from SSE events into the query cache.
- Shows running, completed, failed, cancelled, and interrupted task states with child-session navigation.
- Renders delayed result messages as compact synthetic markers.
