### PR TITLE
refactor(server): type tool runtime contracts

### DIFF
--- a/connectors/google/src/tool-error.ts
+++ b/connectors/google/src/tool-error.ts
@@ -1,6 +1,6 @@
 import { GoogleApiError } from './client.js';
 
-import type { Tool, ToolExecuteFunction } from 'ai';
+import type { Tool } from 'ai';
 
 type GoogleToolErrorResult = { error: string; message: string; retryable: boolean };
 
@@ -28,11 +28,10 @@ export function wrapGoogleToolErrors(tools: Record<string, Tool>): Record<string
 }
 
 function wrapGoogleToolError(currentTool: Tool): Tool {
-  if (!currentTool.execute) {
+  const execute: Tool['execute'] = currentTool.execute;
+  if (!execute) {
     return currentTool;
   }
-
-  const execute = currentTool.execute as ToolExecuteFunction<unknown, unknown>;
 
   return {
     ...currentTool,

--- a/packages/server/src/code-mode/bindings/tool-binding.ts
+++ b/packages/server/src/code-mode/bindings/tool-binding.ts
@@ -1,6 +1,7 @@
 import type { ToolBinding } from '@stitch/sandbox';
 
-import type { Tool, ToolExecutionOptions } from 'ai';
+import type { ToolExecuteOptions } from '@/tools/runtime/runtime.js';
+import type { Tool } from 'ai';
 
 const EXTERNAL_PREFIX = 'external_';
 
@@ -77,8 +78,7 @@ export function toolsToBindings(tools: Record<string, Tool>, abortSignal?: Abort
       inputSchema: schema,
       execute: async (input: unknown, signal?: AbortSignal) => {
         const effectiveSignal = signal ?? abortSignal;
-        // `skipTruncation` is a Stitch-specific flag read by truncationMiddleware.
-        const options: ToolExecutionOptions & { skipTruncation: true } = {
+        const options: ToolExecuteOptions = {
           toolCallId: `code-mode-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
           messages: [],
           skipTruncation: true,

--- a/packages/server/src/tools/core/bash.ts
+++ b/packages/server/src/tools/core/bash.ts
@@ -9,6 +9,7 @@ import { resolvePreferredShell } from '@/lib/shell.js';
 import { ToolValidationError } from '@/tools/errors.js';
 import { deriveCommandFamilies, getCommandFamilySuggestion } from '@/tools/runtime/bash-families.js';
 import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
+import type { ToolInput } from '@/tools/runtime/runtime.js';
 import { validateExistingDirectoryPath } from '@/tools/runtime/shared.js';
 
 const SIGKILL_TIMEOUT_MS = 200;
@@ -202,14 +203,14 @@ Parameter sourcing:
   });
 }
 
-function getPatternTargets(input: unknown): string[] {
-  const command = (input as { command?: unknown }).command;
+function getPatternTargets(input: ToolInput): string[] {
+  const command = input.command;
   if (typeof command !== 'string' || command.trim().length === 0) return [];
   return deriveCommandFamilies(command).map((family) => family.pattern);
 }
 
-function getSuggestion(input: unknown): PermissionSuggestion | null {
-  const command = (input as { command?: unknown }).command;
+function getSuggestion(input: ToolInput): PermissionSuggestion | null {
+  const command = input.command;
   if (typeof command !== 'string' || command.trim().length === 0) return null;
   return getCommandFamilySuggestion(command);
 }

--- a/packages/server/src/tools/core/edit.ts
+++ b/packages/server/src/tools/core/edit.ts
@@ -87,19 +87,11 @@ Parameter sourcing:
   });
 }
 
-function getPatternTargets(input: unknown): string[] {
-  return getFilePathPatternTargets(input);
-}
-
-function getSuggestion(input: unknown) {
-  return getParentDirPermissionSuggestion(input);
-}
-
 export const definition: ToolDefinition = {
   name: 'edit',
   displayName: 'Edit',
   tool: createEditTool(),
-  permission: { getPatternTargets, getSuggestion },
+  permission: { getPatternTargets: getFilePathPatternTargets, getSuggestion: getParentDirPermissionSuggestion },
 };
 
 export { MULTIPLE_MATCHES_ERROR };

--- a/packages/server/src/tools/core/glob.ts
+++ b/packages/server/src/tools/core/glob.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import * as Glob from '@/lib/glob.js';
 import { ToolPathValidationError } from '@/tools/errors.js';
 import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
+import type { ToolInput } from '@/tools/runtime/runtime.js';
 import { validateAbsoluteDirectoryPath } from '@/tools/runtime/shared.js';
 
 const MAX_RESULTS = 100;
@@ -70,8 +71,8 @@ function createGlobTool() {
   return tool({ description: DESCRIPTION, inputSchema: globInputSchema, execute: async (input) => globPaths(input) });
 }
 
-function getPatternTargets(input: unknown): string[] {
-  const target = (input as { path?: unknown }).path;
+function getPatternTargets(input: ToolInput): string[] {
+  const target = input.path;
   return typeof target === 'string' && target.length > 0 ? [target] : [];
 }
 

--- a/packages/server/src/tools/core/grep.ts
+++ b/packages/server/src/tools/core/grep.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import * as Glob from '@/lib/glob.js';
 import { ToolPathValidationError, ToolValidationError } from '@/tools/errors.js';
 import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
+import type { ToolInput } from '@/tools/runtime/runtime.js';
 import { isTextFileBuffer, truncateLine, validateAbsoluteDirectoryPath } from '@/tools/runtime/shared.js';
 
 const MAX_MATCHES = 100;
@@ -162,8 +163,8 @@ function createGrepTool() {
   return tool({ description: DESCRIPTION, inputSchema: grepInputSchema, execute: async (input) => grepContent(input) });
 }
 
-function getPatternTargets(input: unknown): string[] {
-  const target = (input as { path?: unknown }).path;
+function getPatternTargets(input: ToolInput): string[] {
+  const target = input.path;
   return typeof target === 'string' && target.length > 0 ? [target] : [];
 }
 

--- a/packages/server/src/tools/core/read.ts
+++ b/packages/server/src/tools/core/read.ts
@@ -101,17 +101,9 @@ function createReadTool() {
   });
 }
 
-function getPatternTargets(input: unknown): string[] {
-  return getFilePathPatternTargets(input);
-}
-
-function getSuggestion(input: unknown) {
-  return getParentDirPermissionSuggestion(input);
-}
-
 export const definition: ToolDefinition = {
   name: 'read',
   displayName: 'Read',
   tool: createReadTool(),
-  permission: { getPatternTargets, getSuggestion },
+  permission: { getPatternTargets: getFilePathPatternTargets, getSuggestion: getParentDirPermissionSuggestion },
 };

--- a/packages/server/src/tools/core/webfetch.ts
+++ b/packages/server/src/tools/core/webfetch.ts
@@ -2,8 +2,11 @@ import { tool } from 'ai';
 import TurndownService from 'turndown';
 import { z } from 'zod';
 
+import type { PermissionSuggestion } from '@stitch/shared/permissions/types';
+
 import { WebFetchHttpError, WebFetchResponseTooLargeError, WebFetchUrlValidationError } from '@/tools/errors.js';
 import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
+import type { ToolInput } from '@/tools/runtime/runtime.js';
 
 const MAX_RESPONSE_SIZE_BYTES = 5 * 1024 * 1024;
 const DEFAULT_TIMEOUT_SECONDS = 30;
@@ -214,15 +217,15 @@ Parameter sourcing:
   });
 }
 
-function getPatternTargets(input: unknown): string[] {
-  const url = (input as { url?: unknown }).url;
+function getPatternTargets(input: ToolInput): string[] {
+  const url = input.url;
   if (typeof url !== 'string' || url.length === 0) return [];
   const domain = extractDomainForPermission(url);
   return domain ? [domain] : [];
 }
 
-function getSuggestion(input: unknown) {
-  const url = (input as { url?: unknown }).url;
+function getSuggestion(input: ToolInput): PermissionSuggestion | null {
+  const url = input.url;
   if (typeof url !== 'string' || url.length === 0) return null;
   const domain = extractDomainForPermission(url);
   if (!domain) return null;

--- a/packages/server/src/tools/core/write.ts
+++ b/packages/server/src/tools/core/write.ts
@@ -38,17 +38,9 @@ Usage:
   });
 }
 
-function getPatternTargets(input: unknown): string[] {
-  return getFilePathPatternTargets(input);
-}
-
-function getSuggestion(input: unknown) {
-  return getParentDirPermissionSuggestion(input);
-}
-
 export const definition: ToolDefinition = {
   name: 'write',
   displayName: 'Write',
   tool: createWriteTool(),
-  permission: { getPatternTargets, getSuggestion },
+  permission: { getPatternTargets: getFilePathPatternTargets, getSuggestion: getParentDirPermissionSuggestion },
 };

--- a/packages/server/src/tools/runtime/file-permissions.ts
+++ b/packages/server/src/tools/runtime/file-permissions.ts
@@ -2,20 +2,22 @@ import path from 'node:path';
 
 import type { PermissionSuggestion } from '@stitch/shared/permissions/types';
 
-function resolveAbsoluteFilePath(input: unknown): string | null {
-  const filePath = (input as { filePath?: unknown }).filePath;
+import type { ToolInput } from '@/tools/runtime/runtime.js';
+
+function resolveAbsoluteFilePath(input: ToolInput): string | null {
+  const filePath = input.filePath;
   if (typeof filePath !== 'string' || filePath.length === 0) return null;
   if (!path.isAbsolute(filePath)) return null;
   return path.resolve(filePath);
 }
 
-export function getFilePathPatternTargets(input: unknown): string[] {
+export function getFilePathPatternTargets(input: ToolInput): string[] {
   const targetPath = resolveAbsoluteFilePath(input);
   if (!targetPath) return [];
   return [targetPath];
 }
 
-export function getParentDirPermissionSuggestion(input: unknown): PermissionSuggestion | null {
+export function getParentDirPermissionSuggestion(input: ToolInput): PermissionSuggestion | null {
   const targetPath = resolveAbsoluteFilePath(input);
   if (!targetPath) return null;
 

--- a/packages/server/src/tools/runtime/middleware.ts
+++ b/packages/server/src/tools/runtime/middleware.ts
@@ -4,7 +4,7 @@ import * as Log from '@/lib/log.js';
 import { PermissionRejectedError, StreamProtocolViolationError } from '@/llm/stream/errors.js';
 import { getPermissionDecision, requestPermissionResponse } from '@/permission/service.js';
 import { ToolError } from '@/tools/errors.js';
-import type { ToolExecutionInput, ToolMiddleware } from '@/tools/runtime/runtime.js';
+import type { ToolExecutionInput, ToolMiddleware, ToolTruncationLimits } from '@/tools/runtime/runtime.js';
 import { truncateOutput } from '@/tools/runtime/truncation.js';
 
 const log = Log.create({ service: 'tools' });
@@ -21,13 +21,13 @@ function createPermissionDedupeKey(input: ToolExecutionInput, patternTargets: st
 
 type TruncationMeta = { __stitchToolResultMeta: { truncated: true; outputPath: string } };
 
+function hasStringOutput(result: unknown): result is { output: string } {
+  return typeof result === 'object' && result !== null && 'output' in result && typeof result.output === 'string';
+}
+
 function getTruncatableText(result: unknown): string {
   if (typeof result === 'string') return result;
-
-  if (result !== null && typeof result === 'object') {
-    const output = (result as { output?: unknown }).output;
-    if (typeof output === 'string') return output;
-  }
+  if (hasStringOutput(result)) return result.output;
 
   try {
     return JSON.stringify(result);
@@ -52,10 +52,9 @@ export function resultNormalizationMiddleware(): ToolMiddleware {
   };
 }
 
-export function truncationMiddleware(options?: { maxLines?: number; maxBytes?: number }): ToolMiddleware {
+export function truncationMiddleware(options?: ToolTruncationLimits): ToolMiddleware {
   return (next) => async (input) => {
-    const execOptions = input.executeOptions as Record<string, unknown> | undefined;
-    if (execOptions?.['skipTruncation'] === true) {
+    if (input.executeOptions.skipTruncation === true) {
       return next(input);
     }
 
@@ -68,11 +67,7 @@ export function truncationMiddleware(options?: { maxLines?: number; maxBytes?: n
 
     const meta: TruncationMeta = { __stitchToolResultMeta: { truncated: true, outputPath: truncated.outputPath } };
 
-    if (typeof result === 'string') {
-      return { output: truncated.content, ...meta };
-    }
-
-    if (result !== null && typeof result === 'object' && typeof (result as { output?: unknown }).output === 'string') {
+    if (hasStringOutput(result)) {
       return { ...result, output: truncated.content, ...meta };
     }
 
@@ -98,8 +93,7 @@ export function permissionMiddleware(): ToolMiddleware {
       throw new PermissionRejectedError(input.toolName);
     }
 
-    const meta = input.executeOptions as { toolCallId: string; abortSignal?: AbortSignal } | undefined;
-    const toolCallId = meta?.toolCallId;
+    const { toolCallId, abortSignal } = input.executeOptions;
     if (!toolCallId) {
       log.error(
         {
@@ -108,8 +102,7 @@ export function permissionMiddleware(): ToolMiddleware {
           sessionId: input.context.sessionId,
           messageId: input.context.messageId,
           streamRunId: input.context.streamRunId,
-          hasMeta: meta !== undefined,
-          metaKeys: meta ? Object.keys(meta) : [],
+          metaKeys: Object.keys(input.executeOptions),
         },
         'missing toolCallId in tool execute context',
       );
@@ -126,7 +119,7 @@ export function permissionMiddleware(): ToolMiddleware {
       systemReminder: 'Tool execution requires user approval',
       suggestion: behavior.getSuggestion(input.args),
       dedupeKey: createPermissionDedupeKey(input, patternTargets),
-      abortSignal: meta.abortSignal,
+      abortSignal,
     });
 
     if (decision.decision === 'allow') {

--- a/packages/server/src/tools/runtime/pipeline.ts
+++ b/packages/server/src/tools/runtime/pipeline.ts
@@ -1,12 +1,17 @@
-import type { PermissionSuggestion } from '@stitch/shared/permissions/types';
-
 import {
   permissionMiddleware,
   resultNormalizationMiddleware,
   truncationMiddleware,
 } from '@/tools/runtime/middleware.js';
 import { createToolRuntime } from '@/tools/runtime/runtime.js';
-import type { RuntimeToolMetadata, RuntimeToolSource, ToolContext, ToolMiddleware } from '@/tools/runtime/runtime.js';
+import type {
+  RuntimeToolMetadata,
+  RuntimeToolSource,
+  ToolContext,
+  ToolMiddleware,
+  ToolPermissionBehavior,
+  ToolTruncationLimits,
+} from '@/tools/runtime/runtime.js';
 import type { Tool } from 'ai';
 
 export type ToolDefinition = {
@@ -14,11 +19,8 @@ export type ToolDefinition = {
   displayName: string;
   tool: Tool;
   source?: RuntimeToolSource;
-  permission?: {
-    getPatternTargets: (input: unknown) => string[];
-    getSuggestion: (input: unknown) => PermissionSuggestion | null;
-  };
-  truncation?: { maxLines?: number; maxBytes?: number };
+  permission?: ToolPermissionBehavior;
+  truncation?: ToolTruncationLimits;
   /** Extra middleware applied after the standard stack for this tool. */
   extraMiddleware?: ToolMiddleware[];
 };

--- a/packages/server/src/tools/runtime/runtime.ts
+++ b/packages/server/src/tools/runtime/runtime.ts
@@ -1,31 +1,34 @@
 import type { PrefixedString } from '@stitch/shared/id';
 import type { PermissionSuggestion } from '@stitch/shared/permissions/types';
 
-import type { Tool } from 'ai';
+import type { Tool, ToolExecutionOptions } from 'ai';
 
 export type ToolContext = { sessionId: PrefixedString<'ses'>; messageId: PrefixedString<'msg'>; streamRunId: string };
 
 export type RuntimeToolSource = 'core' | 'toolset' | 'mcp' | 'meta' | 'task' | 'code-mode';
 
-type ToolPermissionBehavior = {
-  getPatternTargets: (input: unknown) => string[];
-  getSuggestion: (input: unknown) => PermissionSuggestion | null;
+export type ToolInput = Record<string, unknown>;
+export type ToolExecuteOptions = ToolExecutionOptions & { skipTruncation?: boolean };
+export type ToolTruncationLimits = { maxLines?: number; maxBytes?: number };
+
+export type ToolPermissionBehavior = {
+  getPatternTargets: (input: ToolInput) => string[];
+  getSuggestion: (input: ToolInput) => PermissionSuggestion | null;
 };
 
 export type RuntimeToolMetadata = {
   displayName?: string;
   source?: RuntimeToolSource;
   permission?: ToolPermissionBehavior;
-  truncation?: { maxLines?: number; maxBytes?: number };
-  data?: Record<string, unknown>;
+  truncation?: ToolTruncationLimits;
 };
 
 type RuntimeTool = RuntimeToolMetadata & { name: string; description: string; tool: Tool };
 
 export type ToolExecutionInput = {
   toolName: string;
-  args: unknown;
-  executeOptions: unknown;
+  args: ToolInput;
+  executeOptions: ToolExecuteOptions;
   tool: Tool;
   context: ToolContext;
   metadata: RuntimeToolMetadata;
@@ -58,17 +61,15 @@ export function createToolRuntime(context: ToolContext): ToolRuntime {
     },
 
     wrapTool<T extends Tool>(name: string, tool: T, metadata: RuntimeToolMetadata = {}) {
-      const originalExecute = tool.execute;
+      const originalExecute: Tool['execute'] = tool.execute;
       if (!originalExecute) return tool;
 
-      const executor = compose(middlewares, async (input) =>
-        originalExecute(input.args as never, input.executeOptions as never),
-      );
+      const executor = compose(middlewares, async (input) => originalExecute(input.args, input.executeOptions));
 
       return {
         ...tool,
-        execute: async (...args: Parameters<typeof originalExecute>) =>
-          executor({ toolName: name, args: args.at(0), executeOptions: args.at(1), tool, context, metadata }),
+        execute: async (args: ToolInput, executeOptions: ToolExecuteOptions) =>
+          executor({ toolName: name, args, executeOptions, tool, context, metadata }),
       } as T;
     },
 

--- a/packages/shared/src/tools/types.ts
+++ b/packages/shared/src/tools/types.ts
@@ -14,7 +14,7 @@ export type ToolEnabledState = {
   updatedAt: number;
 };
 
-type ToolDataResult<T = unknown> = { data: T; error?: never; details?: never };
+type ToolDataResult = { data: unknown; error?: never; details?: never };
 
 type ToolErrorResult = { error: string; details?: unknown; data?: never };
 
@@ -23,20 +23,17 @@ export function isToolErrorResult(value: unknown): value is ToolErrorResult {
     return false;
   }
 
-  const candidate = value as { error?: unknown; details?: unknown };
-  if (typeof candidate.error !== 'string' || candidate.error.length === 0) {
+  if (!('error' in value) || typeof value.error !== 'string' || value.error.length === 0) {
     return false;
   }
 
-  const keys = Object.keys(value as Record<string, unknown>);
-  return keys.every((key) => key === 'error' || key === 'details');
+  return Object.keys(value).every((key) => key === 'error' || key === 'details');
 }
 
-export function isToolDataResult<T = unknown>(value: unknown): value is ToolDataResult<T> {
+export function isToolDataResult(value: unknown): value is ToolDataResult {
   if (!value || typeof value !== 'object') {
     return false;
   }
 
-  const candidate = value as { data?: unknown; error?: unknown };
-  return 'data' in candidate && !('error' in candidate);
+  return 'data' in value && !('error' in value);
 }


### PR DESCRIPTION
## Change Summary

Replaces broad and duplicated tool runtime contracts with concrete shared types, removing unchecked casts from the execution pipeline, permission callbacks, result guards, and the Google tool wrapper.

### Improvements & Refactors

- Add typed tool input, execution options, truncation limits, and permission behavior contracts.
- Remove redundant permission wrappers and unsafe result-guard casts.
- Preserve existing runtime behavior while making tool middleware contracts explicit.
