### PR TITLE
fix: standardize AI tool error reporting

### DIFF
--- a/apps/web/src/components/chat/message-bubble/tool-call-display.test.ts
+++ b/apps/web/src/components/chat/message-bubble/tool-call-display.test.ts
@@ -2,20 +2,15 @@ import { describe, expect, test } from 'bun:test';
 
 import type { StoredPart } from '@stitch/shared/chat/messages';
 
-import { buildStoredToolCallDisplayItems } from '@/components/chat/message-bubble/tool-call-display.js';
+import {
+  buildStoredToolCallDisplayItems,
+  getChildSessionId,
+} from '@/components/chat/message-bubble/tool-call-display.js';
 
 type StoredToolResult = StoredPart & { type: 'tool-result' };
 
 function callPart(toolName: string): StoredPart {
-  return {
-    type: 'tool-call',
-    id: 'prt_1',
-    toolCallId: 'call-1',
-    toolName,
-    input: {},
-    startedAt: 0,
-    endedAt: 1,
-  };
+  return { type: 'tool-call', id: 'prt_1', toolCallId: 'call-1', toolName, input: {}, startedAt: 0, endedAt: 1 };
 }
 
 function resultsFor(output: unknown): Map<string, StoredToolResult> {
@@ -43,7 +38,7 @@ describe('buildStoredToolCallDisplayItems', () => {
     const item = buildOne('bash', { title: 'ls', output: 'no such file', failed: true });
 
     expect(item.status).toBe('error');
-    expect(item.error).toBe('Tool execution failed');
+    expect(item.error).toBe('no such file');
   });
 
   test('surfaces the message from a canonical error result', () => {
@@ -71,5 +66,11 @@ describe('buildStoredToolCallDisplayItems', () => {
     const item = buildStoredToolCallDisplayItems([callPart('bash')], new Map(), true)[0];
 
     expect(item.error).toBe('Interrupted');
+  });
+});
+
+describe('getChildSessionId', () => {
+  test('finds child sessions retained in canonical error details', () => {
+    expect(getChildSessionId({ error: 'Task failed', details: { childSessionId: 'ses_child' } })).toBe('ses_child');
   });
 });

--- a/apps/web/src/components/chat/message-bubble/tool-call-display.ts
+++ b/apps/web/src/components/chat/message-bubble/tool-call-display.ts
@@ -121,8 +121,13 @@ function isHiddenToolCall(toolName: string): boolean {
 
 export function getChildSessionId(result: unknown): string | null {
   if (!result || typeof result !== 'object') return null;
-  const id = (result as Record<string, unknown>).childSessionId;
-  return typeof id === 'string' ? id : null;
+  const record = result as Record<string, unknown>;
+  const id = record.childSessionId;
+  if (typeof id === 'string') return id;
+
+  if (!record.details || typeof record.details !== 'object') return null;
+  const detailsId = (record.details as Record<string, unknown>).childSessionId;
+  return typeof detailsId === 'string' ? detailsId : null;
 }
 
 function getToolKind(toolName: string): ToolIconKind {

--- a/connectors/google/src/tool-error.ts
+++ b/connectors/google/src/tool-error.ts
@@ -1,3 +1,4 @@
+import { toolError } from '@stitch/shared/tools/types';
 import type { ToolErrorResult } from '@stitch/shared/tools/types';
 
 import { GoogleApiError } from './client.js';
@@ -61,7 +62,7 @@ export function classifyGoogleToolError(error: unknown): ToolErrorResult | null 
     return null;
   }
 
-  return { error: classifier.message, details: { code: classifier.code, retryable: classifier.retryable } };
+  return toolError(classifier.message, { code: classifier.code, retryable: classifier.retryable });
 }
 
 function isInsufficientScopeError(error: GoogleApiError): boolean {

--- a/packages/server/src/code-mode/tool.test.ts
+++ b/packages/server/src/code-mode/tool.test.ts
@@ -2,24 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import type { IsolateDriver } from '@stitch/sandbox';
 
-import { createCodeModeTool, isErrorResult, serializeIsolateOutput } from '@/code-mode/tool.js';
-
-describe('isErrorResult', () => {
-  test('returns true for objects with error property', () => {
-    expect(isErrorResult({ error: 'something went wrong' })).toBe(true);
-    expect(isErrorResult({ error: null })).toBe(true);
-    expect(isErrorResult({ error: { code: 500 } })).toBe(true);
-  });
-
-  test('returns false for non-error objects', () => {
-    expect(isErrorResult({ value: 42 })).toBe(false);
-    expect(isErrorResult({})).toBe(false);
-    expect(isErrorResult(null)).toBe(false);
-    expect(isErrorResult(undefined)).toBe(false);
-    expect(isErrorResult('string')).toBe(false);
-    expect(isErrorResult(42)).toBe(false);
-  });
-});
+import { createCodeModeTool, serializeIsolateOutput } from '@/code-mode/tool.js';
 
 describe('serializeIsolateOutput', () => {
   test('serializes null result as no return value', () => {
@@ -38,9 +21,11 @@ describe('serializeIsolateOutput', () => {
     expect(output).toContain('Error: something failed');
   });
 
-  test('serializes error result with object error', () => {
-    const output = serializeIsolateOutput({ error: { code: 500, msg: 'bad' } }, []);
-    expect(output).toContain('Error: {"code":500,"msg":"bad"}');
+  test('serializes an object with error data as successful JSON', () => {
+    const output = serializeIsolateOutput({ error: { code: 500, msg: 'bad' }, value: 42 }, []);
+    expect(output).toContain('"error": {');
+    expect(output).toContain('"value": 42');
+    expect(output).not.toContain('Error:');
   });
 
   test('serializes successful object result as JSON', () => {
@@ -84,5 +69,56 @@ describe('createCodeModeTool', () => {
     expect(
       codeModeTool.execute?.({ code: 'const = ;', description: 'broken code' }, { toolCallId: 'call-1', messages: [] }),
     ).rejects.toThrow('Syntax error in provided code');
+  });
+
+  test('returns sandbox execution errors as canonical tool errors', async () => {
+    const driver: IsolateDriver = {
+      createContext: async () => ({
+        execute: async () => ({ result: { error: 'sandbox failed' }, logs: [] }),
+        dispose: () => {},
+      }),
+    };
+    const { tool: codeModeTool } = createCodeModeTool({ getTools: () => ({}), driver });
+
+    const result = await codeModeTool.execute?.(
+      { code: 'return true;', description: 'run valid code' },
+      { toolCallId: 'call-2', messages: [] },
+    );
+
+    expect(result).toEqual({ error: 'sandbox failed' });
+  });
+
+  test('preserves sandbox logs in canonical tool error details', async () => {
+    const driver: IsolateDriver = {
+      createContext: async () => ({
+        execute: async () => ({ result: { error: 'sandbox failed' }, logs: ['[log] before failure'] }),
+        dispose: () => {},
+      }),
+    };
+    const { tool: codeModeTool } = createCodeModeTool({ getTools: () => ({}), driver });
+
+    const result = await codeModeTool.execute?.(
+      { code: 'return true;', description: 'run valid code' },
+      { toolCallId: 'call-3', messages: [] },
+    );
+
+    expect(result).toEqual({ error: 'sandbox failed', details: { logs: ['[log] before failure'] } });
+  });
+
+  test('keeps legitimate objects with error data on the success path', async () => {
+    const driver: IsolateDriver = {
+      createContext: async () => ({
+        execute: async () => ({ result: { error: 'partial failure', value: 42 }, logs: [] }),
+        dispose: () => {},
+      }),
+    };
+    const { tool: codeModeTool } = createCodeModeTool({ getTools: () => ({}), driver });
+
+    const result = await codeModeTool.execute?.(
+      { code: 'return true;', description: 'run valid code' },
+      { toolCallId: 'call-4', messages: [] },
+    );
+
+    expect(result).toMatchObject({ output: expect.stringContaining('"value": 42'), truncated: false });
   });
 });

--- a/packages/server/src/code-mode/tool.ts
+++ b/packages/server/src/code-mode/tool.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 
 import { createProcessSandbox } from '@stitch/sandbox';
 import type { IsolateDriver, IsolateOptions } from '@stitch/sandbox';
+import { isToolErrorResult, toolError } from '@stitch/shared/tools/types';
+import type { ToolErrorResult } from '@stitch/shared/tools/types';
 
 import { toolsToBindings, toolsToTypeInfo } from '@/code-mode/bindings/tool-binding.js';
 import { SandboxExecPathMissingError } from '@/code-mode/errors.js';
@@ -114,10 +116,14 @@ The sandbox has no filesystem, network, or Node.js access beyond these functions
           description,
           durationMs,
           logCount: execResult.logs.length,
-          hasError: isErrorResult(execResult.result),
+          hasError: isToolErrorResult(execResult.result),
         },
         'code mode execution complete',
       );
+
+      if (isToolErrorResult(execResult.result)) {
+        return createSandboxErrorResult(execResult.result, execResult.logs);
+      }
 
       const resultText = serializeIsolateOutput(execResult.result, execResult.logs);
       const truncated = await truncateOutput(resultText);
@@ -152,8 +158,12 @@ function createCodeModeIsolateOptions(
   };
 }
 
-export function isErrorResult(result: unknown): result is { error: unknown } {
-  return result !== null && typeof result === 'object' && 'error' in result;
+function createSandboxErrorResult(result: ToolErrorResult, logs: string[]): ToolErrorResult {
+  if (logs.length === 0) {
+    return result;
+  }
+
+  return toolError(result.error, { logs });
 }
 
 export function serializeIsolateOutput(result: unknown, logs: string[]): string {
@@ -169,9 +179,8 @@ export function serializeIsolateOutput(result: unknown, logs: string[]): string 
 
   if (result === null || result === undefined) {
     parts.push('(no return value)');
-  } else if (isErrorResult(result)) {
-    const errMsg = typeof result.error === 'string' ? result.error : JSON.stringify(result.error);
-    parts.push(`Error: ${errMsg}`);
+  } else if (isToolErrorResult(result)) {
+    parts.push(`Error: ${result.error}`);
   } else {
     try {
       parts.push(JSON.stringify(result, null, 2));

--- a/packages/server/src/llm/stream/stream-accumulator.test.ts
+++ b/packages/server/src/llm/stream/stream-accumulator.test.ts
@@ -250,6 +250,21 @@ describe('StreamAccumulator', () => {
       expect(failedCalls.at(0)).toMatchObject({ toolName: 'webfetch', error: 'connection refused' });
     });
 
+    test('preserves structured tool error details in stored results', () => {
+      const parts: StoredPart[] = [];
+      const acc = createAccumulator(parts);
+      const error = Object.assign(new Error('permission denied'), {
+        details: { code: 'insufficient_permissions', retryable: false },
+      });
+
+      acc.handlePart(part({ type: 'tool-error', toolCallId: 'call_1', toolName: 'gmail_send', input: {}, error }));
+
+      expect(parts.at(0)).toMatchObject({
+        type: 'tool-result',
+        output: { error: 'permission denied', details: { code: 'insufficient_permissions', retryable: false } },
+      });
+    });
+
     test('captures PermissionRejectedError from tool-error', () => {
       const acc = createAccumulator();
       const permError = new PermissionRejectedError('webfetch');

--- a/packages/server/src/llm/stream/stream-accumulator.ts
+++ b/packages/server/src/llm/stream/stream-accumulator.ts
@@ -279,7 +279,11 @@ export class StreamAccumulator {
       case 'tool-error': {
         const now = Date.now();
         const partId = createPartId();
-        const errorText = String(part.error);
+        const errorText = Error.isError(part.error) ? part.error.message : String(part.error);
+        const errorDetails =
+          typeof part.error === 'object' && part.error !== null && 'details' in part.error
+            ? part.error.details
+            : undefined;
 
         internalBus.emit('tool.failed', {
           sessionId: this.sessionId,
@@ -308,7 +312,7 @@ export class StreamAccumulator {
           id: partId,
           toolCallId: part.toolCallId,
           toolName: part.toolName,
-          output: { error: errorText },
+          output: errorDetails === undefined ? { error: errorText } : { error: errorText, details: errorDetails },
           truncated: false,
           startedAt: now,
           endedAt: now,

--- a/packages/server/src/mcp/client.test.ts
+++ b/packages/server/src/mcp/client.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { normalizeMcpToolResult } from '@/mcp/client.js';
+
+describe('normalizeMcpToolResult', () => {
+  test('converts MCP text errors to the shared tool error shape', () => {
+    const result: CallToolResult = {
+      isError: true,
+      content: [
+        { type: 'text', text: 'Request failed' },
+        { type: 'text', text: 'Try a different query' },
+      ],
+    };
+
+    expect(normalizeMcpToolResult(result)).toEqual({
+      error: 'Request failed\nTry a different query',
+      details: result,
+    });
+  });
+
+  test('uses a fallback message when error content has no text', () => {
+    const result: CallToolResult = {
+      isError: true,
+      content: [{ type: 'image', data: 'abc', mimeType: 'image/png' }],
+    };
+
+    expect(normalizeMcpToolResult(result)).toEqual({ error: 'MCP tool call failed', details: result });
+  });
+
+  test('leaves successful MCP results unchanged', () => {
+    const result: CallToolResult = { content: [{ type: 'text', text: 'Success' }] };
+
+    expect(normalizeMcpToolResult(result)).toBe(result);
+  });
+});

--- a/packages/server/src/mcp/client.ts
+++ b/packages/server/src/mcp/client.ts
@@ -6,6 +6,8 @@ import { dynamicTool, jsonSchema } from 'ai';
 
 import type { PrefixedString } from '@stitch/shared/id';
 import type { McpAuthConfig } from '@stitch/shared/mcp/types';
+import { toolError } from '@stitch/shared/tools/types';
+import type { ToolErrorResult } from '@stitch/shared/tools/types';
 
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
@@ -34,6 +36,35 @@ const clientCache = new Map<string, Promise<Client>>();
  * discovery and break the exchange.
  */
 const pendingOAuthTransports = new Map<string, StreamableHTTPClientTransport>();
+
+export function normalizeMcpToolResult<T>(result: T): T | ToolErrorResult {
+  if (
+    typeof result !== 'object' ||
+    result === null ||
+    !('isError' in result) ||
+    result.isError !== true ||
+    !('content' in result) ||
+    !Array.isArray(result.content)
+  ) {
+    return result;
+  }
+
+  const error = result.content
+    .filter(
+      (content): content is { type: 'text'; text: string } =>
+        typeof content === 'object' &&
+        content !== null &&
+        'type' in content &&
+        content.type === 'text' &&
+        'text' in content &&
+        typeof content.text === 'string',
+    )
+    .map((content) => content.text.trim())
+    .filter(Boolean)
+    .join('\n');
+
+  return toolError(error || 'MCP tool call failed', result);
+}
 
 export function registerPendingOAuthTransport(serverId: string, transport: StreamableHTTPClientTransport): void {
   pendingOAuthTransports.set(serverId, transport);
@@ -66,14 +97,16 @@ function createAiTool(server: McpServerRef, tool: McpTool, sessionId: PrefixedSt
       withMcpClient(
         server,
         (client) =>
-          client.callTool(
-            {
-              name: tool.name,
-              arguments: input && typeof input === 'object' ? (input as Record<string, unknown>) : {},
-            },
-            undefined,
-            { signal: abortSignal },
-          ),
+          client
+            .callTool(
+              {
+                name: tool.name,
+                arguments: input && typeof input === 'object' ? (input as Record<string, unknown>) : {},
+              },
+              undefined,
+              { signal: abortSignal },
+            )
+            .then(normalizeMcpToolResult),
         sessionId,
       ),
   });

--- a/packages/server/src/tools/core/bash.ts
+++ b/packages/server/src/tools/core/bash.ts
@@ -4,6 +4,7 @@ import { setTimeout as sleep } from 'node:timers/promises';
 import { z } from 'zod';
 
 import type { PermissionSuggestion } from '@stitch/shared/permissions/types';
+import { toolError } from '@stitch/shared/tools/types';
 
 import { resolvePreferredShell } from '@/lib/shell.js';
 import { ToolValidationError } from '@/tools/errors.js';
@@ -184,21 +185,26 @@ Parameter sourcing:
 
       const cleanedOutput = stripAnsi(output);
       const exitCode = proc.exitCode ?? 0;
-      const failed = exitCode !== 0 && !timedOutState.value && !aborted;
-
-      return {
-        title: input.description,
-        output: cleanedOutput,
-        failed,
-        metadata: {
-          description: input.description,
-          exit: exitCode,
-          output:
-            cleanedOutput.length > MAX_METADATA_LENGTH
-              ? `${cleanedOutput.slice(0, MAX_METADATA_LENGTH)}\n\n...`
-              : cleanedOutput,
-        },
+      const metadata = {
+        description: input.description,
+        exit: exitCode,
+        output:
+          cleanedOutput.length > MAX_METADATA_LENGTH
+            ? `${cleanedOutput.slice(0, MAX_METADATA_LENGTH)}\n\n...`
+            : cleanedOutput,
       };
+
+      if (exitCode !== 0 || timedOutState.value || aborted) {
+        const reason = timedOutState.value
+          ? `Command timed out after ${timeout} ms`
+          : aborted
+            ? 'Command was aborted'
+            : `Command failed with exit code ${exitCode}`;
+        const message = cleanedOutput.trim().length > 0 ? `${reason}:\n${cleanedOutput}` : reason;
+        return toolError(message, { title: input.description, output: cleanedOutput, metadata });
+      }
+
+      return { title: input.description, output: cleanedOutput, metadata };
     },
   });
 }

--- a/packages/server/src/tools/core/create-skill.ts
+++ b/packages/server/src/tools/core/create-skill.ts
@@ -1,6 +1,7 @@
 import { tool } from 'ai';
 
 import { createSkillSchema } from '@stitch/shared/skills/types';
+import { toolError } from '@stitch/shared/tools/types';
 
 import { createSkill } from '@/skills/service.js';
 import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
@@ -11,7 +12,7 @@ const createSkillInputSchema = createSkillSchema.describe('A reusable skill to s
 export async function createSkillFromTool(input: z.input<typeof createSkillSchema>) {
   const result = await createSkill(createSkillSchema.parse(input));
   if (result.error) {
-    return { error: result.error.message };
+    return toolError(result.error.message);
   }
 
   return {

--- a/packages/server/src/tools/core/inspect-image.ts
+++ b/packages/server/src/tools/core/inspect-image.ts
@@ -8,6 +8,7 @@ import type { StoredPart } from '@stitch/shared/chat/messages';
 import { createMessageId, createPartId } from '@stitch/shared/id';
 import type { PrefixedString } from '@stitch/shared/id';
 import type { LlmProviderId } from '@stitch/shared/providers/types';
+import { toolError } from '@stitch/shared/tools/types';
 
 import { createSession } from '@/chat/session-crud.js';
 import { getDb } from '@/db/client.js';
@@ -66,26 +67,20 @@ export function createInspectImageTool(context: ToolContext, deps: InspectImageT
     execute: async ({ imagePath, prompt }, { toolCallId }) => {
       const ext = path.extname(imagePath).toLowerCase();
       if (!SUPPORTED_EXTENSIONS.has(ext)) {
-        return {
-          childSessionId: null,
-          childSessionName: null,
-          summary: `Unsupported image format "${ext}". Supported: ${[...SUPPORTED_EXTENSIONS].join(', ')}`,
-        };
+        return toolError(`Unsupported image format "${ext}". Supported: ${[...SUPPORTED_EXTENSIONS].join(', ')}`);
       }
 
       let stat;
       try {
         stat = await fs.stat(imagePath);
       } catch {
-        return { childSessionId: null, childSessionName: null, summary: `Image file not found: ${imagePath}` };
+        return toolError(`Image file not found: ${imagePath}`);
       }
 
       if (stat.size > MAX_FILE_SIZE) {
-        return {
-          childSessionId: null,
-          childSessionName: null,
-          summary: `Image file too large (${(stat.size / 1024 / 1024).toFixed(1)}MB). Maximum supported size is 20MB.`,
-        };
+        return toolError(
+          `Image file too large (${(stat.size / 1024 / 1024).toFixed(1)}MB). Maximum supported size is 20MB.`,
+        );
       }
 
       const mime = MIME_MAP[ext] ?? 'application/octet-stream';
@@ -98,11 +93,7 @@ export function createInspectImageTool(context: ToolContext, deps: InspectImageT
 
       const sessionResult = await createSession({ title: sessionTitle, parentSessionId: deps.parentSessionId });
       if (sessionResult.error) {
-        return {
-          childSessionId: null,
-          childSessionName: null,
-          summary: `Failed to create inspection session: ${sessionResult.error.message}`,
-        };
+        return toolError(`Failed to create inspection session: ${sessionResult.error.message}`);
       }
       const childSession = sessionResult.data;
       const childSessionId = childSession.id;
@@ -204,11 +195,10 @@ export function createInspectImageTool(context: ToolContext, deps: InspectImageT
           'image inspection failed',
         );
 
-        return {
+        return toolError(`Image inspection failed: ${Error.isError(error) ? error.message : 'Unknown error'}`, {
           childSessionId,
           childSessionName: childSession.title,
-          summary: `Image inspection failed: ${Error.isError(error) ? error.message : 'Unknown error'}`,
-        };
+        });
       } finally {
         deps.parentAbortSignal.removeEventListener('abort', onParentAbort);
         AbortRegistry.cleanup(childSessionId);

--- a/packages/server/src/tools/core/memory.ts
+++ b/packages/server/src/tools/core/memory.ts
@@ -1,6 +1,8 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 
+import { toolError } from '@stitch/shared/tools/types';
+
 import { getMemoryConfig } from '@/memory/config.js';
 import { memoryFileStore } from '@/memory/file-store.js';
 import type { MemoryMutation } from '@/memory/types.js';
@@ -36,7 +38,7 @@ function createMemoryTool(context: ToolContext) {
     inputSchema: mutationSchema,
     execute: async (input) => {
       const config = await getMemoryConfig();
-      if (!config.enabled) return { output: 'Memory is disabled. Enable memory.enabled in settings.' };
+      if (!config.enabled) return toolError('Memory is disabled. Enable memory.enabled in settings.');
 
       const operations: MemoryMutation[] =
         input.action === 'batch'

--- a/packages/server/src/tools/core/skill.ts
+++ b/packages/server/src/tools/core/skill.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { z } from 'zod';
 
+import { toolError } from '@stitch/shared/tools/types';
+
 import { isSkillEnabledByApp } from '@/apps/service.js';
 import { getSkillByName } from '@/skills/service.js';
 import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
@@ -18,10 +20,10 @@ export const definition: ToolDefinition = {
     inputSchema: skillInputSchema,
     execute: async ({ name }) => {
       const enabled = await isSkillEnabledByApp(name);
-      if (!enabled) return { error: `Skill "${name}" is disabled.` };
+      if (!enabled) return toolError(`Skill "${name}" is disabled.`);
 
       const result = await getSkillByName(name);
-      if (result.error) return { error: result.error.message };
+      if (result.error) return toolError(result.error.message);
 
       const skill = result.data;
       const dir = path.dirname(skill.location);

--- a/packages/server/src/tools/core/task.ts
+++ b/packages/server/src/tools/core/task.ts
@@ -6,6 +6,7 @@ import { extractTextFromParts, type StoredPart } from '@stitch/shared/chat/messa
 import { createMessageId, createPartId } from '@stitch/shared/id';
 import type { PrefixedString } from '@stitch/shared/id';
 import type { LlmProviderId } from '@stitch/shared/providers/types';
+import { toolError } from '@stitch/shared/tools/types';
 
 import { cancelBackgroundTask, startBackgroundTask } from '@/background-tasks/service.js';
 import { createSession } from '@/chat/session-crud.js';
@@ -67,11 +68,7 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
     execute: async ({ title, task, background, toolsets: additionalToolsets }, { toolCallId }) => {
       const sessionResult = await createSession({ title, parentSessionId: deps.parentSessionId });
       if (sessionResult.error) {
-        return {
-          childSessionId: null,
-          childSessionName: null,
-          summary: `Task failed: could not create child session — ${sessionResult.error.message}`,
-        };
+        return toolError(`Task failed: could not create child session - ${sessionResult.error.message}`);
       }
       const childSession = sessionResult.data;
 
@@ -162,11 +159,10 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
             summary: 'Background task started. You will be notified automatically when it finishes.',
           };
         } catch (error) {
-          return {
+          return toolError(`Task failed: ${Error.isError(error) ? error.message : 'Unknown error'}`, {
             childSessionId,
             childSessionName: childSession.title,
-            summary: `Task failed: ${Error.isError(error) ? error.message : 'Unknown error'}`,
-          };
+          });
         }
       }
 
@@ -213,11 +209,10 @@ export function createTaskTool(context: ToolContext, deps: TaskToolDeps) {
           'child session task failed',
         );
 
-        return {
+        return toolError(`Task failed: ${Error.isError(error) ? error.message : 'Unknown error'}`, {
           childSessionId,
           childSessionName: childSession.title,
-          summary: `Task failed: ${Error.isError(error) ? error.message : 'Unknown error'}`,
-        };
+        });
       } finally {
         deps.parentAbortSignal.removeEventListener('abort', onParentAbort);
         AbortRegistry.cleanup(childSessionId);

--- a/packages/server/src/tools/core/todo.ts
+++ b/packages/server/src/tools/core/todo.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { TODO_PRIORITIES, TODO_STATUSES } from '@stitch/shared/todos/types';
 import type { SessionTodo, TodoInput } from '@stitch/shared/todos/types';
+import { toolError } from '@stitch/shared/tools/types';
 
 import { listSessionTodos, replaceSessionTodos } from '@/todos/service.js';
 import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
@@ -40,17 +41,17 @@ function createTodoTool(context: ToolContext) {
     execute: async (input) => {
       if (input.action === 'read') {
         const result = await listSessionTodos(context.sessionId);
-        if (result.error) return { output: result.error.message };
+        if (result.error) return toolError(result.error.message);
 
         return { output: formatSummary(result.data), todos: toAgentTodos(result.data) };
       }
 
       if (!input.todos) {
-        return { output: 'Provide todos when action="write".' };
+        return toolError('Provide todos when action="write".');
       }
 
       const result = await replaceSessionTodos({ sessionId: context.sessionId, todos: input.todos });
-      if (result.error) return { output: result.error.message };
+      if (result.error) return toolError(result.error.message);
 
       return { output: `Updated session todos:\n${formatSummary(result.data)}`, todos: toAgentTodos(result.data) };
     },

--- a/packages/server/src/tools/errors.ts
+++ b/packages/server/src/tools/errors.ts
@@ -1,9 +1,11 @@
 class ToolError extends Error {
   readonly toolName?: string;
-  constructor(message: string, toolName?: string) {
+  readonly details?: unknown;
+  constructor(message: string, toolName?: string, details?: unknown) {
     super(message);
     this.name = 'ToolError';
     this.toolName = toolName;
+    this.details = details;
   }
 }
 

--- a/packages/server/src/tools/runtime/middleware.ts
+++ b/packages/server/src/tools/runtime/middleware.ts
@@ -41,7 +41,7 @@ export function resultNormalizationMiddleware(): ToolMiddleware {
     const result = await next(input);
 
     if (isToolErrorResult(result)) {
-      throw new ToolError(result.error);
+      throw new ToolError(result.error, input.toolName, result.details);
     }
 
     if (isToolDataResult(result)) {

--- a/packages/server/src/tools/toolsets/agenda.ts
+++ b/packages/server/src/tools/toolsets/agenda.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { AGENDA_ITEM_PRIORITIES, AGENDA_ITEM_STATUSES } from '@stitch/shared/agenda/types';
 import type { PrefixedString } from '@stitch/shared/id';
+import { toolError } from '@stitch/shared/tools/types';
 
 import {
   createAgendaItem,
@@ -93,7 +94,7 @@ Use when the user asks to add a todo, task, or follow-up. Default priority is "m
     execute: async (input) => {
       const dueAt = input.dueAt ? parseDueDate(input.dueAt, userTimezone) : null;
       if (input.dueAt && dueAt === null) {
-        return { output: 'Invalid due date format. Use ISO 8601 (e.g. "2025-01-15T09:00:00Z").' };
+        return toolError('Invalid due date format. Use ISO 8601 (e.g. "2025-01-15T09:00:00Z").');
       }
 
       const result = createAgendaItem({
@@ -107,7 +108,7 @@ Use when the user asks to add a todo, task, or follow-up. Default priority is "m
       });
 
       if (result.error) {
-        return { output: `Failed to create item: ${result.error.message}` };
+        return toolError(`Failed to create item: ${result.error.message}`);
       }
 
       const item = result.data;
@@ -149,7 +150,7 @@ Use when the user asks to mark something as done, change priority, reschedule, o
       });
 
       if (result.error) {
-        return { output: `No agenda item found with id: ${input.itemId}` };
+        return toolError(`No agenda item found with id: ${input.itemId}`);
       }
 
       const item = result.data;
@@ -184,7 +185,7 @@ Use when the user asks about their tasks, what's pending, or what's due.`,
       });
 
       if (result.error) {
-        return { output: `Failed to list items: ${result.error.message}` };
+        return toolError(`Failed to list items: ${result.error.message}`);
       }
 
       const { items, total } = result.data;
@@ -210,7 +211,7 @@ Use when the user wants to see the complete information about a specific item.`,
     execute: async (input) => {
       const result = getAgendaItem(input.itemId as PrefixedString<'aitm'>);
       if (result.error) {
-        return { output: `No agenda item found with id: ${input.itemId}` };
+        return toolError(`No agenda item found with id: ${input.itemId}`);
       }
 
       const detail = result.data;
@@ -240,7 +241,7 @@ Use when the user wants to organize items into a new list/topic.`,
       const result = createAgendaList({ name: input.name, description: input.description });
 
       if (result.error) {
-        return { output: `Failed to create list: ${result.error.message}` };
+        return toolError(`Failed to create list: ${result.error.message}`);
       }
 
       const list = result.data;
@@ -256,7 +257,7 @@ Use when the user wants to see what lists exist or get an overview of their agen
     execute: async () => {
       const result = getAgendaLists();
       if (result.error) {
-        return { output: `Failed to list agenda lists: ${result.error.message}` };
+        return toolError(`Failed to list agenda lists: ${result.error.message}`);
       }
 
       const lists = result.data;

--- a/packages/server/src/tools/toolsets/browser/index.ts
+++ b/packages/server/src/tools/toolsets/browser/index.ts
@@ -1,6 +1,8 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 
+import { toolError } from '@stitch/shared/tools/types';
+
 import { getBrowserManager } from '@/lib/browser/browser-manager.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 import { summarizeOperationResult, withFreshSnapshot } from '@/tools/toolsets/browser/formatters.js';
@@ -256,6 +258,11 @@ function createBatchTool(context: ToolContext) {
         const outputText = resultLines.length > 0 ? `${summaryText}\n${resultLines.join('\n')}` : summaryText;
         const compactSnapshot = freshSnapshot ? serializeBrowserSnapshot(freshSnapshot) : null;
         const summary = compactSnapshot ? `${outputText}\n\n### Updated Snapshot\n${compactSnapshot.text}` : outputText;
+
+        const errorResults = results.filter((result) => result.status === 'error');
+        if (errorResults.length === results.length || stoppedReason?.startsWith('Stopped on error')) {
+          return toolError(summary, { results, stoppedReason, executed, skipped });
+        }
 
         return {
           output: summary,

--- a/packages/server/src/tools/toolsets/recordings.ts
+++ b/packages/server/src/tools/toolsets/recordings.ts
@@ -2,6 +2,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 
 import type { PrefixedString } from '@stitch/shared/id';
+import { toolError } from '@stitch/shared/tools/types';
 
 import { PATHS } from '@/lib/paths.js';
 import { getRecordingAnalysis, startRecordingAnalysis } from '@/recordings/analysis-service.js';
@@ -27,7 +28,7 @@ Returns status, file path, and Markdown meeting notes.`,
       const result = await getRecordingAnalysis(input.recordingId as PrefixedString<'rec'>);
 
       if (result.error) {
-        return { recordingId: input.recordingId, found: false, message: result.error.message };
+        return toolError(result.error.message, { recordingId: input.recordingId });
       }
 
       if (!result.data.analysis) {
@@ -83,7 +84,7 @@ Use this when analysis is missing or stale.`,
       });
 
       if (result.error) {
-        return { recordingId: input.recordingId, ok: false, message: result.error.message };
+        return toolError(result.error.message, { recordingId: input.recordingId });
       }
 
       return {

--- a/packages/shared/src/tools/types.test.ts
+++ b/packages/shared/src/tools/types.test.ts
@@ -8,8 +8,9 @@ describe('getToolFailureMessage', () => {
     expect(getToolFailureMessage({ error: 'boom', details: { code: 'x' } })).toBe('boom');
   });
 
-  test('reports a failure for the failed flag, which carries no error message', () => {
-    expect(getToolFailureMessage({ failed: true, output: 'exit 1', title: 'ls' })).toBe('Tool execution failed');
+  test('reports the output from a legacy failed result', () => {
+    expect(getToolFailureMessage({ failed: true, output: 'exit 1', title: 'ls' })).toBe('exit 1');
+    expect(getToolFailureMessage({ failed: true, output: '' })).toBe('Tool execution failed');
   });
 
   test('returns null for successful results', () => {

--- a/packages/shared/src/tools/types.ts
+++ b/packages/shared/src/tools/types.ts
@@ -25,6 +25,10 @@ type ToolDataResult = { data: unknown; error?: never; details?: never };
  */
 export type ToolErrorResult = { error: string; details?: unknown; data?: never };
 
+export function toolError(error: string, details?: unknown): ToolErrorResult {
+  return details === undefined ? { error } : { error, details };
+}
+
 export function isToolErrorResult(value: unknown): value is ToolErrorResult {
   if (!value || typeof value !== 'object') {
     return false;
@@ -49,8 +53,7 @@ const TOOL_FAILURE_FALLBACK_MESSAGE = 'Tool execution failed';
 
 /**
  * Returns the message to report for a failed tool result, or null when the result is a success.
- * Recognizes the ToolErrorResult protocol plus the separate `failed: true` flag that bash sets to
- * report a non-zero exit code, since that shape carries its output in `output` rather than `error`.
+ * Recognizes the ToolErrorResult protocol plus legacy results that report failure with `failed: true`.
  */
 export function getToolFailureMessage(output: unknown): string | null {
   if (isToolErrorResult(output)) {
@@ -61,5 +64,11 @@ export function getToolFailureMessage(output: unknown): string | null {
     return null;
   }
 
-  return 'failed' in output && output.failed === true ? TOOL_FAILURE_FALLBACK_MESSAGE : null;
+  if (!('failed' in output) || output.failed !== true) {
+    return null;
+  }
+
+  return 'output' in output && typeof output.output === 'string' && output.output.trim().length > 0
+    ? output.output
+    : TOOL_FAILURE_FALLBACK_MESSAGE;
 }


### PR DESCRIPTION
## Change Summary

Migrates built-in, feature, and MCP tools to a canonical error result shape so models, logs, streams, and the UI receive consistent failure messages and structured details.

### Improvements & Refactors

- Add a shared constructor for canonical tool error results.
- Normalize errors from core tools, agenda, browser, recordings, and MCP integrations.
- Preserve structured metadata such as child session IDs and tool-specific details.
- Expand regression coverage for stream accumulation, code mode, MCP results, and UI rendering.

This PR is stacked on #560.
