### PR TITLE
fix(markdown): render single-variable math

### DIFF
--- a/apps/web/src/components/chat/chat-markdown.test.tsx
+++ b/apps/web/src/components/chat/chat-markdown.test.tsx
@@ -31,6 +31,16 @@ describe('ChatMarkdown', () => {
     expect(html).not.toContain('katex-error');
   });
 
+  test('renders single-letter variables as inline math', () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown text={'The modified weight $W$ during inference.\n\n- **$r$ (Rank)**: Typically small.'} />,
+    );
+
+    expect(html.match(/class="katex"/g)).toHaveLength(2);
+    expect(html).not.toContain('$W$');
+    expect(html).not.toContain('$r$');
+  });
+
   test('renders escaped dollars inside single-dollar inline math', () => {
     const html = renderToStaticMarkup(<ChatMarkdown text={'Cost: $\\$0.02 \\text{ per 1M tokens}$.'} />);
 

--- a/apps/web/src/lib/markdown/normalize-inline-math.ts
+++ b/apps/web/src/lib/markdown/normalize-inline-math.ts
@@ -10,6 +10,7 @@
  */
 
 const LATEX_COMMAND = /\\[a-zA-Z]{2,}|\\[%$&#_{}]|[\^_]\{/;
+const SINGLE_VARIABLE = /^[A-Za-z]$/;
 const BARE_FORMULA_SHAPED = /^[A-Za-z0-9\s+\-*/=<>^_(){}[\].,;:!'"\\]+$/;
 const BARE_FORMULA_OPERATOR = /[=<>^_\\]|\d\s*[+*/]\s*\d/;
 const PADDED_CONTENT = /^\s|\s$/;
@@ -20,6 +21,7 @@ const MAX_BARE_FORMULA_LENGTH = 40;
 function isMathLike(content: string): boolean {
   if (content === '' || content.includes('\n') || PADDED_CONTENT.test(content)) return false;
   if (LATEX_COMMAND.test(content)) return true;
+  if (SINGLE_VARIABLE.test(content)) return true;
   if (content.length > MAX_BARE_FORMULA_LENGTH) return false;
   return BARE_FORMULA_SHAPED.test(content) && BARE_FORMULA_OPERATOR.test(content);
 }


### PR DESCRIPTION
## Change Summary

Render single-letter variables such as `$W$` and `$r$` as inline math while preserving the existing currency safeguards.

### Bug Fixes

- Recognize single ASCII letters as math-like content inside single-dollar delimiters.
- Add regression coverage for single-letter variables in prose and emphasized list items.
