### PR TITLE
feat(skills): persist skill registry

### DIFF
--- a/packages/server/drizzle/0042_chemical_hemingway.sql
+++ b/packages/server/drizzle/0042_chemical_hemingway.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `skills` (
+	`name` text PRIMARY KEY NOT NULL,
+	`type` text NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL
+);

--- a/packages/server/drizzle/meta/0042_snapshot.json
+++ b/packages/server/drizzle/meta/0042_snapshot.json
@@ -1,0 +1,2962 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "fad58c31-78a3-4bd6-8833-2febd88eb71a",
+  "prevId": "591db861-72fd-4e7b-991b-6851edd0e58a",
+  "tables": {
+    "agenda_items": {
+      "name": "agenda_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'todo'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'medium'"
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_session_id": {
+          "name": "source_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_items_list_id_idx": {
+          "name": "agenda_items_list_id_idx",
+          "columns": [
+            "list_id"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_status_idx": {
+          "name": "agenda_items_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_due_at_idx": {
+          "name": "agenda_items_due_at_idx",
+          "columns": [
+            "due_at"
+          ],
+          "isUnique": false
+        },
+        "agenda_items_created_at_idx": {
+          "name": "agenda_items_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agenda_items_list_id_agenda_lists_id_fk": {
+          "name": "agenda_items_list_id_agenda_lists_id_fk",
+          "tableFrom": "agenda_items",
+          "tableTo": "agenda_lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "agenda_items_type_check": {
+          "name": "agenda_items_type_check",
+          "value": "\"agenda_items\".\"type\" in ('todo', 'reminder', 'checkup')"
+        },
+        "agenda_items_status_check": {
+          "name": "agenda_items_status_check",
+          "value": "\"agenda_items\".\"status\" in ('open', 'in_progress', 'done', 'cancelled')"
+        },
+        "agenda_items_priority_check": {
+          "name": "agenda_items_priority_check",
+          "value": "\"agenda_items\".\"priority\" in ('low', 'medium', 'high', 'urgent')"
+        }
+      }
+    },
+    "agenda_lists": {
+      "name": "agenda_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "agenda_lists_name_uidx": {
+          "name": "agenda_lists_name_uidx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "agenda_lists_created_at_idx": {
+          "name": "agenda_lists_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automations": {
+      "name": "automations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_message": {
+          "name": "initial_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "background_tasks": {
+      "name": "background_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "child_session_id": {
+          "name": "child_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_message_id": {
+          "name": "origin_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_tool_call_id": {
+          "name": "origin_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "delivery_status": {
+          "name": "delivery_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "delivery_message_id": {
+          "name": "delivery_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_toolset_ids": {
+          "name": "active_toolset_ids",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "background_tasks_parent_status_idx": {
+          "name": "background_tasks_parent_status_idx",
+          "columns": [
+            "parent_session_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "background_tasks_parent_delivery_idx": {
+          "name": "background_tasks_parent_delivery_idx",
+          "columns": [
+            "parent_session_id",
+            "delivery_status"
+          ],
+          "isUnique": false
+        },
+        "background_tasks_child_session_id_unique": {
+          "name": "background_tasks_child_session_id_unique",
+          "columns": [
+            "child_session_id"
+          ],
+          "isUnique": true
+        },
+        "background_tasks_origin_idx": {
+          "name": "background_tasks_origin_idx",
+          "columns": [
+            "origin_message_id",
+            "origin_tool_call_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "background_tasks_parent_session_id_sessions_id_fk": {
+          "name": "background_tasks_parent_session_id_sessions_id_fk",
+          "tableFrom": "background_tasks",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "background_tasks_child_session_id_sessions_id_fk": {
+          "name": "background_tasks_child_session_id_sessions_id_fk",
+          "tableFrom": "background_tasks",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "child_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "background_tasks_origin_message_id_messages_id_fk": {
+          "name": "background_tasks_origin_message_id_messages_id_fk",
+          "tableFrom": "background_tasks",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "origin_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connector_instances": {
+      "name": "connector_instances",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_ref_id": {
+          "name": "connector_ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_version": {
+          "name": "applied_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending_setup'"
+        },
+        "auth_issue": {
+          "name": "auth_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_email": {
+          "name": "account_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_info": {
+          "name": "account_info",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connector_instances_connector_id_idx": {
+          "name": "connector_instances_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        },
+        "connector_instances_connector_ref_id_idx": {
+          "name": "connector_instances_connector_ref_id_idx",
+          "columns": [
+            "connector_ref_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "connector_instances_connector_ref_id_connectors_id_fk": {
+          "name": "connector_instances_connector_ref_id_connectors_id_fk",
+          "tableFrom": "connector_instances",
+          "tableTo": "connectors",
+          "columnsFrom": [
+            "connector_ref_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connector_status_check": {
+          "name": "connector_status_check",
+          "value": "\"connector_instances\".\"status\" in ('pending_setup', 'awaiting_auth', 'connected', 'error')"
+        }
+      }
+    },
+    "connectors": {
+      "name": "connectors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connectors_connector_id_idx": {
+          "name": "connectors_connector_id_idx",
+          "columns": [
+            "connector_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "connectors_auth_type_check": {
+          "name": "connectors_auth_type_check",
+          "value": "\"connectors\".\"auth_type\" in ('oauth2', 'api_key')"
+        }
+      }
+    },
+    "mcp_elicitations": {
+      "name": "mcp_elicitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "server_name": {
+          "name": "server_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_schema": {
+          "name": "requested_schema",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_elicitation_id": {
+          "name": "external_elicitation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "content": {
+          "name": "content",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_elicitations_session_id_sessions_id_fk": {
+          "name": "mcp_elicitations_session_id_sessions_id_fk",
+          "tableFrom": "mcp_elicitations",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_elicitations_server_id_mcp_servers_id_fk": {
+          "name": "mcp_elicitations_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_elicitations",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_oauth_sessions": {
+      "name": "mcp_oauth_sessions",
+      "columns": {
+        "server_id": {
+          "name": "server_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_information": {
+          "name": "client_information",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovery_state": {
+          "name": "discovery_state",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_oauth_sessions_server_id_mcp_servers_id_fk": {
+          "name": "mcp_oauth_sessions_server_id_mcp_servers_id_fk",
+          "tableFrom": "mcp_oauth_sessions",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'http'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_config": {
+          "name": "auth_config",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_status": {
+          "name": "auth_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "tools": {
+          "name": "tools",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_enabled": {
+      "name": "tool_enabled",
+      "columns": {
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_enabled_scope_identifier_uidx": {
+          "name": "tool_enabled_scope_identifier_uidx",
+          "columns": [
+            "scope",
+            "identifier"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_permissions": {
+      "name": "tool_permissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permission": {
+          "name": "permission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_permissions_tool_pattern_idx": {
+          "name": "tool_permissions_tool_pattern_idx",
+          "columns": [
+            "tool_name",
+            "pattern"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "local_models": {
+      "name": "local_models",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_limit": {
+          "name": "input_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_limit": {
+          "name": "output_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 8192
+        },
+        "input_cost_per_million": {
+          "name": "input_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_cost_per_million": {
+          "name": "output_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_cost_per_million": {
+          "name": "cache_read_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cache_write_cost_per_million": {
+          "name": "cache_write_cost_per_million",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "supports_tool_calls": {
+          "name": "supports_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_vision": {
+          "name": "supports_vision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "supports_reasoning": {
+          "name": "supports_reasoning",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "output_modalities": {
+          "name": "output_modalities",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[\"text\"]'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "local_models_provider_id_pk": {
+          "columns": [
+            "provider",
+            "id"
+          ],
+          "name": "local_models_provider_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_visibility": {
+      "name": "model_visibility",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_visibility_provider_model_idx": {
+          "name": "model_visibility_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "provider_config": {
+      "name": "provider_config",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "questions": {
+      "name": "questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answers": {
+          "name": "answers",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_session_id_sessions_id_fk": {
+          "name": "questions_session_id_sessions_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meeting_note_templates": {
+      "name": "meeting_note_templates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "meeting_note_templates_updated_at_idx": {
+          "name": "meeting_note_templates_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recording_analyses": {
+      "name": "recording_analyses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recording_id": {
+          "name": "recording_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_provider_id": {
+          "name": "transcription_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transcription_model_id": {
+          "name": "transcription_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_provider_id": {
+          "name": "analysis_provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "analysis_model_id": {
+          "name": "analysis_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recording_analyses_recording_id_uidx": {
+          "name": "recording_analyses_recording_id_uidx",
+          "columns": [
+            "recording_id"
+          ],
+          "isUnique": true
+        },
+        "recording_analyses_status_idx": {
+          "name": "recording_analyses_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "recording_analyses_recording_id_recordings_id_fk": {
+          "name": "recording_analyses_recording_id_recordings_id_fk",
+          "tableFrom": "recording_analyses",
+          "tableTo": "recordings",
+          "columnsFrom": [
+            "recording_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recording_analyses_status_check": {
+          "name": "recording_analyses_status_check",
+          "value": "\"recording_analyses\".\"status\" in ('pending', 'processing', 'completed', 'failed')"
+        }
+      }
+    },
+    "recordings": {
+      "name": "recordings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'recording'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "recordings_created_at_idx": {
+          "name": "recordings_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "recordings_status_idx": {
+          "name": "recordings_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "recordings_status_check": {
+          "name": "recordings_status_check",
+          "value": "\"recordings\".\"status\" in ('recording', 'completed', 'failed')"
+        }
+      }
+    },
+    "scheduled_job_runs": {
+      "name": "scheduled_job_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_job_runs_job_id_idx": {
+          "name": "scheduled_job_runs_job_id_idx",
+          "columns": [
+            "job_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_job_runs_key_idx": {
+          "name": "scheduled_job_runs_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_job_runs_job_id_scheduled_jobs_id_fk": {
+          "name": "scheduled_job_runs_job_id_scheduled_jobs_id_fk",
+          "tableFrom": "scheduled_job_runs",
+          "tableTo": "scheduled_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_job_runs_status_check": {
+          "name": "scheduled_job_runs_status_check",
+          "value": "\"scheduled_job_runs\".\"status\" in ('running', 'succeeded', 'failed')"
+        }
+      }
+    },
+    "scheduled_jobs": {
+      "name": "scheduled_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "catchup": {
+          "name": "catchup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'one'"
+        },
+        "catchup_max_runs": {
+          "name": "catchup_max_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "running_count": {
+          "name": "running_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_runs": {
+          "name": "total_runs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_failures": {
+          "name": "total_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_success_at": {
+          "name": "last_success_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_jobs_key_uidx": {
+          "name": "scheduled_jobs_key_uidx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "scheduled_jobs_next_run_at_idx": {
+          "name": "scheduled_jobs_next_run_at_idx",
+          "columns": [
+            "next_run_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "scheduled_jobs_catchup_check": {
+          "name": "scheduled_jobs_catchup_check",
+          "value": "\"scheduled_jobs\".\"catchup\" in ('none', 'one', 'all')"
+        }
+      }
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parts": {
+          "name": "parts",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "finish_reason": {
+          "name": "finish_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_summary": {
+          "name": "is_summary",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_reason": {
+          "name": "archived_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_todos": {
+      "name": "session_todos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_todos_session_id_idx": {
+          "name": "session_todos_session_id_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "session_todos_order_idx": {
+          "name": "session_todos_order_idx",
+          "columns": [
+            "session_id",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_todos_session_id_sessions_id_fk": {
+          "name": "session_todos_session_id_sessions_id_fk",
+          "tableFrom": "session_todos",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'chat'"
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_unread": {
+          "name": "is_unread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "toolset_state": {
+          "name": "toolset_state",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_reason": {
+          "name": "archived_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_automation_id_automations_id_fk": {
+          "name": "sessions_automation_id_automations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "automations",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "keyboard_shortcuts": {
+      "name": "keyboard_shortcuts",
+      "columns": {
+        "action_id": {
+          "name": "action_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hotkey": {
+          "name": "hotkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_sequence": {
+          "name": "is_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Workspace'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_usage_events": {
+      "name": "embedding_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "embedding_usage_events_created_at_idx": {
+          "name": "embedding_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "embedding_usage_events_provider_model_idx": {
+          "name": "embedding_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "llm_usage_events": {
+      "name": "llm_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'succeeded'"
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "usage": {
+          "name": "usage",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "llm_usage_events_source_idx": {
+          "name": "llm_usage_events_source_idx",
+          "columns": [
+            "source"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_created_at_idx": {
+          "name": "llm_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "llm_usage_events_provider_model_idx": {
+          "name": "llm_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stt_usage_events": {
+      "name": "stt_usage_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stt_usage_events_service_idx": {
+          "name": "stt_usage_events_service_idx",
+          "columns": [
+            "service"
+          ],
+          "isUnique": false
+        },
+        "stt_usage_events_created_at_idx": {
+          "name": "stt_usage_events_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "stt_usage_events_provider_model_idx": {
+          "name": "stt_usage_events_provider_model_idx",
+          "columns": [
+            "provider_id",
+            "model_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "stt_usage_events_service_check": {
+          "name": "stt_usage_events_service_check",
+          "value": "\"stt_usage_events\".\"service\" in ('chat-input', 'meeting-recording')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -2,29 +2,167 @@
   "version": "7",
   "dialect": "sqlite",
   "entries": [
-    { "idx": 0, "version": "6", "when": 1774819269133, "tag": "0000_late_catseye", "breakpoints": true },
-    { "idx": 1, "version": "6", "when": 1774826514720, "tag": "0001_aromatic_veda", "breakpoints": true },
-    { "idx": 2, "version": "6", "when": 1774970166986, "tag": "0002_tiny_gabe_jones", "breakpoints": true },
-    { "idx": 3, "version": "6", "when": 1774975296308, "tag": "0003_numerous_marrow", "breakpoints": true },
-    { "idx": 4, "version": "6", "when": 1774992262416, "tag": "0004_graceful_warstar", "breakpoints": true },
-    { "idx": 5, "version": "6", "when": 1775256383180, "tag": "0005_calm_shape", "breakpoints": true },
-    { "idx": 6, "version": "6", "when": 1775258328166, "tag": "0006_cold_the_santerians", "breakpoints": true },
-    { "idx": 7, "version": "6", "when": 1775317825423, "tag": "0007_fluffy_bastion", "breakpoints": true },
-    { "idx": 8, "version": "6", "when": 1775320909985, "tag": "0008_skinny_iceman", "breakpoints": true },
-    { "idx": 9, "version": "6", "when": 1775323352253, "tag": "0009_outgoing_northstar", "breakpoints": true },
-    { "idx": 10, "version": "6", "when": 1775423603592, "tag": "0010_adorable_smiling_tiger", "breakpoints": true },
-    { "idx": 11, "version": "6", "when": 1775853609263, "tag": "0011_glossy_chimera", "breakpoints": true },
-    { "idx": 12, "version": "6", "when": 1775857922368, "tag": "0012_hesitant_ultimo", "breakpoints": true },
-    { "idx": 13, "version": "6", "when": 1775860830198, "tag": "0013_neat_scrambler", "breakpoints": true },
-    { "idx": 14, "version": "6", "when": 1775970433811, "tag": "0014_tiny_junta", "breakpoints": true },
-    { "idx": 15, "version": "6", "when": 1776105631471, "tag": "0015_slimy_randall_flagg", "breakpoints": true },
-    { "idx": 16, "version": "6", "when": 1776139705558, "tag": "0016_loose_devos", "breakpoints": true },
-    { "idx": 17, "version": "6", "when": 1776305872769, "tag": "0017_grey_doctor_spectrum", "breakpoints": true },
-    { "idx": 18, "version": "6", "when": 1776372719576, "tag": "0018_sparkling_firebrand", "breakpoints": true },
-    { "idx": 19, "version": "6", "when": 1776910380189, "tag": "0019_steep_mach_iv", "breakpoints": true },
-    { "idx": 20, "version": "6", "when": 1778712024721, "tag": "0020_acoustic_longshot", "breakpoints": true },
-    { "idx": 21, "version": "6", "when": 1778973792670, "tag": "0021_stale_micromax", "breakpoints": true },
-    { "idx": 22, "version": "6", "when": 1778977588099, "tag": "0022_wise_blue_blade", "breakpoints": true },
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1774819269133,
+      "tag": "0000_late_catseye",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1774826514720,
+      "tag": "0001_aromatic_veda",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1774970166986,
+      "tag": "0002_tiny_gabe_jones",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1774975296308,
+      "tag": "0003_numerous_marrow",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1774992262416,
+      "tag": "0004_graceful_warstar",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1775256383180,
+      "tag": "0005_calm_shape",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1775258328166,
+      "tag": "0006_cold_the_santerians",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1775317825423,
+      "tag": "0007_fluffy_bastion",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1775320909985,
+      "tag": "0008_skinny_iceman",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1775323352253,
+      "tag": "0009_outgoing_northstar",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1775423603592,
+      "tag": "0010_adorable_smiling_tiger",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1775853609263,
+      "tag": "0011_glossy_chimera",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1775857922368,
+      "tag": "0012_hesitant_ultimo",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1775860830198,
+      "tag": "0013_neat_scrambler",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1775970433811,
+      "tag": "0014_tiny_junta",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1776105631471,
+      "tag": "0015_slimy_randall_flagg",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1776139705558,
+      "tag": "0016_loose_devos",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1776305872769,
+      "tag": "0017_grey_doctor_spectrum",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1776372719576,
+      "tag": "0018_sparkling_firebrand",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1776910380189,
+      "tag": "0019_steep_mach_iv",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1778712024721,
+      "tag": "0020_acoustic_longshot",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1778973792670,
+      "tag": "0021_stale_micromax",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1778977588099,
+      "tag": "0022_wise_blue_blade",
+      "breakpoints": true
+    },
     {
       "idx": 23,
       "version": "6",
@@ -32,23 +170,138 @@
       "tag": "0023_dedup_tool_permissions_null_pattern",
       "breakpoints": true
     },
-    { "idx": 24, "version": "6", "when": 1780074152703, "tag": "0024_real_kingpin", "breakpoints": true },
-    { "idx": 25, "version": "6", "when": 1780349118310, "tag": "0025_lean_gorilla_man", "breakpoints": true },
-    { "idx": 26, "version": "6", "when": 1780765566023, "tag": "0026_mixed_guardsmen", "breakpoints": true },
-    { "idx": 27, "version": "6", "when": 1780849802789, "tag": "0027_harsh_ares", "breakpoints": true },
-    { "idx": 28, "version": "6", "when": 1780854201050, "tag": "0028_wandering_cloak", "breakpoints": true },
-    { "idx": 29, "version": "6", "when": 1780862829070, "tag": "0029_drop_queued_messages", "breakpoints": true },
-    { "idx": 30, "version": "6", "when": 1780863726814, "tag": "0030_tough_peter_parker", "breakpoints": true },
-    { "idx": 31, "version": "6", "when": 1780865790791, "tag": "0031_daily_talisman", "breakpoints": true },
-    { "idx": 32, "version": "6", "when": 1780893750152, "tag": "0032_tearful_black_cat", "breakpoints": true },
-    { "idx": 33, "version": "6", "when": 1781297017613, "tag": "0033_glossy_gressill", "breakpoints": true },
-    { "idx": 34, "version": "6", "when": 1781653056873, "tag": "0034_acoustic_eternity", "breakpoints": true },
-    { "idx": 35, "version": "6", "when": 1782067742555, "tag": "0035_slim_sumo", "breakpoints": true },
-    { "idx": 36, "version": "6", "when": 1783382634204, "tag": "0036_perfect_mauler", "breakpoints": true },
-    { "idx": 37, "version": "6", "when": 1783471267511, "tag": "0037_rich_maelstrom", "breakpoints": true },
-    { "idx": 38, "version": "6", "when": 1783713767858, "tag": "0038_right_salo", "breakpoints": true },
-    { "idx": 39, "version": "6", "when": 1784239111266, "tag": "0039_mushy_the_hunter", "breakpoints": true },
-    { "idx": 40, "version": "6", "when": 1786207876027, "tag": "0040_curly_timeslip", "breakpoints": true },
-    { "idx": 41, "version": "6", "when": 1786213804474, "tag": "0041_chief_mentallo", "breakpoints": true }
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1780074152703,
+      "tag": "0024_real_kingpin",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1780349118310,
+      "tag": "0025_lean_gorilla_man",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1780765566023,
+      "tag": "0026_mixed_guardsmen",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "6",
+      "when": 1780849802789,
+      "tag": "0027_harsh_ares",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "6",
+      "when": 1780854201050,
+      "tag": "0028_wandering_cloak",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "6",
+      "when": 1780862829070,
+      "tag": "0029_drop_queued_messages",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "6",
+      "when": 1780863726814,
+      "tag": "0030_tough_peter_parker",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "6",
+      "when": 1780865790791,
+      "tag": "0031_daily_talisman",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "6",
+      "when": 1780893750152,
+      "tag": "0032_tearful_black_cat",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1781297017613,
+      "tag": "0033_glossy_gressill",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1781653056873,
+      "tag": "0034_acoustic_eternity",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "6",
+      "when": 1782067742555,
+      "tag": "0035_slim_sumo",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "6",
+      "when": 1783382634204,
+      "tag": "0036_perfect_mauler",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "6",
+      "when": 1783471267511,
+      "tag": "0037_rich_maelstrom",
+      "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "6",
+      "when": 1783713767858,
+      "tag": "0038_right_salo",
+      "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1784239111266,
+      "tag": "0039_mushy_the_hunter",
+      "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "6",
+      "when": 1786207876027,
+      "tag": "0040_curly_timeslip",
+      "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "6",
+      "when": 1786213804474,
+      "tag": "0041_chief_mentallo",
+      "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "6",
+      "when": 1786396733477,
+      "tag": "0042_chemical_hemingway",
+      "breakpoints": true
+    }
   ]
 }

--- a/packages/server/src/db/schema/skills.ts
+++ b/packages/server/src/db/schema/skills.ts
@@ -1,0 +1,9 @@
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+import type { SkillType } from '@stitch/shared/skills/types';
+
+export const skills = sqliteTable('skills', {
+  name: text('name').primaryKey(),
+  type: text('type').$type<SkillType>().notNull(),
+  enabled: integer('enabled', { mode: 'boolean' }).notNull().default(true),
+});

--- a/packages/server/src/skills/errors.ts
+++ b/packages/server/src/skills/errors.ts
@@ -26,6 +26,13 @@ export class SkillInvalidError extends SkillError {
   }
 }
 
+export class SkillReadOnlyError extends SkillError {
+  constructor(name: string) {
+    super(`Built-in skill "${name}" cannot be edited or deleted`);
+    this.name = 'SkillReadOnlyError';
+  }
+}
+
 export class SkillImportError extends SkillError {
   constructor(message: string) {
     super(message);

--- a/packages/server/src/skills/registry.ts
+++ b/packages/server/src/skills/registry.ts
@@ -1,0 +1,53 @@
+import { and, eq, notInArray } from 'drizzle-orm';
+
+import type { SkillType } from '@stitch/shared/skills/types';
+
+import { getDb, isDbInitialized } from '@/db/client.js';
+import { skills } from '@/db/schema/skills.js';
+
+export type SkillRegistration = { type: SkillType; enabled: boolean };
+
+export async function getSkillRegistrations(): Promise<Map<string, SkillRegistration>> {
+  if (!isDbInitialized()) return new Map();
+
+  const rows = await getDb().select().from(skills);
+  return new Map(rows.map((row) => [row.name, { type: row.type, enabled: row.enabled }]));
+}
+
+export async function getSkillRegistration(name: string): Promise<SkillRegistration | null> {
+  if (!isDbInitialized()) return null;
+
+  const rows = await getDb()
+    .select({ type: skills.type, enabled: skills.enabled })
+    .from(skills)
+    .where(eq(skills.name, name));
+  return rows.at(0) ?? null;
+}
+
+export async function setSkillType(name: string, type: SkillType): Promise<void> {
+  if (!isDbInitialized()) return;
+
+  await getDb().insert(skills).values({ name, type }).onConflictDoUpdate({ target: skills.name, set: { type } });
+}
+
+export async function renameSkillRegistration(previousName: string, name: string): Promise<void> {
+  if (!isDbInitialized()) return;
+
+  await getDb().update(skills).set({ name }).where(eq(skills.name, previousName));
+}
+
+export async function deleteSkillRegistration(name: string): Promise<void> {
+  if (!isDbInitialized()) return;
+
+  await getDb().delete(skills).where(eq(skills.name, name));
+}
+
+export async function listRetiredBuiltInSkillNames(currentNames: string[]): Promise<string[]> {
+  if (!isDbInitialized()) return [];
+
+  const rows = await getDb()
+    .select({ name: skills.name })
+    .from(skills)
+    .where(and(eq(skills.type, 'stitch'), currentNames.length > 0 ? notInArray(skills.name, currentNames) : undefined));
+  return rows.map((row) => row.name);
+}

--- a/packages/server/src/skills/service-built-ins.test.ts
+++ b/packages/server/src/skills/service-built-ins.test.ts
@@ -32,7 +32,7 @@ describe('syncBuiltInSkills', () => {
     expect(content).toContain('Test instructions.');
   });
 
-  test('skips existing skill directories', async () => {
+  test('overwrites existing built-in skill instructions', async () => {
     const skill = {
       name: 'test-skill',
       description: 'Use this test skill.',
@@ -42,15 +42,13 @@ describe('syncBuiltInSkills', () => {
 
     await syncBuiltInSkills([skill]);
 
-    // Manually modify the file to simulate a user edit
     const mdPath = path.join(tempDir, 'test-skill', 'SKILL.md');
     await fs.writeFile(mdPath, 'user modified content', 'utf8');
 
     await syncBuiltInSkills([{ ...skill, content: 'New instructions.' }]);
 
-    // File should remain as the user left it
     const content = await fs.readFile(mdPath, 'utf8');
-    expect(content).toBe('user modified content');
+    expect(content).toContain('New instructions.');
   });
 
   test('syncs companion files for new skills', async () => {
@@ -76,7 +74,7 @@ describe('syncBuiltInSkills', () => {
     expect(await fs.readFile(scriptPath, 'utf8')).toBe('print("hello")');
   });
 
-  test('does not write companion files for existing skill directories', async () => {
+  test('overwrites companion files for existing built-in skills', async () => {
     const skill = {
       name: 'test-skill',
       description: 'A skill.',
@@ -89,7 +87,7 @@ describe('syncBuiltInSkills', () => {
     await syncBuiltInSkills([{ ...skill, files: [{ relativePath: 'references/guide.md', content: 'updated' }] }]);
 
     const guidePath = path.join(tempDir, 'test-skill', 'references', 'guide.md');
-    expect(await fs.readFile(guidePath, 'utf8')).toBe('original');
+    expect(await fs.readFile(guidePath, 'utf8')).toBe('updated');
   });
 });
 

--- a/packages/server/src/skills/service.ts
+++ b/packages/server/src/skills/service.ts
@@ -10,6 +10,7 @@ import type {
   SkillImportInput,
   SkillSearchResult,
   SkillUpdateInput,
+  SkillType,
 } from '@stitch/shared/skills/types';
 
 import { getDisabledAppSkillNames } from '@/apps/service.js';
@@ -18,7 +19,13 @@ import * as Log from '@/lib/log.js';
 import { err, ok } from '@/lib/service-result.js';
 import type { ServiceResult } from '@/lib/service-result.js';
 import type { BuiltInSkill } from '@/skills/built-in-skills.js';
-import { SkillImportError, SkillInvalidError, SkillNameCollisionError, SkillNotFoundError } from '@/skills/errors.js';
+import {
+  SkillImportError,
+  SkillInvalidError,
+  SkillNameCollisionError,
+  SkillNotFoundError,
+  SkillReadOnlyError,
+} from '@/skills/errors.js';
 import {
   buildSkillMd,
   ensureSkillsDir,
@@ -31,6 +38,14 @@ import {
   writeSkillMdFile,
 } from '@/skills/filesystem.js';
 import { parseSkillMarkdown } from '@/skills/parse-skill-markdown.js';
+import {
+  deleteSkillRegistration,
+  getSkillRegistration,
+  getSkillRegistrations,
+  listRetiredBuiltInSkillNames,
+  renameSkillRegistration,
+  setSkillType,
+} from '@/skills/registry.js';
 
 const log = Log.create({ service: 'skills' });
 
@@ -60,7 +75,7 @@ const downloadResponseSchema = z.object({
 const SKILLS_API_BASE = 'https://skills.sh';
 const FETCH_TIMEOUT_MS = 10_000;
 
-async function readSkillFromDisk(name: string): Promise<Skill | null> {
+async function readSkillFromDisk(name: string, type: SkillType, enabled: boolean): Promise<Skill | null> {
   const markdown = await readSkillMdFile(name);
   if (!markdown) return null;
 
@@ -72,6 +87,8 @@ async function readSkillFromDisk(name: string): Promise<Skill | null> {
 
   return {
     name: parsed.name,
+    type,
+    enabled,
     description: parsed.description,
     content: parsed.content,
     location: getSkillMdPath(name),
@@ -88,10 +105,21 @@ export async function listSkills(): Promise<ServiceResult<Skill[]>> {
   const entries = await readdir(skillsDir, { withFileTypes: true });
   const dirs = entries.filter((entry) => entry.isDirectory());
 
+  const registrations = await getSkillRegistrations();
   const skills: Skill[] = [];
+  const registeredNames = new Set<string>();
   for (const dir of dirs) {
-    const skill = await readSkillFromDisk(dir.name);
-    if (skill) skills.push(skill);
+    const registration = registrations.get(dir.name) ?? { type: 'custom' as const, enabled: true };
+    const skill = await readSkillFromDisk(dir.name, registration.type, registration.enabled);
+    if (skill) {
+      skills.push(skill);
+      registeredNames.add(dir.name);
+      if (!registrations.has(dir.name)) await setSkillType(dir.name, registration.type);
+    }
+  }
+
+  for (const name of registrations.keys()) {
+    if (!registeredNames.has(name)) await deleteSkillRegistration(name);
   }
 
   skills.sort((a, b) => a.name.localeCompare(b.name));
@@ -100,7 +128,8 @@ export async function listSkills(): Promise<ServiceResult<Skill[]>> {
 
 export async function getSkillByName(name: string): Promise<ServiceResult<Skill>> {
   await ensureSkillsDir();
-  const skill = await readSkillFromDisk(name);
+  const registration = (await getSkillRegistration(name)) ?? { type: 'custom' as const, enabled: true };
+  const skill = await readSkillFromDisk(name, registration.type, registration.enabled);
   if (!skill) return err(`Skill "${name}" not found`, 404);
   return ok(skill);
 }
@@ -121,11 +150,15 @@ export async function createSkill(input: SkillCreateInput): Promise<ServiceResul
 
   const skill = {
     name: value.name,
+    type: 'custom' as const,
+    enabled: true,
     description: value.description.trim(),
     content: value.content.trim(),
     location: getSkillMdPath(value.name),
     files: [],
   };
+
+  await setSkillType(skill.name, skill.type);
 
   internalBus.emit('skill.created', { name: skill.name });
 
@@ -135,14 +168,21 @@ export async function createSkill(input: SkillCreateInput): Promise<ServiceResul
 export async function syncBuiltInSkills(builtInSkills: BuiltInSkill[]): Promise<void> {
   await ensureSkillsDir();
 
+  const builtInNames = builtInSkills.map((skill) => skill.name);
+  const retiredNames = await listRetiredBuiltInSkillNames(builtInNames);
+  for (const name of retiredNames) {
+    await rm(getSkillDir(name), { recursive: true, force: true });
+    await deleteSkillRegistration(name);
+  }
+
   for (const skill of builtInSkills) {
     const skillDir = getSkillDir(skill.name);
-
-    if (existsSync(skillDir)) continue;
-
     await writeSkillMdFile(skill.name, buildSkillMd(skill));
     await syncCompanionFiles(skillDir, skill.files);
+    await setSkillType(skill.name, 'stitch');
   }
+
+  await listSkills();
 }
 
 export async function updateSkill(name: string, input: SkillUpdateInput): Promise<ServiceResult<Skill>> {
@@ -151,6 +191,10 @@ export async function updateSkill(name: string, input: SkillUpdateInput): Promis
 
   const value = parsed.data;
   await ensureSkillsDir();
+
+  const registration = (await getSkillRegistration(name)) ?? { type: 'custom' as const, enabled: true };
+  const { type } = registration;
+  if (type === 'stitch') return err(new SkillReadOnlyError(name).message, 403);
 
   const currentDir = getSkillDir(name);
   if (!existsSync(currentDir)) {
@@ -163,6 +207,7 @@ export async function updateSkill(name: string, input: SkillUpdateInput): Promis
       return err(new SkillNameCollisionError(value.name).message, 409);
     }
     await rename(currentDir, newDir);
+    await renameSkillRegistration(name, value.name);
   }
 
   await writeSkillMdFile(value.name, buildSkillMd(value));
@@ -172,6 +217,8 @@ export async function updateSkill(name: string, input: SkillUpdateInput): Promis
 
   const skill = {
     name: value.name,
+    type,
+    enabled: registration.enabled,
     description: value.description.trim(),
     content: value.content.trim(),
     location: getSkillMdPath(value.name),
@@ -186,12 +233,15 @@ export async function updateSkill(name: string, input: SkillUpdateInput): Promis
 export async function deleteSkill(name: string): Promise<ServiceResult<null>> {
   await ensureSkillsDir();
 
+  if ((await getSkillRegistration(name))?.type === 'stitch') return err(new SkillReadOnlyError(name).message, 403);
+
   const skillDir = getSkillDir(name);
   if (!existsSync(skillDir)) {
     return err(new SkillNotFoundError(name).message, 404);
   }
 
   await rm(skillDir, { recursive: true, force: true });
+  await deleteSkillRegistration(name);
   internalBus.emit('skill.deleted', { name });
   return ok(null);
 }
@@ -306,11 +356,15 @@ export async function importSkillFromDirectory(input: SkillImportInput): Promise
 
     const skill = {
       name: value.name,
+      type: 'external' as const,
+      enabled: true,
       description: value.description.trim(),
       content: value.content.trim(),
       location: getSkillMdPath(value.name),
       files: skillFiles,
     };
+
+    await setSkillType(skill.name, skill.type);
 
     internalBus.emit('skill.created', { name: skill.name });
 

--- a/packages/shared/src/skills/types.ts
+++ b/packages/shared/src/skills/types.ts
@@ -1,6 +1,18 @@
 import { z } from 'zod';
 
-export type Skill = { name: string; description: string; content: string; location: string; files: string[] };
+export const SKILL_TYPES = ['stitch', 'custom', 'external'] as const;
+
+export type SkillType = (typeof SKILL_TYPES)[number];
+
+export type Skill = {
+  name: string;
+  type: SkillType;
+  enabled: boolean;
+  description: string;
+  content: string;
+  location: string;
+  files: string[];
+};
 
 export type SkillSearchResult = { name: string; slug: string; source: string; installs: number; isImported: boolean };
 

--- a/packages/shared/src/skills/types.ts
+++ b/packages/shared/src/skills/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const SKILL_TYPES = ['stitch', 'custom', 'external'] as const;
+const SKILL_TYPES = ['stitch', 'custom', 'external'] as const;
 
 export type SkillType = (typeof SKILL_TYPES)[number];
 


### PR DESCRIPTION
## Change Summary

Adds a database-backed skill registry so Stitch can reliably track each skill's origin, enabled state, and lifecycle.

### New Features
- Adds the `skills` table and generated migration with `name`, `type`, and default-enabled state.
- Classifies built-in, user-created, imported, and previously unregistered disk skills as `stitch`, `custom`, or `external`.

### Improvements & Refactors
- Reconciles the registry with disk state and removes retired built-ins.
- Makes shipped built-ins authoritative on every startup and rejects attempts to edit or delete them.
