### PR TITLE
chore(lint): disallow pass-through type aliases

### DIFF
--- a/apps/web/src/components/chat/message-bubble/tool-call-display.ts
+++ b/apps/web/src/components/chat/message-bubble/tool-call-display.ts
@@ -16,8 +16,6 @@ const GOOGLE_SERVICE_ICON_SLUGS = {
   calendar: 'googlecalendar',
 } as const;
 
-type ToolSummaryKind = ToolIconKind;
-
 export type ToolCallDisplayItem = {
   id: string;
   toolName: string;
@@ -28,7 +26,7 @@ export type ToolCallDisplayItem = {
 };
 
 export type ToolCallSummary = {
-  kind: ToolSummaryKind;
+  kind: ToolIconKind;
   label: string;
   preview: string;
   meta?: string;
@@ -136,12 +134,12 @@ function getChildSessionId(result: unknown): string | null {
   return typeof id === 'string' ? id : null;
 }
 
-function getToolKind(toolName: string): ToolSummaryKind {
+function getToolKind(toolName: string): ToolIconKind {
   if (parseMcpToolName(toolName)) return 'mcp';
   return getToolIconKind(toolName);
 }
 
-function getToolLabel(toolName: string, displayName: string, kind: ToolSummaryKind): string {
+function getToolLabel(toolName: string, displayName: string, kind: ToolIconKind): string {
   if (toolName === 'gmail_download_attachments') return 'Gmail Attachments';
 
   if (kind === 'mcp') {
@@ -159,7 +157,7 @@ function getConnectorIconSlug(toolName: string): string | null {
   return GOOGLE_SERVICE_ICON_SLUGS[service as keyof typeof GOOGLE_SERVICE_ICON_SLUGS] ?? null;
 }
 
-function getToolPreview(call: ToolCallDisplayItem, kind: ToolSummaryKind): string {
+function getToolPreview(call: ToolCallDisplayItem, kind: ToolIconKind): string {
   if (call.error) return truncateText(call.error, 96);
 
   for (const getPreview of [getToolsetPreview, getGmailPreview, getSkillPreview]) {

--- a/connectors/google/src/client.ts
+++ b/connectors/google/src/client.ts
@@ -58,12 +58,7 @@ type GoogleErrorResponse = {
   };
 };
 
-type RequestOptions = RequestInit;
-
-function mergeHeaders(
-  base: RequestOptions['headers'] | undefined,
-  extra: Record<string, string>,
-): Record<string, string> {
+function mergeHeaders(base: RequestInit['headers'] | undefined, extra: Record<string, string>): Record<string, string> {
   const headers = new Headers(base);
   for (const [key, value] of Object.entries(extra)) headers.set(key, value);
   return { ...Object.fromEntries(headers.entries()), ...extra };
@@ -88,7 +83,7 @@ export class GoogleClient {
     );
   }
 
-  async request<T>(url: string, options?: RequestOptions): Promise<T> {
+  async request<T>(url: string, options?: RequestInit): Promise<T> {
     const response = await this.executeWithRetries(url, {
       ...options,
       headers: mergeHeaders(options?.headers, { 'Content-Type': 'application/json' }),
@@ -96,16 +91,16 @@ export class GoogleClient {
     return (await response.json()) as T;
   }
 
-  async requestRaw(url: string, options?: RequestOptions): Promise<Response> {
+  async requestRaw(url: string, options?: RequestInit): Promise<Response> {
     return this.executeWithRetries(url, options);
   }
 
-  async requestText(url: string, options?: RequestOptions): Promise<string> {
+  async requestText(url: string, options?: RequestInit): Promise<string> {
     const response = await this.executeWithRetries(url, options);
     return await response.text();
   }
 
-  private async executeWithRetries(url: string, options?: RequestOptions): Promise<Response> {
+  private async executeWithRetries(url: string, options?: RequestInit): Promise<Response> {
     const method = options?.method ?? 'GET';
     let forceRefresh = false;
     let retriedUnauthorized = false;

--- a/oxlint.json
+++ b/oxlint.json
@@ -17,6 +17,7 @@
     "no-unused-vars": "error",
     "eqeqeq": "error",
     "no-else-return": "error",
+    "stitch/no-pass-through-type-alias": "error",
     "typescript/no-deprecated": "error",
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/no-unnecessary-condition": "error",

--- a/packages/meeting-detection/src/meeting-detection/macos-classify.ts
+++ b/packages/meeting-detection/src/meeting-detection/macos-classify.ts
@@ -3,8 +3,6 @@ import { mergeObservations } from './observations.js';
 import type { NativeWatchRow } from '../native.js';
 import type { MeetingObservation } from './engine.js';
 
-type WatchRow = NativeWatchRow;
-
 const GOOGLE_MEET_TITLE_RE = /google meet|meet\.google\.com/i;
 
 type DesktopApp = {
@@ -25,7 +23,7 @@ function normalizeProcessName(input: string): string {
   return input.trim().toLowerCase();
 }
 
-function toDesktopObservation(row: WatchRow): MeetingObservation | null {
+function toDesktopObservation(row: NativeWatchRow): MeetingObservation | null {
   const rawProcessName = row.processName.trim();
   if (!rawProcessName) {
     return null;
@@ -47,7 +45,7 @@ function toDesktopObservation(row: WatchRow): MeetingObservation | null {
   };
 }
 
-function toBrowserObservation(row: WatchRow): MeetingObservation | null {
+function toBrowserObservation(row: NativeWatchRow): MeetingObservation | null {
   const rawProcessName = row.processName.trim();
   if (!rawProcessName) {
     return null;
@@ -84,13 +82,13 @@ function toBrowserObservation(row: WatchRow): MeetingObservation | null {
   return null;
 }
 
-function classifyRow(row: WatchRow): MeetingObservation[] {
+function classifyRow(row: NativeWatchRow): MeetingObservation[] {
   return [toDesktopObservation(row), toBrowserObservation(row)].filter((value): value is MeetingObservation =>
     Boolean(value),
   );
 }
 
-export function classifyMacosRows(rows: WatchRow[]): MeetingObservation[] {
+export function classifyMacosRows(rows: NativeWatchRow[]): MeetingObservation[] {
   const observations = rows.flatMap(classifyRow);
   return mergeObservations(observations);
 }

--- a/packages/meeting-detection/src/meeting-detection/watcher.ts
+++ b/packages/meeting-detection/src/meeting-detection/watcher.ts
@@ -7,10 +7,8 @@ import type { NativeWatchEvent, NativeWatchRow } from '../native.js';
 import type { MeetingDetectionOptions, MeetingDetector } from '../types.js';
 import type { MeetingObservation } from './engine.js';
 
-type WatchRow = NativeWatchRow;
-
 /** Per-platform row classification implemented in the classifier files. */
-type RowClassifier = (rows: WatchRow[]) => MeetingObservation[];
+type RowClassifier = (rows: NativeWatchRow[]) => MeetingObservation[];
 
 // The native watcher is edge-triggered, but the engine activates a candidate
 // only after it has been seen for the activation threshold. Re-feed the latest

--- a/packages/meeting-detection/src/meeting-detection/windows-classify.ts
+++ b/packages/meeting-detection/src/meeting-detection/windows-classify.ts
@@ -3,8 +3,6 @@ import { mergeObservations } from './observations.js';
 import type { NativeWatchRow } from '../native.js';
 import type { MeetingObservation } from './engine.js';
 
-type WatchRow = NativeWatchRow;
-
 const TEAMS_CALL_HINT_RE = /meeting|call|microsoft teams|teams/;
 const SLACK_CALL_HINT_RE = /huddle|call/;
 const DISCORD_CALL_HINT_RE = /call|voice|stage/;
@@ -31,7 +29,7 @@ function hasCallHint(platform: 'teams' | 'slack' | 'discord', title: string): bo
   return DISCORD_CALL_HINT_RE.test(normalized);
 }
 
-function classifyRow(row: WatchRow): MeetingObservation[] {
+function classifyRow(row: NativeWatchRow): MeetingObservation[] {
   const rawProcessName = row.processName.trim();
   if (!rawProcessName) {
     return [];
@@ -99,7 +97,7 @@ function classifyRow(row: WatchRow): MeetingObservation[] {
   return observations;
 }
 
-export function classifyWindowsRows(rows: WatchRow[]): MeetingObservation[] {
+export function classifyWindowsRows(rows: NativeWatchRow[]): MeetingObservation[] {
   const observations = rows.flatMap(classifyRow);
   return mergeObservations(observations);
 }

--- a/packages/scheduler/src/scheduler.test.ts
+++ b/packages/scheduler/src/scheduler.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, jest, mock, test } from 'bun:test';
 
+import type { StitchLogger } from '@stitch/shared/logger';
+
 import { createScheduler } from './scheduler.js';
 
-import type { JobSchedule, PersistedJob, PersistedJobRun, SchedulerLogger, SchedulerStore } from './types.js';
+import type { JobSchedule, PersistedJob, PersistedJobRun, SchedulerStore } from './types.js';
 
 const BASE_TIME = new Date('2026-01-01T00:00:00.000Z').getTime();
 let mockNow = BASE_TIME;
@@ -19,7 +21,7 @@ async function advanceTime(ms: number, step = 10): Promise<void> {
   }
 }
 
-function makeLogger(): SchedulerLogger {
+function makeLogger(): StitchLogger {
   const noop = () => {};
   return { debug: noop, info: noop, warn: noop, error: noop };
 }

--- a/packages/scheduler/src/scheduler.ts
+++ b/packages/scheduler/src/scheduler.ts
@@ -1,19 +1,14 @@
+import type { StitchLogger } from '@stitch/shared/logger';
+
 import { getNextCronRunMs } from './cron.js';
 
-import type {
-  CatchupPolicy,
-  JobSchedule,
-  PersistedJobRun,
-  RegisteredJob,
-  SchedulerLogger,
-  SchedulerStore,
-} from './types.js';
+import type { CatchupPolicy, JobSchedule, PersistedJobRun, RegisteredJob, SchedulerStore } from './types.js';
 
 const DEFAULT_POLL_INTERVAL_MS = 1_000;
 const DEFAULT_MAX_CONCURRENCY = 1;
 const DEFAULT_CATCHUP_MAX_RUNS = 100;
 
-type SchedulerOptions = { logger: SchedulerLogger; store: SchedulerStore; pollIntervalMs?: number };
+type SchedulerOptions = { logger: StitchLogger; store: SchedulerStore; pollIntervalMs?: number };
 
 type RegisteredJobInternal = Omit<Required<RegisteredJob>, 'callback' | 'schedule'> & {
   callback: RegisteredJob['callback'];

--- a/packages/scheduler/src/types.ts
+++ b/packages/scheduler/src/types.ts
@@ -1,7 +1,3 @@
-import { type StitchLogger } from '@stitch/shared/logger';
-
-export type SchedulerLogger = StitchLogger;
-
 type IntervalSchedule = { type: 'interval'; everyMs: number };
 
 type CronSchedule = { type: 'cron'; expression: string; timezone?: string };

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -31,8 +31,7 @@ import { validateProviderModel } from '@/llm/resolve-model.js';
 const log = Log.create({ service: 'automations' });
 
 type AutomationDbRow = typeof automations.$inferSelect;
-type AutomationRow = Automation;
-type SyncAutomationSchedule = (automation: AutomationRow) => Promise<void>;
+type SyncAutomationSchedule = (automation: Automation) => Promise<void>;
 
 function normalizeText(value: string): string {
   return value.trim();
@@ -59,7 +58,7 @@ function deserializeAutomationSchedule(blob: AutomationScheduleBlob | null): Aut
   return blob.schedule;
 }
 
-function toAutomationRow(row: AutomationDbRow): AutomationRow {
+function toAutomationRow(row: AutomationDbRow): Automation {
   return { ...row, schedule: deserializeAutomationSchedule(row.schedule) };
 }
 
@@ -80,7 +79,7 @@ export async function listAutomations(input: {
   return ok({ automations: result.items, ...result });
 }
 
-export async function getAutomation(automationId: string): Promise<ServiceResult<AutomationRow>> {
+export async function getAutomation(automationId: string): Promise<ServiceResult<Automation>> {
   const db = getDb();
   const automation = (
     await db
@@ -96,7 +95,7 @@ export async function getAutomation(automationId: string): Promise<ServiceResult
   return ok(toAutomationRow(automation));
 }
 
-async function createAutomation(input: CreateAutomationInput): Promise<ServiceResult<AutomationRow>> {
+async function createAutomation(input: CreateAutomationInput): Promise<ServiceResult<Automation>> {
   const providerId = normalizeText(input.providerId);
   const modelId = normalizeText(input.modelId);
   const title = normalizeText(input.title);
@@ -137,7 +136,7 @@ async function createAutomation(input: CreateAutomationInput): Promise<ServiceRe
 export async function createAutomationAndSync(
   input: CreateAutomationInput,
   syncSchedule: SyncAutomationSchedule,
-): Promise<ServiceResult<AutomationRow>> {
+): Promise<ServiceResult<Automation>> {
   const result = await createAutomation(input);
   if (result.error) return result;
 
@@ -153,7 +152,7 @@ export async function createAutomationAndSync(
 async function updateAutomation(
   automationId: string,
   input: UpdateAutomationInput,
-): Promise<ServiceResult<AutomationRow>> {
+): Promise<ServiceResult<Automation>> {
   const db = getDb();
   const existing = (
     await db
@@ -213,7 +212,7 @@ export async function updateAutomationAndSync(
   automationId: string,
   input: UpdateAutomationInput,
   syncSchedule: SyncAutomationSchedule,
-): Promise<ServiceResult<AutomationRow>> {
+): Promise<ServiceResult<Automation>> {
   const beforeResult = await getAutomation(automationId);
   if (beforeResult.error) return beforeResult;
 

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -13,11 +13,9 @@ import { seedMeetingNoteTemplates } from '@/recordings/meeting-note-templates.js
 import type { Database } from 'bun:sqlite';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 
-type Db = BunSQLiteDatabase;
-
 const log = Log.create({ service: 'db' });
 
-let _db: Db | undefined;
+let _db: BunSQLiteDatabase | undefined;
 let _sqlite: Database | undefined;
 
 function getDatabasePath(): string {
@@ -38,7 +36,7 @@ function getMigrationsDir(): string {
   return migrationsDir;
 }
 
-function seedShortcuts(db: Db): void {
+function seedShortcuts(db: BunSQLiteDatabase): void {
   for (const def of SHORTCUT_DEFAULTS) {
     db.insert(keyboardShortcuts)
       .values({
@@ -53,7 +51,7 @@ function seedShortcuts(db: Db): void {
   }
 }
 
-function seedSettings(db: Db): void {
+function seedSettings(db: BunSQLiteDatabase): void {
   for (const def of SETTINGS_DEFAULTS) {
     db.insert(userSettings)
       .values({ key: def.key, value: def.value, description: def.description })
@@ -62,7 +60,7 @@ function seedSettings(db: Db): void {
   }
 }
 
-export function getDb(): Db {
+export function getDb(): BunSQLiteDatabase {
   if (!_db) throw new DatabaseNotInitializedError();
   return _db;
 }
@@ -91,7 +89,7 @@ export async function initDb(): Promise<void> {
   sqlite.run('PRAGMA foreign_keys = ON');
 
   _sqlite = sqlite;
-  _db = drizzle({ client: sqlite }) as Db;
+  _db = drizzle({ client: sqlite }) as BunSQLiteDatabase;
   migrate(_db, { migrationsFolder: migrationsDir });
 
   seedShortcuts(_db);

--- a/packages/server/src/lib/browser/browser-manager.ts
+++ b/packages/server/src/lib/browser/browser-manager.ts
@@ -2,8 +2,13 @@ import type {
   ElectronBrowserCommand,
   ElectronBrowserCommandResult,
   ElectronBrowserDialogState,
+  ElectronBrowserDropdownOptionsResult,
   ElectronBrowserErrorMessage,
+  ElectronBrowserExtractContentResult,
+  ElectronBrowserFindElementsResult,
   ElectronBrowserResultMessage,
+  ElectronBrowserScreenshotResult,
+  ElectronBrowserSearchPageResult,
 } from '@stitch/shared/browser/electron';
 
 import {
@@ -11,16 +16,7 @@ import {
   BrowserBridgeNotConnectedError,
   BrowserSessionNotSetError,
 } from '@/lib/browser/errors.js';
-import type {
-  BrowserTab,
-  DropdownOptionsResult,
-  ExtractContentResult,
-  FindElementsResult,
-  LaunchOptions,
-  ScreenshotResult,
-  ScrollDirection,
-  SearchPageResult,
-} from '@/lib/browser/types.js';
+import type { BrowserTab, LaunchOptions, ScrollDirection } from '@/lib/browser/types.js';
 
 const BRIDGE_HOST = '127.0.0.1';
 const REQUEST_TIMEOUT_MS = 30_000;
@@ -250,7 +246,7 @@ class BrowserManager {
     return String(await this.send({ action: 'select', ref, values }, signal));
   }
 
-  async getDropdownOptions(ref: string, signal?: AbortSignal): Promise<DropdownOptionsResult> {
+  async getDropdownOptions(ref: string, signal?: AbortSignal): Promise<ElectronBrowserDropdownOptionsResult> {
     return this.send({ action: 'getDropdownOptions', ref }, signal);
   }
 
@@ -268,7 +264,7 @@ class BrowserManager {
 
   async screenshot(
     options: { signal?: AbortSignal; format?: 'png' | 'jpeg'; quality?: number; fullPage?: boolean; ref?: string } = {},
-  ): Promise<ScreenshotResult> {
+  ): Promise<ElectronBrowserScreenshotResult> {
     return this.send({ action: 'screenshot', ...options }, options.signal);
   }
 
@@ -286,14 +282,14 @@ class BrowserManager {
       maxResults?: number;
     },
     signal?: AbortSignal,
-  ): Promise<SearchPageResult> {
+  ): Promise<ElectronBrowserSearchPageResult> {
     return this.send({ action: 'searchPage', ...options }, signal);
   }
 
   async findElements(
     options: { selector: string; attributes?: string[]; maxResults?: number; includeText?: boolean },
     signal?: AbortSignal,
-  ): Promise<FindElementsResult> {
+  ): Promise<ElectronBrowserFindElementsResult> {
     return this.send({ action: 'findElements', ...options }, signal);
   }
 
@@ -314,7 +310,7 @@ class BrowserManager {
       includeImages?: boolean;
       outputSchema?: Record<string, unknown>;
     } = {},
-  ): Promise<string | ExtractContentResult> {
+  ): Promise<string | ElectronBrowserExtractContentResult> {
     return this.send({ action: 'extractPageContent', ...options }, signal);
   }
 }

--- a/packages/server/src/lib/browser/types.ts
+++ b/packages/server/src/lib/browser/types.ts
@@ -1,21 +1,5 @@
-import type {
-  ElectronBrowserDropdownOptionsResult,
-  ElectronBrowserExtractContentResult,
-  ElectronBrowserFindElementsResult,
-  ElectronBrowserScreenshotResult,
-  ElectronBrowserSearchPageResult,
-} from '@stitch/shared/browser/electron';
-
 export type BrowserTab = { id: string; title: string; url: string; type: string };
 
 export type LaunchOptions = { port?: number; width?: number; height?: number };
 
 export type ScrollDirection = 'up' | 'down' | 'left' | 'right';
-
-// Wire-result shapes are defined once in @stitch/shared/browser/electron (the
-// server-to-desktop contract). These aliases keep the server's existing names.
-export type ScreenshotResult = ElectronBrowserScreenshotResult;
-export type SearchPageResult = ElectronBrowserSearchPageResult;
-export type FindElementsResult = ElectronBrowserFindElementsResult;
-export type DropdownOptionsResult = ElectronBrowserDropdownOptionsResult;
-export type ExtractContentResult = ElectronBrowserExtractContentResult;

--- a/packages/server/src/mcp/client.ts
+++ b/packages/server/src/mcp/client.ts
@@ -18,8 +18,6 @@ import type { Tool } from 'ai';
 
 const log = Log.create({ service: 'mcp-client' });
 
-type McpClient = Client;
-
 type McpServerRef = { id: PrefixedString<'mcp'>; name: string; url: string; authConfig: McpAuthConfig };
 
 /**
@@ -27,7 +25,7 @@ type McpServerRef = { id: PrefixedString<'mcp'>; name: string; url: string; auth
  * Clients live for the process lifetime. If a client dies (transport error),
  * it is evicted so the next call reconnects.
  */
-const clientCache = new Map<string, Promise<McpClient>>();
+const clientCache = new Map<string, Promise<Client>>();
 
 /**
  * Transports for in-flight OAuth flows, keyed by server ID. `finishAuth` must
@@ -93,7 +91,7 @@ function clientCacheKey(serverId: string, sessionId?: string): string {
   return sessionId ? `${serverId}:${sessionId}` : serverId;
 }
 
-async function openClient(server: McpServerRef, sessionId?: PrefixedString<'ses'>): Promise<McpClient> {
+async function openClient(server: McpServerRef, sessionId?: PrefixedString<'ses'>): Promise<Client> {
   const transport = buildTransport(server);
   const cacheKey = clientCacheKey(server.id, sessionId);
   const client = new Client(
@@ -150,7 +148,7 @@ async function openClient(server: McpServerRef, sessionId?: PrefixedString<'ses'
 }
 
 /** Get (or create) a cached MCP client for a server. */
-export function getMcpClient(server: McpServerRef, sessionId?: PrefixedString<'ses'>): Promise<McpClient> {
+export function getMcpClient(server: McpServerRef, sessionId?: PrefixedString<'ses'>): Promise<Client> {
   const cacheKey = clientCacheKey(server.id, sessionId);
   const cached = clientCache.get(cacheKey);
   if (cached) return cached;
@@ -180,7 +178,7 @@ export function evictMcpClient(serverId: string): void {
  */
 export async function withMcpClient<T>(
   server: McpServerRef,
-  fn: (client: McpClient) => Promise<T>,
+  fn: (client: Client) => Promise<T>,
   sessionId?: PrefixedString<'ses'>,
 ): Promise<T> {
   const cacheKey = clientCacheKey(server.id, sessionId);

--- a/packages/server/src/tools/runtime/runtime.ts
+++ b/packages/server/src/tools/runtime/runtime.ts
@@ -3,13 +3,7 @@ import type { PermissionSuggestion } from '@stitch/shared/permissions/types';
 
 import type { Tool } from 'ai';
 
-export type ToolRuntimeContext = {
-  sessionId: PrefixedString<'ses'>;
-  messageId: PrefixedString<'msg'>;
-  streamRunId: string;
-};
-
-export type ToolContext = ToolRuntimeContext;
+export type ToolContext = { sessionId: PrefixedString<'ses'>; messageId: PrefixedString<'msg'>; streamRunId: string };
 
 export type RuntimeToolSource = 'core' | 'toolset' | 'mcp' | 'meta' | 'task' | 'code-mode';
 
@@ -33,7 +27,7 @@ export type ToolExecutionInput = {
   args: unknown;
   executeOptions: unknown;
   tool: Tool;
-  context: ToolRuntimeContext;
+  context: ToolContext;
   metadata: RuntimeToolMetadata;
 };
 
@@ -54,7 +48,7 @@ export function defineRuntimeTool(name: string, tool: Tool, metadata: RuntimeToo
   return { ...metadata, name, description: tool.description ?? '', tool };
 }
 
-export function createToolRuntime(context: ToolRuntimeContext): ToolRuntime {
+export function createToolRuntime(context: ToolContext): ToolRuntime {
   const middlewares: ToolMiddleware[] = [];
 
   const runtime: ToolRuntime = {

--- a/packages/server/src/tools/toolsets/browser/formatters.ts
+++ b/packages/server/src/tools/toolsets/browser/formatters.ts
@@ -1,11 +1,12 @@
-import { getBrowserManager } from '@/lib/browser/browser-manager.js';
 import type {
-  BrowserTab,
-  DropdownOptionsResult,
-  ExtractContentResult,
-  FindElementsResult,
-  SearchPageResult,
-} from '@/lib/browser/types.js';
+  ElectronBrowserDropdownOptionsResult,
+  ElectronBrowserExtractContentResult,
+  ElectronBrowserFindElementsResult,
+  ElectronBrowserSearchPageResult,
+} from '@stitch/shared/browser/electron';
+
+import { getBrowserManager } from '@/lib/browser/browser-manager.js';
+import type { BrowserTab } from '@/lib/browser/types.js';
 import { serializeBrowserSnapshot } from '@/tools/toolsets/browser/snapshot-serializer.js';
 
 export function formatTabsOutput(tabs: BrowserTab[]): string {
@@ -16,7 +17,7 @@ export function formatTabsOutput(tabs: BrowserTab[]): string {
   return `Open tabs:\n${tabList}`;
 }
 
-export function formatSearchPageSummary(pattern: string, result: SearchPageResult): string {
+export function formatSearchPageSummary(pattern: string, result: ElectronBrowserSearchPageResult): string {
   const matchLines = result.matches.map((m, i) => `  ${i + 1}. "${m.match}" - ...${m.context}...`);
   const showing = result.matches.length;
   const total = result.total;
@@ -26,7 +27,7 @@ export function formatSearchPageSummary(pattern: string, result: SearchPageResul
   return `Found ${total} match${total !== 1 ? 'es' : ''} for "${pattern}"${showing < total ? ` (showing ${showing})` : ''}:\n${matchLines.join('\n')}`;
 }
 
-export function formatFindElementsSummary(selector: string, result: FindElementsResult): string {
+export function formatFindElementsSummary(selector: string, result: ElectronBrowserFindElementsResult): string {
   const elemLines = result.elements.map((el, i) => {
     let line = `  ${i + 1}. <${el.tag}>`;
     if (el.text) line += ` "${el.text}"`;
@@ -46,7 +47,7 @@ export function formatFindElementsSummary(selector: string, result: FindElements
   return `Found ${total} element${total !== 1 ? 's' : ''} matching "${selector}"${showing < total ? ` (showing ${showing})` : ''}:\n${elemLines.join('\n')}`;
 }
 
-export function formatDropdownOptionsSummary(ref: string, result: DropdownOptionsResult): string {
+export function formatDropdownOptionsSummary(ref: string, result: ElectronBrowserDropdownOptionsResult): string {
   if (result.options.length === 0) {
     return `No dropdown options found for ${ref}.`;
   }
@@ -59,7 +60,10 @@ export function formatDropdownOptionsSummary(ref: string, result: DropdownOption
   return `Dropdown options for ${ref} (${result.type}):\n${lines.join('\n')}\nUse browser_interact action="select_dropdown" with text to choose one.`;
 }
 
-export function formatExtractContent(query: string | undefined, result: string | ExtractContentResult): string {
+export function formatExtractContent(
+  query: string | undefined,
+  result: string | ElectronBrowserExtractContentResult,
+): string {
   if (typeof result === 'string') {
     return `### Extracted Content\n**Query:** ${query ?? 'page content'}\n\n${result}`;
   }

--- a/packages/shared/src/automations/types.ts
+++ b/packages/shared/src/automations/types.ts
@@ -12,13 +12,9 @@ export type Automation = {
   updatedAt: number;
 };
 
-type AutomationCronSchedule = { type: 'cron'; expression: string };
+export type AutomationSchedule = { type: 'cron'; expression: string };
 
-export type AutomationSchedule = AutomationCronSchedule;
-
-type AutomationScheduleBlobV1 = { version: 1; schedule: AutomationSchedule };
-
-export type AutomationScheduleBlob = AutomationScheduleBlobV1;
+export type AutomationScheduleBlob = { version: 1; schedule: AutomationSchedule };
 
 export type CreateAutomationInput = {
   providerId: string;

--- a/packages/shared/src/ipc/types.ts
+++ b/packages/shared/src/ipc/types.ts
@@ -37,14 +37,12 @@ export type RecordingPermissionsPayload = {
 
 export type MeetingCallDismissedPayload = { key: string };
 
-type MeetingDetectedNotificationPayload = MeetingCallDetectedPayload;
-
 export type DesktopNotificationEvent = {
   id: string;
   type: 'meeting-detected';
   createdAt: number;
   autoDismissMs: number | null;
-  payload: MeetingDetectedNotificationPayload;
+  payload: MeetingCallDetectedPayload;
 };
 
 export interface IpcContract {

--- a/tools/oxlint-plugins/index.mjs
+++ b/tools/oxlint-plugins/index.mjs
@@ -1,11 +1,17 @@
 import noCallOnlyAssertions from './no-call-only-assertions.mjs';
+import noPassThroughTypeAlias from './no-pass-through-type-alias.mjs';
 import noWindowConfirm from './no-window-confirm.mjs';
 import uiRules from './ui/index.mjs';
 
 /** @type {{ meta: { name: string }, rules: Record<string, unknown> }} */
 const plugin = {
   meta: { name: 'stitch' },
-  rules: { 'no-call-only-assertions': noCallOnlyAssertions, 'no-window-confirm': noWindowConfirm, ...uiRules },
+  rules: {
+    'no-call-only-assertions': noCallOnlyAssertions,
+    'no-pass-through-type-alias': noPassThroughTypeAlias,
+    'no-window-confirm': noWindowConfirm,
+    ...uiRules,
+  },
 };
 
 export default plugin;

--- a/tools/oxlint-plugins/no-pass-through-type-alias.mjs
+++ b/tools/oxlint-plugins/no-pass-through-type-alias.mjs
@@ -1,0 +1,46 @@
+function isForwardedTypeParameter(typeArgument, typeParameter) {
+  return (
+    typeArgument.type === 'TSTypeReference' &&
+    typeArgument.typeName.type === 'Identifier' &&
+    typeArgument.typeName.name === typeParameter.name.name &&
+    !typeArgument.typeArguments
+  );
+}
+
+function isPassThroughTypeAlias(node) {
+  if (node.typeAnnotation.type !== 'TSTypeReference' || node.typeAnnotation.typeName.type !== 'Identifier') {
+    return false;
+  }
+
+  const typeParameters = node.typeParameters?.params ?? [];
+  const typeArguments = node.typeAnnotation.typeArguments?.params ?? [];
+  return (
+    typeParameters.length === typeArguments.length &&
+    typeParameters.every((typeParameter, index) => isForwardedTypeParameter(typeArguments[index], typeParameter))
+  );
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const noPassThroughTypeAlias = {
+  meta: {
+    type: 'suggestion',
+    docs: { description: 'Disallow type aliases that only rename another type' },
+    messages: { passThroughAlias: 'Use {{typeName}} directly instead of creating a pass-through type alias.' },
+    schema: [],
+  },
+  create(context) {
+    return {
+      TSTypeAliasDeclaration(node) {
+        if (isPassThroughTypeAlias(node)) {
+          context.report({
+            data: { typeName: node.typeAnnotation.typeName.name },
+            messageId: 'passThroughAlias',
+            node,
+          });
+        }
+      },
+    };
+  },
+};
+
+export default noPassThroughTypeAlias;


### PR DESCRIPTION
## 🚀 Change Summary

Adds a custom Oxlint rule that prevents pass-through type aliases and removes the existing aliases it identifies across the repository.

### 🛠 Improvements & Refactors

- Enforce direct type usage for aliases that only rename another type or forward identical generic parameters
- Replace existing pass-through aliases with their underlying types while preserving established structured API types
