### PR TITLE
improvement(server): unify user intervention and approval workflows

### DIFF
--- a/packages/server/src/lib/interactions/broker.test.ts
+++ b/packages/server/src/lib/interactions/broker.test.ts
@@ -87,4 +87,59 @@ describe('InteractionBroker', () => {
     expect(broker.resolve('doom_loop:ses_1', 'continue')).toBe(true);
     expect(second).resolves.toBe('continue');
   });
+
+  test('deduplicates in-flight waits with identical dedupeKey', async () => {
+    const first = broker.wait<string>({
+      id: 'permres_1',
+      kind: 'permission',
+      sessionId: 'ses_1',
+      dedupeKey: 'perm_read_file',
+    });
+
+    const second = broker.wait<string>({
+      id: 'permres_2',
+      kind: 'permission',
+      sessionId: 'ses_1',
+      dedupeKey: 'perm_read_file',
+    });
+
+    expect(broker.getDedupe('perm_read_file')).toBeDefined();
+
+    broker.resolve('permres_1', 'allow');
+
+    expect(first).resolves.toBe('allow');
+    expect(second).resolves.toBe('allow');
+  });
+
+  test('stores payload and supports list filtering and get', async () => {
+    void broker.wait<string, { toolName: string }>({
+      id: 'permres_1',
+      kind: 'permission',
+      sessionId: 'ses_1',
+      payload: { toolName: 'bash' },
+    });
+
+    void broker.wait<string, { toolName: string }>({
+      id: 'doom_1',
+      kind: 'doom_loop',
+      sessionId: 'ses_1',
+      payload: { toolName: 'read' },
+    });
+
+    void broker.wait<string>({ id: 'permres_2', kind: 'permission', sessionId: 'ses_2' });
+
+    expect(broker.has('permres_1')).toBe(true);
+    expect(broker.has('nonexistent')).toBe(false);
+
+    const snapshot = broker.get<{ toolName: string }>('permres_1');
+    expect(snapshot).toBeDefined();
+    expect(snapshot?.payload).toEqual({ toolName: 'bash' });
+    expect(typeof snapshot?.createdAt).toBe('number');
+
+    const session1Interactions = broker.list({ sessionId: 'ses_1' });
+    expect(session1Interactions.map((e) => e.id)).toEqual(['permres_1', 'doom_1']);
+
+    const permissionInteractions = broker.list({ kind: 'permission' });
+    expect(permissionInteractions.map((e) => e.id)).toEqual(['permres_1', 'permres_2']);
+  });
 });

--- a/packages/server/src/lib/interactions/broker.ts
+++ b/packages/server/src/lib/interactions/broker.ts
@@ -1,10 +1,12 @@
 import type {
   AbortSessionOptions,
   InteractionWaitOptions,
+  ListInteractionsFilter,
   PendingInteractionSnapshot,
 } from '@/lib/interactions/types.js';
 
