### PR TITLE
feat(skills): add skill settings controls

### DIFF
--- a/apps/web/src/components/settings/skills.tsx
+++ b/apps/web/src/components/settings/skills.tsx
@@ -305,19 +305,19 @@ export function SkillsSettings() {
             {skills.map((skill) => (
               <div key={skill.name} className="flex items-center justify-between gap-space-xl py-space-l">
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-space-s">
+                  <Stack direction="row" gap="s" align="center">
                     <Text variant="body-strong" truncate>
                       {skill.name}
                     </Text>
                     <Badge variant="soft" size="xs" className="capitalize">
                       {skill.type}
                     </Badge>
-                  </div>
+                  </Stack>
                   <Text variant="caption" tone="muted" lineClamp="2">
                     {skill.description}
                   </Text>
                 </div>
-                <div className="flex items-center gap-space-l">
+                <Stack direction="row" gap="l" align="center">
                   <Switch
                     checked={skill.enabled}
                     disabled={setSkillEnabled.isPending}
@@ -343,7 +343,7 @@ export function SkillsSettings() {
                       </SettingsIconButtonTooltip>
                     )}
                   </ButtonGroup>
-                </div>
+                </Stack>
               </div>
             ))}
           </SettingRows>

--- a/apps/web/src/components/settings/skills.tsx
+++ b/apps/web/src/components/settings/skills.tsx
@@ -17,6 +17,7 @@ import {
   SettingRows,
   SettingsIconButtonTooltip,
 } from '@/components/settings/settings-ui';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ButtonGroup } from '@/components/ui/button-group';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
