### PR TITLE
feat(server): harden background task lifecycle

### DIFF
--- a/packages/server/src/background-tasks/service.test.ts
+++ b/packages/server/src/background-tasks/service.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, test } from 'bun:test';
+import { beforeEach, describe, expect, test } from 'bun:test';
 
 import type { StoredPart } from '@stitch/shared/chat/messages';
 import type { PrefixedString } from '@stitch/shared/id';
 
-import { getBackgroundTask } from '@/background-tasks/repository.js';
-import { cancelBackgroundTask, startBackgroundTask } from '@/background-tasks/service.js';
+import { getBackgroundTask, insertBackgroundTask } from '@/background-tasks/repository.js';
+import {
+  cancelBackgroundTask,
+  initializeBackgroundTaskService,
+  shutdownBackgroundTaskService,
+  startBackgroundTask,
+} from '@/background-tasks/service.js';
+import { archiveSession, deleteSession } from '@/chat/session-crud.js';
 import { getDb } from '@/db/client.js';
 import { messages, sessions } from '@/db/schema/sessions.js';
 import { setupTestDb } from '@/db/test-helpers.js';
@@ -12,6 +18,10 @@ import { internalBus } from '@/lib/internal-bus.js';
 import type { LlmProviderCredentials } from '@/provider/config/schema.js';
 
 setupTestDb();
+
+beforeEach(async () => {
+  await initializeBackgroundTaskService();
+});
 
 const parentSessionId = 'ses_service_parent' as PrefixedString<'ses'>;
 const childSessionId = 'ses_service_child' as PrefixedString<'ses'>;
@@ -162,5 +172,102 @@ describe('background task service', () => {
 
     expect((await getBackgroundTask(childSessionId))?.status).toBe('error');
     expect(scheduled).toEqual([parentSessionId]);
+  });
+
+  test('reconciles stale tasks without emitting lifecycle events', async () => {
+    await setupSessions();
+    await shutdownBackgroundTaskService();
+    await insertBackgroundTask({
+      id: childSessionId,
+      parentSessionId,
+      childSessionId,
+      originMessageId,
+      originToolCallId: 'tool-call',
+      title: 'Child',
+      providerId: 'openai',
+      modelId: 'model',
+      activeToolsetIds: [],
+    });
+
+    const events: string[] = [];
+    const unsubscribe = internalBus.on('background-task.interrupted', async () => {
+      events.push('interrupted');
+    });
+    await initializeBackgroundTaskService();
+    unsubscribe();
+
+    const task = await getBackgroundTask(childSessionId);
+    expect(task?.status).toBe('interrupted');
+    expect(task?.deliveryStatus).toBe('not-applicable');
+    expect(task?.completedAt).toBeNumber();
+    expect(events).toEqual([]);
+  });
+
+  test('shutdown rejects new launches until initialization resets the service', async () => {
+    await setupSessions();
+    await shutdownBackgroundTaskService();
+
+    expect(startBackgroundTask(input(async () => undefined))).rejects.toThrow(
+      'Background task service is shutting down',
+    );
+    expect(await getBackgroundTask(childSessionId)).toBeNull();
+
+    await initializeBackgroundTaskService();
+    await startBackgroundTask(
+      input(async () => undefined),
+      { registerAbort: () => new AbortController().signal, cleanupAbort: () => undefined },
+    );
+    await Bun.sleep(0);
+    expect((await getBackgroundTask(childSessionId))?.status).toBe('completed');
+  });
+
+  test('shutdown cancels and aborts live child streams before returning', async () => {
+    await setupSessions();
+    let childSignal: AbortSignal | undefined;
+    await startBackgroundTask(
+      input(async ({ abortSignal }) => {
+        childSignal = abortSignal;
+        await new Promise<void>((resolve) => abortSignal.addEventListener('abort', () => resolve(), { once: true }));
+      }),
+    );
+
+    await shutdownBackgroundTaskService();
+
+    expect(childSignal?.aborted).toBeTrue();
+    expect((await getBackgroundTask(childSessionId))?.status).toBe('cancelled');
+  });
+
+  test('deleting a parent aborts live descendants before cascading their rows', async () => {
+    await setupSessions();
+    let childSignal: AbortSignal | undefined;
+    await startBackgroundTask(
+      input(async ({ abortSignal }) => {
+        childSignal = abortSignal;
+        await new Promise<void>((resolve) => abortSignal.addEventListener('abort', () => resolve(), { once: true }));
+      }),
+    );
+
+    const result = await deleteSession(parentSessionId);
+
+    expect(result.error).toBeNull();
+    expect(childSignal?.aborted).toBeTrue();
+    expect(await getBackgroundTask(childSessionId)).toBeNull();
+  });
+
+  test('archiving a parent cancels live descendants', async () => {
+    await setupSessions();
+    let childSignal: AbortSignal | undefined;
+    await startBackgroundTask(
+      input(async ({ abortSignal }) => {
+        childSignal = abortSignal;
+        await new Promise<void>((resolve) => abortSignal.addEventListener('abort', () => resolve(), { once: true }));
+      }),
+    );
+
+    const result = await archiveSession(parentSessionId);
+
+    expect(result.error).toBeNull();
+    expect(childSignal?.aborted).toBeTrue();
+    expect((await getBackgroundTask(childSessionId))?.status).toBe('cancelled');
   });
 });

