### PR TITLE
feat(google): support Gmail attachments and Drive deletion

### DIFF
--- a/connectors/google/src/drive/api.test.ts
+++ b/connectors/google/src/drive/api.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { uploadFile } from './api.js';
+import { deleteFiles, uploadFile } from './api.js';
 
 import type { GoogleClient } from '../client.js';
 
@@ -53,5 +53,59 @@ describe('Drive API uploadFile', () => {
       mimeType: 'text/plain',
       webViewLink: 'https://drive.google.com/file/d/file-1/view',
     });
+  });
+});
+
+describe('Drive API deleteFiles', () => {
+  test('deletes multiple files', async () => {
+    let requestUrl = '';
+    let requestOptions: RequestInit | undefined;
+    const client = {
+      requestRaw: async (url: string, options?: RequestInit) => {
+        requestUrl = url;
+        requestOptions = options;
+        return new Response(
+          [
+            '--response',
+            'Content-Type: application/http',
+            '',
+            'HTTP/1.1 204 No Content',
+            '',
+            '--response',
+            'Content-Type: application/http',
+            '',
+            'HTTP/1.1 204 No Content',
+            '',
+            '--response--',
+          ].join('\r\n'),
+        );
+      },
+    } as unknown as GoogleClient;
+
+    const result = await deleteFiles(client, ['file-1', 'file/2']);
+
+    expect(requestUrl).toBe('https://www.googleapis.com/batch/drive/v3');
+    expect(requestOptions?.method).toBe('POST');
+    expect(requestOptions?.headers).toEqual({
+      'Content-Type': expect.stringContaining('multipart/mixed; boundary=drive_delete_'),
+    });
+    expect(requestOptions?.body).toContain('DELETE /drive/v3/files/file-1?supportsAllDrives=true HTTP/1.1');
+    expect(requestOptions?.body).toContain('DELETE /drive/v3/files/file%2F2?supportsAllDrives=true HTTP/1.1');
+    expect(result).toEqual({ deletedFileIds: ['file-1', 'file/2'] });
+  });
+
+  test('reports failed inner delete requests', async () => {
+    const client = {
+      requestRaw: async () =>
+        new Response(
+          ['--response', 'Content-Type: application/http', '', 'HTTP/1.1 404 Not Found', '', '--response--'].join(
+            '\r\n',
+          ),
+        ),
+    } as unknown as GoogleClient;
+
+    expect(deleteFiles(client, ['missing-file'])).rejects.toEqual(
+      expect.objectContaining({ failures: [{ fileId: 'missing-file', status: 404 }] }),
+    );
   });
 });

--- a/connectors/google/src/drive/api.ts
+++ b/connectors/google/src/drive/api.ts
@@ -1,9 +1,13 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+import { DriveBatchDeleteError } from '../errors.js';
+
 import type { GoogleClient } from '../client.js';
 
 const DRIVE_API = 'https://www.googleapis.com/drive/v3';
+const DRIVE_BATCH_API = 'https://www.googleapis.com/batch/drive/v3';
+const DRIVE_BATCH_LIMIT = 100;
 
 type DriveFileRaw = {
   id: string;
@@ -188,4 +192,46 @@ export async function uploadFile(
   );
 
   return { id: raw.id, name: raw.name, mimeType: raw.mimeType, webViewLink: raw.webViewLink };
+}
+
+export async function deleteFiles(client: GoogleClient, fileIds: string[]): Promise<{ deletedFileIds: string[] }> {
+  const batches: string[][] = [];
+  for (let index = 0; index < fileIds.length; index += DRIVE_BATCH_LIMIT) {
+    batches.push(fileIds.slice(index, index + DRIVE_BATCH_LIMIT));
+  }
+
+  await Promise.all(
+    batches.map(async (batch, batchIndex) => {
+      const boundary = `drive_delete_${crypto.randomUUID()}`;
+      const body = [
+        ...batch.flatMap((fileId, index) => [
+          `--${boundary}`,
+          'Content-Type: application/http',
+          `Content-ID: delete-${batchIndex * DRIVE_BATCH_LIMIT + index}`,
+          '',
+          `DELETE /drive/v3/files/${encodeURIComponent(fileId)}?supportsAllDrives=true HTTP/1.1`,
+          '',
+        ]),
+        `--${boundary}--`,
+        '',
+      ].join('\r\n');
+      const response = await client.requestRaw(DRIVE_BATCH_API, {
+        method: 'POST',
+        headers: { 'Content-Type': `multipart/mixed; boundary=${boundary}` },
+        body,
+      });
+      const responseBody = await response.text();
+      const statuses = [...responseBody.matchAll(/^HTTP\/\d(?:\.\d)?\s+(\d{3})/gm)].map((match) => Number(match[1]));
+      if (statuses.length !== batch.length) {
+        throw new DriveBatchDeleteError(batch.map((fileId, index) => ({ fileId, status: statuses.at(index) })));
+      }
+      const failures = batch.flatMap((fileId, index) => {
+        const status = statuses[index];
+        return status >= 200 && status < 300 ? [] : [{ fileId, status }];
+      });
+      if (failures.length > 0) throw new DriveBatchDeleteError(failures);
+    }),
+  );
+
+  return { deletedFileIds: fileIds };
 }

