### PR TITLE
chore: remove any and unknown-as assertions from codebase

### DIFF
--- a/apps/desktop/src/main/browser/ref-resolver.ts
+++ b/apps/desktop/src/main/browser/ref-resolver.ts
@@ -1,16 +1,18 @@
 import { buildRefActionScript } from './scripts/ref-action.injected.js';
 
+import type { RefActionSuccess } from './scripts/ref-action.injected.js';
 import type { RefEntry } from './types.js';
 import type { WebContents } from 'electron';
 
-type RefInteractionResult = {
-  ok: boolean;
+/** The injected script's return value before validation, since it crosses `executeJavaScript`. */
+type UnvalidatedRefAction = {
+  ok?: boolean;
   error?: string;
   result?: unknown;
-  x?: unknown;
-  y?: unknown;
-  width?: unknown;
-  height?: unknown;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
 };
 
 export class RefResolver {
@@ -50,7 +52,8 @@ export class RefResolver {
       ),
       true,
     );
-    return this.unwrapRefCoordinates(ref, result);
+    const { x, y } = this.unwrapRefSuccess(ref, result);
+    return { x, y };
   }
 
   async resolveRefBounds(ref: string): Promise<{ x: number; y: number; width: number; height: number }> {
@@ -63,12 +66,8 @@ export class RefResolver {
       ),
       true,
     );
