### PR TITLE
improvement(server): consolidate toolset turn lifecycle into toolset manager

### DIFF
--- a/packages/server/src/db/schema/sessions.ts
+++ b/packages/server/src/db/schema/sessions.ts
@@ -5,7 +5,7 @@ import type { PrefixedString } from '@stitch/shared/id';
 import type { TodoPriority, TodoStatus } from '@stitch/shared/todos/types';
 
 import { automations } from '@/db/schema/automations.js';
-import type { SessionToolsetState } from '@/llm/stream/session-toolsets.js';
+import type { SessionToolsetState } from '@/tools/toolsets/types.js';
 import type { LanguageModelUsage } from 'ai';
 
 export const sessions = sqliteTable('sessions', {

--- a/packages/server/src/llm/session-summary.ts
+++ b/packages/server/src/llm/session-summary.ts
@@ -19,13 +19,13 @@ import { getProviderOptions } from '@/llm/provider-options.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
 import { mapAIError, toStreamErrorDetails } from '@/llm/stream/ai-error-mapper.js';
-import { getSessionToolsetState } from '@/llm/stream/session-toolsets.js';
 import { getToolPruneProtectOverrides } from '@/llm/tool-prune-policy.js';
 import * as LocalModels from '@/models/llm/local.js';
 import * as Models from '@/models/llm/registry.js';
 import type { LlmProviderCredentials } from '@/provider/config/schema.js';
 import { getSettings } from '@/settings/service.js';
 import { getSessionTodosPromptBlock } from '@/todos/service.js';
+import { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
 import { recordLlmUsage } from '@/usage/ledger.js';
 import { estimate } from '@/utils/token.js';
@@ -445,7 +445,7 @@ export async function compact(input: {
 }
 
 export function buildActiveToolsetInstructionsBlock(sessionId: PrefixedString<'ses'>): string {
-  const activeIds = getSessionToolsetState(sessionId).active.map((entry) => entry.id);
+  const activeIds = ToolsetManager.getSessionState(sessionId).active.map((entry) => entry.id);
   const instructionBlocks = activeIds
     .map((id) => getToolset(id))
     .filter((ts): ts is NonNullable<ReturnType<typeof getToolset>> => !!ts?.instructions)

--- a/packages/server/src/llm/stream/runner.ts
+++ b/packages/server/src/llm/stream/runner.ts
@@ -22,17 +22,10 @@ import {
   isStreamAbortedError,
 } from '@/llm/stream/errors.js';
 import { SessionContext } from '@/llm/stream/session-context.js';
-import {
-  buildNextSessionToolsetState,
-  getSessionToolsetState,
-  getToolsetExpiresAtTurn,
-  setSessionToolsetState,
-} from '@/llm/stream/session-toolsets.js';
 import { executeStepWithRetry, type StepOptions } from '@/llm/stream/step-executor.js';
 import type { LlmProviderCredentials } from '@/provider/config/schema.js';
 import { MAX_STEPS, MAX_STEPS_WARNING } from '@/tools/runtime/registry.js';
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
-import { getToolset } from '@/tools/toolsets/registry.js';
 import { getToolsetSettings } from '@/tools/toolsets/settings.js';
 import * as Usage from '@/utils/usage.js';
 import type { ModelMessage, LanguageModelUsage, Tool } from 'ai';
@@ -866,19 +859,7 @@ class StreamRunner {
       log.warn({ sessionId: this.ctx.sessionId, error }, 'post-stream prune failed');
     });
 
-    const currentToolsetState = getSessionToolsetState(this.ctx.sessionId);
-    setSessionToolsetState(
-      this.ctx.sessionId,
-      buildNextSessionToolsetState({
-        currentState: currentToolsetState,
-        active: this.ctx.toolsetManager.getPersistableActivationState(),
-        expiredRunToolsets: this.ctx.toolsetManager.getExpiredRunToolsets(),
-        getToolNames: (toolsetId) =>
-          getToolset(toolsetId)
-            ?.tools()
-            .map((tool) => tool.name) ?? [],
-      }),
-    );
+    this.ctx.toolsetManager.advanceTurn();
 
     const toolCallCount = this.state.accumulatedParts.filter((p) => p.type === 'tool-call').length;
     const toolErrorCount = this.state.accumulatedParts.filter(
@@ -915,11 +896,8 @@ class StreamRunner {
 
   private async renewToolsetActivity(toolCalls: ToolCallRecord[]): Promise<void> {
     const settings = await getToolsetSettings();
-    const currentTurn = getSessionToolsetState(this.ctx.sessionId).turnCounter;
-    const expiresAtTurn = getToolsetExpiresAtTurn(currentTurn, settings.ttlTurns);
-
     for (const call of toolCalls) {
-      this.ctx.toolsetManager.renewTtlForTool(call.toolName, expiresAtTurn);
+      this.ctx.toolsetManager.renewTtlForTool(call.toolName, settings.ttlTurns);
     }
   }
 

--- a/packages/server/src/llm/stream/session-context.ts
+++ b/packages/server/src/llm/stream/session-context.ts
@@ -1,14 +1,8 @@
 import type { PrefixedString } from '@stitch/shared/id';
 
 import { createCodeModeTool } from '@/code-mode/tool.js';
-import * as Log from '@/lib/log.js';
 import { PromptComposer } from '@/llm/prompt/composer.js';
 import { buildActiveToolsetInstructionsBlock } from '@/llm/session-summary.js';
-import {
-  getCurrentSessionToolsetState,
-  getSessionToolsetState,
-  type SessionExpiredToolset,
-} from '@/llm/stream/session-toolsets.js';
 import type { LlmProviderCredentials } from '@/provider/config/schema.js';
 import { buildSkillsSystemPrompt } from '@/skills/service.js';
 import { createInspectImageTool } from '@/tools/core/inspect-image.js';
@@ -19,9 +13,8 @@ import { createTools } from '@/tools/runtime/registry.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
+import type { SessionExpiredToolset } from '@/tools/toolsets/types.js';
 import type { ModelMessage, Tool } from 'ai';
-
-const log = Log.create({ service: 'session-context' });
 
 type SessionContextOptions = {
   sessionId: PrefixedString<'ses'>;
@@ -92,23 +85,11 @@ export class SessionContext {
   }
 
   async assemble(): Promise<AssembledResult> {
-    const sessionState = getSessionToolsetState(this.opts.sessionId);
-    const currentSessionState = getCurrentSessionToolsetState(sessionState, (toolsetId) =>
-      SessionContext.getToolNames(toolsetId),
-    );
-    const activeEntries = this.opts.activeToolsetIds
-      ? this.opts.activeToolsetIds.map((id) => ({ id, scope: 'until_deactivated' as const }))
-      : currentSessionState.active;
-    const expiredEntries = this.opts.activeToolsetIds ? [] : currentSessionState.expired;
-    const expiredPrompt = this.opts.activeToolsetIds ? '' : buildExpiredToolsetsPrompt(expiredEntries);
-
-    const toolsetManager = new ToolsetManager(this.toolContext, activeEntries, {
+    const toolsetManager = await ToolsetManager.forSession(this.toolContext, {
+      initialActiveToolsetIds: this.opts.activeToolsetIds,
       excludedToolsetIds: this.opts.excludedToolsetIds,
     });
-    await this.restoreToolsets(
-      toolsetManager,
-      activeEntries.map((entry) => entry.id),
-    );
+    const expiredPrompt = buildExpiredToolsetsPrompt(toolsetManager.getExpiredToolsets());
 
     const coreTools = await createTools(this.toolContext);
     const metaTools = this.buildToolsetMetaTools(toolsetManager);
@@ -145,34 +126,10 @@ export class SessionContext {
     return { messages: composer.compose(this.opts.llmMessages), tools, toolsetManager };
   }
 
-  private static getToolNames(toolsetId: string): string[] {
-    return (
-      getToolset(toolsetId)
-        ?.tools()
-        .map((tool) => tool.name) ?? []
-    );
-  }
-
-  private async restoreToolsets(manager: ToolsetManager, toolsetIds: string[]): Promise<void> {
-    if (toolsetIds.length === 0) return;
-
-    await Promise.all(
-      toolsetIds.map(async (id) => {
-        const result = await manager.activate(id);
-        if (result.status === 'not_found' || result.status === 'disabled') {
-          log.warn(
-            { event: 'toolset.restore.failed', toolsetId: id, reason: result.status },
-            'failed to restore previously active toolset — skipping',
-          );
-        }
-      }),
-    );
-  }
-
   private buildToolsetMetaTools(manager: ToolsetManager): Record<string, Tool> {
     const pipeline = ToolPipeline.create(this.toolContext);
     return pipeline.registerAll(
-      Object.entries(createToolsetTools(manager, this.toolContext.sessionId)).map(([name, tool]) => ({
+      Object.entries(createToolsetTools(manager)).map(([name, tool]) => ({
         name,
         displayName: name,
         tool,

--- a/packages/server/src/llm/stream/session-toolsets.ts
+++ b/packages/server/src/llm/stream/session-toolsets.ts
@@ -1,37 +1,11 @@
-import { eq } from 'drizzle-orm';
-
 import type { PrefixedString } from '@stitch/shared/id';
 
-import { getDb } from '@/db/client.js';
-import { sessions } from '@/db/schema/sessions.js';
+import { ToolsetManager } from '@/tools/toolsets/manager.js';
+import type { SessionActiveToolset, SessionToolsetState } from '@/tools/toolsets/types.js';
 
-export type SessionToolsetScope = 'current_run' | 'ttl_turns' | 'until_deactivated';
-
-export type SessionActiveToolset = { id: string; scope: SessionToolsetScope; expiresAtTurn?: number };
-
-export type SessionExpiredToolset = { id: string; expiredAtTurn: number; toolNames: string[] };
-
-export type SessionToolsetState = {
-  turnCounter: number;
-  active: SessionActiveToolset[];
-  expired: SessionExpiredToolset[];
-};
-
-const EMPTY_SESSION_TOOLSET_STATE: SessionToolsetState = { turnCounter: 0, active: [], expired: [] };
+export { type SessionActiveToolset, type SessionToolsetState } from '@/tools/toolsets/types.js';
 
 type ExpiredToolsetInput = { id: string; toolNames: string[] };
-
-function cloneState(state: SessionToolsetState): SessionToolsetState {
-  return {
-    turnCounter: state.turnCounter,
-    active: state.active.map((entry) => ({ ...entry })),
-    expired: state.expired.map((entry) => ({ ...entry, toolNames: [...entry.toolNames] })),
-  };
-}
-
-export function getToolsetExpiresAtTurn(currentTurn: number, ttlTurns: number): number {
-  return currentTurn + ttlTurns - 1;
-}
 
 function partitionActiveToolsets(
   active: SessionActiveToolset[],
@@ -49,6 +23,10 @@ function partitionActiveToolsets(
   }
 
   return { active: nextActive, expired };
+}
+
+export function getToolsetExpiresAtTurn(currentTurn: number, ttlTurns: number): number {
+  return ToolsetManager.getToolsetExpiresAtTurn(currentTurn, ttlTurns);
 }
 
 export function getCurrentSessionToolsetState(
@@ -88,19 +66,9 @@ export function buildNextSessionToolsetState(input: {
 }
 
 export function getSessionToolsetState(sessionId: PrefixedString<'ses'>): SessionToolsetState {
-  const row = getDb()
-    .select({ toolsetState: sessions.toolsetState })
-    .from(sessions)
-    .where(eq(sessions.id, sessionId))
-    .get();
-
-  return cloneState(row?.toolsetState ?? EMPTY_SESSION_TOOLSET_STATE);
+  return ToolsetManager.getSessionState(sessionId);
 }
 
 export function setSessionToolsetState(sessionId: PrefixedString<'ses'>, state: SessionToolsetState): void {
-  getDb()
-    .update(sessions)
-    .set({ toolsetState: cloneState(state), updatedAt: Date.now() })
-    .where(eq(sessions.id, sessionId))
-    .run();
+  ToolsetManager.setSessionState(sessionId, state);
 }

--- a/packages/server/src/tools/core/toolset-management.ts
+++ b/packages/server/src/tools/core/toolset-management.ts
@@ -4,33 +4,19 @@ import { z } from 'zod';
 import type { PrefixedString } from '@stitch/shared/id';
 import { humanizeToolName } from '@stitch/shared/tools/display';
 
-import {
-  getToolsetExpiresAtTurn,
-  getSessionToolsetState,
-  setSessionToolsetState,
-  type SessionToolsetScope,
-} from '@/llm/stream/session-toolsets.js';
 import { isToolEnabled } from '@/tools/enabled-service.js';
 import { ToolsetDisabledError, ToolsetNotFoundError, ToolsetNotInCatalogError } from '@/tools/errors.js';
-import type { ToolsetManager } from '@/tools/toolsets/manager.js';
+import { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { getToolset } from '@/tools/toolsets/registry.js';
 import { getToolsetSettings } from '@/tools/toolsets/settings.js';
+import type { SessionToolsetScope } from '@/tools/toolsets/types.js';
 import { toToolsetView } from '@/tools/toolsets/view.js';
 
 /**
  * Create the three toolset management meta-tools bound to a specific ToolsetManager instance.
  * These are always-active tools that let the LLM discover, activate, and deactivate toolsets.
  */
-export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedString<'ses'>) {
-  const persistManagerState = () => {
-    const current = getSessionToolsetState(sessionId);
-    setSessionToolsetState(sessionId, {
-      ...current,
-      active: manager.getPersistableActivationState(),
-      expired: current.expired.filter((entry) => !manager.isActive(entry.id)),
-    });
-  };
-
+export function createToolsetTools(manager: ToolsetManager, _sessionId?: PrefixedString<'ses'>) {
   const resolveActivationState = async (input: { persist?: boolean; scope?: SessionToolsetScope }) => {
     if (input.persist === true) {
       return { scope: 'until_deactivated' as const };
@@ -39,10 +25,7 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
     const settings = await getToolsetSettings();
     const scope = input.scope ?? settings.defaultScope;
     return scope === 'ttl_turns'
-      ? {
-          scope,
-          expiresAtTurn: getToolsetExpiresAtTurn(getSessionToolsetState(sessionId).turnCounter, settings.ttlTurns),
-        }
+      ? { scope, expiresAtTurn: ToolsetManager.getToolsetExpiresAtTurn(manager.getTurnCounter(), settings.ttlTurns) }
       : { scope };
   };
 
@@ -135,7 +118,6 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
         const wasPersisted = manager.isPersisted(toolsetId);
         const toolsetName = getToolset(toolsetId)?.name ?? toolsetId;
         manager.setActivationState(toolsetId, activationState);
-        persistManagerState();
 
         return {
           toolsetId,
@@ -157,8 +139,6 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
       if (result.status === 'disabled') {
         throw new ToolsetDisabledError(toolsetId);
       }
-
-      persistManagerState();
 
       const { toolNames, collisions } = result;
       const toolset = getToolset(toolsetId);
@@ -212,8 +192,6 @@ export function createToolsetTools(manager: ToolsetManager, sessionId: PrefixedS
           message: `Toolset "${toolsetName}" was not active.`,
         };
       }
-
-      persistManagerState();
 
       return {
         toolsetId,

--- a/packages/server/src/tools/toolsets/manager.test.ts
+++ b/packages/server/src/tools/toolsets/manager.test.ts
@@ -1,10 +1,15 @@
 import { jsonSchema } from 'ai';
 import { beforeEach, describe, expect, test } from 'bun:test';
 
+import { getDb } from '@/db/client.js';
+import { sessions } from '@/db/schema/sessions.js';
+import { setupTestDb } from '@/db/test-helpers.js';
 import { ToolsetManager } from '@/tools/toolsets/manager.js';
 import { listToolsetIds, registerToolset, unregisterToolset } from '@/tools/toolsets/registry.js';
 import type { Toolset } from '@/tools/toolsets/types.js';
 import type { Tool } from 'ai';
+
+setupTestDb();
 
 function clearToolsets(): void {
   for (const id of listToolsetIds()) {
@@ -350,5 +355,144 @@ describe('ToolsetManager activation state', () => {
     expect(manager.renewTtlForTool('missing_tool', 5)).toBeNull();
     expect(manager.renewTtlForTool('persisted_tool', 5)).toBeNull();
     expect(manager.getPersistableActivationState()).toEqual([{ id: 'persisted', scope: 'until_deactivated' }]);
+  });
+});
+
+describe('ToolsetManager.advanceTurn and lifecycle', () => {
+  beforeEach(() => {
+    clearToolsets();
+  });
+
+  test('increments turnCounter and rolls over current_run activations to expired', async () => {
+    registerToolset({
+      id: 'run-only',
+      kind: 'native',
+      name: 'Run Only',
+      description: 'Run only',
+      tools: () => [{ name: 'run_tool', description: 'run' }],
+      activate: async () => ({ run_tool: makeTool('run') }),
+    } satisfies Toolset);
+    registerToolset({
+      id: 'persisted',
+      kind: 'native',
+      name: 'Persisted',
+      description: 'Persisted',
+      tools: () => [{ name: 'persisted_tool', description: 'persisted' }],
+      activate: async () => ({ persisted_tool: makeTool('persisted') }),
+    } satisfies Toolset);
+
+    const manager = new ToolsetManager(
+      { sessionId: 'ses_test' as never, messageId: 'msg_test' as never, streamRunId: 'run_test' },
+      [],
+      { turnCounter: 1 },
+    );
+
+    await manager.activate('run-only', { scope: 'current_run' });
+    await manager.activate('persisted', { scope: 'until_deactivated' });
+
+    expect(manager.isActive('run-only')).toBe(true);
+    expect(manager.isActive('persisted')).toBe(true);
+    expect(manager.getTurnCounter()).toBe(1);
+
+    const nextState = manager.advanceTurn({ persist: false });
+
+    expect(manager.getTurnCounter()).toBe(2);
+    expect(manager.isActive('run-only')).toBe(false);
+    expect(manager.isActive('persisted')).toBe(true);
+    expect(nextState.turnCounter).toBe(2);
+    expect(nextState.active).toEqual([{ id: 'persisted', scope: 'until_deactivated' }]);
+    expect(nextState.expired).toEqual([{ id: 'run-only', expiredAtTurn: 2, toolNames: ['run_tool'] }]);
+    expect(manager.getExpiredToolsets()).toEqual([{ id: 'run-only', expiredAtTurn: 2, toolNames: ['run_tool'] }]);
+  });
+
+  test('expires TTL toolsets when turn counter passes expiration turn', async () => {
+    registerToolset({
+      id: 'ttl-ts',
+      kind: 'native',
+      name: 'TTL Toolset',
+      description: 'TTL Toolset',
+      tools: () => [{ name: 'ttl_tool', description: 'ttl' }],
+      activate: async () => ({ ttl_tool: makeTool('ttl') }),
+    } satisfies Toolset);
+
+    const manager = new ToolsetManager(
+      { sessionId: 'ses_test' as never, messageId: 'msg_test' as never, streamRunId: 'run_test' },
+      [],
+      { turnCounter: 1 },
+    );
+
+    // Expires at turn 2 (meaning valid on turn 1 and turn 2)
+    await manager.activate('ttl-ts', { scope: 'ttl_turns', expiresAtTurn: 2 });
+
+    expect(manager.isActive('ttl-ts')).toBe(true);
+
+    // Advance to turn 2 - still valid because expiresAtTurn (2) >= nextTurnCounter (2)
+    manager.advanceTurn({ persist: false });
+    expect(manager.getTurnCounter()).toBe(2);
+    expect(manager.isActive('ttl-ts')).toBe(true);
+
+    // Advance to turn 3 - should expire because expiresAtTurn (2) < nextTurnCounter (3)
+    const state3 = manager.advanceTurn({ persist: false });
+    expect(manager.getTurnCounter()).toBe(3);
+    expect(manager.isActive('ttl-ts')).toBe(false);
+    expect(state3.active).toEqual([]);
+    expect(state3.expired).toEqual([{ id: 'ttl-ts', expiredAtTurn: 3, toolNames: ['ttl_tool'] }]);
+  });
+});
+
+describe('ToolsetManager.forSession hydration and persistence', () => {
+  beforeEach(() => {
+    clearToolsets();
+  });
+
+  test('hydrates state from DB, restores tools, and manages turn persistence', async () => {
+    const sessionId = 'ses_hydration_test' as never;
+    getDb().insert(sessions).values({ id: sessionId, title: 'Hydration test' }).run();
+
+    registerToolset({
+      id: 'hydrated-toolset',
+      kind: 'native',
+      name: 'Hydrated',
+      description: 'Hydrated toolset',
+      tools: () => [{ name: 'hydrated_tool', description: 'hydrated' }],
+      activate: async () => ({ hydrated_tool: makeTool('hydrated') }),
+    } satisfies Toolset);
+
+    ToolsetManager.setSessionState(sessionId, {
+      turnCounter: 1,
+      active: [{ id: 'hydrated-toolset', scope: 'until_deactivated' }],
+      expired: [],
+    });
+
+    const manager = await ToolsetManager.forSession({
+      sessionId,
+      messageId: 'msg_test' as never,
+      streamRunId: 'run_test',
+    });
+
+    expect(manager.getTurnCounter()).toBe(1);
+    expect(manager.isActive('hydrated-toolset')).toBe(true);
+    expect(manager.getActiveTools()).toHaveProperty('hydrated_tool');
+
+    // Activate a run-only toolset
+    registerToolset({
+      id: 'dynamic-run',
+      kind: 'native',
+      name: 'Dynamic Run',
+      description: 'Dynamic run',
+      tools: () => [{ name: 'dyn_tool', description: 'dyn' }],
+      activate: async () => ({ dyn_tool: makeTool('dyn') }),
+    } satisfies Toolset);
+
+    await manager.activate('dynamic-run', { scope: 'current_run' });
+    expect(manager.isActive('dynamic-run')).toBe(true);
+
+    // Advance turn - should expire dynamic-run and persist state to DB
+    manager.advanceTurn();
+
+    const dbState = ToolsetManager.getSessionState(sessionId);
+    expect(dbState.turnCounter).toBe(2);
+    expect(dbState.active).toEqual([{ id: 'hydrated-toolset', scope: 'until_deactivated' }]);
+    expect(dbState.expired).toEqual([{ id: 'dynamic-run', expiredAtTurn: 2, toolNames: ['dyn_tool'] }]);
   });
 });

--- a/packages/server/src/tools/toolsets/manager.ts
+++ b/packages/server/src/tools/toolsets/manager.ts
@@ -1,10 +1,23 @@
+import { eq } from 'drizzle-orm';
+
+import type { PrefixedString } from '@stitch/shared/id';
+
 import { getDisabledAppToolsetIds, isToolsetEnabledByApp } from '@/apps/service.js';
+import { getDb } from '@/db/client.js';
+import { sessions } from '@/db/schema/sessions.js';
 import * as Log from '@/lib/log.js';
-import type { SessionActiveToolset, SessionToolsetScope } from '@/llm/stream/session-toolsets.js';
 import { getDisabledToolIdentifiers, isToolEnabled } from '@/tools/enabled-service.js';
 import { ToolPipeline } from '@/tools/runtime/pipeline.js';
 import type { ToolContext } from '@/tools/runtime/runtime.js';
 import { getToolset, listToolsets } from '@/tools/toolsets/registry.js';
+import { getToolsetSettings } from '@/tools/toolsets/settings.js';
+import {
+  EMPTY_SESSION_TOOLSET_STATE,
+  type SessionActiveToolset,
+  type SessionExpiredToolset,
+  type SessionToolsetScope,
+  type SessionToolsetState,
+} from '@/tools/toolsets/types.js';
 import { toToolsetView, type ToolsetView } from '@/tools/toolsets/view.js';
 import type { Tool } from 'ai';
 
@@ -12,10 +25,43 @@ const log = Log.create({ service: 'toolset-manager' });
 
 type ToolsetActivationEntry = { state: SessionActiveToolset; tools?: Record<string, Tool> };
 
+export type ToolsetManagerOptions = {
+  excludedToolsetIds?: Iterable<string>;
+  turnCounter?: number;
+  expired?: SessionExpiredToolset[];
+  autoPersist?: boolean;
+};
+
+function cloneState(state: SessionToolsetState): SessionToolsetState {
+  return {
+    turnCounter: state.turnCounter,
+    active: state.active.map((entry) => ({ ...entry })),
+    expired: state.expired.map((entry) => ({ ...entry, toolNames: [...entry.toolNames] })),
+  };
+}
+
+function partitionActiveToolsets(
+  active: SessionActiveToolset[],
+  currentTurn: number,
+): { active: SessionActiveToolset[]; expired: SessionActiveToolset[] } {
+  const nextActive: SessionActiveToolset[] = [];
+  const expired: SessionActiveToolset[] = [];
+
+  for (const entry of active) {
+    if (entry.scope === 'ttl_turns' && (entry.expiresAtTurn ?? -1) < currentTurn) {
+      expired.push(entry);
+    } else {
+      nextActive.push(entry);
+    }
+  }
+
+  return { active: nextActive, expired };
+}
+
 /**
  * Per-session manager that tracks which toolsets are currently active.
  * Tools from active toolsets are merged with core tools each step.
- * This is mutable — toolsets can be activated/deactivated between LLM steps.
+ * Owns toolset activations, turn lifecycles, TTL renewals, and persistence.
  */
 export class ToolsetManager {
   private readonly activations = new Map<string, ToolsetActivationEntry>();
@@ -24,17 +70,119 @@ export class ToolsetManager {
 
   private readonly excludedToolsetIds: Set<string>;
 
+  private turnCounter: number;
+
+  private expired: SessionExpiredToolset[];
+
+  private readonly autoPersist: boolean;
+
   constructor(
     context: ToolContext,
     activationState: Iterable<string | SessionActiveToolset> = [],
-    options: { excludedToolsetIds?: Iterable<string> } = {},
+    options: ToolsetManagerOptions = {},
   ) {
     this.context = context;
     this.excludedToolsetIds = new Set(options.excludedToolsetIds ?? []);
+    this.turnCounter = options.turnCounter ?? 0;
+    this.expired = options.expired ? options.expired.map((e) => ({ ...e, toolNames: [...e.toolNames] })) : [];
+    this.autoPersist = options.autoPersist ?? true;
+
     for (const entry of activationState) {
       const state = typeof entry === 'string' ? { id: entry, scope: 'until_deactivated' as const } : entry;
       this.activations.set(state.id, { state });
     }
+  }
+
+  static getToolsetExpiresAtTurn(currentTurn: number, ttlTurns: number): number {
+    return currentTurn + ttlTurns - 1;
+  }
+
+  static getToolNamesForToolset(toolsetId: string): string[] {
+    return (
+      getToolset(toolsetId)
+        ?.tools()
+        .map((tool) => tool.name) ?? []
+    );
+  }
+
+  static getSessionState(sessionId: PrefixedString<'ses'>): SessionToolsetState {
+    const row = getDb()
+      .select({ toolsetState: sessions.toolsetState })
+      .from(sessions)
+      .where(eq(sessions.id, sessionId))
+      .get();
+
+    return cloneState(row?.toolsetState ?? EMPTY_SESSION_TOOLSET_STATE);
+  }
+
+  static setSessionState(sessionId: PrefixedString<'ses'>, state: SessionToolsetState): void {
+    getDb()
+      .update(sessions)
+      .set({ toolsetState: cloneState(state), updatedAt: Date.now() })
+      .where(eq(sessions.id, sessionId))
+      .run();
+  }
+
+  /**
+   * Hydrate and initialize a ToolsetManager instance for a session.
+   * Loads persisted session state, partitions expired toolsets, and restores active tools.
+   */
+  static async forSession(
+    context: ToolContext,
+    options: { initialActiveToolsetIds?: string[]; excludedToolsetIds?: Iterable<string> } = {},
+  ): Promise<ToolsetManager> {
+    const sessionState = ToolsetManager.getSessionState(context.sessionId);
+    const partitioned = partitionActiveToolsets(sessionState.active, sessionState.turnCounter);
+
+    const activeEntries = options.initialActiveToolsetIds
+      ? options.initialActiveToolsetIds.map((id) => ({ id, scope: 'until_deactivated' as const }))
+      : partitioned.active;
+
+    const expiredEntries: SessionExpiredToolset[] = options.initialActiveToolsetIds
+      ? []
+      : [
+          ...sessionState.expired,
+          ...partitioned.expired.map((entry) => ({
+            id: entry.id,
+            expiredAtTurn: sessionState.turnCounter,
+            toolNames: ToolsetManager.getToolNamesForToolset(entry.id),
+          })),
+        ];
+
+    const manager = new ToolsetManager(context, activeEntries, {
+      excludedToolsetIds: options.excludedToolsetIds,
+      turnCounter: sessionState.turnCounter,
+      expired: expiredEntries,
+      autoPersist: true,
+    });
+
+    if (activeEntries.length > 0) {
+      await Promise.all(
+        activeEntries.map(async (entry) => {
+          const result = await manager.activate(entry.id, entry);
+          if (result.status === 'not_found' || result.status === 'disabled') {
+            log.warn(
+              { event: 'toolset.restore.failed', toolsetId: entry.id, reason: result.status },
+              'failed to restore previously active toolset — skipping',
+            );
+          }
+        }),
+      );
+    }
+
+    if (partitioned.expired.length > 0 && !options.initialActiveToolsetIds) {
+      manager.persistState();
+    }
+
+    return manager;
+  }
+
+  getTurnCounter(): number {
+    return this.turnCounter;
+  }
+
+  getExpiredToolsets(): SessionExpiredToolset[] {
+    return this.expired.map((entry) => ({ ...entry, toolNames: [...entry.toolNames] }));
   }
 
   /**
@@ -43,7 +191,7 @@ export class ToolsetManager {
    */
   async activate(
     toolsetId: string,
-    state?: { scope: SessionToolsetScope; expiresAtTurn?: number },
+    state?: { scope?: SessionToolsetScope; expiresAtTurn?: number; persist?: boolean },
   ): Promise<
     | { status: 'activated'; toolNames: string[]; collisions: string[] }
     | { status: 'not_found' }
@@ -51,6 +199,9 @@ export class ToolsetManager {
   > {
     const existing = this.activations.get(toolsetId);
     if (existing?.tools) {
+      if (state) {
+        this.setActivationState(toolsetId, state);
+      }
       return { status: 'activated', toolNames: Object.keys(existing.tools), collisions: [] };
     }
 
@@ -101,8 +252,16 @@ export class ToolsetManager {
       );
     }
 
+    const resolvedScope: SessionToolsetScope =
+      state?.persist === true ? 'until_deactivated' : (state?.scope ?? existing?.state.scope ?? 'current_run');
+    let expiresAtTurn = state?.expiresAtTurn ?? existing?.state.expiresAtTurn;
+    if (resolvedScope === 'ttl_turns' && expiresAtTurn === undefined) {
+      const settings = await getToolsetSettings();
+      expiresAtTurn = ToolsetManager.getToolsetExpiresAtTurn(this.turnCounter, settings.ttlTurns);
+    }
+
     this.activations.set(toolsetId, {
-      state: this.buildActivationState(toolsetId, state ?? existing?.state ?? { scope: 'current_run' }),
+      state: { id: toolsetId, scope: resolvedScope, ...(expiresAtTurn !== undefined && { expiresAtTurn }) },
       tools,
     });
 
@@ -110,6 +269,10 @@ export class ToolsetManager {
       { event: 'toolset.activated', toolsetId, toolCount: Object.keys(tools).length, toolNames: Object.keys(tools) },
       'toolset activated',
     );
+
+    if (this.autoPersist) {
+      this.persistState();
+    }
 
     return { status: 'activated', toolNames: Object.keys(tools), collisions };
   }
@@ -123,6 +286,11 @@ export class ToolsetManager {
     this.activations.delete(toolsetId);
 
     log.info({ event: 'toolset.deactivated', toolsetId }, 'toolset deactivated');
+
+    if (this.autoPersist) {
+      this.persistState();
+    }
+
     return true;
   }
 
@@ -158,13 +326,25 @@ export class ToolsetManager {
       .map(([id, entry]) => ({ id, toolNames: Object.keys(entry.tools) }));
   }
 
-  renewTtlForTool(toolName: string, expiresAtTurn: number): string | null {
+  renewTtlForTool(toolName: string, ttlTurnsOrExpiresAtTurn: number): string | null {
+    if (ttlTurnsOrExpiresAtTurn <= 0) return null;
+
+    const expiresAtTurn =
+      ttlTurnsOrExpiresAtTurn >= this.turnCounter
+        ? ttlTurnsOrExpiresAtTurn
+        : ToolsetManager.getToolsetExpiresAtTurn(this.turnCounter, ttlTurnsOrExpiresAtTurn);
+
     for (const [toolsetId, entry] of this.getActiveEntries()) {
       if (!(toolName in entry.tools)) continue;
 
       if (entry.state.scope !== 'ttl_turns') return null;
 
       this.activations.set(toolsetId, { ...entry, state: { ...entry.state, expiresAtTurn } });
+
+      if (this.autoPersist) {
+        this.persistState();
+      }
+
       return toolsetId;
     }
 
@@ -197,9 +377,80 @@ export class ToolsetManager {
     return this.excludedToolsetIds.has(toolsetId);
   }
 
-  setActivationState(toolsetId: string, state: { scope: SessionToolsetScope; expiresAtTurn?: number }): void {
+  setActivationState(
+    toolsetId: string,
+    state: { scope?: SessionToolsetScope; expiresAtTurn?: number; persist?: boolean },
+  ): void {
     const existing = this.activations.get(toolsetId);
-    this.activations.set(toolsetId, { state: this.buildActivationState(toolsetId, state), tools: existing?.tools });
+    const resolvedScope: SessionToolsetScope =
+      state.persist === true ? 'until_deactivated' : (state.scope ?? existing?.state.scope ?? 'current_run');
+    const expiresAtTurn = state.expiresAtTurn ?? existing?.state.expiresAtTurn;
+
+    this.activations.set(toolsetId, {
+      state: { id: toolsetId, scope: resolvedScope, ...(expiresAtTurn !== undefined && { expiresAtTurn }) },
+      tools: existing?.tools,
+    });
+
+    if (this.autoPersist) {
+      this.persistState();
+    }
+  }
+
+  /**
+   * Advance the session turn counter, roll over single-turn and expired TTL toolsets into expired state,
+   * and persist the resulting state.
+   */
+  advanceTurn(options: { persist?: boolean } = {}): SessionToolsetState {
+    const nextTurnCounter = this.turnCounter + 1;
+    this.turnCounter = nextTurnCounter;
+
+    const nextExpired: SessionExpiredToolset[] = [];
+
+    // Expire current-run toolsets
+    for (const [id, entry] of this.activations.entries()) {
+      const toolNames = entry.tools ? Object.keys(entry.tools) : ToolsetManager.getToolNamesForToolset(id);
+
+      if (entry.state.scope === 'current_run') {
+        nextExpired.push({ id, expiredAtTurn: nextTurnCounter, toolNames });
+        this.activations.delete(id);
+      } else if (entry.state.scope === 'ttl_turns' && (entry.state.expiresAtTurn ?? -1) < nextTurnCounter) {
+        nextExpired.push({ id, expiredAtTurn: nextTurnCounter, toolNames });
+        this.activations.delete(id);
+      }
+    }
+
+    this.expired = [...this.expired, ...nextExpired];
+
+    if (options.persist !== false && this.autoPersist) {
+      this.persistState();
+    }
+
+    return { turnCounter: this.turnCounter, active: this.getPersistableActivationState(), expired: this.expired };
+  }
+
+  /**
+   * Synchronize the current persistable toolset state to SQLite.
+   */
+  persistState(): void {
+    try {
+      const currentState = ToolsetManager.getSessionState(this.context.sessionId);
+      ToolsetManager.setSessionState(this.context.sessionId, {
+        turnCounter: this.turnCounter,
+        active: this.getPersistableActivationState(),
+        expired: [
+          ...currentState.expired.filter((entry) => !this.isActive(entry.id)),
+          ...this.expired.filter((entry) => !this.isActive(entry.id)),
+        ].filter(
+          (entry, index, self) =>
+            index === self.findIndex((e) => e.id === entry.id && e.expiredAtTurn === entry.expiredAtTurn),
+        ),
+      });
+    } catch (error) {
+      log.warn(
+        { event: 'toolset.persist.error', sessionId: this.context.sessionId, error },
+        'failed to persist toolset state',
+      );
+    }
   }
 
   /**
@@ -235,13 +486,6 @@ export class ToolsetManager {
           includeTools: options?.includeTools,
         }),
       );
-  }
-
-  private buildActivationState(
-    toolsetId: string,
-    state: { scope: SessionToolsetScope; expiresAtTurn?: number },
-  ): SessionActiveToolset {
-    return { id: toolsetId, ...state };
   }
 
   private getActiveEntries(): Array<[string, ToolsetActivationEntry & { tools: Record<string, Tool> }]> {

--- a/packages/server/src/tools/toolsets/settings.ts
+++ b/packages/server/src/tools/toolsets/settings.ts
@@ -1,6 +1,6 @@
 import { isDbInitialized } from '@/db/client.js';
-import type { SessionToolsetScope } from '@/llm/stream/session-toolsets.js';
 import { getSettings } from '@/settings/service.js';
+import type { SessionToolsetScope } from '@/tools/toolsets/types.js';
 
 type ToolsetSettings = { defaultScope: SessionToolsetScope; ttlTurns: number };
 

--- a/packages/server/src/tools/toolsets/types.ts
+++ b/packages/server/src/tools/toolsets/types.ts
@@ -16,6 +16,20 @@ export type ToolsetPrompt = {
 
 export type ToolsetKind = 'native' | 'provider' | 'connector' | 'mcp';
 
+export type SessionToolsetScope = 'current_run' | 'ttl_turns' | 'until_deactivated';
+
+export type SessionActiveToolset = { id: string; scope: SessionToolsetScope; expiresAtTurn?: number };
+
+export type SessionExpiredToolset = { id: string; expiredAtTurn: number; toolNames: string[] };
+
+export type SessionToolsetState = {
+  turnCounter: number;
+  active: SessionActiveToolset[];
+  expired: SessionExpiredToolset[];
+};
+
+export const EMPTY_SESSION_TOOLSET_STATE: SessionToolsetState = { turnCounter: 0, active: [], expired: [] };
+
 /**
  * A Toolset is a named group of related tools managed as a single unit.
  * Toolsets can be activated/deactivated dynamically during a session to


### PR DESCRIPTION
## 🚀 Change Summary

Consolidates toolset turn lifecycle, TTL scoping, session state restoration, and SQLite persistence directly inside `ToolsetManager`, turning it into a deep module and eliminating manual state coordination across stream runners and session context assemblers.

### 🛠 Improvements & Refactors
- **Deep ToolsetManager**: Encapsulates `turnCounter`, active toolset instances, and expired toolsets directly within `ToolsetManager`, providing `advanceTurn()`, `renewTtlForTool()`, `forSession()`, and auto-persistence.
- **SessionContext Simplification**: Replaces manual state partitioning and toolset restoration loops in `SessionContext.assemble()` with `ToolsetManager.forSession()`.
- **StreamRunner Cleanup**: Replaces manual next-state calculation and DB updates in `StreamRunner.finalize()` with `toolsetManager.advanceTurn()`.
- **Meta-Tools Persistence**: Removes manual DB synchronization closures in toolset management meta-tools in favor of manager-owned persistence.
- **Type Centralization**: Centralizes session toolset state types in `packages/server/src/tools/toolsets/types.ts`.
