### PR TITLE
fix(sandbox): tighten protocol types and validate tool input

### DIFF
--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -1,3 +1,3 @@
 export { createProcessSandbox } from './process-driver.js';
 export { startProcessRuntime } from './process-runtime.js';
-export type { IsolateDriver, IsolateOptions, ToolBinding } from './types.js';
+export type { IsolateDriver, IsolateExecuteResult, IsolateOptions, ToolBinding } from './types.js';

--- a/packages/sandbox/src/process-driver.ts
+++ b/packages/sandbox/src/process-driver.ts
@@ -95,6 +95,7 @@ async function dispatchToolCall(
       `Tool call timed out after ${ctx.toolTimeoutMs}ms`,
     );
     try {
+      await binding.validateInput(message.args);
       const result = await Promise.race([binding.execute(message.args, ctx.abortSignal), timeoutRace.promise]);
 
       const response: HostMessage = { type: 'tool_result', id: message.id, result };
@@ -161,7 +162,13 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
         }
       };
 
-      proc.send({ type: 'init', toolNames, libraries, memoryReportIntervalMs: MEMORY_REPORT_INTERVAL_MS });
+      const initMessage: HostMessage = {
+        type: 'init',
+        toolNames,
+        libraries,
+        memoryReportIntervalMs: MEMORY_REPORT_INTERVAL_MS,
+      };
+      proc.send(initMessage);
 
       const toolCallCtx: ToolCallContext = {
         bindings,
@@ -176,7 +183,7 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
 
       return {
         async execute(code: string): Promise<IsolateExecuteResult> {
-          if (disposed) return { result: { error: 'Sandbox context is disposed' }, logs: [] };
+          if (disposed) return { ok: false, error: 'Sandbox context is disposed', logs: [] };
 
           const startedAt = Date.now();
           const timeoutRace = createExecutionTimeoutRace(timer, startedAt, timeoutMs, terminate);
@@ -200,20 +207,20 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
                 if (message.rss > memoryLimitBytes) {
                   cleanup();
                   terminate();
-                  settle({ result: { error: new SandboxMemoryError(memoryLimitMB).message }, logs: [] });
+                  settle({ ok: false, error: new SandboxMemoryError(memoryLimitMB).message, logs: [] });
                 }
                 return;
               }
 
               if (message.type === 'complete') {
                 cleanup();
-                settle({ result: message.result, logs: message.logs });
+                settle({ ok: true, result: message.result, logs: message.logs });
                 return;
               }
 
               if (message.type === 'error') {
                 cleanup();
-                settle({ result: { error: message.error }, logs: message.logs });
+                settle({ ok: false, error: message.error, logs: message.logs });
                 return;
               }
 
@@ -224,7 +231,7 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
               cleanup();
               if (settled) return;
               if (disposed) {
-                settle({ result: { error: 'Sandbox execution terminated' }, logs: [] });
+                settle({ ok: false, error: 'Sandbox execution terminated', logs: [] });
                 return;
               }
               reject(new Error('Sandbox process exited unexpectedly'));
@@ -240,9 +247,8 @@ export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions)
           } catch (err) {
             terminate();
             return {
-              result: {
-                error: timeoutRace.isTimedOut() ? new SandboxTimeoutError(timeoutMs).message : toErrorMessage(err),
-              },
+              ok: false,
+              error: timeoutRace.isTimedOut() ? new SandboxTimeoutError(timeoutMs).message : toErrorMessage(err),
               logs: [],
             };
           } finally {

--- a/packages/sandbox/src/process-runtime.ts
+++ b/packages/sandbox/src/process-runtime.ts
@@ -3,9 +3,6 @@ import { assertSafeCode, DANGEROUS_GLOBALS, harden } from './hardening.js';
 import { isHostMessage } from './protocol.js';
 
 import type { HostMessage, WorkerMessage } from './protocol.js';
-import type { SandboxLibrary } from './types.js';
-
-const CODE_ERROR_KEY = '__codeError';
 
 /** Global names shadowed as `undefined` in sandbox function params (includes 'Function'). */
 const HIDDEN_GLOBAL_NAMES: readonly string[] = [...DANGEROUS_GLOBALS, 'Function'];
@@ -13,7 +10,7 @@ const HIDDEN_GLOBAL_VALUES: readonly undefined[] = HIDDEN_GLOBAL_NAMES.map(() =>
 
 type PendingCall = { resolve: (value: unknown) => void; reject: (reason: Error) => void };
 
-type InitData = { toolNames?: string[]; libraries?: Record<string, SandboxLibrary>; memoryReportIntervalMs?: number };
+type InitMessage = Extract<HostMessage, { type: 'init' }>;
 
 /**
  * Starts the sandbox process runtime. Call this from a process entry file.
@@ -41,7 +38,7 @@ export function startProcessRuntime(preloadedModules: Record<string, Record<stri
   ) => Promise<Record<string, unknown>>;
   let injectedLibraries: Record<string, unknown> = {};
   let toolNames: string[] = [];
-  let libraries: Record<string, SandboxLibrary> = {};
+  let libraries: InitMessage['libraries'] = {};
 
   function post(message: WorkerMessage): void {
     ipcSend(message);
@@ -121,30 +118,20 @@ export function startProcessRuntime(preloadedModules: Record<string, Record<stri
         ...HIDDEN_GLOBAL_NAMES,
         ...libraryNames,
         `return (async () => {
-        try {
-          const __result = await (async () => {
-            ${code}
-          })();
-          return __result;
-        } catch (e) {
-          return { ${JSON.stringify(CODE_ERROR_KEY)}: e && e.message ? e.message : String(e) };
-        }
-      })();`,
+          ${code}
+        })();`,
       ) as (console: Console, ...args: unknown[]) => Promise<unknown>;
 
-      let result = await execute(sandboxConsole, ...HIDDEN_GLOBAL_VALUES, ...libraryValues);
-      if (result !== null && typeof result === 'object' && CODE_ERROR_KEY in result) {
-        result = { error: (result as Record<string, unknown>)[CODE_ERROR_KEY] };
-      }
+      const result = await execute(sandboxConsole, ...HIDDEN_GLOBAL_VALUES, ...libraryValues);
       post({ type: 'complete', result, logs });
     } catch (err) {
       post({ type: 'error', error: toErrorMessage(err), logs });
     }
   }
 
-  async function initialize(initData: InitData): Promise<void> {
-    toolNames = initData.toolNames ?? [];
-    libraries = initData.libraries ?? {};
+  async function initialize(initData: InitMessage): Promise<void> {
+    toolNames = initData.toolNames;
+    libraries = initData.libraries;
     injectedLibraries = await loadLibraries();
     // Pre-import allowed modules before hardening freezes globals.
     await importLibrary('node:fs');
@@ -164,7 +151,7 @@ export function startProcessRuntime(preloadedModules: Record<string, Record<stri
 
   let initialization: Promise<void> | null = null;
 
-  function handleInit(data: InitData): void {
+  function handleInit(data: InitMessage): void {
     initialization = initialize(data);
     initialization.catch((err) => {
       post({ type: 'error', error: toErrorMessage(err), logs });
@@ -191,18 +178,12 @@ export function startProcessRuntime(preloadedModules: Record<string, Record<stri
   }
 
   ipcOn('message', (message) => {
-    if (message === null || typeof message !== 'object') return;
-    const msg = message as { type?: string };
-
-    // Init message is not part of HostMessage protocol (sent only once before execution).
-    if (msg.type === 'init') {
-      handleInit(message as InitData);
-      return;
-    }
-
     if (!isHostMessage(message)) return;
 
     switch (message.type) {
+      case 'init':
+        handleInit(message);
+        break;
       case 'tool_result':
         handleToolResult(message);
         break;

--- a/packages/sandbox/src/protocol.test.ts
+++ b/packages/sandbox/src/protocol.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test';
+
+import { isHostMessage, isWorkerMessage } from './protocol.js';
+
+describe('sandbox protocol', () => {
+  test('accepts valid worker message variants', () => {
+    expect(isWorkerMessage({ type: 'tool_call', id: 'call-1', name: 'external_read', args: undefined })).toBe(true);
+    expect(isWorkerMessage({ type: 'error', error: 'failed', logs: [] })).toBe(true);
+    expect(isWorkerMessage({ type: 'unknown' })).toBe(false);
+  });
+
+  test('validates complete worker messages', () => {
+    expect(isWorkerMessage({ type: 'complete', result: 42, logs: ['done'] })).toBe(true);
+    expect(isWorkerMessage({ type: 'complete' })).toBe(false);
+    expect(isWorkerMessage({ type: 'complete', result: 42, logs: [1] })).toBe(false);
+  });
+
+  test('validates memory reports', () => {
+    expect(isWorkerMessage({ type: 'memory_report', rss: 1024 })).toBe(true);
+    expect(isWorkerMessage({ type: 'memory_report', rss: Number.NaN })).toBe(false);
+    expect(isWorkerMessage({ type: 'memory_report', rss: -1 })).toBe(false);
+  });
+
+  test('validates host initialization messages', () => {
+    expect(
+      isHostMessage({
+        type: 'init',
+        toolNames: ['external_read'],
+        libraries: { libpdf: { specifier: '@libpdf/core' } },
+        memoryReportIntervalMs: 500,
+      }),
+    ).toBe(true);
+    expect(isHostMessage({ type: 'init', toolNames: [1], libraries: {}, memoryReportIntervalMs: 500 })).toBe(false);
+    expect(
+      isHostMessage({
+        type: 'init',
+        toolNames: [],
+        libraries: { invalid: { specifier: 'pkg', inject: 'yes' } },
+        memoryReportIntervalMs: 500,
+      }),
+    ).toBe(false);
+  });
+
+  test('accepts valid host message variants', () => {
+    expect(isHostMessage({ type: 'execute', code: 'return true;' })).toBe(true);
+    expect(isHostMessage({ type: 'tool_result', id: 'call-1', result: undefined })).toBe(true);
+    expect(isHostMessage({ type: 'tool_error', id: 'call-1', error: 'failed' })).toBe(true);
+    expect(isHostMessage([])).toBe(false);
+  });
+
+  test('rejects host messages with missing required fields', () => {
+    expect(isHostMessage({ type: 'execute' })).toBe(false);
+    expect(isHostMessage({ type: 'tool_result', id: 'call-1' })).toBe(false);
+    expect(isHostMessage({ type: 'tool_error', id: 'call-1', error: 42 })).toBe(false);
+  });
+});

--- a/packages/sandbox/src/protocol.ts
+++ b/packages/sandbox/src/protocol.ts
@@ -1,10 +1,19 @@
+import type { SandboxLibrary } from './types.js';
+
 type WorkerExecuteMessage = { type: 'execute'; code: string };
 
 type WorkerToolResultMessage = { type: 'tool_result'; id: string; result: unknown };
 
 type WorkerToolErrorMessage = { type: 'tool_error'; id: string; error: string };
 
-export type HostMessage = WorkerExecuteMessage | WorkerToolResultMessage | WorkerToolErrorMessage;
+type WorkerInitMessage = {
+  type: 'init';
+  toolNames: string[];
+  libraries: Record<string, SandboxLibrary>;
+  memoryReportIntervalMs: number;
+};
+
+export type HostMessage = WorkerExecuteMessage | WorkerToolResultMessage | WorkerToolErrorMessage | WorkerInitMessage;
 
 type SandboxToolCallMessage = { type: 'tool_call'; id: string; name: string; args: unknown };
 
@@ -20,14 +29,66 @@ export type WorkerMessage =
   | SandboxErrorMessage
   | SandboxMemoryReportMessage;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasUnknownField(value: Record<string, unknown>, field: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, field);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isSandboxLibrary(value: unknown): value is SandboxLibrary {
+  if (!isRecord(value) || typeof value['specifier'] !== 'string') return false;
+  if (value['globalName'] !== undefined && typeof value['globalName'] !== 'string') return false;
+  return value['inject'] === undefined || typeof value['inject'] === 'boolean';
+}
+
+function isLibraryRecord(value: unknown): value is Record<string, SandboxLibrary> {
+  return isRecord(value) && Object.values(value).every(isSandboxLibrary);
+}
+
 export function isWorkerMessage(message: unknown): message is WorkerMessage {
-  if (message === null || typeof message !== 'object') return false;
-  const type = (message as { type?: unknown }).type;
-  return type === 'tool_call' || type === 'complete' || type === 'error' || type === 'memory_report';
+  if (!isRecord(message)) return false;
+
+  switch (message['type']) {
+    case 'tool_call':
+      return (
+        typeof message['id'] === 'string' && typeof message['name'] === 'string' && hasUnknownField(message, 'args')
+      );
+    case 'complete':
+      return hasUnknownField(message, 'result') && isStringArray(message['logs']);
+    case 'error':
+      return typeof message['error'] === 'string' && isStringArray(message['logs']);
+    case 'memory_report':
+      return typeof message['rss'] === 'number' && Number.isFinite(message['rss']) && message['rss'] >= 0;
+    default:
+      return false;
+  }
 }
 
 export function isHostMessage(message: unknown): message is HostMessage {
-  if (message === null || typeof message !== 'object') return false;
-  const type = (message as { type?: unknown }).type;
-  return type === 'execute' || type === 'tool_result' || type === 'tool_error';
+  if (!isRecord(message)) return false;
+
+  switch (message['type']) {
+    case 'init':
+      return (
+        isStringArray(message['toolNames']) &&
+        isLibraryRecord(message['libraries']) &&
+        typeof message['memoryReportIntervalMs'] === 'number' &&
+        Number.isFinite(message['memoryReportIntervalMs']) &&
+        message['memoryReportIntervalMs'] > 0
+      );
+    case 'execute':
+      return typeof message['code'] === 'string';
+    case 'tool_result':
+      return typeof message['id'] === 'string' && hasUnknownField(message, 'result');
+    case 'tool_error':
+      return typeof message['id'] === 'string' && typeof message['error'] === 'string';
+    default:
+      return false;
+  }
 }

--- a/packages/sandbox/src/sandbox.test.ts
+++ b/packages/sandbox/src/sandbox.test.ts
@@ -24,21 +24,25 @@ describe('process sandbox', () => {
   test('executes code and returns the result', async () => {
     const result = await execute('return [1, 2, 3].map((value) => value * 2);');
 
-    expect(result.result).toEqual([2, 4, 6]);
-    expect(result.logs).toEqual([]);
+    expect(result).toEqual({ ok: true, result: [2, 4, 6], logs: [] });
   });
 
   test('captures console output', async () => {
     const result = await execute('console.log("hello", { value: 42 }); return true;');
 
-    expect(result.result).toBe(true);
-    expect(result.logs).toEqual(['[log] hello {"value":42}']);
+    expect(result).toEqual({ ok: true, result: true, logs: ['[log] hello {"value":42}'] });
   });
 
   test('returns runtime errors as result errors', async () => {
     const result = await execute('throw new Error("boom");');
 
-    expect(result.result).toEqual({ error: 'boom' });
+    expect(result).toEqual({ ok: false, error: 'boom', logs: [] });
+  });
+
+  test('preserves returned error-shaped objects as successful data', async () => {
+    const result = await execute('return { error: "status text" };');
+
+    expect(result).toEqual({ ok: true, result: { error: 'status text' }, logs: [] });
   });
 
   test('calls host tool bindings', async () => {
@@ -47,6 +51,7 @@ describe('process sandbox', () => {
         name: 'external_sum',
         description: 'sum values',
         inputSchema: { type: 'object' },
+        validateInput: () => {},
         execute: async (input) => {
           const { values } = input as { values: number[] };
           return values.reduce((total, value) => total + value, 0);
@@ -56,7 +61,7 @@ describe('process sandbox', () => {
 
     const result = await execute('return await external_sum({ values: [1, 2, 3] });', bindings);
 
-    expect(result.result).toBe(6);
+    expect(result).toEqual({ ok: true, result: 6, logs: [] });
   });
 
   test('injects host-approved libraries', async () => {
@@ -87,13 +92,17 @@ describe('process sandbox', () => {
         };
       `);
 
-      expect(result.result).toEqual({
-        label: 'sample-library',
-        doubled: 42,
-        frozen: true,
-        canReadFunctionPrototype: true,
-        hasGlobalSampleWorker: true,
-        sampleGlobalType: 'object',
+      expect(result).toEqual({
+        ok: true,
+        result: {
+          label: 'sample-library',
+          doubled: 42,
+          frozen: true,
+          canReadFunctionPrototype: true,
+          hasGlobalSampleWorker: true,
+          sampleGlobalType: 'object',
+        },
+        logs: [],
       });
     } finally {
       context.dispose();
@@ -104,7 +113,7 @@ describe('process sandbox', () => {
     const context = await createDriver().createContext({}, { timeout: 200 });
     try {
       const result = await context.execute('while (true) {}');
-      expect(result.result).toEqual({ error: 'Execution timed out after 200ms' });
+      expect(result).toEqual({ ok: false, error: 'Execution timed out after 200ms', logs: [] });
     } finally {
       context.dispose();
     }
@@ -123,7 +132,7 @@ describe('process sandbox', () => {
           await new Promise(r => setTimeout(r, 5));
         }
       `);
-      expect(result.result).toEqual({ error: 'Sandbox memory limit exceeded (64MB)' });
+      expect(result).toEqual({ ok: false, error: 'Sandbox memory limit exceeded (64MB)', logs: [] });
     } finally {
       context.dispose();
     }

--- a/packages/sandbox/src/security.test.ts
+++ b/packages/sandbox/src/security.test.ts
@@ -29,7 +29,11 @@ describe('sandbox hardening', () => {
       };
     `);
 
-    expect(result.result).toEqual({ process: 'undefined', Bun: 'undefined', require: 'undefined', fetch: 'undefined' });
+    expect(result).toEqual({
+      ok: true,
+      result: { process: 'undefined', Bun: 'undefined', require: 'undefined', fetch: 'undefined' },
+      logs: [],
+    });
   });
 
   test('does not expose callable eval or Function', async () => {
@@ -42,11 +46,10 @@ describe('sandbox hardening', () => {
       };
     `);
 
-    expect(result.result).toEqual({
-      eval: 'undefined',
-      Function: 'undefined',
-      globalFunction: 'object',
-      canCallGlobalFunction: false,
+    expect(result).toEqual({
+      ok: true,
+      result: { eval: 'undefined', Function: 'undefined', globalFunction: 'object', canCallGlobalFunction: false },
+      logs: [],
     });
   });
 
@@ -59,7 +62,7 @@ describe('sandbox hardening', () => {
       };
     `);
 
-    expect(result.result).toEqual({});
+    expect(result).toEqual({ ok: true, result: {}, logs: [] });
   });
 
   test('allows node fs dynamic imports', async () => {
@@ -68,19 +71,27 @@ describe('sandbox hardening', () => {
       return { readFile: typeof fs.readFile };
     `);
 
-    expect(result.result).toEqual({ readFile: 'function' });
+    expect(result).toEqual({ ok: true, result: { readFile: 'function' }, logs: [] });
   });
 
   test('rejects non-fs dynamic imports', async () => {
     const result = await run('return await import("node:child_process");');
 
-    expect(result.result).toEqual({ error: 'dynamic import is only available for node:fs and node:fs/promises' });
+    expect(result).toEqual({
+      ok: false,
+      error: 'dynamic import is only available for node:fs and node:fs/promises',
+      logs: [],
+    });
   });
 
   test('rejects non-literal dynamic imports', async () => {
     const result = await run('const moduleName = "node:fs"; return await import(moduleName);');
 
-    expect(result.result).toEqual({ error: 'dynamic import is only available for node:fs and node:fs/promises' });
+    expect(result).toEqual({
+      ok: false,
+      error: 'dynamic import is only available for node:fs and node:fs/promises',
+      logs: [],
+    });
   });
 
   test('rejects unsafe library names', () => {

--- a/packages/sandbox/src/tools.test.ts
+++ b/packages/sandbox/src/tools.test.ts
@@ -15,6 +15,7 @@ const echoBinding: ToolBinding = {
   name: 'external_echo',
   description: 'echo input',
   inputSchema: { type: 'object' },
+  validateInput: () => {},
   execute: async (input) => input,
 };
 
@@ -25,6 +26,7 @@ describe('sandbox tools', () => {
         name: 'external_fail',
         description: 'fail',
         inputSchema: { type: 'object' },
+        validateInput: () => {},
         execute: async () => {
           throw new Error('tool failed');
         },
@@ -40,7 +42,42 @@ describe('sandbox tools', () => {
         }
       `);
 
-      expect(result.result).toBe('tool failed');
+      expect(result).toEqual({ ok: true, result: 'tool failed', logs: [] });
+    } finally {
+      context.dispose();
+    }
+  });
+
+  test('validates tool input before execution', async () => {
+    let executed = false;
+    const context = await createDriver().createContext({
+      external_validate: {
+        name: 'external_validate',
+        description: 'validate input',
+        inputSchema: { type: 'object' },
+        validateInput: (input) => {
+          if (typeof input !== 'object' || input === null || !('value' in input)) {
+            throw new Error('value is required');
+          }
+        },
+        execute: async () => {
+          executed = true;
+          return true;
+        },
+      },
+    });
+
+    try {
+      const result = await context.execute(`
+        try {
+          await external_validate({});
+        } catch (error) {
+          return error.message;
+        }
+      `);
+
+      expect(result).toEqual({ ok: true, result: 'value is required', logs: [] });
+      expect(executed).toBe(false);
     } finally {
       context.dispose();
     }
@@ -59,7 +96,7 @@ describe('sandbox tools', () => {
         }
       `);
 
-      expect(result.result).toBe('Exceeded maximum tool calls (1)');
+      expect(result).toEqual({ ok: true, result: 'Exceeded maximum tool calls (1)', logs: [] });
     } finally {
       context.dispose();
     }

--- a/packages/sandbox/src/types.ts
+++ b/packages/sandbox/src/types.ts
@@ -2,10 +2,13 @@ export type ToolBinding = {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  validateInput: (input: unknown) => void | Promise<void>;
   execute: (input: unknown, abortSignal?: AbortSignal) => Promise<unknown>;
 };
 
-export type IsolateExecuteResult = { result: unknown; logs: string[] };
+export type IsolateExecuteResult =
+  | { ok: true; result: unknown; logs: string[] }
+  | { ok: false; error: string; logs: string[] };
 
 export type IsolateContext = { execute(code: string): Promise<IsolateExecuteResult>; dispose(): void };
 

--- a/packages/server/src/code-mode/bindings/tool-binding.test.ts
+++ b/packages/server/src/code-mode/bindings/tool-binding.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { jsonSchema, tool } from 'ai';
+
+import { toolsToBindings } from '@/code-mode/bindings/tool-binding.js';
+
+describe('toolsToBindings', () => {
+  test('validates sandbox input against the tool schema', () => {
+    const bindings = toolsToBindings({
+      read: tool({
+        description: 'read a file',
+        inputSchema: jsonSchema({
+          type: 'object',
+          properties: { path: { type: 'string' } },
+          required: ['path'],
+          additionalProperties: false,
+        }),
+        execute: async ({ path }) => path,
+      }),
+    });
+    const binding = bindings['external_read'];
+
+    expect(binding).toBeDefined();
+    expect(() => binding.validateInput({})).toThrow();
+    expect(() => binding.validateInput({ path: '/tmp/file' })).not.toThrow();
+  });
+});

--- a/packages/server/src/code-mode/bindings/tool-binding.ts
+++ b/packages/server/src/code-mode/bindings/tool-binding.ts
@@ -1,9 +1,13 @@
+import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv';
+
 import type { ToolBinding } from '@stitch/sandbox';
 
+import { ToolValidationError } from '@/tools/errors.js';
 import type { ToolExecuteOptions } from '@/tools/runtime/runtime.js';
 import type { Tool } from 'ai';
 
 const EXTERNAL_PREFIX = 'external_';
+const validator = new AjvJsonSchemaValidator();
 
 export type ToolTypeInfo = { name: string; description: string; inputSchema: Record<string, unknown> };
 
@@ -72,10 +76,15 @@ export function toolsToTypeInfo(tools: Record<string, Tool>): Record<string, Too
 
 export function toolsToBindings(tools: Record<string, Tool>, abortSignal?: AbortSignal): Record<string, ToolBinding> {
   return mapExecutableTools(tools, ({ bindingName, description, schema, execute }) => {
+    const validate = validator.getValidator(schema);
     return {
       name: bindingName,
       description,
       inputSchema: schema,
+      validateInput: (input: unknown) => {
+        const result = validate(input);
+        if (!result.valid) throw new ToolValidationError(result.errorMessage, bindingName);
+      },
       execute: async (input: unknown, signal?: AbortSignal) => {
         const effectiveSignal = signal ?? abortSignal;
         const options: ToolExecuteOptions = {

--- a/packages/server/src/code-mode/tool.test.ts
+++ b/packages/server/src/code-mode/tool.test.ts
@@ -16,9 +16,9 @@ describe('serializeIsolateOutput', () => {
     expect(output).toContain('(no return value)');
   });
 
-  test('serializes error result with string error', () => {
+  test('serializes error-shaped data as successful JSON', () => {
     const output = serializeIsolateOutput({ error: 'something failed' }, []);
-    expect(output).toContain('Error: something failed');
+    expect(output).toContain('"error": "something failed"');
   });
 
   test('serializes an object with error data as successful JSON', () => {
@@ -74,7 +74,7 @@ describe('createCodeModeTool', () => {
   test('returns sandbox execution errors as canonical tool errors', async () => {
     const driver: IsolateDriver = {
       createContext: async () => ({
-        execute: async () => ({ result: { error: 'sandbox failed' }, logs: [] }),
+        execute: async () => ({ ok: false, error: 'sandbox failed', logs: [] }),
         dispose: () => {},
       }),
     };
@@ -91,7 +91,7 @@ describe('createCodeModeTool', () => {
   test('preserves sandbox logs in canonical tool error details', async () => {
     const driver: IsolateDriver = {
       createContext: async () => ({
-        execute: async () => ({ result: { error: 'sandbox failed' }, logs: ['[log] before failure'] }),
+        execute: async () => ({ ok: false, error: 'sandbox failed', logs: ['[log] before failure'] }),
         dispose: () => {},
       }),
     };
@@ -105,10 +105,10 @@ describe('createCodeModeTool', () => {
     expect(result).toEqual({ error: 'sandbox failed', details: { logs: ['[log] before failure'] } });
   });
 
-  test('keeps legitimate objects with error data on the success path', async () => {
+  test('keeps legitimate error-shaped objects on the success path', async () => {
     const driver: IsolateDriver = {
       createContext: async () => ({
-        execute: async () => ({ result: { error: 'partial failure', value: 42 }, logs: [] }),
+        execute: async () => ({ ok: true, result: { error: 'status text' }, logs: [] }),
         dispose: () => {},
       }),
     };
@@ -119,6 +119,6 @@ describe('createCodeModeTool', () => {
       { toolCallId: 'call-4', messages: [] },
     );
 
-    expect(result).toMatchObject({ output: expect.stringContaining('"value": 42'), truncated: false });
+    expect(result).toMatchObject({ output: expect.stringContaining('"error": "status text"'), truncated: false });
   });
 });

--- a/packages/server/src/code-mode/tool.ts
+++ b/packages/server/src/code-mode/tool.ts
@@ -2,8 +2,8 @@ import { tool } from 'ai';
 import { z } from 'zod';
 
 import { createProcessSandbox } from '@stitch/sandbox';
-import type { IsolateDriver, IsolateOptions } from '@stitch/sandbox';
-import { isToolErrorResult, toolError } from '@stitch/shared/tools/types';
+import type { IsolateDriver, IsolateExecuteResult, IsolateOptions } from '@stitch/sandbox';
+import { toolError } from '@stitch/shared/tools/types';
 import type { ToolErrorResult } from '@stitch/shared/tools/types';
 
 import { toolsToBindings, toolsToTypeInfo } from '@/code-mode/bindings/tool-binding.js';
@@ -97,7 +97,7 @@ The sandbox has no filesystem, network, or Node.js access beyond these functions
 
       const context = await driver.createContext(bindings, createCodeModeIsolateOptions(isolateOptions, abortSignal));
 
-      let execResult: { result: unknown; logs: string[] };
+      let execResult: IsolateExecuteResult;
       try {
         execResult = await context.execute(stripped.code);
       } finally {
@@ -116,13 +116,13 @@ The sandbox has no filesystem, network, or Node.js access beyond these functions
           description,
           durationMs,
           logCount: execResult.logs.length,
-          hasError: isToolErrorResult(execResult.result),
+          hasError: !execResult.ok,
         },
         'code mode execution complete',
       );
 
-      if (isToolErrorResult(execResult.result)) {
-        return createSandboxErrorResult(execResult.result, execResult.logs);
+      if (!execResult.ok) {
+        return createSandboxErrorResult(execResult.error, execResult.logs);
       }
 
       const resultText = serializeIsolateOutput(execResult.result, execResult.logs);
@@ -158,12 +158,12 @@ function createCodeModeIsolateOptions(
   };
 }
 
-function createSandboxErrorResult(result: ToolErrorResult, logs: string[]): ToolErrorResult {
+function createSandboxErrorResult(error: string, logs: string[]): ToolErrorResult {
   if (logs.length === 0) {
-    return result;
+    return toolError(error);
   }
 
-  return toolError(result.error, { logs });
+  return toolError(error, { logs });
 }
 
 export function serializeIsolateOutput(result: unknown, logs: string[]): string {
@@ -179,8 +179,6 @@ export function serializeIsolateOutput(result: unknown, logs: string[]): string 
 
   if (result === null || result === undefined) {
     parts.push('(no return value)');
-  } else if (isToolErrorResult(result)) {
-    parts.push(`Error: ${result.error}`);
   } else {
     try {
       parts.push(JSON.stringify(result, null, 2));


### PR DESCRIPTION
## 🚀 Change Summary

Tightens the sandbox IPC protocol and its downstream consumers so message validation is exhaustive, execution results are unambiguous, and untrusted tool arguments are validated before reaching host bindings.

### 🛠 Improvements & Refactors
- **Exhaustive protocol guards**: `isWorkerMessage` and `isHostMessage` now validate every required field per variant instead of only the `type` tag, so malformed payloads are rejected at the trust boundary.
- **Typed `init` message**: `init` is now a first-class `HostMessage` variant with required, validated fields — removes the ad-hoc cast and optional-field defaulting in `process-runtime.ts`.
- **Discriminated execution results**: `IsolateExecuteResult` is now `{ ok: true; result; logs } | { ok: false; error; logs }`, eliminating `{ error: string }` shape-guessing in code-mode so legitimate error-shaped return values are treated as successful data.
- **Tool argument validation**: `ToolBinding` now requires a `validateInput` callback invoked before `execute`. Code-mode implements it with the existing AJV JSON Schema validator, so sandbox tool calls are schema-checked before reaching host tool implementations.
- **Removed error wrapper codegen**: dropped the `CODE_ERROR_KEY` try/catch wrapper in the sandbox executor; uncaught exceptions flow through the existing `error` message path.

### 📚 Documentation
- Exported `IsolateExecuteResult` from `@stitch/sandbox`.

### ✅ Testing
- Added `protocol.test.ts` covering valid and malformed variants for both message directions.
- Added `tool-binding.test.ts` verifying AJV-based input validation.
- Added regression coverage for error-shaped return values and validation-before-execution.