### PR TITLE
fix(web): synchronize appearance themes

### DIFF
--- a/apps/web/src/components/settings/appearance.tsx
+++ b/apps/web/src/components/settings/appearance.tsx
@@ -1,4 +1,5 @@
-import type { AppearanceMode } from '@stitch/shared/appearance/types';
+import { APPEARANCE_THEMES } from '@stitch/shared/appearance/types';
+import type { AppearanceMode, AppearanceTheme } from '@stitch/shared/appearance/types';
 
 import { Stack } from '@/components/primitives/stack';
 import { Text } from '@/components/primitives/text';
@@ -7,14 +8,21 @@ import { SettingPage, SettingSection } from '@/components/settings/settings-ui';
 import { Button } from '@/components/ui/button';
 import { useTheme } from '@/hooks/ui/use-theme';
 
-const APPEARANCE_OPTIONS: { theme: string; mode: AppearanceMode; label: string }[] = [
-  { theme: 'default', mode: 'system', label: 'Default System' },
-  { theme: 'default', mode: 'light', label: 'Default Light' },
-  { theme: 'default', mode: 'dark', label: 'Default Dark' },
-  { theme: 'solarized', mode: 'light', label: 'Solarized Light' },
-  { theme: 'tokyonight', mode: 'dark', label: 'Tokyo Night' },
-  { theme: 'dracula', mode: 'dark', label: 'Dracula' },
-];
+type AppearanceOption = { mode: Exclude<AppearanceMode, 'system'>; label: string };
+
+const APPEARANCE_OPTIONS_BY_THEME = {
+  default: [
+    { mode: 'light', label: 'Default Light' },
+    { mode: 'dark', label: 'Default Dark' },
+  ],
+  solarized: [{ mode: 'light', label: 'Solarized Light' }],
+  tokyonight: [{ mode: 'dark', label: 'Tokyo Night' }],
+  dracula: [{ mode: 'dark', label: 'Dracula' }],
+} satisfies Record<AppearanceTheme, AppearanceOption[]>;
+
+const APPEARANCE_OPTIONS = APPEARANCE_THEMES.flatMap((theme) =>
+  APPEARANCE_OPTIONS_BY_THEME[theme].map((option) => ({ theme, ...option })),
+);
 
 export function AppearanceSettings() {
   const page = SETTINGS_PAGE_BY_ID.appearance;
@@ -34,12 +42,6 @@ export function AppearanceSelector() {
     <SettingSection title="Appearance">
       <div className="grid grid-cols-1 gap-space-m sm:grid-cols-2 lg:grid-cols-3">
         {APPEARANCE_OPTIONS.map((option) => {
-          const previewMode =
-            option.mode === 'system'
-              ? window.matchMedia('(prefers-color-scheme: dark)').matches
-                ? 'dark'
-                : 'light'
-              : option.mode;
           const selected = mode === option.mode && themeName === option.theme;
 
           return (
@@ -55,7 +57,7 @@ export function AppearanceSelector() {
                 setTheme(option.theme);
               }}>
               <Stack width="full" gap="m" padding="m">
-                <ThemePreview theme={option.theme} mode={previewMode} />
+                <ThemePreview theme={option.theme} mode={option.mode} />
                 <Text as="span" variant="body-strong">
                   {option.label}
                 </Text>

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,22 +1,24 @@
-import type { AppearanceMode } from '@stitch/shared/appearance/types';
+import { APPEARANCE_THEMES } from '@stitch/shared/appearance/types';
+import type { AppearanceMode, AppearanceTheme } from '@stitch/shared/appearance/types';
 
 /** Shiki bundled theme ids for each appearance mode. */
 export type CodeTheme = { light: string; dark: string };
 
-type ThemeDefinition = { name: string; label: string; code: CodeTheme };
+type ThemeDefinition = { name: AppearanceTheme; code: CodeTheme };
 
-const THEMES: ThemeDefinition[] = [
-  { name: 'default', label: 'Default', code: { light: 'github-light', dark: 'github-dark' } },
-  { name: 'tokyonight', label: 'Tokyo Night', code: { light: 'tokyo-night', dark: 'tokyo-night' } },
-  { name: 'solarized', label: 'Solarized', code: { light: 'solarized-light', dark: 'solarized-light' } },
-  { name: 'dracula', label: 'Dracula', code: { light: 'dracula', dark: 'dracula' } },
-];
+const THEME_CODE = {
+  default: { light: 'github-light', dark: 'github-dark' },
+  solarized: { light: 'solarized-light', dark: 'solarized-light' },
+  tokyonight: { light: 'tokyo-night', dark: 'tokyo-night' },
+  dracula: { light: 'dracula', dark: 'dracula' },
+} satisfies Record<AppearanceTheme, CodeTheme>;
 
-export const DEFAULT_THEME = 'default';
+export const DEFAULT_THEME: AppearanceTheme = 'default';
 export const DEFAULT_MODE: AppearanceMode = 'system';
 
 export function getTheme(name: string): ThemeDefinition {
-  return THEMES.find((t) => t.name === name) ?? THEMES[0];
+  const resolvedName = APPEARANCE_THEMES.find((theme) => theme === name) ?? DEFAULT_THEME;
+  return { name: resolvedName, code: THEME_CODE[resolvedName] };
 }
 
 const SPLASH_MODE_KEY = 'stitch.appearance.mode';

--- a/packages/shared/src/appearance/types.ts
+++ b/packages/shared/src/appearance/types.ts
@@ -1,3 +1,5 @@
-const APPEARANCE_MODES = ['light', 'dark', 'system'] as const;
+export const APPEARANCE_MODES = ['light', 'dark', 'system'] as const;
+export const APPEARANCE_THEMES = ['default', 'solarized', 'tokyonight', 'dracula'] as const;
 
 export type AppearanceMode = (typeof APPEARANCE_MODES)[number];
+export type AppearanceTheme = (typeof APPEARANCE_THEMES)[number];

--- a/packages/shared/src/settings/types.test.ts
+++ b/packages/shared/src/settings/types.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
+import { APPEARANCE_THEMES } from '../appearance/types.js';
 import { SETTINGS_SCHEMAS, isValidLeaderKeyHotkey } from './types';
 
 describe('SETTINGS_SCHEMAS', () => {
@@ -7,6 +8,12 @@ describe('SETTINGS_SCHEMAS', () => {
     expect(SETTINGS_SCHEMAS['recordings.autoAnalyze'].parse('true')).toBe(true);
     expect(SETTINGS_SCHEMAS['recordings.autoAnalyze'].parse('false')).toBe(false);
     expect(SETTINGS_SCHEMAS['mail.alwaysLoadRemoteImages'].parse('true')).toBe(true);
+  });
+
+  test('accepts every available appearance theme', () => {
+    for (const theme of APPEARANCE_THEMES) {
+      expect(SETTINGS_SCHEMAS['appearance.theme'].parse(theme)).toBe(theme);
+    }
   });
 });
 

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { APPEARANCE_MODES, APPEARANCE_THEMES } from '../appearance/types.js';
+
 const booleanSetting = z.enum(['true', 'false']).transform((value) => value === 'true');
 
 /**
@@ -63,12 +65,12 @@ const SETTINGS_REGISTRY = {
     description: 'Turns of inactivity before a TTL-scoped toolset expires.',
   },
   'appearance.mode': {
-    schema: z.enum(['light', 'dark', 'system']),
+    schema: z.enum(APPEARANCE_MODES),
     default: 'system',
     description: 'Preferred appearance mode: light, dark, or system.',
   },
   'appearance.theme': {
-    schema: z.enum(['default', 'dracula', 'solarized', 'tokyonight']),
+    schema: z.enum(APPEARANCE_THEMES),
     default: 'default',
     description: 'Selected application theme name.',
   },


### PR DESCRIPTION
## 🚀 Change Summary

Centralizes appearance theme and mode definitions so settings validation, theme lookup, and the appearance picker stay synchronized.

### 🛠 Improvements & Refactors
- **Shared Appearance Contracts**: Exposes canonical theme and mode constants with derived types from the shared package.
- **Synchronized Theme Configuration**: Builds settings schemas, code theme lookup, and appearance options from the shared contracts instead of duplicated string lists.
- **Validation Coverage**: Verifies every available appearance theme is accepted by the settings schema.