-    const coordinates = this.unwrapRefCoordinates(ref, result);
-    const { width, height } = coordinates;
-    if (typeof width !== 'number' || typeof height !== 'number') {
-      throw new Error(`Browser interaction on ${ref} did not return bounds.`);
-    }
-    return { x: coordinates.x, y: coordinates.y, width, height };
+    const { x, y, width, height } = this.unwrapRefSuccess(ref, result);
+    return { x, y, width, height };
   }
 
   async focusRef(ref: string): Promise<void> {
@@ -94,38 +93,27 @@ export class RefResolver {
     return buildRefActionScript(entry, buildScript);
   }
 
-  private unwrapRefCoordinates(
-    ref: string,
-    result: unknown,
-  ): { x: number; y: number; width?: number; height?: number } {
-    const success = this.unwrapRefSuccess(ref, result);
-    if (typeof success.x !== 'number' || typeof success.y !== 'number') {
-      throw new Error(`Browser interaction on ${ref} did not return coordinates.`);
-    }
-    return {
-      x: success.x,
-      y: success.y,
-      width: typeof success.width === 'number' ? success.width : undefined,
-      height: typeof success.height === 'number' ? success.height : undefined,
-    };
-  }
-
   private unwrapRefResult(ref: string, result: unknown): unknown {
     return this.unwrapRefSuccess(ref, result).result;
   }
 
-  private unwrapRefSuccess(ref: string, result: unknown): RefInteractionResult {
+  private unwrapRefSuccess(ref: string, result: unknown): RefActionSuccess {
     if (!result || typeof result !== 'object' || !('ok' in result)) {
       throw new Error(`Browser interaction on ${ref} did not return a valid result.`);
     }
 
-    const interaction = result as RefInteractionResult;
+    const { ok, error, result: actionResult, x, y, width, height } = result as UnvalidatedRefAction;
 
-    if (!interaction.ok) {
-      const error = interaction.error ?? 'Element interaction failed';
-      throw new Error(`${error}: ${ref}. Take a fresh browser_snapshot before retrying.`);
+    if (!ok) {
+      throw new Error(
+        `${error ?? 'Element interaction failed'}: ${ref}. Take a fresh browser_snapshot before retrying.`,
+      );
     }
 
-    return interaction;
+    if (typeof x !== 'number' || typeof y !== 'number' || typeof width !== 'number' || typeof height !== 'number') {
+      throw new Error(`Browser interaction on ${ref} did not return coordinates.`);
+    }
+
+    return { ok: true, result: actionResult, x, y, width, height };
   }
 }

--- a/apps/desktop/src/main/browser/ref-resolver.ts
+++ b/apps/desktop/src/main/browser/ref-resolver.ts
@@ -3,6 +3,16 @@ import { buildRefActionScript } from './scripts/ref-action.injected.js';
 import type { RefEntry } from './types.js';
 import type { WebContents } from 'electron';
 
+type RefInteractionResult = {
+  ok: boolean;
+  error?: string;
+  result?: unknown;
+  x?: unknown;
+  y?: unknown;
+  width?: unknown;
+  height?: unknown;
+};
+
 export class RefResolver {
   private refs = new Map<string, RefEntry>();
 
@@ -104,19 +114,18 @@ export class RefResolver {
     return this.unwrapRefSuccess(ref, result).result;
   }
 
-  private unwrapRefSuccess(
-    ref: string,
-    result: unknown,
-  ): { result: unknown; x?: unknown; y?: unknown; width?: unknown; height?: unknown } {
+  private unwrapRefSuccess(ref: string, result: unknown): RefInteractionResult {
     if (!result || typeof result !== 'object' || !('ok' in result)) {
       throw new Error(`Browser interaction on ${ref} did not return a valid result.`);
     }
 
-    if (!(result as { ok: boolean }).ok) {
-      const error = (result as { error?: string }).error ?? 'Element interaction failed';
+    const interaction = result as RefInteractionResult;
+
+    if (!interaction.ok) {
+      const error = interaction.error ?? 'Element interaction failed';
       throw new Error(`${error}: ${ref}. Take a fresh browser_snapshot before retrying.`);
     }
 
-    return result as unknown as { result: unknown; x?: unknown; y?: unknown; width?: unknown; height?: unknown };
+    return interaction;
   }
 }

--- a/apps/desktop/src/main/browser/scripts/ref-action.injected.ts
+++ b/apps/desktop/src/main/browser/scripts/ref-action.injected.ts
@@ -2,6 +2,12 @@ import { DOM_HELPERS_SCRIPT } from './dom-helpers.injected.js';
 
 import type { RefEntry } from '../types.js';
 
+/**
+ * Successful return value of the script built below. Coordinates are the viewport-relative
+ * center of the element; `result` is whatever the caller's `buildScript` returns.
+ */
+export type RefActionSuccess = { ok: true; result: unknown; x: number; y: number; width: number; height: number };
+
 export function buildRefActionScript(entry: RefEntry, buildScript: (element: string) => string): string {
   return `(() => {
     const target = ${JSON.stringify(entry)};

--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -9,5 +9,7 @@ export function registerIpcHandler<TKey extends keyof IpcContract>(
     ...args: IpcContract[TKey]['args']
   ) => Promise<IpcContract[TKey]['return']> | IpcContract[TKey]['return'],
 ): void {
-  ipcMain.handle(channel, handler as any);
+  ipcMain.handle(channel, (event: Electron.IpcMainInvokeEvent, ...args: unknown[]) =>
+    handler(event, ...(args as IpcContract[TKey]['args'])),
+  );
 }

--- a/apps/web/src/hooks/sse/sse-context.tsx
+++ b/apps/web/src/hooks/sse/sse-context.tsx
@@ -40,7 +40,13 @@ function parseJson(raw: string): unknown {
   }
 }
 
-type AnyHandler = (data: never) => void;
+/** `never` makes this a supertype of every `(data: SseEventPayloadMap[K]) => void`. */
+type StoredSseHandler = (data: never) => void;
+
+/** Restores the event-name→payload pairing that the single handler map erases. */
+function callHandler(handler: StoredSseHandler | undefined, payload: unknown): void {
+  (handler as ((data: unknown) => void) | undefined)?.(payload);
+}
 
 function getSessionIdFromPayload(eventName: SseEventName, payload: unknown): string | null {
   if (!payload || typeof payload !== 'object') return null;
@@ -100,7 +106,7 @@ export function SseProvider({ children }: { children: React.ReactNode }) {
   const [lastHeartbeat, setLastHeartbeat] = React.useState<Date | null>(null);
 
   // Map from event name → set of handlers so multiple subscribers can coexist per event.
-  const handlersRef = React.useRef<Map<SseEventName, Set<AnyHandler>>>(new Map());
+  const handlersRef = React.useRef<Map<SseEventName, Set<StoredSseHandler>>>(new Map());
 
   React.useEffect(() => {
     const connection = createSseConnection({
@@ -114,8 +120,8 @@ export function SseProvider({ children }: { children: React.ReactNode }) {
         // meaningful for remote servers whose clock is skewed from the client's.
         if (eventName === 'heartbeat') setLastHeartbeat(new Date());
 
-        const payload = parseJson(raw) as never;
-        handlersRef.current.get(eventName)?.forEach((handler) => handler(payload));
+        const payload = parseJson(raw);
+        handlersRef.current.get(eventName)?.forEach((handler) => callHandler(handler, payload));
       },
     });
 
@@ -137,7 +143,7 @@ export function SseProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const subscribe = React.useCallback((handlers: SseHandlers) => {
-    const entries = Object.entries(handlers) as [SseEventName, AnyHandler][];
+    const entries = Object.entries(handlers) as [SseEventName, StoredSseHandler][];
 
     entries.forEach(([eventName, handler]) => {
       let eventHandlers = handlersRef.current.get(eventName);
@@ -189,8 +195,7 @@ export function useSSE(handlers: SseHandlers = {}): UseSseResult {
       eventNames.map((key) => [
         key,
         (data: unknown) => {
-          const h = handlersRef.current[key] as AnyHandler | undefined;
-          h?.(data as never);
+          callHandler(handlersRef.current[key], data);
         },
       ]),
     ) as SseHandlers;
@@ -224,8 +229,7 @@ export function useSessionEvents(
           const currentSessionId = sessionIdRef.current;
           const payloadSessionId = getSessionIdFromPayload(eventName, payload);
           if (payloadSessionId === currentSessionId) {
-            const h = handlersRef.current[eventName] as AnyHandler | undefined;
-            h?.(payload as never);
+            callHandler(handlersRef.current[eventName], payload);
           }
         },
       ]),
@@ -260,8 +264,7 @@ export function useRecordingEvents(
 
           const payloadRecordingId = getRecordingIdFromPayload(eventName, payload);
           if (payloadRecordingId === currentRecordingId) {
-            const h = handlersRef.current[eventName] as AnyHandler | undefined;
-            h?.(payload as never);
+            callHandler(handlersRef.current[eventName], payload);
           }
         },
       ]),

--- a/apps/web/src/lib/queries/providers.ts
+++ b/apps/web/src/lib/queries/providers.ts
@@ -2,6 +2,7 @@ import { queryOptions } from '@tanstack/react-query';
 
 import type { EmbeddingProviderModels } from '@stitch/shared/embedding/types';
 import { buildDefaultVisibleSet, isModelVisible } from '@stitch/shared/providers/model-visibility';
+import type { ModelCost } from '@stitch/shared/providers/types';
 import type { SttProviderModels } from '@stitch/shared/stt/types';
 
 import { serverRequest } from '@/lib/api';
@@ -21,7 +22,7 @@ export type ModelSummary = {
   name: string;
   family?: string;
   release_date?: string;
-  cost?: Record<string, unknown>;
+  cost?: ModelCost;
   limit?: { context: number; input?: number; output: number };
   modalities?: { input: string[]; output: string[] };
 };

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "apps/desktop": {
       "name": "@stitch/desktop",
-      "version": "0.7.6",
+      "version": "0.7.9",
       "dependencies": {
         "@stitch/audio-capture": "workspace:*",
         "@stitch/meeting-detection": "workspace:*",
@@ -40,7 +40,7 @@
     },
     "apps/web": {
       "name": "@stitch/web",
-      "version": "0.7.6",
+      "version": "0.7.9",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@stitch/scheduler": "workspace:*",
@@ -224,6 +224,7 @@
         "zod": "catalog:",
       },
       "devDependencies": {
+        "@ai-sdk/provider": "catalog:ai",
         "@types/bun": "catalog:",
         "@types/node": "^25.5.0",
         "@types/turndown": "^5.0.6",

--- a/connectors/google/src/client.test.ts
+++ b/connectors/google/src/client.test.ts
@@ -1,20 +1,18 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
 import { GoogleApiError, GoogleClient } from './client.js';
 import { resetGoogleRateLimitCoordinatorForTests } from './rate-limit.js';
 import { classifyGoogleToolError } from './tool-error.js';
 import { buildGoogleToolsets } from './toolsets.js';
 
-const originalFetch = globalThis.fetch;
-
 describe('GoogleClient', () => {
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    mock.restore();
     resetGoogleRateLimitCoordinatorForTests();
   });
 
   test('retries with Retry-After when Google returns rate-limit errors', async () => {
-    const fetchMock = mock<typeof fetch>()
+    const fetchMock = spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
@@ -35,8 +33,6 @@ describe('GoogleClient', () => {
         new Response(JSON.stringify({ ok: true }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
       );
 
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
-
     const client = new GoogleClient({ getAccessToken: async () => 'token', quotaAccountKey: 'retry-test-account' });
 
     const result = await client.request<{ ok: boolean }>('https://www.googleapis.com/drive/v3/files');
@@ -46,7 +42,7 @@ describe('GoogleClient', () => {
   });
 
   test('forces one token refresh retry after a 401 response', async () => {
-    const fetchMock = mock<typeof fetch>()
+    const fetchMock = spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ error: { message: 'Invalid Credentials', status: 'UNAUTHENTICATED' } }), {
           status: 401,
@@ -61,8 +57,6 @@ describe('GoogleClient', () => {
     const getAccessToken = mock<(options?: { forceRefresh?: boolean }) => Promise<string>>()
       .mockResolvedValueOnce('stale-token')
       .mockResolvedValueOnce('fresh-token');
-
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     const client = new GoogleClient({ getAccessToken, quotaAccountKey: 'reauth-test-account' });
 
@@ -80,7 +74,7 @@ describe('GoogleClient', () => {
   });
 
   test('preserves Google error signals for tool error classification', async () => {
-    const fetchMock = mock<typeof fetch>().mockResolvedValueOnce(
+    const fetchMock = spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(
         JSON.stringify({
           error: {
@@ -93,8 +87,6 @@ describe('GoogleClient', () => {
         { status: 403, statusText: 'Forbidden', headers: { 'Content-Type': 'application/json' } },
       ),
     );
-
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     const client = new GoogleClient({ getAccessToken: async () => 'token', quotaAccountKey: 'scope-test-account' });
 
@@ -115,7 +107,7 @@ describe('GoogleClient', () => {
   });
 
   test('returns insufficient scope as a tool result instead of throwing', async () => {
-    const fetchMock = mock<typeof fetch>().mockResolvedValueOnce(
+    const fetchMock = spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(
         JSON.stringify({
           error: {
@@ -132,8 +124,6 @@ describe('GoogleClient', () => {
         },
       ),
     );
-
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
 
     const client = new GoogleClient({
       getAccessToken: async () => 'token',

--- a/connectors/google/src/docs/tools.test.ts
+++ b/connectors/google/src/docs/tools.test.ts
@@ -3,15 +3,15 @@ import { describe, expect, test } from 'bun:test';
 import { StubGoogleClient } from '../test-helpers.js';
 import { createDocsTools } from './tools.js';
 
-type ExecutableTool = { execute: (input: unknown) => Promise<unknown> };
+type ExecutableTool = { execute: (input: Record<string, unknown>) => Promise<unknown> };
 
-function getToolExecutor(tools: Record<string, unknown>, name: string): ExecutableTool {
-  const candidate = tools[name];
-  if (!candidate || typeof candidate !== 'object' || !('execute' in candidate)) {
+function getToolExecutor(tools: ReturnType<typeof createDocsTools>, name: string): ExecutableTool {
+  const tool = tools[name] as { execute?: ExecutableTool['execute'] } | undefined;
+  if (!tool || typeof tool.execute !== 'function') {
     throw new Error(`Missing execute for tool: ${name}`);
   }
 
-  return candidate as ExecutableTool;
+  return tool as ExecutableTool;
 }
 
 function createDocsDocument(documentId: string, title: string, text: string) {

--- a/connectors/google/src/docs/tools.test.ts
+++ b/connectors/google/src/docs/tools.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
+import { StubGoogleClient } from '../test-helpers.js';
 import { createDocsTools } from './tools.js';
-
-import type { GoogleClient } from '../client.js';
 
 type ExecutableTool = { execute: (input: unknown) => Promise<unknown> };
 
@@ -25,10 +24,10 @@ function createDocsDocument(documentId: string, title: string, text: string) {
 
 function createDocsClient(documentId: string, title: string, text: string) {
   const batchUpdates: unknown[] = [];
-  const client = {
-    request: async (url: string, options?: { body?: string }) => {
+  const client = new StubGoogleClient({
+    request: async (url: string, options?: RequestInit) => {
       if (url === `https://docs.googleapis.com/v1/documents/${documentId}:batchUpdate`) {
-        batchUpdates.push(JSON.parse(options?.body ?? '{}'));
+        batchUpdates.push(JSON.parse(typeof options?.body === 'string' ? options.body : '{}'));
         return {};
       }
 
@@ -38,7 +37,7 @@ function createDocsClient(documentId: string, title: string, text: string) {
 
       throw new Error(`Unexpected URL: ${url}`);
     },
-  } as unknown as GoogleClient;
+  });
 
   const resolveClient: Parameters<typeof createDocsTools>[0] = async () => ({
     client,

--- a/connectors/google/src/drive/api.test.ts
+++ b/connectors/google/src/drive/api.test.ts
@@ -3,9 +3,14 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
+import { StubGoogleClient } from '../test-helpers.js';
 import { deleteFiles, uploadFile } from './api.js';
 
-import type { GoogleClient } from '../client.js';
+function decodeBody(body: BodyInit | null | undefined): string {
+  if (typeof body === 'string') return body;
+  if (body instanceof ArrayBuffer) return Buffer.from(body).toString();
+  throw new Error('Expected a string or ArrayBuffer request body');
+}
 
 describe('Drive API uploadFile', () => {
   test('uploads a local file with metadata', async () => {
@@ -14,11 +19,11 @@ describe('Drive API uploadFile', () => {
     await fs.writeFile(filePath, 'hello drive');
 
     let requestUrl = '';
-    let requestOptions: { method?: string; headers?: Record<string, string>; body?: string | ArrayBuffer } = {};
-    const client = {
-      request: async (url: string, options?: typeof requestOptions) => {
+    let requestOptions: RequestInit | undefined;
+    const client = new StubGoogleClient({
+      request: async (url: string, options?: RequestInit) => {
         requestUrl = url;
-        requestOptions = options ?? {};
+        requestOptions = options;
         return {
           id: 'file-1',
           name: 'Report.txt',
@@ -26,7 +31,7 @@ describe('Drive API uploadFile', () => {
           webViewLink: 'https://drive.google.com/file/d/file-1/view',
         };
       },
-    } as unknown as GoogleClient;
+    });
 
     const result = await uploadFile(client, filePath, {
       name: 'Report.txt',
@@ -37,12 +42,11 @@ describe('Drive API uploadFile', () => {
     expect(requestUrl).toBe(
       'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,mimeType,webViewLink',
     );
-    expect(requestOptions.method).toBe('POST');
-    expect(requestOptions.headers?.['Content-Type']).toBe('multipart/related; boundary=drive_upload_boundary');
-    const requestBody =
-      typeof requestOptions.body === 'string'
-        ? requestOptions.body
-        : Buffer.from(new Uint8Array(requestOptions.body ?? new ArrayBuffer(0))).toString();
+    expect(requestOptions?.method).toBe('POST');
+    expect(new Headers(requestOptions?.headers).get('Content-Type')).toBe(
+      'multipart/related; boundary=drive_upload_boundary',
+    );
+    const requestBody = decodeBody(requestOptions?.body);
 
     expect(requestBody).toContain('hello drive');
     expect(requestBody).toContain('Content-Type: text/plain\r\n\r\nhello drive');
@@ -60,7 +64,7 @@ describe('Drive API deleteFiles', () => {
   test('deletes multiple files', async () => {
     let requestUrl = '';
     let requestOptions: RequestInit | undefined;
-    const client = {
+    const client = new StubGoogleClient({
       requestRaw: async (url: string, options?: RequestInit) => {
         requestUrl = url;
         requestOptions = options;
@@ -80,7 +84,7 @@ describe('Drive API deleteFiles', () => {
           ].join('\r\n'),
         );
       },
-    } as unknown as GoogleClient;
+    });
 
     const result = await deleteFiles(client, ['file-1', 'file/2']);
 
@@ -95,14 +99,14 @@ describe('Drive API deleteFiles', () => {
   });
 
   test('reports failed inner delete requests', async () => {
-    const client = {
+    const client = new StubGoogleClient({
       requestRaw: async () =>
         new Response(
           ['--response', 'Content-Type: application/http', '', 'HTTP/1.1 404 Not Found', '', '--response--'].join(
             '\r\n',
           ),
         ),
-    } as unknown as GoogleClient;
+    });
 
     expect(deleteFiles(client, ['missing-file'])).rejects.toEqual(
       expect.objectContaining({ failures: [{ fileId: 'missing-file', status: 404 }] }),

--- a/connectors/google/src/gmail/api.test.ts
+++ b/connectors/google/src/gmail/api.test.ts
@@ -4,9 +4,8 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { GmailAttachmentSizeLimitError } from '../errors.js';
+import { StubGoogleClient } from '../test-helpers.js';
 import { downloadAttachments, sendMessage } from './api.js';
-
-import type { GoogleClient } from '../client.js';
 
 function base64Url(value: string): string {
   return Buffer.from(value, 'utf8').toString('base64url');
@@ -52,7 +51,7 @@ describe('gmail api', () => {
 
       throw new Error(`Unexpected URL: ${url}`);
     };
-    const client = { request } as unknown as GoogleClient;
+    const client = new StubGoogleClient({ request });
 
     const result = await downloadAttachments(client, 'msg-1', root);
 
@@ -74,13 +73,13 @@ describe('gmail api', () => {
     await fs.writeFile(filePath, 'attachment contents');
 
     let requestBody = '';
-    const client = {
+    const client = new StubGoogleClient({
       request: async (_url: string, options?: RequestInit) => {
         if (typeof options?.body !== 'string') throw new Error('Expected a JSON request body');
         requestBody = options.body;
         return { id: 'msg-1', threadId: 'thread-1' };
       },
-    } as unknown as GoogleClient;
+    });
 
     await sendMessage(client, 'person@example.com', 'Report', 'See attached.', {
       attachments: [{ filePath, mimeType: 'text/plain' }],
@@ -100,11 +99,11 @@ describe('gmail api', () => {
     const filePath = path.join(root, 'large.bin');
     await fs.writeFile(filePath, '');
     await fs.truncate(filePath, 25 * 1024 * 1024 + 1);
-    const client = {
+    const client = new StubGoogleClient({
       request: async () => {
         throw new Error('Request should not be sent');
       },
-    } as unknown as GoogleClient;
+    });
 
     expect(
       sendMessage(client, 'person@example.com', 'Large file', 'See attached.', { attachments: [{ filePath }] }),

--- a/connectors/google/src/test-helpers.ts
+++ b/connectors/google/src/test-helpers.ts
@@ -1,0 +1,34 @@
+import { GoogleClient } from './client.js';
+
+type StubHandlers = {
+  request?: (url: string, options?: RequestInit) => Promise<unknown>;
+  requestRaw?: (url: string, options?: RequestInit) => Promise<Response>;
+};
+
+/** GoogleClient whose HTTP methods are served by in-test handlers instead of fetch. */
+export class StubGoogleClient extends GoogleClient {
+  private readonly handlers: StubHandlers;
+
+  constructor(handlers: StubHandlers) {
+    super({ getAccessToken: async () => 'test-token' });
+    this.handlers = handlers;
+  }
+
+  override async request<T>(url: string, options?: RequestInit): Promise<T> {
+    const handler = this.handlers.request;
+    if (!handler) {
+      throw new Error(`Unexpected request: ${url}`);
+    }
+
+    return (await handler(url, options)) as T;
+  }
+
+  override async requestRaw(url: string, options?: RequestInit): Promise<Response> {
+    const handler = this.handlers.requestRaw;
+    if (!handler) {
+      throw new Error(`Unexpected raw request: ${url}`);
+    }
+
+    return handler(url, options);
+  }
+}

--- a/packages/mail/src/sync/engine.test.ts
+++ b/packages/mail/src/sync/engine.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 import { closeMailDb, getMailDb, initMailDb } from '../db/client.js';
 import { mailAccounts } from '../db/schema.js';
-import { createMailEngine } from './engine.js';
+import { createMailEngine, type MailEngineEvent } from './engine.js';
 
 const migrationsDir = fileURLToPath(new URL('../../drizzle', import.meta.url));
 
@@ -14,7 +14,7 @@ afterEach(() => {
 describe('mail engine enrollment', () => {
   test('creates new accounts with manual first sync defaults', async () => {
     await initMailDb(':memory:', migrationsDir);
-    const events: unknown[] = [];
+    const events: MailEngineEvent[] = [];
     const engine = createMailEngine({
       attachmentsDir: '',
       createHttpClient: () => ({ request: () => Promise.reject(new Error('unexpected request')) }),

--- a/packages/sandbox/src/process-runtime.ts
+++ b/packages/sandbox/src/process-runtime.ts
@@ -196,7 +196,7 @@ export function startProcessRuntime(preloadedModules: Record<string, Record<stri
 
     // Init message is not part of HostMessage protocol (sent only once before execution).
     if (msg.type === 'init') {
-      handleInit(message as unknown as InitData);
+      handleInit(message as InitData);
       return;
     }
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -39,6 +39,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ai-sdk/provider": "catalog:ai",
     "@types/bun": "catalog:",
     "@types/node": "^25.5.0",
     "@types/turndown": "^5.0.6",

--- a/packages/server/src/agenda/service.ts
+++ b/packages/server/src/agenda/service.ts
@@ -144,7 +144,7 @@ export function updateAgendaList(id: PrefixedString<'alist'>, input: UpdateAgend
   const existing = db.select().from(agendaLists).where(eq(agendaLists.id, id)).get();
   if (!existing) return err('List not found', 404);
 
-  const updates: Record<string, unknown> = { updatedAt: Date.now() };
+  const updates: Partial<AgendaListRow> = { updatedAt: Date.now() };
   if (input.name !== undefined) updates.name = input.name;
   if (input.description !== undefined) updates.description = input.description;
   if (input.color !== undefined) updates.color = input.color;
@@ -286,7 +286,7 @@ export function updateAgendaItem(id: PrefixedString<'aitm'>, input: UpdateAgenda
   if (!existing) return err('Item not found', 404);
 
   const now = Date.now();
-  const updates: Record<string, unknown> = { updatedAt: now };
+  const updates: Partial<AgendaItemRow> = { updatedAt: now };
   if (input.title !== undefined) updates.title = input.title;
   if (input.description !== undefined) updates.description = input.description;
   if (input.priority !== undefined) updates.priority = input.priority;

--- a/packages/server/src/code-mode/bindings/tool-binding.ts
+++ b/packages/server/src/code-mode/bindings/tool-binding.ts
@@ -1,6 +1,6 @@
 import type { ToolBinding } from '@stitch/sandbox';
 
-import type { Tool } from 'ai';
+import type { Tool, ToolExecutionOptions } from 'ai';
 
 const EXTERNAL_PREFIX = 'external_';
 
@@ -27,10 +27,8 @@ function extractJsonSchema(schema: unknown): Record<string, unknown> {
 }
 
 function getToolSchema(tool: Tool): Record<string, unknown> {
-  return extractJsonSchema(
-    (tool as unknown as Record<string, unknown>)['parameters'] ??
-      (tool as unknown as Record<string, unknown>)['inputSchema'],
-  );
+  const carrier: { parameters?: unknown; inputSchema?: unknown } = tool;
+  return extractJsonSchema(carrier.parameters ?? carrier.inputSchema);
 }
 
 type ToolMeta = {
@@ -79,15 +77,14 @@ export function toolsToBindings(tools: Record<string, Tool>, abortSignal?: Abort
       inputSchema: schema,
       execute: async (input: unknown, signal?: AbortSignal) => {
         const effectiveSignal = signal ?? abortSignal;
-        return execute(
-          input as Parameters<typeof execute>[0],
-          {
-            toolCallId: `code-mode-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-            messages: [],
-            skipTruncation: true,
-            abortSignal: effectiveSignal,
-          } as unknown as Parameters<typeof execute>[1],
-        );
+        // `skipTruncation` is a Stitch-specific flag read by truncationMiddleware.
+        const options: ToolExecutionOptions & { skipTruncation: true } = {
+          toolCallId: `code-mode-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          messages: [],
+          skipTruncation: true,
+          abortSignal: effectiveSignal,
+        };
+        return execute(input as Parameters<typeof execute>[0], options);
       },
     };
   });

--- a/packages/server/src/connectors/service.ts
+++ b/packages/server/src/connectors/service.ts
@@ -395,7 +395,7 @@ export async function updateConnectorInstance(
 
   if (!existing) return err('Connector instance not found', 404);
 
-  const setValues: Record<string, unknown> = { updatedAt: Date.now() };
+  const setValues: Partial<typeof connectorInstances.$inferInsert> = { updatedAt: Date.now() };
   if (updates.label !== undefined) setValues['label'] = updates.label;
   if (updates.scopes !== undefined) setValues['scopes'] = updates.scopes;
 

--- a/packages/server/src/db/schema/mcp.ts
+++ b/packages/server/src/db/schema/mcp.ts
@@ -12,6 +12,7 @@ import type {
 } from '@stitch/shared/mcp/types';
 
 import { sessions } from '@/db/schema/sessions.js';
+import type { OAuthDiscoveryState } from '@modelcontextprotocol/sdk/client/auth.js';
 
 export const mcpServers = sqliteTable('mcp_servers', {
   id: text('id').$type<PrefixedString<'mcp'>>().primaryKey(),
@@ -59,7 +60,7 @@ export const mcpOAuthSessions = sqliteTable('mcp_oauth_sessions', {
   clientInformation: blob('client_information', { mode: 'json' }).$type<OAuthClientInformation>(),
   tokens: blob('tokens', { mode: 'json' }).$type<OAuthSessionTokens>(),
   codeVerifier: text('code_verifier'),
-  discoveryState: blob('discovery_state', { mode: 'json' }).$type<Record<string, unknown>>(),
+  discoveryState: blob('discovery_state', { mode: 'json' }).$type<OAuthDiscoveryState>(),
   state: text('state'),
   createdAt: integer('created_at', { mode: 'number' })
     .notNull()

--- a/packages/server/src/lib/paginated-query.ts
+++ b/packages/server/src/lib/paginated-query.ts
@@ -8,6 +8,13 @@ export function computeTotalPages(total: number, pageSize: number): number {
   return total === 0 ? 0 : Math.ceil(total / pageSize);
 }
 
+type PaginatedQueryInput<TRow> = {
+  dataQuery: { limit: (n: number) => { offset: (n: number) => Promise<TRow[]> | PromiseLike<TRow[]> } };
+  countQuery: PromiseLike<{ total: number }[]>;
+  page: number;
+  pageSize: number;
+};
+
 /**
  * Runs a paginated data query in parallel with a count query.
  * Returns a standardized envelope with items, page, pageSize, total, totalPages.
@@ -18,19 +25,19 @@ export function computeTotalPages(total: number, pageSize: number): number {
  * @param pageSize   - Items per page
  * @param transform  - Optional row mapper applied to each data row
  */
-export async function paginatedQuery<TRow, TOut = TRow>(input: {
-  dataQuery: { limit: (n: number) => { offset: (n: number) => Promise<TRow[]> | PromiseLike<TRow[]> } };
-  countQuery: PromiseLike<{ total: number }[]>;
-  page: number;
-  pageSize: number;
-  transform?: (row: TRow) => TOut;
-}): Promise<PaginatedResult<TOut>> {
+export async function paginatedQuery<TRow, TOut>(
+  input: PaginatedQueryInput<TRow> & { transform: (row: TRow) => TOut },
+): Promise<PaginatedResult<TOut>>;
+export async function paginatedQuery<TRow>(input: PaginatedQueryInput<TRow>): Promise<PaginatedResult<TRow>>;
+export async function paginatedQuery<TRow, TOut>(
+  input: PaginatedQueryInput<TRow> & { transform?: (row: TRow) => TOut },
+): Promise<PaginatedResult<TRow | TOut>> {
   const offset = (input.page - 1) * input.pageSize;
 
   const [rows, countRows] = await Promise.all([input.dataQuery.limit(input.pageSize).offset(offset), input.countQuery]);
 
   const total = Number(countRows.at(0)?.total ?? 0);
-  const transform = input.transform ?? ((row: TRow) => row as unknown as TOut);
+  const transform: (row: TRow) => TRow | TOut = input.transform ?? ((row) => row);
 
   return {
     items: rows.map(transform),

--- a/packages/server/src/llm/cache-control.test.ts
+++ b/packages/server/src/llm/cache-control.test.ts
@@ -1,7 +1,12 @@
+import { jsonSchema } from 'ai';
 import { describe, test, expect } from 'bun:test';
 
 import { addCacheControlToMessages, addCacheControlToTools, getCacheConfig } from '@/llm/cache-control.js';
 import type { ModelMessage, Tool } from 'ai';
+
+function makeTool(description: string): Tool {
+  return { description, inputSchema: jsonSchema({ type: 'object', properties: {} }) };
+}
 
 describe('getCacheConfig', () => {
   test('returns anthropic config for google-vertex with claude model', () => {
@@ -220,7 +225,7 @@ describe('addCacheControlToMessages', () => {
 
 describe('addCacheControlToTools', () => {
   test('returns tools unchanged for implicit caching providers', () => {
-    const tools = { bash: { description: 'Run a command' } } as unknown as Record<string, Tool>;
+    const tools: Record<string, Tool> = { bash: makeTool('Run a command') };
     const result = addCacheControlToTools(tools, 'openai', 'gpt-4o');
     expect(result).toBe(tools);
   });
@@ -232,32 +237,25 @@ describe('addCacheControlToTools', () => {
   });
 
   test('marks the last tool with anthropic cache control', () => {
-    const tools = {
-      bash: { description: 'Run a command' },
-      read: { description: 'Read a file' },
-      write: { description: 'Write a file' },
-    } as unknown as Record<string, Tool>;
+    const tools: Record<string, Tool> = {
+      bash: makeTool('Run a command'),
+      read: makeTool('Read a file'),
+      write: makeTool('Write a file'),
+    };
 
     const result = addCacheControlToTools(tools, 'anthropic', 'claude-sonnet-4-5');
 
-    expect((result.bash as { providerOptions?: unknown }).providerOptions).toBeUndefined();
-    expect((result.read as { providerOptions?: unknown }).providerOptions).toBeUndefined();
-    expect((result.write as { providerOptions?: unknown }).providerOptions).toEqual({
-      anthropic: { cacheControl: { type: 'ephemeral' } },
-    });
+    expect(result.bash.providerOptions).toBeUndefined();
+    expect(result.read.providerOptions).toBeUndefined();
+    expect(result.write.providerOptions).toEqual({ anthropic: { cacheControl: { type: 'ephemeral' } } });
   });
 
   test('marks the last tool with bedrock cache point', () => {
-    const tools = { bash: { description: 'Run a command' }, read: { description: 'Read a file' } } as unknown as Record<
-      string,
-      Tool
-    >;
+    const tools: Record<string, Tool> = { bash: makeTool('Run a command'), read: makeTool('Read a file') };
 
     const result = addCacheControlToTools(tools, 'amazon-bedrock', 'anthropic.claude-3-7-sonnet-20250219-v1:0');
 
-    expect((result.bash as { providerOptions?: unknown }).providerOptions).toBeUndefined();
-    expect((result.read as { providerOptions?: unknown }).providerOptions).toEqual({
-      bedrock: { cachePoint: { type: 'default' } },
-    });
+    expect(result.bash.providerOptions).toBeUndefined();
+    expect(result.read.providerOptions).toEqual({ bedrock: { cachePoint: { type: 'default' } } });
   });
 });

--- a/packages/server/src/llm/provider-schema.test.ts
+++ b/packages/server/src/llm/provider-schema.test.ts
@@ -70,10 +70,7 @@ describe('sanitizeToolSchemasForProvider', () => {
   });
 
   test('splits multi-type arrays into anyOf and lifts null to nullable', () => {
-    const schema = {
-      type: 'object',
-      properties: { value: { type: ['string', 'number', 'null'] } },
-    } as unknown as JSONSchema7;
+    const schema: JSONSchema7 = { type: 'object', properties: { value: { type: ['string', 'number', 'null'] } } };
 
     const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'google' as LlmProviderId, 'gemini-3.5-flash');
 
@@ -122,7 +119,7 @@ describe('sanitizeToolSchemasForProvider', () => {
 
   describe('openai sanitizer', () => {
     test('replaces const with single-value enum and infers object type', () => {
-      const schema = { properties: { mode: { const: 'fast' } } } as unknown as JSONSchema7;
+      const schema: JSONSchema7 = { properties: { mode: { const: 'fast' } } };
 
       const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
@@ -133,7 +130,7 @@ describe('sanitizeToolSchemasForProvider', () => {
     });
 
     test('lowers boolean schema nodes to string type', () => {
-      const schema = { type: 'object', properties: { anything: true } } as unknown as JSONSchema7;
+      const schema: JSONSchema7 = { type: 'object', properties: { anything: true } };
 
       const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
@@ -141,7 +138,7 @@ describe('sanitizeToolSchemasForProvider', () => {
     });
 
     test('infers array type and defaults missing items to string', () => {
-      const schema = { type: 'object', properties: { tags: { items: {} } } } as unknown as JSONSchema7;
+      const schema: JSONSchema7 = { type: 'object', properties: { tags: { items: {} } } };
 
       const out = sanitizeToolSchemasForProvider({ t: mcpTool(schema) }, 'openai' as LlmProviderId, 'gpt-4o');
 
@@ -179,7 +176,7 @@ describe('sanitizeToolSchemasForProvider', () => {
     });
 
     test('applies openai sanitizer for non-gemini models on a gateway provider', () => {
-      const schema = { type: 'object', properties: { mode: { const: 'x' } } } as unknown as JSONSchema7;
+      const schema: JSONSchema7 = { type: 'object', properties: { mode: { const: 'x' } } };
 
       const out = sanitizeToolSchemasForProvider(
         { t: mcpTool(schema) },

--- a/packages/server/src/llm/session-summary.test.ts
+++ b/packages/server/src/llm/session-summary.test.ts
@@ -76,7 +76,7 @@ describe('isOverflow', () => {
     const usage = {
       inputTokens: 180_000,
       outputTokens: 15_000,
-      totalTokens: undefined as unknown as number,
+      totalTokens: undefined,
       inputTokenDetails: { noCacheTokens: 0, cacheReadTokens: 200, cacheWriteTokens: 300 },
       outputTokenDetails: { textTokens: 0, reasoningTokens: 0 },
     };

--- a/packages/server/src/llm/stream/session-context.test.ts
+++ b/packages/server/src/llm/stream/session-context.test.ts
@@ -1,3 +1,4 @@
+import { jsonSchema } from 'ai';
 import { beforeEach, describe, expect, test } from 'bun:test';
 
 import { getDb } from '@/db/client.js';
@@ -27,7 +28,7 @@ function clearToolsets(): void {
 }
 
 function makeTool(description: string): Tool {
-  return { description, parameters: { type: 'object', properties: {} } } as unknown as Tool;
+  return { description, inputSchema: jsonSchema({ type: 'object', properties: {} }) };
 }
 
 describe('buildExpiredToolsetsPrompt', () => {

--- a/packages/server/src/llm/stream/step-executor.test.ts
+++ b/packages/server/src/llm/stream/step-executor.test.ts
@@ -57,7 +57,7 @@ function getDefaultOpts(model: MockLanguageModelV3, overrides?: Partial<StepOpti
     sessionId: 'ses_1' as StepOptions['sessionId'],
     messageId: 'msg_1' as StepOptions['messageId'],
     step: 0,
-    model: model as unknown as StepOptions['model'],
+    model,
     conversation: [{ role: 'user', content: 'Hello' }],
     accumulatedParts: [],
     providerId: 'openai',
@@ -179,10 +179,7 @@ describe('executeStepWithRetry', () => {
     });
 
     const accumulatedParts: StoredPart[] = [];
-    const opts = getDefaultOpts(model, {
-      accumulatedParts,
-      tools: { read: readTool } as unknown as StepOptions['tools'],
-    });
+    const opts = getDefaultOpts(model, { accumulatedParts, tools: { read: readTool } });
     const result = await executeStepWithRetry(opts);
 
     expect(result.finishReason).toBe('tool-calls');
@@ -212,10 +209,7 @@ describe('executeStepWithRetry', () => {
     });
 
     const accumulatedParts: StoredPart[] = [];
-    const opts = getDefaultOpts(model, {
-      accumulatedParts,
-      tools: { webfetch: failingTool } as unknown as StepOptions['tools'],
-    });
+    const opts = getDefaultOpts(model, { accumulatedParts, tools: { webfetch: failingTool } });
 
     expect(executeStepWithRetry(opts)).rejects.toBeInstanceOf(PermissionRejectedError);
 
@@ -242,10 +236,7 @@ describe('executeStepWithRetry', () => {
     });
 
     const accumulatedParts: StoredPart[] = [];
-    const opts = getDefaultOpts(model, {
-      accumulatedParts,
-      tools: { bash: bashTool } as unknown as StepOptions['tools'],
-    });
+    const opts = getDefaultOpts(model, { accumulatedParts, tools: { bash: bashTool } });
 
     const result = await executeStepWithRetry(opts);
 

--- a/packages/server/src/llm/stream/step-executor.test.ts
+++ b/packages/server/src/llm/stream/step-executor.test.ts
@@ -9,6 +9,7 @@ import { internalBus } from '@/lib/internal-bus.js';
 import type { InternalEventMap, InternalEventName } from '@/lib/internal-bus.js';
 import { PermissionRejectedError, StreamAbortedError } from '@/llm/stream/errors.js';
 import { executeStepWithRetry, type StepOptions } from '@/llm/stream/step-executor.js';
+import type { LanguageModelV3StreamPart, LanguageModelV3StreamResult } from '@ai-sdk/provider';
 
 type EmittedEvent = [InternalEventName, InternalEventMap[InternalEventName]];
 let emittedEvents: EmittedEvent[] = [];
@@ -47,8 +48,7 @@ function createMockModel(doStream: MockLanguageModelV3['doStream']): MockLanguag
   return new MockLanguageModelV3({ doStream });
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function makeStreamResult(chunks: any[]) {
+function makeStreamResult(chunks: LanguageModelV3StreamPart[]): LanguageModelV3StreamResult {
   return { stream: simulateReadableStream({ chunks, initialDelayInMs: null, chunkDelayInMs: null }) };
 }
 

--- a/packages/server/src/llm/stream/stream-accumulator.test.ts
+++ b/packages/server/src/llm/stream/stream-accumulator.test.ts
@@ -328,7 +328,7 @@ describe('StreamAccumulator', () => {
       const acc = createAccumulator(parts);
 
       acc.handlePart(
-        part({ type: 'file', file: { uint8Array: new Uint8Array(), mediaType: 'image/png', base64: '' } as any }),
+        part({ type: 'file', file: { uint8Array: new Uint8Array(), mediaType: 'image/png', base64: '' } }),
       );
 
       expect(parts).toHaveLength(1);
@@ -343,18 +343,18 @@ describe('StreamAccumulator', () => {
       const parts: StoredPart[] = [];
       const acc = createAccumulator(parts);
 
-      acc.handlePart(part({ type: 'start-step', request: {} as any, warnings: [] }));
+      acc.handlePart(part({ type: 'start-step', request: {}, warnings: [] }));
       acc.handlePart(
         part({
           type: 'finish-step',
-          response: {} as any,
+          response: { id: 'resp_1', timestamp: new Date(0), modelId: 'test-model' },
           usage: {
             inputTokens: 0,
             outputTokens: 0,
             totalTokens: 0,
-            inputTokenDetails: {},
-            outputTokenDetails: {},
-          } as any,
+            inputTokenDetails: { noCacheTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+            outputTokenDetails: { textTokens: 0, reasoningTokens: 0 },
+          },
           finishReason: 'stop',
           rawFinishReason: 'stop',
           providerMetadata: undefined,

--- a/packages/server/src/mcp/oauth-provider.ts
+++ b/packages/server/src/mcp/oauth-provider.ts
@@ -128,12 +128,12 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
-    await this.upsertSession({ discoveryState: state as unknown as Record<string, unknown> });
+    await this.upsertSession({ discoveryState: state });
   }
 
   async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
     const session = await this.getSession();
-    return (session?.discoveryState as unknown as OAuthDiscoveryState | undefined) ?? undefined;
+    return session?.discoveryState ?? undefined;
   }
 
   async invalidateCredentials(scope: 'all' | 'client' | 'tokens' | 'verifier' | 'discovery'): Promise<void> {

--- a/packages/server/src/provider/config/service.ts
+++ b/packages/server/src/provider/config/service.ts
@@ -8,9 +8,9 @@ import { localModels, providerConfig } from '@/db/schema/providers.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import { isAllowedProvider } from '@/models/llm/registry.js';
-import { ProviderCredentialsSchema } from '@/provider/config/schema.js';
+import { ProviderCredentialsSchema, type ProviderCredentials } from '@/provider/config/schema.js';
 
-export async function getProviderCredentials(providerId: string): Promise<ServiceResult<unknown>> {
+export async function getProviderCredentials(providerId: string): Promise<ServiceResult<ProviderCredentials>> {
   if (!isAllowedProvider(providerId)) {
     return err('Provider not found', 404);
   }

--- a/packages/server/src/settings/service.ts
+++ b/packages/server/src/settings/service.ts
@@ -28,7 +28,7 @@ export async function getSettings<const Keys extends readonly SettingsKey[]>(key
   const rows = await db
     .select({ key: userSettings.key, value: userSettings.value })
     .from(userSettings)
-    .where(inArray(userSettings.key, keys as unknown as SettingsKey[]));
+    .where(inArray(userSettings.key, [...keys]));
 
   const rawByKey = new Map(rows.map((r) => [r.key, r.value]));
 

--- a/packages/server/src/stt/ws-transport.ts
+++ b/packages/server/src/stt/ws-transport.ts
@@ -25,8 +25,7 @@ export type WsMessageResult = { transcript?: TranscriptEvent; usage?: STTUsage; 
 
 /**
  * Creates an STTTransport backed by a WebSocket connection.
- * Encapsulates the open/message/close/error lifecycle and the `as unknown as string[]` cast
- * required by the WebSocket constructor for custom headers.
+ * Encapsulates the open/message/close/error lifecycle and per-connection headers.
  */
 export function createWsTransport(
   config: WsTransportConfig,
@@ -40,9 +39,7 @@ export function createWsTransport(
     const closeListeners: (() => void)[] = [];
     const pendingErrors: Error[] = [];
 
-    // The WebSocket constructor in Node does not have a typed overload for headers.
-    // This cast is isolated here so adapters don't repeat it.
-    const ws = new WebSocket(config.url, { headers: config.headers } as unknown as string[]);
+    const ws = new WebSocket(config.url, { headers: config.headers });
 
     let opened = false;
     let closed = false;

--- a/packages/server/src/tools/core/toolset-management.test.ts
+++ b/packages/server/src/tools/core/toolset-management.test.ts
@@ -1,3 +1,4 @@
+import { jsonSchema } from 'ai';
 import { beforeEach, describe, expect, test } from 'bun:test';
 
 import { getDb } from '@/db/client.js';
@@ -25,7 +26,7 @@ function createManager(): ToolsetManager {
 }
 
 function makeTool(description: string): Tool {
-  return { description, parameters: { type: 'object', properties: {} } } as unknown as Tool;
+  return { description, inputSchema: jsonSchema({ type: 'object', properties: {} }) };
 }
 
 function registerTestToolset(overrides: Partial<Toolset> = {}): Toolset {

--- a/packages/server/src/tools/toolsets/manager.test.ts
+++ b/packages/server/src/tools/toolsets/manager.test.ts
@@ -1,3 +1,4 @@
+import { jsonSchema } from 'ai';
 import { beforeEach, describe, expect, test } from 'bun:test';
 
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
@@ -20,7 +21,7 @@ function createManager(): ToolsetManager {
 }
 
 function makeTool(description: string): Tool {
-  return { description, parameters: { type: 'object', properties: {} } } as unknown as Tool;
+  return { description, inputSchema: jsonSchema({ type: 'object', properties: {} }) };
 }
 
 describe('ToolsetManager.activate collision detection', () => {

--- a/packages/server/src/utils/usage.test.ts
+++ b/packages/server/src/utils/usage.test.ts
@@ -37,13 +37,13 @@ describe('normalizeUsage', () => {
   });
 
   test('falls back to token details when total is absent', () => {
-    const usage = {
+    const usage: LanguageModelUsage = {
       inputTokens: 100,
       outputTokens: 50,
       totalTokens: undefined,
-      inputTokenDetails: { cacheReadTokens: 20, cacheWriteTokens: 10 },
-      outputTokenDetails: { reasoningTokens: 15 },
-    } as unknown as LanguageModelUsage;
+      inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: 20, cacheWriteTokens: 10 },
+      outputTokenDetails: { textTokens: undefined, reasoningTokens: 15 },
+    };
 
     expect(normalizeUsage(usage)).toEqual({
       inputTokens: 100,
@@ -57,13 +57,13 @@ describe('normalizeUsage', () => {
   });
 
   test('treats non-finite values as zero', () => {
-    const usage = {
+    const usage: LanguageModelUsage = {
       inputTokens: Number.NaN,
       outputTokens: Number.POSITIVE_INFINITY,
       totalTokens: Number.NaN,
-      inputTokenDetails: { cacheReadTokens: 5, cacheWriteTokens: Number.NEGATIVE_INFINITY },
-      outputTokenDetails: { reasoningTokens: 7 },
-    } as unknown as LanguageModelUsage;
+      inputTokenDetails: { noCacheTokens: undefined, cacheReadTokens: 5, cacheWriteTokens: Number.NEGATIVE_INFINITY },
+      outputTokenDetails: { textTokens: undefined, reasoningTokens: 7 },
+    };
 
     expect(normalizeUsage(usage)).toEqual({
       inputTokens: 0,

--- a/packages/shared/src/providers/types.ts
+++ b/packages/shared/src/providers/types.ts
@@ -94,6 +94,14 @@ export function isEmbeddingProviderId(providerId: string): providerId is Embeddi
   return hasProviderCapability(providerId, 'embedding');
 }
 
+export type ModelCost = {
+  input: number;
+  output: number;
+  cache_read?: number;
+  cache_write?: number;
+  context_over_200k?: { input: number; output: number; cache_read?: number; cache_write?: number };
+};
+
 export type ProviderMeta = {
   displayName: string;
   description?: string;

--- a/scripts/check.ts
+++ b/scripts/check.ts
@@ -4,13 +4,13 @@ import { spawnSync } from 'bun';
 const steps = [
   { name: 'design-system', cmd: ['bun', 'run', 'scripts/check-design-system.ts'] },
   { name: 'knip', cmd: ['bunx', 'knip', '--fix', '--allow-remove-files'] },
-  { name: 'typecheck', cmd: ['bun', 'run', 'typecheck'] },
-  { name: 'test', cmd: ['bun', 'run', 'test'] },
-  {
+    {
     name: 'lint',
     cmd: ['bunx', 'oxlint', '--config', 'oxlint.json', '--type-aware', '--fix', '--fix-suggestions', '.'],
   },
   { name: 'lint:check', cmd: ['bunx', 'oxlint', '--config', 'oxlint.json', '--type-aware', '--deny-warnings', '.'] },
+  { name: 'typecheck', cmd: ['bun', 'run', 'typecheck'] },
+  { name: 'test', cmd: ['bun', 'run', 'test'] },
   { name: 'catalogs', cmd: ['bun', 'run', 'scripts/check-catalogs.ts'] },
   { name: 'format:changed:check', cmd: ['bun', 'run', 'format:changed:check'] },
 ];


### PR DESCRIPTION
## 🚀 Change Summary

Removes `any` and `as unknown as` type assertions across the codebase, replacing them with specific domain types and improving type safety.

### 🛠 Improvements & Refactors
- Replace `any` assertions in first-party source, tests, and connectors with precise domain types
- Remove `as unknown as` casts across server, web, desktop, and google connector code
- Type the ref action script's return contract and `makeStreamResult` test helper
- Consolidate SSE handler type assertions and replace generic `unknown` with specific domain types in services and queries
- Reorder the check script and add test helpers to support typed tests