--- a/packages/server/src/background-tasks/service.ts
+++ b/packages/server/src/background-tasks/service.ts
@@ -10,6 +10,7 @@ import {
   failBackgroundTask,
   getBackgroundTask,
   insertBackgroundTask,
+  interruptStaleBackgroundTasks,
   listBackgroundTasks,
   listRunningBackgroundTasks,
   markBackgroundTaskCancelled,
@@ -30,6 +31,10 @@ import { abortQuestions } from '@/question/service.js';
 import type { ModelMessage } from 'ai';
 
 const log = Log.create({ service: 'background-task-service' });
+const liveExecutions = new Map<PrefixedString<'ses'>, Promise<void>>();
+let acceptingTasks = false;
+let pendingStarts = 0;
+let pendingStartsDrained: (() => void) | null = null;
 
 type StartBackgroundTaskInput = {
   taskId: PrefixedString<'ses'>;
@@ -118,31 +123,88 @@ async function executeBackgroundTask(
   }
 }
 
+function finishPendingStart(): void {
+  pendingStarts--;
+  if (pendingStarts === 0) {
+    pendingStartsDrained?.();
+    pendingStartsDrained = null;
+  }
+}
+
+function waitForPendingStarts(): Promise<void> {
+  if (pendingStarts === 0) return Promise.resolve();
+  return new Promise((resolve) => {
+    pendingStartsDrained = resolve;
+  });
+}
+
+function isAcceptingTasks(): boolean {
+  return acceptingTasks;
+}
+
+export async function initializeBackgroundTaskService(): Promise<void> {
+  acceptingTasks = false;
+  const interrupted = await interruptStaleBackgroundTasks();
+  if (interrupted.length > 0) {
+    log.warn(
+      { event: 'background_task.interrupted', count: interrupted.length, taskIds: interrupted.map((task) => task.id) },
+      'interrupted stale background tasks during startup',
+    );
+  }
+  acceptingTasks = true;
+}
+
+export async function shutdownBackgroundTaskService(): Promise<void> {
+  acceptingTasks = false;
+  await waitForPendingStarts();
+
+  const taskIds = [...liveExecutions.keys()];
+  const executions = [...liveExecutions.values()];
+  await Promise.all(taskIds.map((taskId) => cancelBackgroundTask(taskId)));
+  await Promise.all(executions);
+}
+
 export async function startBackgroundTask(
   input: StartBackgroundTaskInput,
   dependencies: BackgroundTaskServiceDependencies = defaultDependencies,
 ): Promise<void> {
-  const task = await insertBackgroundTask({
-    id: input.taskId,
-    parentSessionId: input.parentSessionId,
-    childSessionId: input.childSessionId,
-    originMessageId: input.originMessageId,
-    originToolCallId: input.originToolCallId,
-    title: input.title,
-    providerId: input.providerId,
-    modelId: input.modelId,
-    activeToolsetIds: input.activeToolsetIds,
-  });
-  internalBus.emit('background-task.started', { task });
+  if (!isAcceptingTasks()) throw new Error('Background task service is shutting down');
 
-  const abortSignal = dependencies.registerAbort(input.childSessionId);
-  const execution = executeBackgroundTask(input, abortSignal, dependencies);
-  void execution.catch((error) => {
-    log.error(
-      { event: 'background_task.execution.unhandled', taskId: input.taskId, error },
-      'detached execution failed',
-    );
-  });
+  pendingStarts++;
+  try {
+    const task = await insertBackgroundTask({
+      id: input.taskId,
+      parentSessionId: input.parentSessionId,
+      childSessionId: input.childSessionId,
+      originMessageId: input.originMessageId,
+      originToolCallId: input.originToolCallId,
+      title: input.title,
+      providerId: input.providerId,
+      modelId: input.modelId,
+      activeToolsetIds: input.activeToolsetIds,
+    });
+
+    if (!isAcceptingTasks()) {
+      await markBackgroundTaskCancelled(input.taskId);
+      throw new Error('Background task service is shutting down');
+    }
+
+    internalBus.emit('background-task.started', { task });
+    const abortSignal = dependencies.registerAbort(input.childSessionId);
+    const execution = executeBackgroundTask(input, abortSignal, dependencies)
+      .catch((error) => {
+        log.error(
+          { event: 'background_task.execution.unhandled', taskId: input.taskId, error },
+          'detached execution failed',
+        );
+      })
+      .finally(() => {
+        liveExecutions.delete(input.taskId);
+      });
+    liveExecutions.set(input.taskId, execution);
+  } finally {
+    finishPendingStart();
+  }
 }
 
 export async function cancelBackgroundTask(taskId: PrefixedString<'ses'>) {

--- a/packages/server/src/chat/session-crud.ts
+++ b/packages/server/src/chat/session-crud.ts
@@ -111,6 +111,10 @@ export async function listSessionMessages(
 export async function deleteSession(sessionId: PrefixedString<'ses'>): Promise<ServiceResult<{ id: string }>> {
   await cancelBackgroundTasksForParent(sessionId);
   const db = getDb();
+  const children = await db.select({ id: sessions.id }).from(sessions).where(eq(sessions.parentSessionId, sessionId));
+  for (const child of children) {
+    await deleteSession(child.id);
+  }
   const result = await db.delete(sessions).where(eq(sessions.id, sessionId)).returning({ id: sessions.id });
   if (result.length === 0) return err('Session not found', 404);
   return ok(result[0]);

--- a/packages/server/src/init.ts
+++ b/packages/server/src/init.ts
@@ -6,6 +6,7 @@ import { initMailDb } from '@stitch/mail/db/client';
 
 import { registerAdapters } from '@/adapters/index.js';
 import { syncAllAutomationSchedules } from '@/automations/scheduler.js';
+import { initializeBackgroundTaskService } from '@/background-tasks/service.js';
 import { registerAllConnectors } from '@/connectors/definitions/index.js';
 import { initConnectorRuntime } from '@/connectors/runtime.js';
 import { initDb } from '@/db/client.js';
@@ -35,6 +36,7 @@ export async function init() {
   registerAdapters();
 
   await initDb();
+  await initializeBackgroundTaskService();
   await initMailDb(PATHS.filePaths.mailDb, resolveMailMigrationsDir());
 
   const builtInSkills = await loadBuiltInSkills();

--- a/packages/server/src/shutdown.ts
+++ b/packages/server/src/shutdown.ts
@@ -1,5 +1,6 @@
 import { closeMailDb } from '@stitch/mail/db/client';
 
+import { shutdownBackgroundTaskService } from '@/background-tasks/service.js';
 import { shutdownConnectorRuntime } from '@/connectors/runtime.js';
 import { closeDb } from '@/db/client.js';
 import * as Log from '@/lib/log.js';
@@ -11,6 +12,7 @@ const log = Log.create({ service: 'shutdown' });
 
 async function shutdown(signal: string) {
   log.info({ signal }, 'shutting down');
+  await shutdownBackgroundTaskService();
   await stopScheduler();
   await stopMailEngine().catch((error) => {
     log.warn({ error }, 'failed to stop mail engine during shutdown');


### PR DESCRIPTION
## Change Summary

Hardens background tasks across process startup, shutdown, and session lifecycle operations.

### Improvements
- Reconciles stale running tasks as interrupted before accepting new launches.
- Stops new work, aborts live children, and drains detached executions before database shutdown.
- Cancels descendant background work before parent sessions are archived or deleted.
- Covers launch/shutdown races and lifecycle cleanup with service tests.
