### PR TITLE
fix: unify tool failure detection

### DIFF
--- a/apps/web/src/components/chat/message-bubble/tool-call-display.test.ts
+++ b/apps/web/src/components/chat/message-bubble/tool-call-display.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { StoredPart } from '@stitch/shared/chat/messages';
+
+import { buildStoredToolCallDisplayItems } from '@/components/chat/message-bubble/tool-call-display.js';
+
+type StoredToolResult = StoredPart & { type: 'tool-result' };
+
+function callPart(toolName: string): StoredPart {
+  return {
+    type: 'tool-call',
+    id: 'prt_1',
+    toolCallId: 'call-1',
+    toolName,
+    input: {},
+    startedAt: 0,
+    endedAt: 1,
+  };
+}
+
+function resultsFor(output: unknown): Map<string, StoredToolResult> {
+  const result: StoredToolResult = {
+    type: 'tool-result',
+    id: 'prt_2',
+    toolCallId: 'call-1',
+    toolName: 'bash',
+    input: {},
+    output,
+    truncated: false,
+    startedAt: 0,
+    endedAt: 1,
+  };
+
+  return new Map([['call-1', result]]);
+}
+
+function buildOne(toolName: string, output: unknown) {
+  return buildStoredToolCallDisplayItems([callPart(toolName)], resultsFor(output), false)[0];
+}
+
+describe('buildStoredToolCallDisplayItems', () => {
+  test('reports a readable error for a failed bash command that carries no error field', () => {
+    const item = buildOne('bash', { title: 'ls', output: 'no such file', failed: true });
+
+    expect(item.status).toBe('error');
+    expect(item.error).toBe('Tool execution failed');
+  });
+
+  test('surfaces the message from a canonical error result', () => {
+    const item = buildOne('read', { error: 'File not found' });
+
+    expect(item.status).toBe('error');
+    expect(item.error).toBe('File not found');
+  });
+
+  test('treats data results containing an error field as completed', () => {
+    const item = buildOne('grep', { error: 'non-fatal', matches: [], total: 0 });
+
+    expect(item.status).toBe('completed');
+    expect(item.error).toBeUndefined();
+  });
+
+  test('marks a call with no result as errored', () => {
+    const item = buildStoredToolCallDisplayItems([callPart('bash')], new Map(), false)[0];
+
+    expect(item.status).toBe('error');
+    expect(item.error).toBe('Blocked or failed before completion');
+  });
+
+  test('reports an aborted call with no result as interrupted', () => {
+    const item = buildStoredToolCallDisplayItems([callPart('bash')], new Map(), true)[0];
+
+    expect(item.error).toBe('Interrupted');
+  });
+});

--- a/apps/web/src/components/chat/message-bubble/tool-call-display.ts
+++ b/apps/web/src/components/chat/message-bubble/tool-call-display.ts
@@ -2,6 +2,7 @@ import type { StoredPart } from '@stitch/shared/chat/messages';
 import type { ToolCallStatus } from '@stitch/shared/chat/stream-events';
 import { LIQUID_UI_TOOL_NAME } from '@stitch/shared/liquid-ui/constants';
 import { parseMcpToolName } from '@stitch/shared/mcp/types';
+import { getToolFailureMessage } from '@stitch/shared/tools/types';
 
 import { formatToolDisplayName, truncateText } from './tool-call/card-primitives';
 
