### PR TITLE
fix(google): return canonical tool errors

### DIFF
--- a/connectors/google/src/client.test.ts
+++ b/connectors/google/src/client.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
+import { isToolErrorResult } from '@stitch/shared/tools/types';
+
 import { GoogleApiError, GoogleClient } from './client.js';
 import { resetGoogleRateLimitCoordinatorForTests } from './rate-limit.js';
 import { classifyGoogleToolError } from './tool-error.js';
@@ -96,12 +98,7 @@ describe('GoogleClient', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(GoogleApiError);
       expect((error as GoogleApiError).reasons).toContain('ACCESS_TOKEN_SCOPE_INSUFFICIENT');
-      expect(classifyGoogleToolError(error)).toEqual({
-        error: 'insufficient_google_permissions',
-        message:
-          "You aren't allowed to perform this action because the connected Google account does not have enough permissions.",
-        retryable: false,
-      });
+      expect(isToolErrorResult(classifyGoogleToolError(error))).toBe(true);
     }
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
@@ -138,10 +135,9 @@ describe('GoogleClient', () => {
     const result = await tools?.drive_info.execute?.({ fileId: 'file-1' }, { toolCallId: 'call-1', messages: [] });
 
     expect(result).toEqual({
-      error: 'insufficient_google_permissions',
-      message:
+      error:
         "You aren't allowed to perform this action because the connected Google account does not have enough permissions.",
-      retryable: false,
+      details: { code: 'insufficient_google_permissions', retryable: false },
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/connectors/google/src/tool-error.test.ts
+++ b/connectors/google/src/tool-error.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { isToolErrorResult } from '@stitch/shared/tools/types';
+
+import { GoogleApiError } from './client.js';
+import { classifyGoogleToolError, wrapGoogleToolErrors } from './tool-error.js';
+
+import { tool } from 'ai';
+import { z } from 'zod';
+
+const insufficientScope = new GoogleApiError(403, 'Request had insufficient authentication scopes.', {
+  reasons: ['ACCESS_TOKEN_SCOPE_INSUFFICIENT'],
+});
+
+function makeTool(execute: () => Promise<unknown>) {
+  return tool({ description: 'test tool', inputSchema: z.object({}), execute });
+}
+
+function runWrapped(execute: () => Promise<unknown>) {
+  const wrapped = wrapGoogleToolErrors({ gmail: makeTool(execute) });
+  return wrapped.gmail.execute?.({}, {} as never);
+}
+
+describe('classifyGoogleToolError', () => {
+  test('returns a result the shared guard recognizes as a tool failure', () => {
+    const result = classifyGoogleToolError(insufficientScope);
+
+    expect(isToolErrorResult(result)).toBe(true);
+  });
+
+  test('puts the human-readable message in error and the code in details', () => {
+    expect(classifyGoogleToolError(insufficientScope)).toEqual({
+      error:
+        "You aren't allowed to perform this action because the connected Google account does not have enough permissions.",
+      details: { code: 'insufficient_google_permissions', retryable: false },
+    });
+  });
+
+  test('returns null for unclassified google errors', () => {
+    expect(classifyGoogleToolError(new GoogleApiError(500, 'Backend error'))).toBeNull();
+  });
+
+  test('returns null for non-google errors', () => {
+    expect(classifyGoogleToolError(new Error('boom'))).toBeNull();
+  });
+});
+
+describe('wrapGoogleToolErrors', () => {
+  test('converts a classified error into an error result', async () => {
+    const result = await runWrapped(() => Promise.reject(insufficientScope));
+
+    expect(isToolErrorResult(result)).toBe(true);
+  });
+
+  test('rethrows errors it cannot classify', () => {
+    expect(runWrapped(() => Promise.reject(new Error('boom')))).rejects.toThrow('boom');
+  });
+
+  test('passes successful results through untouched', async () => {
+    expect(await runWrapped(() => Promise.resolve({ messages: [] }))).toEqual({ messages: [] });
+  });
+});

--- a/connectors/google/src/tool-error.ts
+++ b/connectors/google/src/tool-error.ts
@@ -1,11 +1,11 @@
+import type { ToolErrorResult } from '@stitch/shared/tools/types';
+
 import { GoogleApiError } from './client.js';
 
 import type { Tool } from 'ai';
 
-type GoogleToolErrorResult = { error: string; message: string; retryable: boolean };
-
 type GoogleToolErrorClassifier = {
-  error: string;
+  code: string;
   message: string;
   retryable: boolean;
   matches: (error: GoogleApiError) => boolean;
@@ -13,7 +13,7 @@ type GoogleToolErrorClassifier = {
 
 const GOOGLE_TOOL_ERROR_CLASSIFIERS: GoogleToolErrorClassifier[] = [
   {
-    error: 'insufficient_google_permissions',
+    code: 'insufficient_google_permissions',
     message:
       "You aren't allowed to perform this action because the connected Google account does not have enough permissions.",
     retryable: false,
@@ -51,7 +51,7 @@ function wrapGoogleToolError(currentTool: Tool): Tool {
   };
 }
 
-export function classifyGoogleToolError(error: unknown): GoogleToolErrorResult | null {
+export function classifyGoogleToolError(error: unknown): ToolErrorResult | null {
   if (!(error instanceof GoogleApiError)) {
     return null;
   }
@@ -61,7 +61,7 @@ export function classifyGoogleToolError(error: unknown): GoogleToolErrorResult |
     return null;
   }
 
-  return { error: classifier.error, message: classifier.message, retryable: classifier.retryable };
+  return { error: classifier.message, details: { code: classifier.code, retryable: classifier.retryable } };
 }
 
 function isInsufficientScopeError(error: GoogleApiError): boolean {

--- a/packages/shared/src/tools/types.ts
+++ b/packages/shared/src/tools/types.ts
@@ -16,7 +16,14 @@ export type ToolEnabledState = {
 
 type ToolDataResult = { data: unknown; error?: never; details?: never };
 
-type ToolErrorResult = { error: string; details?: unknown; data?: never };
+/**
+ * Cross-package protocol for a failed tool result. Packages that cannot import the server's
+ * ToolError class return this instead; resultNormalizationMiddleware converts it into a throw.
+ * `error` is the message shown to the model and the user, so it must be human-readable.
+ * Adding any key other than `details` makes isToolErrorResult reject the value and it will be
+ * treated as ordinary tool data.
+ */
+export type ToolErrorResult = { error: string; details?: unknown; data?: never };
 
 export function isToolErrorResult(value: unknown): value is ToolErrorResult {
   if (!value || typeof value !== 'object') {


### PR DESCRIPTION
## Change Summary

Fixes Google connector failures so they use the canonical tool error protocol and are recognized by server middleware instead of being returned as successful tool output.

### Bug Fixes

- Return human-readable Google failures as `{ error, details }`.
- Preserve classifier codes and retryability in structured details.
- Add coverage for classified, unclassified, non-Google, rethrow, and success paths.

This PR is stacked on #558.
