### PR TITLE
refactor(background-tasks): simplify feature integration

### DIFF
--- a/apps/web/src/components/chat/message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble.tsx
@@ -17,7 +17,7 @@ export function MessageBubble({ role, parts, finishReason, onAbortTool, onSplit,
   const backgroundTaskResults = parts.filter(
     (part): part is Extract<StoredPart, { type: 'background-task-result' }> => part.type === 'background-task-result',
   );
-  if (backgroundTaskResults.length > 0) {
+  if (role === 'user' && backgroundTaskResults.length === parts.length && backgroundTaskResults.length > 0) {
     return <BackgroundTaskResultBubble parts={backgroundTaskResults} />;
   }
 

--- a/apps/web/src/components/chat/message-bubble/assistant-message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble/assistant-message-bubble.tsx
@@ -1,8 +1,7 @@
 import { toUserFacingStreamError } from '@stitch/shared/chat/errors';
 import type { StreamErrorDetails } from '@stitch/shared/chat/errors';
-import type { StoredPart } from '@stitch/shared/chat/messages';
+import { extractTextFromParts, type StoredPart } from '@stitch/shared/chat/messages';
 
-import { extractTextFromParts } from './extract-text';
 import { buildDisplaySegments, collectToolResults } from './segment-utils';
 import { AssistantBubbleWrapper, FileBlock, InterruptedLabel, MessageCopyButton } from './shared-components';
 

--- a/apps/web/src/components/chat/message-bubble/background-task-result-bubble.test.tsx
+++ b/apps/web/src/components/chat/message-bubble/background-task-result-bubble.test.tsx
@@ -12,9 +12,7 @@ describe('background task result message', () => {
       id: 'prt_result',
       startedAt: 1,
       endedAt: 1,
-      tasks: [
-        { taskId: 'ses_child', childSessionId: 'ses_child', title: 'Task', state: 'completed', text: 'done' },
-      ],
+      tasks: [{ taskId: 'ses_child', childSessionId: 'ses_child', title: 'Task', state: 'completed', text: 'done' }],
     };
     const messageRole = 'user';
     const html = renderToStaticMarkup(
@@ -25,5 +23,30 @@ describe('background task result message', () => {
     expect(html).not.toContain('Edit');
     expect(html).not.toContain('Split');
     expect(html).not.toContain('done');
+  });
+
+  test('does not hide content in a mixed message', () => {
+    const now = 1;
+    const messageRole = 'assistant';
+    const html = renderToStaticMarkup(
+      <MessageBubble
+        role={messageRole}
+        parts={[
+          {
+            type: 'background-task-result',
+            id: 'prt_result',
+            startedAt: now,
+            endedAt: now,
+            tasks: [
+              { taskId: 'ses_child', childSessionId: 'ses_child', title: 'Task', state: 'completed', text: 'done' },
+            ],
+          },
+          { type: 'text-delta', id: 'prt_text', text: 'Visible response', startedAt: now, endedAt: now },
+        ]}
+      />,
+    );
+
+    expect(html).toContain('Visible response');
+    expect(html).not.toContain('Background task result received');
   });
 });

--- a/apps/web/src/components/chat/message-bubble/compaction-divider.tsx
+++ b/apps/web/src/components/chat/message-bubble/compaction-divider.tsx
@@ -1,9 +1,9 @@
 import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 
 import type { StoredPart } from '@stitch/shared/chat/messages';
+import { extractTextFromParts } from '@stitch/shared/chat/messages';
 
 import ChatMarkdown from '@/components/chat/chat-markdown';
-import { extractTextFromParts } from '@/components/chat/message-bubble/extract-text.js';
 import { Icon } from '@/components/primitives/icon.js';
 import { Text } from '@/components/primitives/text.js';
 

--- a/apps/web/src/components/chat/message-bubble/extract-text.ts
+++ b/apps/web/src/components/chat/message-bubble/extract-text.ts
@@ -1,8 +1,0 @@
-import type { StoredPart } from '@stitch/shared/chat/messages';
-
-export function extractTextFromParts(parts: StoredPart[]): string {
-  return parts
-    .filter((p): p is Extract<StoredPart, { type: 'text-delta' }> => p.type === 'text-delta')
-    .map((p) => p.text)
-    .join('');
-}

--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -35,41 +35,32 @@ type ToolCallGroupProps = { calls: ToolCallDisplayItem[]; onAbort?: () => void }
 
 type ToolErrorDetails = { toolName: string; label: string; error: string };
 
-const STATUS_TONE = {
-  pending: 'muted',
-  'in-progress': 'primary',
-  completed: 'success',
-  error: 'destructive',
-} as const satisfies Record<ToolCallStatus, 'muted' | 'primary' | 'success' | 'destructive'>;
-
-const STATUS_LABEL: Record<ToolCallStatus, string> = {
-  pending: 'Pending',
-  'in-progress': 'Running',
-  completed: 'Done',
-  error: 'Error',
+type StatusPresentation = {
+  label: string;
+  tone: 'muted' | 'primary' | 'success' | 'destructive';
+  icon: 'pending' | 'running' | 'success' | 'error' | 'muted';
 };
 
-const BACKGROUND_STATUS_LABEL: Record<BackgroundTaskStatus, string> = {
-  running: 'Running',
-  completed: 'Completed',
-  error: 'Failed',
-  cancelled: 'Cancelled',
-  interrupted: 'Interrupted',
-};
+const TOOL_STATUS = {
+  pending: { label: 'Pending', tone: 'muted', icon: 'pending' },
+  'in-progress': { label: 'Running', tone: 'primary', icon: 'running' },
+  completed: { label: 'Done', tone: 'success', icon: 'success' },
+  error: { label: 'Error', tone: 'destructive', icon: 'error' },
+} as const satisfies Record<ToolCallStatus, StatusPresentation>;
 
-const BACKGROUND_STATUS_TONE = {
-  running: 'primary',
-  completed: 'success',
-  error: 'destructive',
-  cancelled: 'muted',
-  interrupted: 'muted',
-} as const;
+const BACKGROUND_TASK_STATUS = {
+  running: { label: 'Running', tone: 'primary', icon: 'running' },
+  completed: { label: 'Completed', tone: 'success', icon: 'success' },
+  error: { label: 'Failed', tone: 'destructive', icon: 'error' },
+  cancelled: { label: 'Cancelled', tone: 'muted', icon: 'muted' },
+  interrupted: { label: 'Interrupted', tone: 'muted', icon: 'muted' },
+} as const satisfies Record<BackgroundTaskStatus, StatusPresentation>;
 
 type ToolCallRowContextValue = {
   call: ToolCallDisplayItem;
   summary: ToolCallSummary;
+  status: StatusPresentation;
   errorDetails: ToolErrorDetails | null;
-  backgroundTask: BackgroundTask | undefined;
   onViewErrorDetails: (details: ToolErrorDetails) => void;
 };
 
@@ -78,6 +69,15 @@ const ToolCallRowContext = React.createContext<ToolCallRowContextValue | null>(n
 export function ToolCallGroup({ calls, onAbort }: ToolCallGroupProps) {
   const [expanded, setExpanded] = React.useState(false);
   const [errorDetails, setErrorDetails] = React.useState<ToolErrorDetails | null>(null);
+  const sessionId = useParams({ strict: false }).id;
+  const hasBackgroundTask = calls.some((call) => call.toolName === 'task' && getChildSessionId(call.result));
+  const { data: backgroundTasks } = useQuery({
+    ...backgroundTasksQueryOptions(sessionId ?? ''),
+    enabled: Boolean(sessionId && hasBackgroundTask),
+  });
+  const backgroundTasksBySessionId = new Map<string, BackgroundTask>(
+    backgroundTasks?.map((task) => [task.childSessionId, task]),
+  );
   const hiddenCount = Math.max(0, calls.length - VISIBLE_TOOL_COUNT);
   const visibleCalls = expanded ? calls : calls.slice(hiddenCount);
   // Only animate counts that grew after mount, so restored history stays static.
@@ -113,6 +113,11 @@ export function ToolCallGroup({ calls, onAbort }: ToolCallGroupProps) {
           <ToolCallDisplayRow
             key={call.id}
             call={call}
+            backgroundTask={
+              call.toolName === 'task'
+                ? backgroundTasksBySessionId.get(getChildSessionId(call.result) ?? '')
+                : undefined
+            }
             onAbort={onAbort}
             onViewErrorDetails={setErrorDetails}
             animateIn={index === visibleCalls.length - 1}
@@ -127,30 +132,25 @@ export function ToolCallGroup({ calls, onAbort }: ToolCallGroupProps) {
 
 function ToolCallDisplayRow({
   call,
+  backgroundTask,
   onAbort,
   onViewErrorDetails,
   animateIn,
 }: {
   call: ToolCallDisplayItem;
+  backgroundTask: BackgroundTask | undefined;
   onAbort?: () => void;
   onViewErrorDetails: (details: ToolErrorDetails) => void;
   animateIn: boolean;
 }) {
   const displayName = useStitchToolDisplayName(call.toolName);
-  const params = useParams({ strict: false });
-  const childSessionId = getChildSessionId(call.result);
-  const isBackgroundTask = call.toolName === 'task' && Boolean(params.id && childSessionId);
-  const { data: backgroundTasks } = useQuery({
-    ...backgroundTasksQueryOptions(params.id ?? ''),
-    enabled: isBackgroundTask,
-  });
-  const backgroundTask = backgroundTasks?.find((task) => task.childSessionId === childSessionId);
   const baseSummary = getToolSummary(call, displayName);
   const summary =
     backgroundTask?.status === 'error' && backgroundTask.error
       ? { ...baseSummary, preview: truncateText(backgroundTask.error, 96) }
       : baseSummary;
   const isActive = call.status === 'pending' || call.status === 'in-progress';
+  const status = backgroundTask ? BACKGROUND_TASK_STATUS[backgroundTask.status] : TOOL_STATUS[call.status];
   const errorDetails =
     backgroundTask?.status === 'error' && backgroundTask.error
       ? { toolName: call.toolName, label: summary.label, error: backgroundTask.error }
@@ -163,8 +163,8 @@ function ToolCallDisplayRow({
     <ToolCallRow.Root
       call={call}
       summary={summary}
+      status={status}
       errorDetails={errorDetails}
-      backgroundTask={backgroundTask}
       onViewErrorDetails={onViewErrorDetails}
       animateIn={animateIn && isActive}>
       <ToolCallRow.Icon />
@@ -193,23 +193,23 @@ const ToolCallRow = {
 function ToolCallRowRoot({
   call,
   summary,
+  status,
   errorDetails,
-  backgroundTask,
   onViewErrorDetails,
   animateIn,
   children,
 }: {
   call: ToolCallDisplayItem;
   summary: ToolCallSummary;
+  status: StatusPresentation;
   errorDetails: ToolErrorDetails | null;
-  backgroundTask: BackgroundTask | undefined;
   onViewErrorDetails: (details: ToolErrorDetails) => void;
   animateIn: boolean;
   children: React.ReactNode;
 }) {
   const contextValue = React.useMemo(
-    () => ({ call, summary, errorDetails, backgroundTask, onViewErrorDetails }),
-    [call, summary, errorDetails, backgroundTask, onViewErrorDetails],
+    () => ({ call, summary, status, errorDetails, onViewErrorDetails }),
+    [call, summary, status, errorDetails, onViewErrorDetails],
   );
 
   return (
@@ -226,8 +226,8 @@ function ToolCallRowRoot({
 }
 
 function ToolCallRowIcon() {
-  const { call, summary, backgroundTask } = useToolCallRow();
-  return <ToolStatusIcon status={call.status} summary={summary} backgroundStatus={backgroundTask?.status} />;
+  const { summary, status } = useToolCallRow();
+  return <ToolStatusIcon status={status} summary={summary} />;
 }
 
 function ToolCallRowLabel() {
@@ -282,30 +282,20 @@ function ToolCallRowMeta() {
 }
 
 function ToolCallRowStatus() {
-  const { call, errorDetails, backgroundTask, onViewErrorDetails } = useToolCallRow();
-
-  if (backgroundTask && !errorDetails) {
-    return (
-      <span className="flex h-5 w-16 shrink-0 items-center justify-end">
-        <Text as="span" variant="micro" tone={BACKGROUND_STATUS_TONE[backgroundTask.status]} align="right">
-          {BACKGROUND_STATUS_LABEL[backgroundTask.status]}
-        </Text>
-      </span>
-    );
-  }
+  const { status, errorDetails, onViewErrorDetails } = useToolCallRow();
 
   if (!errorDetails) {
     return (
-      <span className="flex h-5 w-12 shrink-0 items-center justify-end">
-        <Text as="span" variant="micro" tone={STATUS_TONE[call.status]} align="right">
-          {STATUS_LABEL[call.status]}
+      <span className="flex h-5 w-16 shrink-0 items-center justify-end">
+        <Text as="span" variant="micro" tone={status.tone} align="right">
+          {status.label}
         </Text>
       </span>
     );
   }
 
   return (
-    <span className="flex h-5 w-12 shrink-0 items-center justify-end">
+    <span className="flex h-5 w-16 shrink-0 items-center justify-end">
       <Button
         type="button"
         variant="destructive-quiet"
@@ -313,7 +303,7 @@ function ToolCallRowStatus() {
         onClick={() => onViewErrorDetails(errorDetails)}
         className="hover:underline"
         title="View full error">
-        {backgroundTask?.status === 'error' ? BACKGROUND_STATUS_LABEL.error : STATUS_LABEL[call.status]}
+        {status.label}
       </Button>
     </span>
   );
@@ -402,24 +392,12 @@ function ToolErrorDetailsDialog({
   );
 }
 
-function ToolStatusIcon({
-  status,
-  summary,
-  backgroundStatus,
-}: {
-  status: ToolCallStatus;
-  summary: ToolCallSummary;
-  backgroundStatus?: BackgroundTaskStatus;
-}) {
-  if (backgroundStatus === 'running') {
-    return <Spinner size="sm" tone="primary" className="shrink-0" />;
-  }
-
-  if (status === 'pending') {
+function ToolStatusIcon({ status, summary }: { status: StatusPresentation; summary: ToolCallSummary }) {
+  if (status.icon === 'pending') {
     return <Icon as={ClockIcon} size="s" color="var(--muted-foreground)" />;
   }
 
-  if (status === 'in-progress') {
+  if (status.icon === 'running') {
     return <Spinner size="sm" tone="primary" className="shrink-0" />;
   }
 
@@ -429,11 +407,7 @@ function ToolStatusIcon({
         icon={{ type: 'simpleIcons', slug: summary.connectorIconSlug }}
         className={cn(
           'size-3.5 shrink-0',
-          backgroundStatus === 'cancelled' || backgroundStatus === 'interrupted'
-            ? 'bg-muted-foreground'
-            : status === 'error' || backgroundStatus === 'error'
-              ? 'bg-destructive'
-              : 'bg-success',
+          status.icon === 'muted' ? 'bg-muted-foreground' : status.icon === 'error' ? 'bg-destructive' : 'bg-success',
         )}
       />
     );
@@ -448,9 +422,9 @@ function ToolStatusIcon({
       kind={summary.kind}
       className={cn(
         'size-3.5 shrink-0',
-        backgroundStatus === 'cancelled' || backgroundStatus === 'interrupted'
+        status.icon === 'muted'
           ? 'text-muted-foreground'
-          : status === 'error' || backgroundStatus === 'error'
+          : status.icon === 'error'
             ? 'text-destructive'
             : 'text-success',
       )}

--- a/apps/web/src/components/chat/message-bubble/user-message-bubble.tsx
+++ b/apps/web/src/components/chat/message-bubble/user-message-bubble.tsx
@@ -3,9 +3,9 @@ import { FileIcon, FileTextIcon, GitForkIcon, ChevronsDownUpIcon, ChevronsUpDown
 import { useRef, useState, useEffect } from 'react';
 
 import type { StoredPart } from '@stitch/shared/chat/messages';
+import { extractTextFromParts } from '@stitch/shared/chat/messages';
 
 import ChatMarkdown from '@/components/chat/chat-markdown.js';
-import { extractTextFromParts } from '@/components/chat/message-bubble/extract-text.js';
 import { MESSAGE_ACTION_BUTTON_CLASS, MessageCopyButton } from '@/components/chat/message-bubble/shared-components.js';
 import { Icon } from '@/components/primitives/icon.js';
 import { Stack } from '@/components/primitives/stack.js';

--- a/apps/web/src/components/session/session-chat-pane.tsx
+++ b/apps/web/src/components/session/session-chat-pane.tsx
@@ -5,12 +5,12 @@ import { StickToBottom } from 'use-stick-to-bottom';
 import { useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 
+import { extractTextFromParts } from '@stitch/shared/chat/messages';
 import { createMessageId, type PrefixedString } from '@stitch/shared/id';
 
 import { ChatInput } from '@/components/chat/chat-input';
 import type { Attachment } from '@/components/chat/chat-input-parts/types';
 import { DockContainer } from '@/components/chat/docks/dock';
-import { extractTextFromParts } from '@/components/chat/message-bubble/extract-text';
 import { MessageList } from '@/components/chat/message-list';
 import { Text } from '@/components/primitives/text';
 import { findLastUsedModel } from '@/components/session/session-chat-pane/session-message-context';

--- a/apps/web/src/lib/queries/background-tasks.ts
+++ b/apps/web/src/lib/queries/background-tasks.ts
@@ -23,10 +23,14 @@ export function updateBackgroundTaskCache(queryClient: QueryClient, task: Backgr
   const previous = queryClient.getQueryData<BackgroundTask[]>(queryKey);
   const previousTask = previous?.find((item) => item.id === task.id);
 
-  const next = previousTask ? previous?.map((item) => (item.id === task.id ? task : item)) : [task, ...(previous ?? [])];
-  queryClient.setQueryData(queryKey, next?.toSorted((a, b) => b.startedAt - a.startedAt));
+  const next = previousTask
+    ? previous?.map((item) => (item.id === task.id ? task : item))
+    : [task, ...(previous ?? [])];
+  queryClient.setQueryData(
+    queryKey,
+    next?.toSorted((a, b) => b.startedAt - a.startedAt),
+  );
 
-  void queryClient.invalidateQueries({ queryKey });
   return previousTask;
 }
 

--- a/packages/server/src/background-tasks/service.test.ts
+++ b/packages/server/src/background-tasks/service.test.ts
@@ -55,7 +55,7 @@ async function setupSessions(): Promise<void> {
 
 function input(
   run: Parameters<typeof startBackgroundTask>[0]['run'],
-  scheduleResult?: (parentId: PrefixedString<'ses'>) => void,
+  scheduleResult?: (parentId: PrefixedString<'ses'>) => void | Promise<void>,
 ) {
   return {
     taskId: childSessionId,
@@ -114,7 +114,9 @@ describe('background task service', () => {
               duration: 0,
             });
         },
-        (parentId) => scheduled.push(parentId),
+        (parentId) => {
+          scheduled.push(parentId);
+        },
       ),
       { registerAbort: () => new AbortController().signal, cleanupAbort: () => undefined },
     );
@@ -136,7 +138,9 @@ describe('background task service', () => {
     await startBackgroundTask(
       input(
         async () => streamGate.promise,
-        (parentId) => scheduled.push(parentId),
+        (parentId) => {
+          scheduled.push(parentId);
+        },
       ),
       { registerAbort: () => new AbortController().signal, cleanupAbort: () => undefined },
     );
@@ -163,7 +167,9 @@ describe('background task service', () => {
         async () => {
           throw new Error('stream failed');
         },
-        (parentId) => scheduled.push(parentId),
+        (parentId) => {
+          scheduled.push(parentId);
+        },
       ),
       { registerAbort: () => new AbortController().signal, cleanupAbort: () => undefined },
     );
@@ -172,6 +178,27 @@ describe('background task service', () => {
 
     expect((await getBackgroundTask(childSessionId))?.status).toBe('error');
     expect(scheduled).toEqual([parentSessionId]);
+  });
+
+  test('keeps a completed task settled when result scheduling fails asynchronously', async () => {
+    await setupSessions();
+    const completedEvent = Promise.withResolvers<void>();
+    const unsubscribe = internalBus.on('background-task.completed', async () => completedEvent.resolve());
+
+    await startBackgroundTask(
+      input(
+        async () => undefined,
+        async () => {
+          throw new Error('delivery unavailable');
+        },
+      ),
+      { registerAbort: () => new AbortController().signal, cleanupAbort: () => undefined },
+    );
+    await completedEvent.promise;
+    await Bun.sleep(0);
+    unsubscribe();
+
+    expect((await getBackgroundTask(childSessionId))?.status).toBe('completed');
   });
 
   test('reconciles stale tasks without emitting lifecycle events', async () => {

--- a/packages/server/src/background-tasks/service.ts
+++ b/packages/server/src/background-tasks/service.ts
@@ -1,7 +1,7 @@
 import { and, eq } from 'drizzle-orm';
 
 import type { BackgroundTask } from '@stitch/shared/background-tasks/types';
-import type { StoredPart } from '@stitch/shared/chat/messages';
+import { extractTextFromParts } from '@stitch/shared/chat/messages';
 import type { PrefixedString } from '@stitch/shared/id';
 import type { LlmProviderId } from '@stitch/shared/providers/types';
 
@@ -22,12 +22,9 @@ import * as AbortRegistry from '@/lib/abort-registry.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { err, ok, type ServiceResult } from '@/lib/service-result.js';
-import { cancelDecision } from '@/llm/stream/doom-loop.js';
 import type { runStream } from '@/llm/stream/runner.js';
-import { abortMcpElicitations } from '@/mcp/elicitation-service.js';
-import { abortPermissionResponses } from '@/permission/service.js';
+import { abortSessionInteractions } from '@/llm/stream/session-abort.js';
 import type { LlmProviderCredentials } from '@/provider/config/schema.js';
-import { abortQuestions } from '@/question/service.js';
 import type { ModelMessage } from 'ai';
 
 const log = Log.create({ service: 'background-task-service' });
@@ -63,17 +60,6 @@ const defaultDependencies: BackgroundTaskServiceDependencies = {
   cleanupAbort: AbortRegistry.cleanup,
 };
 
-function extractAssistantText(parts: StoredPart[] | undefined): string {
-  const text = parts
-    ?.filter(
-      (part): part is StoredPart & { type: 'text-delta'; text: string } =>
-        part.type === 'text-delta' && typeof (part as { text?: unknown }).text === 'string',
-    )
-    .map((part) => part.text)
-    .join('');
-  return text || 'Task completed.';
-}
-
 async function scheduleResult(input: StartBackgroundTaskInput): Promise<void> {
   try {
     (input.scheduleResult ?? scheduleBackgroundTaskResult)(input.parentSessionId);
@@ -106,7 +92,10 @@ async function executeBackgroundTask(
         .from(messages)
         .where(and(eq(messages.sessionId, input.childSessionId), eq(messages.id, input.childAssistantMessageId)))
     ).at(0);
-    const settled = await completeBackgroundTask(input.taskId, extractAssistantText(assistantMessage?.parts));
+    const settled = await completeBackgroundTask(
+      input.taskId,
+      extractTextFromParts(assistantMessage?.parts) || 'Task completed.',
+    );
     if (!settled) return;
 
     internalBus.emit('background-task.completed', { task: settled });
@@ -214,13 +203,7 @@ export async function cancelBackgroundTask(taskId: PrefixedString<'ses'>) {
   const cancelled = await markBackgroundTaskCancelled(taskId);
   if (!cancelled) return getBackgroundTask(taskId);
 
-  AbortRegistry.abort(cancelled.childSessionId);
-  cancelDecision(cancelled.childSessionId);
-  await Promise.all([
-    abortQuestions(cancelled.childSessionId),
-    abortPermissionResponses(cancelled.childSessionId),
-    abortMcpElicitations(cancelled.childSessionId),
-  ]);
+  await abortSessionInteractions(cancelled.childSessionId);
   internalBus.emit('background-task.cancelled', { task: cancelled });
   return cancelled;
 }

--- a/packages/server/src/background-tasks/service.ts
+++ b/packages/server/src/background-tasks/service.ts
@@ -62,7 +62,7 @@ const defaultDependencies: BackgroundTaskServiceDependencies = {
 
 async function scheduleResult(input: StartBackgroundTaskInput): Promise<void> {
   try {
-    (input.scheduleResult ?? scheduleBackgroundTaskResult)(input.parentSessionId);
+    await Promise.resolve((input.scheduleResult ?? scheduleBackgroundTaskResult)(input.parentSessionId));
   } catch (error) {
     log.error({ event: 'background_task.delivery.failed', taskId: input.taskId, error }, 'result scheduling failed');
   }

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -13,27 +13,24 @@ import { cancelBackgroundTasksForParent } from '@/background-tasks/service.js';
 import { getDb } from '@/db/client.js';
 import { providerConfig } from '@/db/schema/providers.js';
 import { messages, sessions } from '@/db/schema/sessions.js';
-import * as AbortRegistry from '@/lib/abort-registry.js';
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { buildSessionLlmMessages } from '@/llm/session-history.js';
 import { compact } from '@/llm/session-summary.js';
-import { cancelDecision, resolveDecision, type DoomLoopResponse } from '@/llm/stream/doom-loop.js';
+import { resolveDecision, type DoomLoopResponse } from '@/llm/stream/doom-loop.js';
 import { runStream } from '@/llm/stream/runner.js';
+import { abortSessionInteractions } from '@/llm/stream/session-abort.js';
 import {
   abortActiveSessionRun,
   cancelQueuedSessionRuns,
   enqueueSessionRun,
 } from '@/llm/stream/session-run-coordinator.js';
-import { abortMcpElicitations } from '@/mcp/elicitation-service.js';
 import * as LocalModels from '@/models/llm/local.js';
 import * as Models from '@/models/llm/registry.js';
-import { abortPermissionResponses } from '@/permission/service.js';
 import { isLlmProviderCredentials, type LlmProviderCredentials } from '@/provider/config/schema.js';
 import { listProvidersWithCapabilities, type ProviderWithCapabilities } from '@/provider/service.js';
-import { abortQuestions } from '@/question/service.js';
 import { normalizeUsage } from '@/utils/usage.js';
 
 const log = Log.create({ service: 'chat-service' });
@@ -349,7 +346,6 @@ export async function abortSessionRun(sessionId: PrefixedString<'ses'>): Promise
   log.info({ event: 'stream.abort.requested', sessionId }, 'stream abort requested');
   abortActiveSessionRun(sessionId);
   cancelQueuedSessionRuns(sessionId);
-  cancelDecision(sessionId);
 
   const db = getDb();
   const childSessions = await db
@@ -359,14 +355,8 @@ export async function abortSessionRun(sessionId: PrefixedString<'ses'>): Promise
 
   await Promise.all([
     cancelBackgroundTasksForParent(sessionId),
-    abortQuestions(sessionId),
-    abortPermissionResponses(sessionId),
-    abortMcpElicitations(sessionId),
-    ...childSessions.map(async (child) => {
-      AbortRegistry.abort(child.id);
-      cancelDecision(child.id);
-      await Promise.all([abortQuestions(child.id), abortPermissionResponses(child.id), abortMcpElicitations(child.id)]);
-    }),
+    abortSessionInteractions(sessionId),
+    ...childSessions.map((child) => abortSessionInteractions(child.id)),
   ]);
 
   return ok(null);

--- a/packages/server/src/chat/session-crud.ts
+++ b/packages/server/src/chat/session-crud.ts
@@ -108,16 +108,20 @@ export async function listSessionMessages(
   return ok({ messages: page, hasMore });
 }
 
-export async function deleteSession(sessionId: PrefixedString<'ses'>): Promise<ServiceResult<{ id: string }>> {
-  await cancelBackgroundTasksForParent(sessionId);
+async function deleteSessionTree(sessionId: PrefixedString<'ses'>): Promise<ServiceResult<{ id: string }>> {
   const db = getDb();
   const children = await db.select({ id: sessions.id }).from(sessions).where(eq(sessions.parentSessionId, sessionId));
   for (const child of children) {
-    await deleteSession(child.id);
+    await deleteSessionTree(child.id);
   }
   const result = await db.delete(sessions).where(eq(sessions.id, sessionId)).returning({ id: sessions.id });
   if (result.length === 0) return err('Session not found', 404);
   return ok(result[0]);
+}
+
+export async function deleteSession(sessionId: PrefixedString<'ses'>): Promise<ServiceResult<{ id: string }>> {
+  await cancelBackgroundTasksForParent(sessionId);
+  return deleteSessionTree(sessionId);
 }
 
 export async function archiveSession(

--- a/packages/server/src/llm/stream/session-abort.ts
+++ b/packages/server/src/llm/stream/session-abort.ts
@@ -1,0 +1,17 @@
+import type { PrefixedString } from '@stitch/shared/id';
+
+import * as AbortRegistry from '@/lib/abort-registry.js';
+import { cancelDecision } from '@/llm/stream/doom-loop.js';
+import { abortMcpElicitations } from '@/mcp/elicitation-service.js';
+import { abortPermissionResponses } from '@/permission/service.js';
+import { abortQuestions } from '@/question/service.js';
+
+export async function abortSessionInteractions(sessionId: PrefixedString<'ses'>): Promise<void> {
+  AbortRegistry.abort(sessionId);
+  cancelDecision(sessionId);
+  await Promise.all([
+    abortQuestions(sessionId),
+    abortPermissionResponses(sessionId),
+    abortMcpElicitations(sessionId),
+  ]);
+}

--- a/packages/server/src/llm/stream/session-run-coordinator.ts
+++ b/packages/server/src/llm/stream/session-run-coordinator.ts
@@ -2,16 +2,9 @@ import type { PrefixedString } from '@stitch/shared/id';
 
 type SessionRun = (abortSignal: AbortSignal) => Promise<void>;
 
-type QueuedRun = {
-  run: SessionRun;
-  resolve: () => void;
-  reject: (error: unknown) => void;
-};
+type QueuedRun = { run: SessionRun; resolve: () => void; reject: (error: unknown) => void };
 
-type SessionQueue = {
-  runs: QueuedRun[];
-  activeController: AbortController | null;
-};
+type SessionQueue = { runs: QueuedRun[]; activeController: AbortController | null };
 
 const queues = new Map<PrefixedString<'ses'>, SessionQueue>();
 
@@ -64,5 +57,5 @@ export function cancelQueuedSessionRuns(sessionId: PrefixedString<'ses'>): void 
 }
 
 export function isSessionRunActive(sessionId: PrefixedString<'ses'>): boolean {
-  return queues.get(sessionId)?.activeController !== null && queues.has(sessionId);
+  return Boolean(queues.get(sessionId)?.activeController);
 }

--- a/packages/server/src/tools/core/task.ts
+++ b/packages/server/src/tools/core/task.ts
@@ -2,7 +2,7 @@ import { tool } from 'ai';
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 
-import type { StoredPart } from '@stitch/shared/chat/messages';
+import { extractTextFromParts, type StoredPart } from '@stitch/shared/chat/messages';
 import { createMessageId, createPartId } from '@stitch/shared/id';
 import type { PrefixedString } from '@stitch/shared/id';
 import type { LlmProviderId } from '@stitch/shared/providers/types';
@@ -115,10 +115,10 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
       // Build history (just the system prompt + user message)
       const llmMessages = await buildSessionLlmMessages(childSessionId, { useBasePrompt: true, systemPrompt: null });
       const assistantMessageId = createMessageId();
+      const inheritedToolsetIds = [...deps.toolsetManager.getActiveIds()];
+      const allToolsetIds = [...new Set([...inheritedToolsetIds, ...(additionalToolsets ?? [])])];
 
       if (background) {
-        const inheritedToolsetIds = [...deps.toolsetManager.getActiveIds()];
-        const allToolsetIds = [...new Set([...inheritedToolsetIds, ...(additionalToolsets ?? [])])];
         try {
           await db
             .insert(messages)
@@ -179,10 +179,6 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
       };
       deps.parentAbortSignal.addEventListener('abort', onParentAbort, { once: true });
 
-      // Compute toolset IDs to pre-activate in child session
-      const inheritedToolsetIds = [...deps.toolsetManager.getActiveIds()];
-      const allToolsetIds = [...new Set([...inheritedToolsetIds, ...(additionalToolsets ?? [])])];
-
       try {
         await runStream({
           sessionId: childSessionId,
@@ -208,19 +204,7 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
           .where(and(eq(messages.sessionId, childSessionId), eq(messages.id, assistantMessageId)));
 
         const assistantMessage = childMessages.at(0);
-        let summary = 'Task completed.';
-
-        if (assistantMessage?.parts) {
-          const textParts = assistantMessage.parts
-            .filter(
-              (p: StoredPart): p is StoredPart & { type: 'text-delta'; text: string } =>
-                p.type === 'text-delta' && typeof (p as { text?: unknown }).text === 'string',
-            )
-            .map((p: { text: string }) => p.text);
-          if (textParts.length > 0) {
-            summary = textParts.join('');
-          }
-        }
+        const summary = extractTextFromParts(assistantMessage?.parts) || 'Task completed.';
 
         return { childSessionId, childSessionName: childSession.title, summary };
       } catch (error) {

--- a/packages/shared/src/chat/messages.test.ts
+++ b/packages/shared/src/chat/messages.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+
+import { extractTextFromParts, type StoredPart } from './messages.js';
+
+describe('extractTextFromParts', () => {
+  test('joins text parts and ignores other parts', () => {
+    const parts: StoredPart[] = [
+      { type: 'text-delta', id: 'prt_first', text: 'Hello', startedAt: 1, endedAt: 1 },
+      { type: 'reasoning-delta', id: 'prt_reasoning', text: 'hidden', startedAt: 1, endedAt: 1 },
+      { type: 'text-delta', id: 'prt_second', text: ' world', startedAt: 1, endedAt: 1 },
+    ];
+
+    expect(extractTextFromParts(parts)).toBe('Hello world');
+    expect(extractTextFromParts(undefined)).toBe('');
+  });
+});

--- a/packages/shared/src/chat/messages.ts
+++ b/packages/shared/src/chat/messages.ts
@@ -89,6 +89,15 @@ type AllPart =
 
 export type StoredPart = AllPart & { id: PartId; startedAt: number; endedAt: number };
 
+export function extractTextFromParts(parts: StoredPart[] | undefined): string {
+  return (
+    parts
+      ?.filter((part): part is Extract<StoredPart, { type: 'text-delta' }> => part.type === 'text-delta')
+      .map((part) => part.text)
+      .join('') ?? ''
+  );
+}
+
 export type Message = {
   id: PrefixedString<'msg'>;
   sessionId: PrefixedString<'ses'>;


### PR DESCRIPTION
## Change Summary

Performs the final maintainability pass over the background-task feature, deleting duplicated state handling and tightening integration boundaries without changing intended behavior.

### Improvements
- Resolves background-task data once per tool group and normalizes foreground/background visual status into one presentation model.
- Centralizes stored text extraction and session interaction cancellation.
- Removes redundant query refetching and repeated descendant cancellation during session deletion.
- Preserves mixed message content instead of allowing synthetic markers to shadow it.
- Handles asynchronous result-scheduling failures without destabilizing completed tasks.