-type PendingInteraction = PendingInteractionSnapshot & {
+type PendingInteraction<TPayload = unknown> = PendingInteractionSnapshot<TPayload> & {
+  dedupeKey?: string;
   resolve: (decision: unknown) => void;
   reject: (error: Error) => void;
   abortError: () => Error;
@@ -22,23 +24,34 @@ const defaultAbortError = () => new InteractionAbortedError();
 
 export class InteractionBroker {
   private readonly pending = new Map<string, PendingInteraction>();
+  private readonly byDedupeKey = new Map<string, Promise<unknown>>();
 
-  wait<TDecision>(opts: InteractionWaitOptions<TDecision>): Promise<TDecision> {
+  wait<TDecision, TPayload = unknown>(opts: InteractionWaitOptions<TDecision, TPayload>): Promise<TDecision> {
+    if (opts.dedupeKey) {
+      const inFlight = this.byDedupeKey.get(opts.dedupeKey);
+      if (inFlight) {
+        return inFlight as Promise<TDecision>;
+      }
+    }
+
     const existing = this.pending.get(opts.id);
     if (existing) {
       void this.resolveDuplicate(existing, opts.onDuplicate);
     }
 
-    return new Promise<TDecision>((resolve, reject) => {
-      let timeout: ReturnType<typeof setTimeout> | undefined;
-      const abortError = opts.abortError ?? defaultAbortError;
-      let pendingEntry: PendingInteraction;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const abortError = opts.abortError ?? defaultAbortError;
+    let pendingEntry: PendingInteraction<TPayload>;
 
+    const promise = new Promise<TDecision>((resolve, reject) => {
       const cleanup = () => {
         if (timeout) clearTimeout(timeout);
         opts.abortSignal?.removeEventListener('abort', abortHandler);
         if (this.pending.get(opts.id) === pendingEntry) {
           this.pending.delete(opts.id);
+        }
+        if (opts.dedupeKey && this.byDedupeKey.get(opts.dedupeKey) === promise) {
+          this.byDedupeKey.delete(opts.dedupeKey);
         }
       };
 
@@ -77,13 +90,22 @@ export class InteractionBroker {
         kind: opts.kind,
         sessionId: opts.sessionId,
         streamRunId: opts.streamRunId,
+        createdAt: Date.now(),
+        payload: opts.payload,
+        dedupeKey: opts.dedupeKey,
         resolve: settleResolve,
         reject: settleReject,
         abortError,
         cleanup,
       };
-      this.pending.set(opts.id, pendingEntry);
+      this.pending.set(opts.id, pendingEntry as PendingInteraction);
     });
+
+    if (opts.dedupeKey) {
+      this.byDedupeKey.set(opts.dedupeKey, promise);
+    }
+
+    return promise;
   }
 
   resolve<TDecision>(id: string, decision: TDecision): boolean {
@@ -114,9 +136,28 @@ export class InteractionBroker {
     return aborted.map(toSnapshot);
   }
 
-  get(id: string): PendingInteractionSnapshot | undefined {
+  get<TPayload = unknown>(id: string): PendingInteractionSnapshot<TPayload> | undefined {
     const entry = this.pending.get(id);
-    return entry ? toSnapshot(entry) : undefined;
+    return entry ? (toSnapshot(entry) as PendingInteractionSnapshot<TPayload>) : undefined;
+  }
+
+  getDedupe<TDecision>(dedupeKey: string): Promise<TDecision> | undefined {
+    return this.byDedupeKey.get(dedupeKey) as Promise<TDecision> | undefined;
+  }
+
+  has(id: string): boolean {
+    return this.pending.has(id);
+  }
+
+  list(filter?: ListInteractionsFilter): PendingInteractionSnapshot[] {
+    let entries = [...this.pending.values()];
+    if (filter?.sessionId) {
+      entries = entries.filter((e) => e.sessionId === filter.sessionId);
+    }
+    if (filter?.kind) {
+      entries = entries.filter((e) => e.kind === filter.kind);
+    }
+    return entries.map(toSnapshot);
   }
 
   clear(): void {
@@ -124,6 +165,7 @@ export class InteractionBroker {
       entry.cleanup();
     }
     this.pending.clear();
+    this.byDedupeKey.clear();
   }
 
   private async resolveDuplicate<TDecision>(
@@ -145,6 +187,13 @@ export class InteractionBroker {
 
 export const interactionBroker = new InteractionBroker();
 
-function toSnapshot(entry: PendingInteraction): PendingInteractionSnapshot {
-  return { id: entry.id, kind: entry.kind, sessionId: entry.sessionId, streamRunId: entry.streamRunId };
+function toSnapshot<TPayload>(entry: PendingInteraction<TPayload>): PendingInteractionSnapshot<TPayload> {
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    sessionId: entry.sessionId,
+    streamRunId: entry.streamRunId,
+    createdAt: entry.createdAt,
+    payload: entry.payload,
+  };
 }

--- a/packages/server/src/lib/interactions/types.ts
+++ b/packages/server/src/lib/interactions/types.ts
@@ -2,18 +2,22 @@ import type { PrefixedString } from '@stitch/shared/id';
 
 type InteractionKind = 'permission' | 'question' | 'doom_loop' | 'mcp_elicitation';
 
-export type PendingInteractionSnapshot = {
+export type PendingInteractionSnapshot<TPayload = unknown> = {
   id: string;
   kind: InteractionKind;
   sessionId: PrefixedString<'ses'>;
   streamRunId?: string;
+  createdAt: number;
+  payload?: TPayload;
 };
 
-export type InteractionWaitOptions<TDecision> = {
+export type InteractionWaitOptions<TDecision, TPayload = unknown> = {
   id: string;
   kind: InteractionKind;
   sessionId: PrefixedString<'ses'>;
   streamRunId?: string;
+  payload?: TPayload;
+  dedupeKey?: string;
   abortSignal?: AbortSignal;
   abortError?: () => Error;
   timeoutMs?: number;
@@ -22,3 +26,5 @@ export type InteractionWaitOptions<TDecision> = {
 };
 
 export type AbortSessionOptions = { sessionId: PrefixedString<'ses'>; kind?: InteractionKind; error?: Error };
+
+export type ListInteractionsFilter = { sessionId?: PrefixedString<'ses'>; kind?: InteractionKind };

--- a/packages/server/src/llm/stream/doom-loop.ts
+++ b/packages/server/src/llm/stream/doom-loop.ts
@@ -39,11 +39,15 @@ export function isDoomLoop(history: ToolCallRecord[]): boolean {
  * Pause execution until the user responds via the API endpoint.
  * Automatically resolves with `'stop'` after `DECISION_TIMEOUT_MS`.
  */
-export function waitForUserDecision(sessionId: PrefixedString<'ses'>): Promise<DoomLoopResponse> {
+export function waitForUserDecision(
+  sessionId: PrefixedString<'ses'>,
+  payload?: { toolName: string; consecutiveCount: number },
+): Promise<DoomLoopResponse> {
   return interactionBroker.wait<DoomLoopResponse>({
     id: sessionId,
     kind: 'doom_loop',
     sessionId,
+    payload,
     timeoutMs: DECISION_TIMEOUT_MS,
     onTimeout: () => {
       log.warn({ sessionId }, 'doom loop decision timed out, auto-stopping');
@@ -106,7 +110,10 @@ export async function checkAndHandleDoomLoop(opts: {
     consecutiveCount: DOOM_LOOP_THRESHOLD,
   });
 
-  const decision = await waitForUserDecision(sessionId);
+  const decision = await waitForUserDecision(sessionId, {
+    toolName: repeatedTool,
+    consecutiveCount: DOOM_LOOP_THRESHOLD,
+  });
 
   if (decision === 'stop') {
     log.info({ sessionId }, 'user stopped doom loop');

--- a/packages/server/src/permission/service.ts
+++ b/packages/server/src/permission/service.ts
@@ -21,7 +21,6 @@ import { PermissionResponseAbortedError } from '@/llm/stream/errors.js';
 import { resolvePermissionFromRules } from '@/permission/policy.js';
 
 const log = Log.create({ service: 'permission-service' });
-const pendingPermissionRequests = new Map<string, Promise<PermissionDecisionResult>>();
 
 const permissionResponseStore = new Map<PrefixedString<'permres'>, PermissionResponse>();
 
@@ -93,7 +92,14 @@ type RequestPermissionResponseOptions = {
   abortSignal?: AbortSignal;
 };
 
-async function createPermissionResponse(opts: RequestPermissionResponseOptions): Promise<PermissionDecisionResult> {
+export async function requestPermissionResponse(
+  opts: RequestPermissionResponseOptions,
+): Promise<PermissionDecisionResult> {
+  if (opts.dedupeKey) {
+    const existing = interactionBroker.getDedupe<PermissionDecisionResult>(opts.dedupeKey);
+    if (existing) return existing;
+  }
+
   const id = createPermissionResponseId();
 
   const permissionResponse: PermissionResponse = {
@@ -124,32 +130,16 @@ async function createPermissionResponse(opts: RequestPermissionResponseOptions):
     'permission requested',
   );
 
-  return interactionBroker.wait<PermissionDecisionResult>({
+  return interactionBroker.wait<PermissionDecisionResult, PermissionResponse>({
     id,
     kind: 'permission',
     sessionId: opts.sessionId,
     streamRunId: opts.streamRunId,
+    payload: permissionResponse,
+    dedupeKey: opts.dedupeKey,
     abortSignal: opts.abortSignal,
     abortError: () => new PermissionResponseAbortedError(),
   });
-}
-
-export async function requestPermissionResponse(
-  opts: RequestPermissionResponseOptions,
-): Promise<PermissionDecisionResult> {
-  const dedupeKey = opts.dedupeKey;
-  if (!dedupeKey) {
-    return createPermissionResponse(opts);
-  }
-
-  const existing = pendingPermissionRequests.get(dedupeKey);
-  if (existing) return existing;
-
-  const promise = createPermissionResponse(opts).finally(() => {
-    pendingPermissionRequests.delete(dedupeKey);
-  });
-  pendingPermissionRequests.set(dedupeKey, promise);
-  return promise;
 }
 
 async function resolvePermissionResponse(opts: {


### PR DESCRIPTION
## 🚀 Change Summary

Deepens the interaction coordinator seam by consolidating in-flight request deduplication, payload tracking, and lifecycle management into `InteractionBroker`. This unifies user intervention and approval workflows across tool permissions, doom-loop detection, and interactive prompts while eliminating fractured in-memory promise caching maps.

### 🛠 Improvements & Refactors
- **Centralized In-Flight Request Deduplication**: Moved promise deduplication via `dedupeKey` directly into `InteractionBroker`, removing duplicate caching logic in `permission/service.ts`.
- **Interaction Payload & Metadata Storage**: Added `payload` and `createdAt` tracking to `PendingInteractionSnapshot`, allowing centralized querying and filtering by `sessionId` and `kind`.
- **Streamlined User Intervention Seams**: Standardized doom-loop decision requests to attach structured payload metadata and cleaned up session interaction abort handling.