@@ -24,6 +25,7 @@ import { Empty, EmptyDescription, EmptyTitle } from '@/components/ui/empty';
 import { FieldError, fieldErrorMessage } from '@/components/ui/field-error';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import {
   skillsQueryOptions,
@@ -31,6 +33,7 @@ import {
   useDeleteSkill,
   useImportSkill,
   useSearchSkills,
+  useSetSkillEnabled,
   useUpdateSkill,
 } from '@/lib/queries/skills';
 
@@ -124,6 +127,8 @@ function SkillEditor({ skill, onBack }: { skill: Skill | null; onBack: () => voi
     defaultValues: toDraft(skill),
     validators: { onMount: createSkillSchema, onChange: createSkillSchema },
     onSubmit: async ({ value }) => {
+      if (skill?.type === 'stitch') return;
+
       const input = { name: value.name.trim(), description: value.description.trim(), content: value.content.trim() };
 
       if (skill) {
@@ -137,11 +142,16 @@ function SkillEditor({ skill, onBack }: { skill: Skill | null; onBack: () => voi
   });
 
   const isEditing = !!skill;
+  const isReadOnly = skill?.type === 'stitch';
 
   return (
     <SettingSubPage
-      title={isEditing ? 'Edit Skill' : 'Add Skill'}
-      description="Markdown instructions the agent can load when a task matches the description."
+      title={isReadOnly ? 'View Skill' : isEditing ? 'Edit Skill' : 'Add Skill'}
+      description={
+        isReadOnly
+          ? 'Built-in Stitch skills are updated automatically and cannot be edited.'
+          : 'Markdown instructions the agent can load when a task matches the description.'
+      }
       onBack={onBack}
       backLabel="Back to skills">
       <Stack
@@ -159,6 +169,7 @@ function SkillEditor({ skill, onBack }: { skill: Skill | null; onBack: () => voi
               <Input
                 id="skill-name"
                 value={field.state.value}
+                readOnly={isReadOnly}
                 placeholder="example-skill"
                 aria-invalid={!!fieldErrorMessage(field.state.meta)}
                 onBlur={field.handleBlur}
@@ -179,6 +190,7 @@ function SkillEditor({ skill, onBack }: { skill: Skill | null; onBack: () => voi
               <Textarea
                 id="skill-description"
                 value={field.state.value}
+                readOnly={isReadOnly}
                 rows={3}
                 placeholder="What this skill does and when the agent should use it."
                 aria-invalid={!!fieldErrorMessage(field.state.meta)}
@@ -197,6 +209,7 @@ function SkillEditor({ skill, onBack }: { skill: Skill | null; onBack: () => voi
               <Textarea
                 id="skill-content"
                 value={field.state.value}
+                readOnly={isReadOnly}
                 placeholder="# Skill Instructions\n\nDescribe the workflow, constraints, examples, and expected behavior."
                 className="thin-scrollbar min-h-0 resize-none overflow-auto font-mono text-xs"
                 aria-invalid={!!fieldErrorMessage(field.state.meta)}
@@ -212,11 +225,13 @@ function SkillEditor({ skill, onBack }: { skill: Skill | null; onBack: () => voi
           {(isSubmitting) => (
             <div className="mt-auto flex justify-end gap-space-m border-t border-border-subtle pt-space-xl">
               <Button type="button" variant="outline" onClick={onBack} disabled={isSubmitting}>
-                Cancel
+                {isReadOnly ? 'Back' : 'Cancel'}
               </Button>
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? 'Saving...' : 'Save skill'}
-              </Button>
+              {!isReadOnly && (
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? 'Saving...' : 'Save skill'}
+                </Button>
+              )}
             </div>
           )}
         </form.Subscribe>
@@ -230,6 +245,7 @@ export function SkillsSettings() {
   const PageIcon = page.icon;
   const { data: skills } = useSuspenseQuery(skillsQueryOptions);
   const deleteSkill = useDeleteSkill();
+  const setSkillEnabled = useSetSkillEnabled();
   const [view, setView] = React.useState<SkillView>({ type: 'list' });
   const [pendingDelete, setPendingDelete] = React.useState<Skill | null>(null);
 
@@ -284,35 +300,50 @@ export function SkillsSettings() {
           </EmptyDescription>
         </Empty>
       ) : (
-        <SettingSection title="My Skills">
+        <SettingSection title="Skills">
           <SettingRows>
             {skills.map((skill) => (
               <div key={skill.name} className="flex items-center justify-between gap-space-xl py-space-l">
                 <div className="min-w-0 flex-1">
-                  <Text variant="body-strong" truncate>
-                    {skill.name}
-                  </Text>
+                  <div className="flex items-center gap-space-s">
+                    <Text variant="body-strong" truncate>
+                      {skill.name}
+                    </Text>
+                    <Badge variant="soft" size="xs" className="capitalize">
+                      {skill.type}
+                    </Badge>
+                  </div>
                   <Text variant="caption" tone="muted" lineClamp="2">
                     {skill.description}
                   </Text>
                 </div>
-                <ButtonGroup>
-                  <SettingsIconButtonTooltip label={`View Skill`}>
-                    <Button variant="outline" size="icon" onClick={() => handleEdit(skill)} aria-label={`View Skill`}>
-                      <Icon as={EyeIcon} size="m" />
-                    </Button>
-                  </SettingsIconButtonTooltip>
-                  <SettingsIconButtonTooltip label={`Delete Skill`}>
-                    <Button
-                      variant="destructive"
-                      size="icon"
-                      onClick={() => handleDelete(skill)}
-                      disabled={deleteSkill.isPending}
-                      aria-label={`Delete Skill`}>
-                      <Icon as={Trash2Icon} size="m" />
-                    </Button>
-                  </SettingsIconButtonTooltip>
-                </ButtonGroup>
+                <div className="flex items-center gap-space-l">
+                  <Switch
+                    checked={skill.enabled}
+                    disabled={setSkillEnabled.isPending}
+                    aria-label={`${skill.enabled ? 'Disable' : 'Enable'} ${skill.name}`}
+                    onCheckedChange={(enabled) => setSkillEnabled.mutate({ name: skill.name, enabled })}
+                  />
+                  <ButtonGroup>
+                    <SettingsIconButtonTooltip label={`View Skill`}>
+                      <Button variant="outline" size="icon" onClick={() => handleEdit(skill)} aria-label={`View Skill`}>
+                        <Icon as={EyeIcon} size="m" />
+                      </Button>
+                    </SettingsIconButtonTooltip>
+                    {skill.type !== 'stitch' && (
+                      <SettingsIconButtonTooltip label="Delete Skill">
+                        <Button
+                          variant="destructive"
+                          size="icon"
+                          onClick={() => handleDelete(skill)}
+                          disabled={deleteSkill.isPending}
+                          aria-label="Delete Skill">
+                          <Icon as={Trash2Icon} size="m" />
+                        </Button>
+                      </SettingsIconButtonTooltip>
+                    )}
+                  </ButtonGroup>
+                </div>
               </div>
             ))}
           </SettingRows>

--- a/apps/web/src/lib/queries/skills.ts
+++ b/apps/web/src/lib/queries/skills.ts
@@ -86,6 +86,22 @@ export function useDeleteSkill() {
   });
 }
 
+export function useSetSkillEnabled() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ name, enabled }: { name: string; enabled: boolean }) =>
+      serverRequest<void>('/config/tools/enabled', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scope: 'skill', identifier: name, enabled }),
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: skillKeys.all });
+    },
+    onError: (error: Error) => toast.error(error.message, { id: 'skill-enabled' }),
+  });
+}
+
 export function useImportSkill() {
   const queryClient = useQueryClient();
   return useMutation({


### PR DESCRIPTION
## Change Summary

Adds skill origin and enablement controls to the Skills settings page.

### New Features
- Shows each skill's `stitch`, `custom`, or `external` origin.
- Adds an enable switch backed by the permissions API and persisted skill state.

### Improvements & Refactors
- Presents built-in Stitch skills in a read-only viewer and removes their delete action.
- Keeps custom and external skill editing and deletion unchanged.