--- a/connectors/google/src/drive/tools.ts
+++ b/connectors/google/src/drive/tools.ts
@@ -58,6 +58,14 @@ const driveUploadSchema = z.object({
   parentId: z.string().optional().describe('Optional parent folder ID to place the file in. Defaults to Drive root.'),
 });
 
+const driveDeleteSchema = z.object({
+  account: z
+    .string()
+    .optional()
+    .describe('Optional account email or label when multiple Google accounts are connected'),
+  fileIds: z.array(z.string()).min(1).describe('Google Drive file IDs to permanently delete'),
+});
+
 export function createDriveTools(
   resolveClient: (account?: string) => Promise<{ client: GoogleClient; usedAccount: string | null }>,
   hasWrite = false,
@@ -115,6 +123,15 @@ export function createDriveTools(
           mimeType: input.mimeType,
           parentId: input.parentId,
         });
+        return { ...result, usedAccount };
+      },
+    });
+    tools['drive_delete'] = tool({
+      description: 'Permanently delete one or more Google Drive files by ID.',
+      inputSchema: driveDeleteSchema,
+      execute: async (input: z.infer<typeof driveDeleteSchema>) => {
+        const { client, usedAccount } = await resolveClient(input.account);
+        const result = await DriveApi.deleteFiles(client, input.fileIds);
         return { ...result, usedAccount };
       },
     });

--- a/connectors/google/src/errors.ts
+++ b/connectors/google/src/errors.ts
@@ -66,10 +66,30 @@ export class GmailAttachmentMissingDataError extends GoogleConnectorError {
   }
 }
 
+export class GmailAttachmentSizeLimitError extends GoogleConnectorError {
+  readonly totalBytes: number;
+  readonly maxBytes: number;
+  constructor(totalBytes: number, maxBytes: number) {
+    super(`Gmail attachments total ${totalBytes} bytes, exceeding the ${maxBytes} byte limit`);
+    this.name = 'GmailAttachmentSizeLimitError';
+    this.totalBytes = totalBytes;
+    this.maxBytes = maxBytes;
+  }
+}
+
 export class GmailFilterNoCriteriaError extends GoogleConnectorError {
   constructor() {
     super('A filter must have at least one criteria field (e.g. from, to, subject, query, hasAttachment).');
     this.name = 'GmailFilterNoCriteriaError';
+  }
+}
+
+export class DriveBatchDeleteError extends GoogleConnectorError {
+  readonly failures: { fileId: string; status: number | undefined }[];
+  constructor(failures: { fileId: string; status: number | undefined }[]) {
+    super(`Failed to delete ${failures.length} Google Drive file(s)`);
+    this.name = 'DriveBatchDeleteError';
+    this.failures = failures;
   }
 }
 

--- a/connectors/google/src/gmail/api.test.ts
+++ b/connectors/google/src/gmail/api.test.ts
@@ -3,7 +3,8 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { downloadAttachments } from './api.js';
+import { GmailAttachmentSizeLimitError } from '../errors.js';
+import { downloadAttachments, sendMessage } from './api.js';
 
 import type { GoogleClient } from '../client.js';
 
@@ -64,5 +65,49 @@ describe('gmail api', () => {
     });
     expect(result.attachments.at(0)?.path).toBe(path.join(root, 'gmail-attachments', 'msg-1', 'report.pdf'));
     expect(fs.readFile(result.attachments.at(0)?.path ?? '', 'utf8')).resolves.toBe('hello world');
