### PR TITLE
improvement(types): tighten unknown usage

### DIFF
--- a/apps/web/src/components/settings/providers/local-models-panel.tsx
+++ b/apps/web/src/components/settings/providers/local-models-panel.tsx
@@ -438,7 +438,7 @@ export function LocalModelsPanel({ provider }: Props) {
 
   const upsertMutation = useMutation({
     mutationFn: (input: LocalModelInput) =>
-      serverRequest<unknown>(`/llm/local/${provider}/models`, {
+      serverRequest<LocalModel>(`/llm/local/${provider}/models`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),

--- a/apps/web/src/hooks/session/use-session-docks.tsx
+++ b/apps/web/src/hooks/session/use-session-docks.tsx
@@ -23,10 +23,10 @@ type UseSessionDocksOptions = {
   pendingPermissionResponses: PermissionResponse[];
   pendingMcpElicitations: McpElicitationRequest[];
   todos: SessionTodo[];
-  replyQuestion: UseMutationResult<unknown, Error, { sessionId: string; questionId: string; answers: string[][] }>;
-  rejectQuestion: UseMutationResult<unknown, Error, { sessionId: string; questionId: string }>;
+  replyQuestion: UseMutationResult<null, Error, { sessionId: string; questionId: string; answers: string[][] }>;
+  rejectQuestion: UseMutationResult<null, Error, { sessionId: string; questionId: string }>;
   allowPermissionResponse: UseMutationResult<
-    unknown,
+    null,
     Error,
     {
       sessionId: string;
@@ -35,7 +35,7 @@ type UseSessionDocksOptions = {
     }
   >;
   rejectPermissionResponse: UseMutationResult<
-    unknown,
+    null,
     Error,
     {
       sessionId: string;
@@ -44,12 +44,12 @@ type UseSessionDocksOptions = {
     }
   >;
   alternativePermissionResponse: UseMutationResult<
-    unknown,
+    null,
     Error,
     { sessionId: string; permissionResponseId: string; entry: string }
   >;
   respondMcpElicitation: UseMutationResult<
-    unknown,
+    null,
     Error,
     { sessionId: string; elicitationId: string; action: McpElicitationAction; content?: McpElicitationContent }
   >;
@@ -72,7 +72,7 @@ export function useSessionDocks({
 }: UseSessionDocksOptions): DockItem[] {
   const items: DockItem[] = [];
 
-  const runMutation = async (action: () => Promise<unknown>, errorMessage: string) => {
+  const runMutation = async (action: () => Promise<null>, errorMessage: string) => {
     try {
       await action();
     } catch (error) {

--- a/apps/web/src/lib/queries/agenda.ts
+++ b/apps/web/src/lib/queries/agenda.ts
@@ -5,6 +5,8 @@ import { queryOptions, useMutation, useQueryClient } from '@tanstack/react-query
 import type {
   AgendaItemPriority,
   AgendaItemStatus,
+  AgendaItem,
+  AgendaList,
   AgendaListWithCounts,
   ListAgendaItemsResponse,
 } from '@stitch/shared/agenda/types';
@@ -63,7 +65,7 @@ export function useCreateAgendaList() {
 
   return useMutation({
     mutationFn: (input: { name: string; description?: string; color?: string }) =>
-      serverRequest<unknown>('/agenda/lists', {
+      serverRequest<AgendaList>('/agenda/lists', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
@@ -84,7 +86,7 @@ export function useUpdateAgendaList() {
       id: string;
       updates: { name?: string; description?: string; color?: string | null; isArchived?: boolean };
     }) =>
-      serverRequest<unknown>(`/agenda/lists/${input.id}`, {
+      serverRequest<AgendaList>(`/agenda/lists/${input.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input.updates),
@@ -124,7 +126,7 @@ export function useCreateAgendaItem() {
       listId?: string;
       listName?: string;
     }) =>
-      serverRequest<unknown>('/agenda/items', {
+      serverRequest<AgendaItem>('/agenda/items', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input),
@@ -153,7 +155,7 @@ export function useUpdateAgendaItem() {
         listId?: string;
       };
     }) =>
-      serverRequest<unknown>(`/agenda/items/${input.id}`, {
+      serverRequest<AgendaItem>(`/agenda/items/${input.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(input.updates),
@@ -191,7 +193,7 @@ export function useMergeAgendaLists() {
 
   return useMutation({
     mutationFn: (input: { targetId: string; sourceId: string }) =>
-      serverRequest<unknown>(`/agenda/lists/${input.targetId}/merge`, {
+      serverRequest<AgendaList>(`/agenda/lists/${input.targetId}/merge`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sourceId: input.sourceId }),

--- a/apps/web/src/lib/queries/mcp-elicitations.ts
+++ b/apps/web/src/lib/queries/mcp-elicitations.ts
@@ -27,7 +27,7 @@ export function useRespondMcpElicitation() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (input: RespondInput) =>
-      serverRequest<unknown>(`/chat/sessions/${input.sessionId}/mcp-elicitations/${input.elicitationId}/respond`, {
+      serverRequest<null>(`/chat/sessions/${input.sessionId}/mcp-elicitations/${input.elicitationId}/respond`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: input.action, content: input.content }),

--- a/apps/web/src/lib/queries/memories.ts
+++ b/apps/web/src/lib/queries/memories.ts
@@ -5,6 +5,7 @@ import { queryOptions, type MutationOptions, type QueryClient } from '@tanstack/
 import type {
   DailyMemoryFilesResponse,
   ManagedMemoryEntry,
+  MemoryConsolidationResult,
   MemoryFileSnapshot,
   MemoryFilesOverview,
   MemorySearchResult,
@@ -109,7 +110,9 @@ export function saveRawMemoryMutationOptions(
   };
 }
 
-export function consolidateMemoryMutationOptions(queryClient: QueryClient): MutationOptions<unknown, Error, void> {
+export function consolidateMemoryMutationOptions(
+  queryClient: QueryClient,
+): MutationOptions<MemoryConsolidationResult, Error, void> {
   return {
     mutationFn: () => serverRequest('/memory/consolidate', { method: 'POST' }),
     onSuccess: () => {

--- a/apps/web/src/lib/queries/permissions.ts
+++ b/apps/web/src/lib/queries/permissions.ts
@@ -29,7 +29,7 @@ export function useAllowPermissionResponse() {
 
   return useMutation({
     mutationFn: (input: PermissionBaseInput) =>
-      serverRequest<unknown>(
+      serverRequest<null>(
         `/chat/sessions/${input.sessionId}/permission-responses/${input.permissionResponseId}/allow`,
         {
           method: 'POST',
@@ -48,7 +48,7 @@ export function useRejectPermissionResponse() {
 
   return useMutation({
     mutationFn: (input: PermissionBaseInput) =>
-      serverRequest<unknown>(
+      serverRequest<null>(
         `/chat/sessions/${input.sessionId}/permission-responses/${input.permissionResponseId}/reject`,
         {
           method: 'POST',
@@ -67,7 +67,7 @@ export function useAlternativePermissionResponse() {
 
   return useMutation({
     mutationFn: (input: PermissionAlternativeInput) =>
-      serverRequest<unknown>(
+      serverRequest<null>(
         `/chat/sessions/${input.sessionId}/permission-responses/${input.permissionResponseId}/alternative`,
         {
           method: 'POST',

--- a/apps/web/src/lib/queries/questions.ts
+++ b/apps/web/src/lib/queries/questions.ts
@@ -25,7 +25,7 @@ export function useReplyQuestion() {
 
   return useMutation({
     mutationFn: (input: ReplyQuestionInput) =>
-      serverRequest<unknown>(`/chat/sessions/${input.sessionId}/questions/${input.questionId}/reply`, {
+      serverRequest<null>(`/chat/sessions/${input.sessionId}/questions/${input.questionId}/reply`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ answers: input.answers }),
@@ -41,9 +41,7 @@ export function useRejectQuestion() {
 
   return useMutation({
     mutationFn: (input: RejectQuestionInput) =>
-      serverRequest<unknown>(`/chat/sessions/${input.sessionId}/questions/${input.questionId}/reject`, {
-        method: 'POST',
-      }),
+      serverRequest<null>(`/chat/sessions/${input.sessionId}/questions/${input.questionId}/reject`, { method: 'POST' }),
     onSuccess: (_data, input) => {
       void queryClient.invalidateQueries({ queryKey: questionKeys.list(input.sessionId) });
     },

--- a/connectors/google/src/calendar/api.ts
+++ b/connectors/google/src/calendar/api.ts
@@ -36,6 +36,16 @@ type CalendarEvent = {
 
 type CalendarSearchResult = { events: CalendarEvent[]; nextPageToken: string | undefined };
 
+type CalendarEventBody = {
+  summary?: string;
+  description?: string;
+  location?: string;
+  start?: { dateTime: string; timeZone?: string };
+  end?: { dateTime: string; timeZone?: string };
+  attendees?: { email: string }[];
+  conferenceData?: { createRequest: { requestId: string } };
+};
+
 function mapEvent(raw: CalendarEventRaw): CalendarEvent {
   const meetLink = raw.conferenceData?.entryPoints?.find((ep) => ep.entryPointType === 'video')?.uri;
 
@@ -116,7 +126,7 @@ export async function createEvent(
   const url = new URL(`${CALENDAR_API}/calendars/${encodeURIComponent(calendarId)}/events`);
   if (event.addMeet) url.searchParams.set('conferenceDataVersion', '1');
 
-  const body: Record<string, unknown> = {
+  const body: CalendarEventBody = {
     summary: event.summary,
     description: event.description,
     location: event.location,
@@ -153,7 +163,7 @@ export async function updateEvent(
   url.searchParams.set('sendUpdates', sendUpdates);
   if (patch.addMeet) url.searchParams.set('conferenceDataVersion', '1');
 
-  const body: Record<string, unknown> = {};
+  const body: CalendarEventBody = {};
   if (patch.summary !== undefined) body['summary'] = patch.summary;
   if (patch.description !== undefined) body['description'] = patch.description;
   if (patch.location !== undefined) body['location'] = patch.location;

--- a/connectors/google/src/docs/api.ts
+++ b/connectors/google/src/docs/api.ts
@@ -30,6 +30,10 @@ type DocsSearchResult = {
 
 type DocsReadResult = { id: string; title: string; text: string; webViewLink: string };
 
+type DocsBatchUpdateRequest =
+  | { deleteContentRange: { range: { startIndex: number; endIndex: number } } }
+  | { insertText: { location: { index: number }; text: string } };
+
 function collectText(elements: DocsStructuralElement[] | undefined): string {
   if (!elements?.length) {
     return '';
@@ -159,7 +163,7 @@ export async function updateDocument(
 ): Promise<{ id: string; title: string; webViewLink: string }> {
   const doc = await client.request<DocsDocumentRaw>(`${DOCS_API}/documents/${documentId}`);
   const bodyEndIndex = getBodyEndIndex(doc);
-  const requests: Array<Record<string, unknown>> = [];
+  const requests: DocsBatchUpdateRequest[] = [];
 
   if (mode === 'replace' && bodyEndIndex > 2) {
     requests.push({ deleteContentRange: { range: { startIndex: 1, endIndex: bodyEndIndex - 1 } } });

--- a/connectors/google/src/drive/api.ts
+++ b/connectors/google/src/drive/api.ts
@@ -34,6 +34,8 @@ type DriveSearchResult = { files: DriveFile[]; nextPageToken: string | undefined
 
 type DriveFileContent = { id: string; name: string; mimeType: string; content: string };
 
+type DriveFileMetadata = { name: string; mimeType?: string; parents?: string[] };
+
 function mapFile(raw: DriveFileRaw): DriveFile {
   return {
     id: raw.id,
@@ -121,7 +123,7 @@ export async function createFile(
   mimeType = 'text/plain',
   parentId?: string,
 ): Promise<DriveWriteResult> {
-  const metadata: Record<string, unknown> = { name, mimeType };
+  const metadata: DriveFileMetadata = { name, mimeType };
   if (parentId) metadata['parents'] = [parentId];
 
   const metadataPart = JSON.stringify(metadata);
@@ -155,7 +157,7 @@ export async function uploadFile(
   const content = await fs.readFile(filePath);
   const name = options?.name ?? path.basename(filePath);
   const mimeType = options?.mimeType ?? 'application/octet-stream';
-  const metadata: Record<string, unknown> = { name };
+  const metadata: DriveFileMetadata = { name };
   if (options?.parentId) metadata['parents'] = [options.parentId];
 
   const boundary = 'drive_upload_boundary';

--- a/packages/server/src/memory/consolidation.ts
+++ b/packages/server/src/memory/consolidation.ts
@@ -1,5 +1,7 @@
 import { generateText, Output } from 'ai';
 
+import type { MemoryConsolidationResult } from '@stitch/shared/memory/types';
+
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { createProvider } from '@/llm/provider/provider.js';
@@ -14,16 +16,7 @@ const MAX_CANDIDATE_CHARACTERS = 20_000;
 type ConsolidationCheckpoint = {
   processedDailyHashes: Record<string, string>;
   processedCandidateIds: string[];
-  lastRun: ConsolidationResult;
-};
-
-export type ConsolidationResult = {
-  status: 'accepted' | 'rejected' | 'failed' | 'noop';
-  lastRunAt: string;
-  summary: string;
-  candidateCount: number;
-  promotedCount: number;
-  rejectedCount: number;
+  lastRun: MemoryConsolidationResult;
 };
 
 type ValidationInput = {
@@ -177,7 +170,7 @@ function nextCheckpoint(
   previous: ConsolidationCheckpoint | null,
   pending: Awaited<ReturnType<typeof eligibleCandidates>>,
   handledIds: string[],
-  result: ConsolidationResult,
+  result: MemoryConsolidationResult,
 ): ConsolidationCheckpoint {
   const processedCandidateIds = [...new Set([...(previous?.processedCandidateIds ?? []), ...handledIds])];
   const processed = new Set(processedCandidateIds);
@@ -189,11 +182,14 @@ function nextCheckpoint(
   return { processedDailyHashes, processedCandidateIds, lastRun: result };
 }
 
-function auditMarkdown(result: ConsolidationResult): string {
+function auditMarkdown(result: MemoryConsolidationResult): string {
   return `## ${result.lastRunAt} - ${result.status}\n\n${result.summary}\n\n- Candidates: ${result.candidateCount}\n- Promoted: ${result.promotedCount}\n- Rejected/no-op: ${result.rejectedCount}`;
 }
 
-async function recordRejected(store: MemoryFileStore, result: ConsolidationResult): Promise<ConsolidationResult> {
+async function recordRejected(
+  store: MemoryFileStore,
+  result: MemoryConsolidationResult,
+): Promise<MemoryConsolidationResult> {
   await store
     .appendConsolidationLog(auditMarkdown(result))
     .catch((error) => log.warn({ error }, 'failed to append rejected consolidation audit'));
@@ -206,7 +202,7 @@ export async function consolidateMemories(
     maxCandidates?: number;
     propose?: (prompt: string) => Promise<ConsolidationProposal>;
   } = {},
-): Promise<ConsolidationResult> {
+): Promise<MemoryConsolidationResult> {
   const previous = maintenanceQueue;
   let release = (): void => undefined;
   maintenanceQueue = new Promise<void>((resolve) => {
@@ -235,7 +231,7 @@ export async function consolidateMemories(
       };
     }
     if (pending.candidates.length === 0) {
-      const result: ConsolidationResult = {
+      const result: MemoryConsolidationResult = {
         status: 'noop',
         lastRunAt,
         summary: 'No eligible user-origin candidates were found.',
@@ -297,7 +293,7 @@ export async function consolidateMemories(
       memoryHash: memory.contentHash,
       userHash: user.contentHash,
     });
-    const result: ConsolidationResult = {
+    const result: MemoryConsolidationResult = {
       status: 'accepted',
       lastRunAt,
       summary: proposal.summary,

--- a/packages/server/src/memory/maintenance.ts
+++ b/packages/server/src/memory/maintenance.ts
@@ -1,12 +1,14 @@
+import type { MemoryConsolidationResult } from '@stitch/shared/memory/types';
+
 import * as Log from '@/lib/log.js';
 import { ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { getMemoryConfig } from '@/memory/config.js';
-import { consolidateMemories, type ConsolidationResult } from '@/memory/consolidation.js';
+import { consolidateMemories } from '@/memory/consolidation.js';
 
 const log = Log.create({ service: 'memory-consolidation' });
 
-export async function runMemoryMaintenance(): Promise<ServiceResult<ConsolidationResult>> {
+export async function runMemoryMaintenance(): Promise<ServiceResult<MemoryConsolidationResult>> {
   const config = await getMemoryConfig();
   if (!config.enabled) {
     return ok({

--- a/packages/server/src/models/stt/service.ts
+++ b/packages/server/src/models/stt/service.ts
@@ -5,7 +5,7 @@ import type { ModelDescriptor } from '@/stt/types.js';
 type CatalogEntry = { providerId: string; providerName: string; models: ModelDescriptor[] };
 
 function toModelDescriptor(model: SttModel): ModelDescriptor {
-  return model as unknown as ModelDescriptor;
+  return model;
 }
 
 function toCatalogEntry(provider: SttProvider): CatalogEntry {

--- a/packages/server/src/stt/adapters/openai.ts
+++ b/packages/server/src/stt/adapters/openai.ts
@@ -112,7 +112,11 @@ export function createOpenAIMessageParser(sessionStartMs: number) {
 }
 
 function buildSessionConfig(config: STTConnectionConfig): string {
-  const audioInput: Record<string, unknown> = {
+  const audioInput: {
+    format: { type: 'audio/pcm'; rate: number };
+    transcription: { model: string; language?: string };
+    turn_detection: null;
+  } = {
     format: { type: 'audio/pcm', rate: 24000 },
     transcription: { model: config.modelId, ...(config.language ? { language: config.language } : {}) },
     turn_detection: null,

--- a/packages/server/src/tools/core/create-skill.ts
+++ b/packages/server/src/tools/core/create-skill.ts
@@ -4,12 +4,12 @@ import { createSkillSchema } from '@stitch/shared/skills/types';
 
 import { createSkill } from '@/skills/service.js';
 import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
+import type { z } from 'zod';
 
 const createSkillInputSchema = createSkillSchema.describe('A reusable skill to save for future use');
 
-export async function createSkillFromTool(input: unknown) {
-  const parsed = createSkillSchema.parse(input);
-  const result = await createSkill(parsed);
+export async function createSkillFromTool(input: z.input<typeof createSkillSchema>) {
+  const result = await createSkill(createSkillSchema.parse(input));
   if (result.error) {
     return { error: result.error.message };
   }

--- a/packages/shared/src/memory/types.ts
+++ b/packages/shared/src/memory/types.ts
@@ -57,6 +57,12 @@ export type MemoryConsolidationStatus = {
   rejectedCount: number;
 };
 
+export type MemoryConsolidationResult = Omit<MemoryConsolidationStatus, 'status' | 'lastRunAt' | 'summary'> & {
+  status: Exclude<MemoryConsolidationStatus['status'], 'never'>;
+  lastRunAt: string;
+  summary: string;
+};
+
 export type MemoryFilesOverview = {
   memory: MemoryFileSnapshot;
   user: MemoryFileSnapshot;


### PR DESCRIPTION
## 🚀 Change Summary

Replace convenience uses of `unknown` with concrete application types while retaining `unknown` at genuine trust boundaries such as external JSON, IPC, SSE, schemas, and arbitrary tool outputs.

### 🛠 Improvements & Refactors

- Type web mutation responses using their actual entities, `null` results, and shared memory consolidation contract.
- Define concrete Google Calendar, Drive, and Docs request payload shapes.
- Remove avoidable casts from STT model mapping and use schema-derived input typing for skill creation.