@@ -48,14 +49,13 @@ export function buildStoredToolCallDisplayItems(
 
     const result = resultsByCallId.get(part.toolCallId);
     const output = result && 'output' in result ? result.output : undefined;
-    const isError = isToolResultError(output);
+    const failureMessage = getToolFailureMessage(output);
     const missingResult = !result;
-    const status = missingResult || isError ? 'error' : 'completed';
+    const status = missingResult || failureMessage !== null ? 'error' : 'completed';
 
     let toolError: string | undefined;
-    if (isError) {
-      const rawError = (output as { error?: unknown }).error;
-      toolError = typeof rawError === 'string' ? rawError : String(rawError);
+    if (failureMessage !== null) {
+      toolError = failureMessage;
     } else if (missingResult) {
       toolError = wasAborted ? 'Interrupted' : 'Blocked or failed before completion';
     }
@@ -117,15 +117,6 @@ function isVisibleStoredToolCallPart(
 
 function isHiddenToolCall(toolName: string): boolean {
   return toolName === 'todo' || toolName === LIQUID_UI_TOOL_NAME;
-}
-
-function isToolResultError(output: unknown): boolean {
-  return (
-    output !== null &&
-    output !== undefined &&
-    typeof output === 'object' &&
-    ('error' in output || (output as { failed?: unknown }).failed === true)
-  );
 }
 
 export function getChildSessionId(result: unknown): string | null {

--- a/packages/server/src/code-mode/tool.test.ts
+++ b/packages/server/src/code-mode/tool.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 
-import { isErrorResult, serializeIsolateOutput } from '@/code-mode/tool.js';
+import type { IsolateDriver } from '@stitch/sandbox';
+
+import { createCodeModeTool, isErrorResult, serializeIsolateOutput } from '@/code-mode/tool.js';
 
 describe('isErrorResult', () => {
   test('returns true for objects with error property', () => {
@@ -66,5 +68,21 @@ describe('serializeIsolateOutput', () => {
     circular.self = circular;
     const output = serializeIsolateOutput(circular, []);
     expect(output).toContain('[unserializable result]');
+  });
+});
+
+describe('createCodeModeTool', () => {
+  test('throws on invalid syntax without creating a sandbox context', () => {
+    const driver: IsolateDriver = {
+      createContext: () => {
+        throw new Error('context should not be created for invalid syntax');
+      },
+    };
+
+    const { tool: codeModeTool } = createCodeModeTool({ getTools: () => ({}), driver });
+
+    expect(
+      codeModeTool.execute?.({ code: 'const = ;', description: 'broken code' }, { toolCallId: 'call-1', messages: [] }),
+    ).rejects.toThrow('Syntax error in provided code');
   });
 });

--- a/packages/server/src/code-mode/tool.ts
+++ b/packages/server/src/code-mode/tool.ts
@@ -11,6 +11,7 @@ import type { CodeModeToolFilter } from '@/code-mode/filter.js';
 import { stripTypeScript } from '@/code-mode/strip-typescript.js';
 import { buildCodeModeSystemPrompt } from '@/code-mode/system-prompt.js';
 import * as Log from '@/lib/log.js';
+import { ToolValidationError } from '@/tools/errors.js';
 import { truncateOutput } from '@/tools/runtime/truncation.js';
 import type { Tool } from 'ai';
 
@@ -72,7 +73,11 @@ The sandbox has no filesystem, network, or Node.js access beyond these functions
       const stripped = stripTypeScript(code);
       if (stripped.error !== null) {
         log.warn({ event: 'code-mode.syntax-error', description, error: stripped.error }, 'code mode syntax error');
-        return { error: `Syntax error in provided code:\n${stripped.error}`, description };
+        throw new ToolValidationError(
+          `Syntax error in provided code:\n${stripped.error}`,
+          'execute_typescript',
+          'code',
+        );
       }
 
       const filteredTools = getFilteredTools();

--- a/packages/server/src/llm/stream/stream-accumulator.ts
+++ b/packages/server/src/llm/stream/stream-accumulator.ts
@@ -2,7 +2,7 @@ import type { PartId, StoredPart } from '@stitch/shared/chat/messages';
 import type { PartDelta, PartUpdate } from '@stitch/shared/chat/stream-events';
 import type { PrefixedString } from '@stitch/shared/id';
 import { createPartId } from '@stitch/shared/id';
-import { isToolErrorResult } from '@stitch/shared/tools/types';
+import { getToolFailureMessage } from '@stitch/shared/tools/types';
 
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
@@ -240,21 +240,15 @@ export class StreamAccumulator {
         const partId = createPartId();
         const truncationMeta = this.getToolTruncationMeta(part.output);
         const sanitizedOutput = this.stripToolTruncationMeta(part.output);
-        const fallbackError = isToolErrorResult(sanitizedOutput) ? sanitizedOutput.error : undefined;
-        const isBashFailure =
-          !fallbackError &&
-          sanitizedOutput !== null &&
-          typeof sanitizedOutput === 'object' &&
-          (sanitizedOutput as { failed?: unknown }).failed === true;
-        const isError = Boolean(fallbackError) || isBashFailure;
+        const failureMessage = getToolFailureMessage(sanitizedOutput);
 
-        if (isError) {
+        if (failureMessage !== null) {
           internalBus.emit('tool.failed', {
             sessionId: this.sessionId,
             messageId: this.messageId,
             toolCallId: part.toolCallId,
             toolName: part.toolName,
-            error: fallbackError ?? 'Tool execution failed',
+            error: failureMessage,
           });
         } else {
           internalBus.emit('tool.completed', {

--- a/packages/shared/src/tools/types.test.ts
+++ b/packages/shared/src/tools/types.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+
+import { getToolFailureMessage } from './types.js';
+
+describe('getToolFailureMessage', () => {
+  test('returns the message from a canonical error result', () => {
+    expect(getToolFailureMessage({ error: 'boom' })).toBe('boom');
+    expect(getToolFailureMessage({ error: 'boom', details: { code: 'x' } })).toBe('boom');
+  });
+
+  test('reports a failure for the failed flag, which carries no error message', () => {
+    expect(getToolFailureMessage({ failed: true, output: 'exit 1', title: 'ls' })).toBe('Tool execution failed');
+  });
+
+  test('returns null for successful results', () => {
+    expect(getToolFailureMessage({ output: 'hello' })).toBeNull();
+    expect(getToolFailureMessage({ failed: false, output: 'ok' })).toBeNull();
+    expect(getToolFailureMessage({})).toBeNull();
+  });
+
+  test('returns null for non-object outputs', () => {
+    expect(getToolFailureMessage(undefined)).toBeNull();
+    expect(getToolFailureMessage(null)).toBeNull();
+    expect(getToolFailureMessage('some text output')).toBeNull();
+  });
+
+  test('does not report a failure for data results that merely contain an error field', () => {
+    expect(getToolFailureMessage({ error: 'non-fatal', matches: [], total: 0 })).toBeNull();
+  });
+
+  test('does not report a failure for an empty error message', () => {
+    expect(getToolFailureMessage({ error: '' })).toBeNull();
+  });
+});

--- a/packages/shared/src/tools/types.ts
+++ b/packages/shared/src/tools/types.ts
@@ -44,3 +44,22 @@ export function isToolDataResult(value: unknown): value is ToolDataResult {
 
   return 'data' in value && !('error' in value);
 }
+
+const TOOL_FAILURE_FALLBACK_MESSAGE = 'Tool execution failed';
+
+/**
+ * Returns the message to report for a failed tool result, or null when the result is a success.
+ * Recognizes the ToolErrorResult protocol plus the separate `failed: true` flag that bash sets to
+ * report a non-zero exit code, since that shape carries its output in `output` rather than `error`.
+ */
+export function getToolFailureMessage(output: unknown): string | null {
+  if (isToolErrorResult(output)) {
+    return output.error;
+  }
+
+  if (!output || typeof output !== 'object') {
+    return null;
+  }
+
+  return 'failed' in output && output.failed === true ? TOOL_FAILURE_FALLBACK_MESSAGE : null;
+}


### PR DESCRIPTION
## Change Summary

Unifies failed-tool detection across shared code, server streaming, and the web UI so canonical errors and legacy failed command results render consistently.

### Bug Fixes

- Add one shared failure-message helper for canonical and legacy tool results.
- Prevent successful data containing an `error` field from rendering as a tool failure.
- Report failed bash output correctly instead of displaying `undefined`.
- Throw code-mode syntax validation failures through the server tool error path.

This PR is stacked on #559.