+  });
+
+  test('sends local files as MIME attachments', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'gmail-send-test-'));
+    tempRoot = root;
+    const filePath = path.join(root, 'report.txt');
+    await fs.writeFile(filePath, 'attachment contents');
+
+    let requestBody = '';
+    const client = {
+      request: async (_url: string, options?: RequestInit) => {
+        if (typeof options?.body !== 'string') throw new Error('Expected a JSON request body');
+        requestBody = options.body;
+        return { id: 'msg-1', threadId: 'thread-1' };
+      },
+    } as unknown as GoogleClient;
+
+    await sendMessage(client, 'person@example.com', 'Report', 'See attached.', {
+      attachments: [{ filePath, mimeType: 'text/plain' }],
+    });
+
+    const raw = JSON.parse(requestBody).raw as string;
+    const message = Buffer.from(raw, 'base64url').toString();
+    expect(message).toContain('Content-Type: multipart/mixed; boundary=');
+    expect(message).toContain('Content-Type: text/plain; charset="UTF-8"\r\n\r\nSee attached.');
+    expect(message).toContain('Content-Disposition: attachment; filename="report.txt"');
+    expect(message).toContain(Buffer.from('attachment contents').toString('base64'));
+  });
+
+  test('rejects attachments over Gmail total size limit before sending', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'gmail-send-limit-test-'));
+    tempRoot = root;
+    const filePath = path.join(root, 'large.bin');
+    await fs.writeFile(filePath, '');
+    await fs.truncate(filePath, 25 * 1024 * 1024 + 1);
+    const client = {
+      request: async () => {
+        throw new Error('Request should not be sent');
+      },
+    } as unknown as GoogleClient;
+
+    expect(
+      sendMessage(client, 'person@example.com', 'Large file', 'See attached.', { attachments: [{ filePath }] }),
+    ).rejects.toBeInstanceOf(GmailAttachmentSizeLimitError);
   });
 });

--- a/connectors/google/src/gmail/api.ts
+++ b/connectors/google/src/gmail/api.ts
@@ -1,11 +1,16 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { GmailAttachmentMissingDataError, GmailFilterNoCriteriaError } from '../errors.js';
+import {
+  GmailAttachmentMissingDataError,
+  GmailAttachmentSizeLimitError,
+  GmailFilterNoCriteriaError,
+} from '../errors.js';
 
 import type { GoogleClient } from '../client.js';
 
 const GMAIL_API = 'https://gmail.googleapis.com/gmail/v1/users/me';
+const GMAIL_ATTACHMENT_SIZE_LIMIT_BYTES = 25 * 1024 * 1024;
 
 type GmailHeader = { name: string; value: string };
 
