### PR TITLE
fix(chat): prevent tool error text clipping

### DIFF
--- a/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
+++ b/apps/web/src/components/chat/message-bubble/tool-call-group.tsx
@@ -261,7 +261,7 @@ function ToolCallRowPreview() {
       size="inline"
       align="start"
       onClick={() => onViewErrorDetails(errorDetails)}
-      className="min-w-0 flex-1 truncate"
+      className="min-w-0 flex-1"
       title="View full error">
       <Text as="span" variant="caption" tone="muted" truncate>
         {summary.preview}


### PR DESCRIPTION
## Change Summary

Prevents tool-call error previews from clipping letter descenders by leaving overflow truncation to the inner text element instead of the button wrapper.

### Bug Fixes

- Fixes `path` rendering as `oath` in failed tool-call previews.
