### PR TITLE
chore: type promise and mutation errors

### DIFF
--- a/apps/web/src/components/mail/thread-view.tsx
+++ b/apps/web/src/components/mail/thread-view.tsx
@@ -194,7 +194,7 @@ export function ThreadView({ accountId, threadId, onClose }: ThreadViewProps) {
         });
         if (!currentThread.isTrashed) onClose();
       })
-      .catch((error: unknown) =>
+      .catch((error: Error) =>
         toast.error(getErrorMessage(error, 'Failed to update thread'), { id: 'mail-thread-trash' }),
       );
   }

--- a/apps/web/src/components/recordings/meeting-recording-banner.tsx
+++ b/apps/web/src/components/recordings/meeting-recording-banner.tsx
@@ -212,7 +212,7 @@ export function MeetingRecordingBanner() {
                       requestDismissMeeting(detection.key);
                       toast.success('Recording started', { id: 'meeting-recording-start-3' });
                     },
-                    (error: unknown) => {
+                    (error: Error) => {
                       toast.error(getErrorMessage(error, 'Failed to start recording'), {
                         id: 'meeting-recording-start-3',
                       });
@@ -237,7 +237,7 @@ export function MeetingRecordingBanner() {
                         requestDismissMeeting(detection.key);
                         toast.success('Recording started', { id: 'meeting-recording-start-stt' });
                       },
-                      (error: unknown) => {
+                      (error: Error) => {
                         toast.error(getErrorMessage(error, 'Failed to start recording'), {
                           id: 'meeting-recording-start-stt',
                         });
@@ -266,7 +266,7 @@ export function MeetingRecordingBanner() {
                     requestDismissMeeting(detection.key);
                     toast.success('Recording started', { id: 'meeting-recording-start' });
                   },
-                  (error: unknown) => {
+                  (error: Error) => {
                     toast.error(getErrorMessage(error, 'Failed to start recording'), { id: 'meeting-recording-start' });
                   },
                 );

--- a/apps/web/src/components/recordings/recording-analysis-page.tsx
+++ b/apps/web/src/components/recordings/recording-analysis-page.tsx
@@ -57,7 +57,7 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
         toast.success('Recording deleted', { id: 'analysis-recording-delete' });
         void navigate({ to: '/recordings' });
       },
-      (error: unknown) =>
+      (error: Error) =>
         toast.error(getErrorMessage(error, 'Failed to delete recording'), { id: 'analysis-recording-delete' }),
     );
   };
@@ -70,7 +70,7 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
 
     void startAnalysis.mutateAsync({ recordingId, force: true, templateId: selectedTemplate.id }).then(
       () => toast.success('Analysis started', { id: 'analysis-start' }),
-      (error: unknown) =>
+      (error: Error) =>
         toast.error(getErrorMessage(error, 'Failed to start recording analysis'), { id: 'analysis-start' }),
     );
   };
@@ -78,7 +78,7 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
   const handleCancelAnalysis = () => {
     void cancelAnalysis.mutateAsync(recordingId).then(
       () => toast.success('Analysis cancelled', { id: 'analysis-cancel' }),
-      (error: unknown) =>
+      (error: Error) =>
         toast.error(getErrorMessage(error, 'Failed to cancel recording analysis'), { id: 'analysis-cancel' }),
     );
   };
@@ -110,7 +110,7 @@ export function RecordingAnalysisPage({ recordingId }: { recordingId: string }) 
           onStopRecording={() => {
             void stopRecording.mutateAsync().then(
               () => toast.success('Recording stopped', { id: 'analysis-recording-stop' }),
-              (error: unknown) =>
+              (error: Error) =>
                 toast.error(getErrorMessage(error, 'Failed to stop recording'), { id: 'analysis-recording-stop' }),
             );
           }}

--- a/apps/web/src/components/recordings/recordings-page.tsx
+++ b/apps/web/src/components/recordings/recordings-page.tsx
@@ -57,7 +57,7 @@ export function RecordingsPage() {
         onSuccess?.();
         toast.success('Recording deleted', { id: 'recording-delete' });
       },
-      (error: unknown) => toast.error(getErrorMessage(error, 'Failed to delete recording'), { id: 'recording-delete' }),
+      (error: Error) => toast.error(getErrorMessage(error, 'Failed to delete recording'), { id: 'recording-delete' }),
     );
   };
 