@@ -341,9 +346,23 @@ export async function sendMessage(
   to: string,
   subject: string,
   body: string,
-  options?: { from?: string; cc?: string; bcc?: string; inReplyTo?: string; threadId?: string },
+  options?: {
+    from?: string;
+    cc?: string;
+    bcc?: string;
+    inReplyTo?: string;
+    threadId?: string;
+    attachments?: { filePath: string; name?: string; mimeType?: string }[];
+  },
 ): Promise<{ id: string; threadId: string }> {
-  const headers = [`To: ${to}`, `Subject: ${subject}`, `Content-Type: text/plain; charset="UTF-8"`];
+  const attachments = options?.attachments ?? [];
+  const attachmentStats = await Promise.all(attachments.map((attachment) => fs.stat(attachment.filePath)));
+  const totalAttachmentBytes = attachmentStats.reduce((total, stat) => total + stat.size, 0);
+  if (totalAttachmentBytes > GMAIL_ATTACHMENT_SIZE_LIMIT_BYTES) {
+    throw new GmailAttachmentSizeLimitError(totalAttachmentBytes, GMAIL_ATTACHMENT_SIZE_LIMIT_BYTES);
+  }
+
+  const headers = [`To: ${to}`, `Subject: ${subject}`];
 
   if (options?.from) headers.push(`From: ${options.from}`);
   if (options?.cc) headers.push(`Cc: ${options.cc}`);
@@ -353,8 +372,36 @@ export async function sendMessage(
     headers.push(`References: ${options.inReplyTo}`);
   }
 
-  const rawMessage = `${headers.join('\r\n')}\r\n\r\n${body}`;
-  const encoded = btoa(rawMessage).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  let messageBody = body;
+  if (attachments.length > 0) {
+    const boundary = `gmail_boundary_${crypto.randomUUID()}`;
+    headers.push('MIME-Version: 1.0', `Content-Type: multipart/mixed; boundary="${boundary}"`);
+    const parts = [
+      `--${boundary}\r\nContent-Type: text/plain; charset="UTF-8"\r\n\r\n${body}`,
+      ...(await Promise.all(
+        attachments.map(async (attachment) => {
+          const filename = safeFilename(attachment.name ?? path.basename(attachment.filePath));
+          const mimeType = attachment.mimeType ?? 'application/octet-stream';
+          const content = await fs.readFile(attachment.filePath);
+          return [
+            `--${boundary}`,
+            `Content-Type: ${mimeType}; name="${filename}"`,
+            'Content-Transfer-Encoding: base64',
+            `Content-Disposition: attachment; filename="${filename}"`,
+            '',
+            content.toString('base64'),
+          ].join('\r\n');
+        }),
+      )),
+      `--${boundary}--`,
+    ];
+    messageBody = parts.join('\r\n');
+  } else {
+    headers.push('Content-Type: text/plain; charset="UTF-8"');
+  }
+
+  const rawMessage = `${headers.join('\r\n')}\r\n\r\n${messageBody}`;
+  const encoded = Buffer.from(rawMessage).toString('base64url');
 
   const payload: Record<string, string> = { raw: encoded };
   if (options?.threadId) payload['threadId'] = options.threadId;

--- a/connectors/google/src/gmail/tools.ts
+++ b/connectors/google/src/gmail/tools.ts
@@ -56,6 +56,16 @@ const gmailSendSchema = z.object({
     .optional()
     .describe('Message-ID header of the message being replied to — read the original message first to get this value'),
   threadId: z.string().optional().describe('Gmail thread ID to reply within'),
+  attachments: z
+    .array(
+      z.object({
+        filePath: z.string().describe('Local path of the file to attach'),
+        name: z.string().optional().describe('Optional attachment filename. Defaults to the local filename.'),
+        mimeType: z.string().optional().describe('Optional MIME type. Defaults to application/octet-stream.'),
+      }),
+    )
+    .optional()
+    .describe('Local files to attach. Their combined size must not exceed 25 MiB.'),
 });
 
 const gmailListLabelsSchema = z.object({
@@ -281,7 +291,8 @@ export function createGmailTools(
 
   if (canSend) {
     tools['gmail_send'] = tool({
-      description: 'Send an email via Gmail. Can also reply to an existing thread by providing inReplyTo and threadId.',
+      description:
+        'Send an email via Gmail, optionally with local file attachments. Can also reply to an existing thread by providing inReplyTo and threadId.',
       inputSchema: gmailSendSchema,
       execute: async (input: z.infer<typeof gmailSendSchema>) => {
         const { client, usedAccount } = await resolveClient(input.account);
@@ -291,6 +302,7 @@ export function createGmailTools(
           bcc: input.bcc,
           inReplyTo: input.inReplyTo,
           threadId: input.threadId,
+          attachments: input.attachments,
         });
         return { ...result, usedAccount };
       },

--- a/connectors/google/src/rate-limit.ts
+++ b/connectors/google/src/rate-limit.ts
@@ -175,7 +175,11 @@ export function resolveGoogleQuotaOperation(url: string, method: string | undefi
   }
 
   if (parsed.hostname === 'www.googleapis.com') {
-    if (parsed.pathname.startsWith('/drive/') || parsed.pathname.startsWith('/upload/drive/')) {
+    if (
+      parsed.pathname.startsWith('/drive/') ||
+      parsed.pathname.startsWith('/upload/drive/') ||
+      parsed.pathname.startsWith('/batch/drive/')
+    ) {
       return {
         service: 'drive',
         quotaCost: resolveDriveQuotaCost(parsed.pathname, normalizedMethod, parsed.searchParams),

--- a/connectors/google/src/toolsets.test.ts
+++ b/connectors/google/src/toolsets.test.ts
@@ -149,8 +149,16 @@ describe('buildGoogleToolsets', () => {
     expect(toolNames(readOnly)).toEqual(expect.arrayContaining(['drive_search', 'drive_read', 'drive_info']));
     expect(toolNames(readOnly)).not.toContain('drive_write');
     expect(toolNames(readOnly)).not.toContain('drive_upload');
+    expect(toolNames(readOnly)).not.toContain('drive_delete');
     expect(toolNames(writable)).toEqual(
-      expect.arrayContaining(['drive_search', 'drive_read', 'drive_info', 'drive_write', 'drive_upload']),
+      expect.arrayContaining([
+        'drive_search',
+        'drive_read',
+        'drive_info',
+        'drive_write',
+        'drive_upload',
+        'drive_delete',
+      ]),
     );
   });
 });


### PR DESCRIPTION
## 🚀 Change Summary

Adds attachment support to Gmail sending and permanent batch deletion to Google Drive tools.

### ✨ New Features
- **Gmail attachments**: Send local files as MIME attachments with aggregate validation against Gmail's 25 MiB attachment limit.
- **Drive deletion**: Permanently delete one or more Drive files using Drive's multipart HTTP batch API, chunked to its 100-request limit.

### 🛠 Improvements & Refactors
- Validate each inner Drive batch response and report failed file IDs and statuses.
- Recognize Drive batch requests in Google connector rate-limit routing.
