### PR TITLE
improvement(markdown): optimize inline math normalization

### DIFF
--- a/apps/web/src/components/chat/chat-markdown.test.tsx
+++ b/apps/web/src/components/chat/chat-markdown.test.tsx
@@ -141,6 +141,16 @@ describe('ChatMarkdown', () => {
     expect(html).not.toContain('katex-error');
   });
 
+  test('renders multiline display math whose delimiters share content lines', () => {
+    const text =
+      '$$\\begin{pmatrix}\na & b \\\\\nc & d\n\\end{pmatrix}$$\n\nFollowing prose must remain outside the equation.';
+    const html = renderToStaticMarkup(<ChatMarkdown text={text} />);
+
+    expect(html).toContain('class="katex-display"');
+    expect(html).toContain('Following prose must remain outside the equation.');
+    expect(html).not.toContain('katex-error');
+  });
+
   test('uses the shared thin scrollbar for streaming code blocks', () => {
     const html = renderToStaticMarkup(<ChatMarkdown text={'```text\nlong code line\n```'} isStreaming />);
 

--- a/apps/web/src/lib/markdown/normalize-inline-math.test.ts
+++ b/apps/web/src/lib/markdown/normalize-inline-math.test.ts
@@ -73,6 +73,17 @@ describe('normalizeInlineMath', () => {
     );
   });
 
+  test('puts multiline double-dollar delimiters on their own lines', () => {
+    expect(normalizeInlineMath('Before\n\n$$\\begin{pmatrix}\na & b \\\\\nc & d\n\\end{pmatrix}$$\n\nAfter')).toBe(
+      'Before\n\n$$\n\\begin{pmatrix}\na & b \\\\\nc & d\n\\end{pmatrix}\n$$\n\nAfter',
+    );
+  });
+
+  test('adds only the missing display-math delimiter line break', () => {
+    expect(normalizeInlineMath('$$\na = b\n\\end{aligned}$$')).toBe('$$\na = b\n\\end{aligned}\n$$');
+    expect(normalizeInlineMath('$$\\begin{aligned}\na = b\n$$')).toBe('$$\n\\begin{aligned}\na = b\n$$');
+  });
+
   test('escapes an unpaired double dollar', () => {
     expect(normalizeInlineMath('Price is $$20')).toBe('Price is \\$\\$20');
   });

--- a/apps/web/src/lib/markdown/normalize-inline-math.test.ts
+++ b/apps/web/src/lib/markdown/normalize-inline-math.test.ts
@@ -7,6 +7,11 @@ describe('normalizeInlineMath', () => {
     expect(normalizeInlineMath('Plain **markdown** with `code`.')).toBe('Plain **markdown** with `code`.');
   });
 
+  test('handles long unchanged regions around math without altering them', () => {
+    const prose = 'ordinary markdown '.repeat(1_000);
+    expect(normalizeInlineMath(`${prose}$x=1$${prose}`)).toBe(`${prose}$$x=1$$${prose}`);
+  });
+
   test('promotes spans containing LaTeX commands to double-dollar math', () => {
     expect(normalizeInlineMath('$100,000 \\text{ LOC} \\approx 600,000 \\text{ tokens}$.')).toBe(
       '$$100,000 \\text{ LOC} \\approx 600,000 \\text{ tokens}$$.',
@@ -54,6 +59,12 @@ describe('normalizeInlineMath', () => {
 
   test('leaves already-escaped dollars alone', () => {
     expect(normalizeInlineMath('Costs \\$20 per seat.')).toBe('Costs \\$20 per seat.');
+  });
+
+  test('leaves escaped dollars unchanged next to normalized math', () => {
+    expect(normalizeInlineMath('Costs \\$20; equation $x=1$; then \\$30.')).toBe(
+      'Costs \\$20; equation $$x=1$$; then \\$30.',
+    );
   });
 
   test('passes existing double-dollar math through unchanged', () => {

--- a/apps/web/src/lib/markdown/normalize-inline-math.ts
+++ b/apps/web/src/lib/markdown/normalize-inline-math.ts
@@ -85,6 +85,27 @@ export function normalizeInlineMath(markdown: string): string {
     if (markdown[index + 1] === '$') {
       const closeIndex = markdown.indexOf('$$', index + 2);
       if (closeIndex !== -1) {
+        const content = markdown.slice(index + 2, closeIndex);
+        const needsOpeningLineBreak =
+          content.includes('\n') && !content.startsWith('\n') && !content.startsWith('\r\n');
+        const needsClosingLineBreak = content.includes('\n') && !content.endsWith('\n');
+
+        if (needsOpeningLineBreak || needsClosingLineBreak) {
+          const lineBreak = content.includes('\r\n') ? '\r\n' : '\n';
+          parts ??= [];
+          parts.push(
+            markdown.slice(unchangedStart, index),
+            '$$',
+            needsOpeningLineBreak ? lineBreak : '',
+            content,
+            needsClosingLineBreak ? lineBreak : '',
+            '$$',
+          );
+          index = closeIndex + 2;
+          unchangedStart = index;
+          continue;
+        }
+
         index = closeIndex + 2;
         continue;
       }

--- a/apps/web/src/lib/markdown/normalize-inline-math.ts
+++ b/apps/web/src/lib/markdown/normalize-inline-math.ts
@@ -58,27 +58,26 @@ function findCodeSpanEnd(markdown: string, startIndex: number): number {
 export function normalizeInlineMath(markdown: string): string {
   if (!markdown.includes('$')) return markdown;
 
-  let out = '';
+  let parts: string[] | undefined;
+  let unchangedStart = 0;
   let index = 0;
+  let tickIndex = markdown.indexOf('`');
 
   while (index < markdown.length) {
-    const char = markdown[index];
+    const dollarIndex = markdown.indexOf('$', index);
+    if (dollarIndex === -1) break;
 
-    if (char === '`') {
-      const end = findCodeSpanEnd(markdown, index);
-      out += markdown.slice(index, end);
-      index = end;
+    if (tickIndex !== -1 && tickIndex < index) tickIndex = markdown.indexOf('`', index);
+
+    if (tickIndex !== -1 && tickIndex < dollarIndex) {
+      index = findCodeSpanEnd(markdown, tickIndex);
+      tickIndex = markdown.indexOf('`', index);
       continue;
     }
 
-    if (char === '\\' && markdown[index + 1] === '$') {
-      out += '\\$';
-      index += 2;
-      continue;
-    }
+    index = dollarIndex;
 
-    if (char !== '$') {
-      out += char;
+    if (markdown[index - 1] === '\\') {
       index++;
       continue;
     }
@@ -86,7 +85,6 @@ export function normalizeInlineMath(markdown: string): string {
     if (markdown[index + 1] === '$') {
       const closeIndex = markdown.indexOf('$$', index + 2);
       if (closeIndex !== -1) {
-        out += markdown.slice(index, closeIndex + 2);
         index = closeIndex + 2;
         continue;
       }
@@ -94,15 +92,22 @@ export function normalizeInlineMath(markdown: string): string {
 
     const spanEnd = findSpanEnd(markdown, index);
     const content = spanEnd === -1 ? '' : markdown.slice(index + 1, spanEnd);
+    parts ??= [];
+    parts.push(markdown.slice(unchangedStart, index));
+
     if (isMathLike(content)) {
-      out += `$$${content}$$`;
+      parts.push('$$', content, '$$');
       index = spanEnd + 1;
+      unchangedStart = index;
       continue;
     }
 
-    out += '\\$';
+    parts.push('\\$');
     index++;
+    unchangedStart = index;
   }
 
-  return out;
+  if (!parts) return markdown;
+  parts.push(markdown.slice(unchangedStart));
+  return parts.join('');
 }


### PR DESCRIPTION
## 🚀 Change Summary

Improves inline math normalization performance and fixes rendering of multiline math blocks whose `$$` delimiters share a line with content.

### 🛠 Improvements & Refactors
- Reworked `normalizeInlineMath` to operate on spans instead of character-by-character, avoiding string append hot-path overhead for long unchanged prose regions

### 🐛 Bug Fixes
- Multiline display math now renders correctly when `$$` delimiters share a line with equation content (e.g. `$$\begin{pmatrix}...\end{pmatrix}$$`), keeping following prose outside the equation