@@ -100,14 +100,14 @@ export function RecordingsPage() {
                   setTitle('');
                   toast.success('Recording started', { id: 'recording-start' });
                 },
-                (error: unknown) =>
+                (error: Error) =>
                   toast.error(getErrorMessage(error, 'Failed to start recording'), { id: 'recording-start' }),
               );
           }}
           onStop={() => {
             void stopRecording.mutateAsync().then(
               () => toast.success('Recording stopped', { id: 'recording-stop' }),
-              (error: unknown) =>
+              (error: Error) =>
                 toast.error(getErrorMessage(error, 'Failed to stop recording'), { id: 'recording-stop' }),
             );
           }}

--- a/apps/web/src/components/settings/app-enable-setting.tsx
+++ b/apps/web/src/components/settings/app-enable-setting.tsx
@@ -16,7 +16,7 @@ export function AppEnableSetting({ appId, label }: { appId: AppId; label: string
   const toggleId = `${appId}-app-toggle`;
 
   function handleToggle(checked: boolean) {
-    void setAppEnabledState.mutateAsync({ appId, enabled: checked }).catch((error: unknown) => {
+    void setAppEnabledState.mutateAsync({ appId, enabled: checked }).catch((error: Error) => {
       toast.error(getErrorMessage(error, `Failed to update ${label}`), { id: 'app-enable' });
     });
   }

--- a/apps/web/src/components/settings/mail/eligible-accounts-section.tsx
+++ b/apps/web/src/components/settings/mail/eligible-accounts-section.tsx
@@ -19,7 +19,7 @@ export function EligibleAccountsSection() {
   const enrollMutation = useEnrollMailAccount();
 
   function handleEnroll(connectorInstanceId: string) {
-    void enrollMutation.mutateAsync({ connectorInstanceId }).catch((caught: unknown) => {
+    void enrollMutation.mutateAsync({ connectorInstanceId }).catch((caught: Error) => {
       toast.error(getErrorMessage(caught, 'Failed to enroll mail account'), {
         id: `mail-enroll-${connectorInstanceId}`,
       });

--- a/apps/web/src/components/settings/mail/mail-account-card.tsx
+++ b/apps/web/src/components/settings/mail/mail-account-card.tsx
@@ -118,7 +118,7 @@ function AccountErrorBanner({ account, error }: { account: MailAccountView; erro
   const resyncMutation = useResyncMailAccount();
 
   function handleRetry() {
-    void resyncMutation.mutateAsync({ id: account.id, mode: 'incremental' }).catch((caught: unknown) => {
+    void resyncMutation.mutateAsync({ id: account.id, mode: 'incremental' }).catch((caught: Error) => {
       toast.error(getErrorMessage(caught, 'Failed to retry sync'), { id: `mail-retry-${account.id}` });
     });
   }
@@ -159,13 +159,13 @@ export function MailAccountCard({ account, status }: { account: MailAccountView;
   const controlsDisabled = updateMutation.isPending || removeMutation.isPending;
 
   function handleUpdate(input: { enabled?: boolean; syncFrequencySeconds?: number; backfillDays?: number }) {
-    void updateMutation.mutateAsync({ id: account.id, ...input }).catch((error: unknown) => {
+    void updateMutation.mutateAsync({ id: account.id, ...input }).catch((error: Error) => {
       toast.error(getErrorMessage(error, 'Failed to update mail account'), { id: `mail-update-${account.id}` });
     });
   }
 
   function handleResync(mode: 'full' | 'incremental') {
-    void resyncMutation.mutateAsync({ id: account.id, mode }).catch((error: unknown) => {
+    void resyncMutation.mutateAsync({ id: account.id, mode }).catch((error: Error) => {
       toast.error(getErrorMessage(error, 'Failed to start resync'), { id: `mail-resync-${account.id}` });
     });
   }
@@ -174,7 +174,7 @@ export function MailAccountCard({ account, status }: { account: MailAccountView;
     void removeMutation
       .mutateAsync(account.id)
       .then(() => setRemoveOpen(false))
-      .catch((error: unknown) => {
+      .catch((error: Error) => {
         toast.error(getErrorMessage(error, 'Failed to remove mail account'), { id: `mail-remove-${account.id}` });
       });
   }

--- a/apps/web/src/components/settings/permissions.tsx
+++ b/apps/web/src/components/settings/permissions.tsx
@@ -130,7 +130,7 @@ export function ToolsSettings() {
   };
 
   const updateEnabled = (kind: 'tool' | 'toolset' | 'mcp_tool', identifier: string, enabled: boolean) => {
-    void setToolEnabledState.mutateAsync({ scope: kind, identifier, enabled }).catch((error: unknown) => {
+    void setToolEnabledState.mutateAsync({ scope: kind, identifier, enabled }).catch((error: Error) => {
       toast.error(getErrorMessage(error, 'Failed to update tool state'), { id: 'tool-state' });
     });
   };

--- a/apps/web/src/components/settings/permissions/permission-policy-editor.tsx
+++ b/apps/web/src/components/settings/permissions/permission-policy-editor.tsx
@@ -78,19 +78,19 @@ function ToolPermissionEditor({
   const isMutating = upsertPermission.isPending || deletePermission.isPending;
 
   const handleGlobalChange = (permission: ToolPermissionValue) => {
-    void upsertPermission.mutateAsync({ toolName, pattern: null, permission }).catch((error: unknown) => {
+    void upsertPermission.mutateAsync({ toolName, pattern: null, permission }).catch((error: Error) => {
       toast.error(getErrorMessage(error, 'Failed to update permission'), { id: 'permission-update' });
     });
   };
 
   const handlePatternPermissionChange = (rule: ToolPermission, permission: ToolPermissionValue) => {
-    void upsertPermission.mutateAsync({ toolName, pattern: rule.pattern, permission }).catch((error: unknown) => {
+    void upsertPermission.mutateAsync({ toolName, pattern: rule.pattern, permission }).catch((error: Error) => {
       toast.error(getErrorMessage(error, 'Failed to update permission'), { id: 'permission-update' });
     });
   };
 
   const handleDeleteRule = (rule: ToolPermission) => {
-    void deletePermission.mutateAsync(rule.id).catch((error: unknown) => {
+    void deletePermission.mutateAsync(rule.id).catch((error: Error) => {
       toast.error(getErrorMessage(error, 'Failed to delete rule'), { id: 'permission-delete' });
     });
   };
@@ -105,7 +105,7 @@ function ToolPermissionEditor({
         setNewPattern('');
         setNewPermission('ask');
       })
-      .catch((error: unknown) => {
+      .catch((error: Error) => {
         toast.error(getErrorMessage(error, 'Failed to add rule'), { id: 'permission-add-rule' });
       });
   };
@@ -210,7 +210,7 @@ function ToolPermissionEditor({
                       } else {
                         void upsertPermission
                           .mutateAsync({ toolName, pattern: preset.pattern, permission: 'allow' })
-                          .catch((error: unknown) => {
+                          .catch((error: Error) => {
                             toast.error(getErrorMessage(error, 'Failed to add rule'), { id: 'permission-add-preset' });
                           });
                       }

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -862,7 +862,7 @@ class StreamRunner {
     });
 
     await this.deps.markSessionUnread(this.ctx.sessionId);
-    void this.deps.pruneSession(this.ctx.sessionId).catch((error: unknown) => {
+    void this.deps.pruneSession(this.ctx.sessionId).catch((error: Error) => {
       log.warn({ sessionId: this.ctx.sessionId, error }, 'post-stream prune failed');
     });
 

--- a/packages/server/src/routes/automations.ts
+++ b/packages/server/src/routes/automations.ts
@@ -78,7 +78,7 @@ automationsRouter.delete(
     const result = await deleteAutomation(id, body);
     if (result.error) return unwrapResult(c, result);
 
-    await unregisterAutomationSchedule(id).catch((error: unknown) => {
+    await unregisterAutomationSchedule(id).catch((error: Error) => {
       log.error({ error }, 'failed to unregister automation schedule');
     });
 


### PR DESCRIPTION
## 🚀 Change Summary

Types promise/mutation error handlers with `Error` instead of `unknown` across web and server code.

### 🛠 Improvements & Refactors
- Type promise error handlers in server routes (automations, stream runner)
- Type mutation error handlers across web components (recordings, mail, settings, permissions)