### PR TITLE
feat(skills): enforce skill enablement

### DIFF
--- a/packages/server/src/skills/registry.ts
+++ b/packages/server/src/skills/registry.ts
@@ -30,6 +30,19 @@ export async function setSkillType(name: string, type: SkillType): Promise<void>
   await getDb().insert(skills).values({ name, type }).onConflictDoUpdate({ target: skills.name, set: { type } });
 }
 
+export async function setSkillEnabled(name: string, enabled: boolean): Promise<void> {
+  if (!isDbInitialized()) return;
+
+  await getDb().update(skills).set({ enabled }).where(eq(skills.name, name));
+}
+
+export async function getDisabledSkillNames(): Promise<Set<string>> {
+  if (!isDbInitialized()) return new Set();
+
+  const rows = await getDb().select({ name: skills.name }).from(skills).where(eq(skills.enabled, false));
+  return new Set(rows.map((row) => row.name));
+}
+
 export async function renameSkillRegistration(previousName: string, name: string): Promise<void> {
   if (!isDbInitialized()) return;
 

--- a/packages/server/src/skills/service.ts
+++ b/packages/server/src/skills/service.ts
@@ -46,6 +46,7 @@ import {
   renameSkillRegistration,
   setSkillType,
 } from '@/skills/registry.js';
+import { getDisabledToolIdentifiers } from '@/tools/enabled-service.js';
 
 const log = Log.create({ service: 'skills' });
 
@@ -382,9 +383,12 @@ export async function buildSkillsSystemPrompt(): Promise<string> {
   const result = await listSkills();
   if (result.error || result.data.length === 0) return '';
 
-  const disabledSkillNames = await getDisabledAppSkillNames();
+  const [disabledAppSkillNames, disabledSkillNames] = await Promise.all([
+    getDisabledAppSkillNames(),
+    getDisabledToolIdentifiers('skill'),
+  ]);
   const lines = result.data
-    .filter((skill) => !disabledSkillNames.has(skill.name))
+    .filter((skill) => !disabledAppSkillNames.has(skill.name) && !disabledSkillNames.has(skill.name))
     .map((skill) => `- ${skill.name}: ${skill.description}`);
   if (lines.length === 0) return '';
 

--- a/packages/server/src/tools/core/skill.ts
+++ b/packages/server/src/tools/core/skill.ts
@@ -7,6 +7,7 @@ import { toolError } from '@stitch/shared/tools/types';
 
 import { isSkillEnabledByApp } from '@/apps/service.js';
 import { getSkillByName } from '@/skills/service.js';
+import { isToolEnabled } from '@/tools/enabled-service.js';
 import type { ToolDefinition } from '@/tools/runtime/pipeline.js';
 
 const skillInputSchema = z.object({ name: z.string().min(1).describe('The name of the skill from available_skills') });
@@ -19,8 +20,11 @@ export const definition: ToolDefinition = {
       'Load a specialized skill when the task at hand matches one of the skills listed in the system prompt.\n\nUse this tool to inject the skill\'s instructions and resources into current conversation. The output may contain detailed workflow guidance as well as references to scripts, files, etc in the same directory as the skill.\n\nThe skill name must match one of the skills listed in your system prompt.\n\nLoad a specialized skill that provides domain-specific instructions and workflows.\n\nWhen you recognize that a task matches one of the available skills listed below, use this tool to load the full skill instructions.\n\nThe skill will inject detailed instructions, workflows, and access to bundled resources (scripts, references, templates) into the conversation context.\n\nTool output includes a `<skill_content name="...">` block with the loaded content.',
     inputSchema: skillInputSchema,
     execute: async ({ name }) => {
-      const enabled = await isSkillEnabledByApp(name);
-      if (!enabled) return toolError(`Skill "${name}" is disabled.`);
+      const [enabledByApp, enabledBySkill] = await Promise.all([
+        isSkillEnabledByApp(name),
+        isToolEnabled({ scope: 'skill', identifier: name }),
+      ]);
+      if (!enabledByApp || !enabledBySkill) return toolError(`Skill "${name}" is disabled.`);
 
       const result = await getSkillByName(name);
       if (result.error) return toolError(result.error.message);

--- a/packages/server/src/tools/enabled-service.ts
+++ b/packages/server/src/tools/enabled-service.ts
@@ -4,14 +4,28 @@ import type { ToolEnabledScope, ToolEnabledState } from '@stitch/shared/tools/ty
 
 import { getDb, isDbInitialized } from '@/db/client.js';
 import { toolEnabled } from '@/db/schema/permissions.js';
+import {
+  getDisabledSkillNames,
+  getSkillRegistration,
+  getSkillRegistrations,
+  setSkillEnabled,
+} from '@/skills/registry.js';
 
 export async function getToolEnabledStates(): Promise<ToolEnabledState[]> {
   if (!isDbInitialized()) {
     return [];
   }
 
-  const db = getDb();
-  return db.select().from(toolEnabled);
+  const [toolStates, skillRegistrations] = await Promise.all([
+    getDb().select().from(toolEnabled),
+    getSkillRegistrations(),
+  ]);
+  const skillStates: ToolEnabledState[] = Array.from(skillRegistrations, ([identifier, registration]) => ({
+    scope: 'skill',
+    identifier,
+    enabled: registration.enabled,
+  }));
+  return [...toolStates, ...skillStates];
 }
 
 export async function setToolEnabledState(opts: {
@@ -20,6 +34,11 @@ export async function setToolEnabledState(opts: {
   enabled: boolean;
 }): Promise<void> {
   if (!isDbInitialized()) {
+    return;
+  }
+
+  if (opts.scope === 'skill') {
+    await setSkillEnabled(opts.identifier, opts.enabled);
     return;
   }
 
@@ -40,6 +59,10 @@ export async function isToolEnabled(opts: { scope: ToolEnabledScope; identifier:
     return true;
   }
 
+  if (opts.scope === 'skill') {
+    return (await getSkillRegistration(opts.identifier))?.enabled ?? true;
+  }
+
   const db = getDb();
   const rows = await db
     .select({ enabled: toolEnabled.enabled })
@@ -54,6 +77,8 @@ export async function getDisabledToolIdentifiers(scope: ToolEnabledScope): Promi
   if (!isDbInitialized()) {
     return new Set();
   }
+
+  if (scope === 'skill') return getDisabledSkillNames();
 
   const db = getDb();
   const rows = await db

--- a/packages/shared/src/tools/types.ts
+++ b/packages/shared/src/tools/types.ts
@@ -2,7 +2,7 @@ const TOOL_TYPES = ['stitch', 'mcp', 'plugin'] as const;
 
 export type ToolType = (typeof TOOL_TYPES)[number];
 
-export const TOOL_ENABLED_SCOPES = ['tool', 'toolset', 'mcp_tool', 'app'] as const;
+export const TOOL_ENABLED_SCOPES = ['tool', 'toolset', 'mcp_tool', 'app', 'skill'] as const;
 
 export type ToolEnabledScope = (typeof TOOL_ENABLED_SCOPES)[number];
 
@@ -10,8 +10,6 @@ export type ToolEnabledState = {
   scope: ToolEnabledScope;
   identifier: string;
   enabled: boolean;
-  createdAt: number;
-  updatedAt: number;
 };
 
 type ToolDataResult = { data: unknown; error?: never; details?: never };


### PR DESCRIPTION
## Change Summary

Integrates skills into the existing enablement permissions system while keeping `skills.enabled` as the single source of truth.

### New Features
- Adds the `skill` enablement scope to the shared permissions contract.
- Supports reading and updating skill state through the existing tool enablement API.

### Improvements & Refactors
- Omits disabled skills from the system prompt and rejects direct attempts to load them.
- Requires both the parent app and individual skill to be enabled for app-linked skills.
