### PR TITLE
feat(web): add missing theme modes

### DIFF
--- a/apps/web/public/splash-preload.js
+++ b/apps/web/public/splash-preload.js
@@ -10,9 +10,7 @@
   var FALLBACK_LIGHT = 'oklch(1 0 0)';
   var FALLBACK_DARK = 'oklch(0.145 0 0)';
 
-  var mode = localStorage.getItem('stitch.appearance.mode') || 'system';
-  var prefersDark = matchMedia('(prefers-color-scheme: dark)').matches;
-  var isDark = mode === 'dark' || (mode === 'system' && prefersDark);
+  var isDark = localStorage.getItem('stitch.appearance.mode') === 'dark';
 
   var light = localStorage.getItem('stitch.splash.bg.light') || FALLBACK_LIGHT;
   var dark = localStorage.getItem('stitch.splash.bg.dark') || FALLBACK_DARK;

--- a/apps/web/src/components/desktop-notifications/desktop-notification-root.tsx
+++ b/apps/web/src/components/desktop-notifications/desktop-notification-root.tsx
@@ -2,13 +2,12 @@ import * as React from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 
-import type { AppearanceMode } from '@stitch/shared/appearance/types';
 import type { DesktopNotificationEvent } from '@stitch/shared/ipc/types';
 
 import { MeetingDetectedNotification } from './meeting-detected-notification';
 
 import { settingsQueryOptions } from '@/lib/queries/settings';
-import { applyAppearanceMode, applyTheme, DEFAULT_MODE, DEFAULT_THEME, getTheme } from '@/lib/theme';
+import { applyAppearanceMode, applyTheme, DEFAULT_THEME, getAppearanceMode, getTheme } from '@/lib/theme';
 
 const EXIT_ANIMATION_MS = 220;
 const NOTIFICATION_HASH_PREFIX = '#/desktop-notifications?';
@@ -86,7 +85,7 @@ export function DesktopNotificationRoot() {
 function useDesktopNotificationTheme(): void {
   const { data: settings } = useQuery(settingsQueryOptions);
   const themeName = settings?.['appearance.theme'] ?? DEFAULT_THEME;
-  const mode = (settings?.['appearance.mode'] as AppearanceMode | undefined) ?? DEFAULT_MODE;
+  const mode = getAppearanceMode(settings?.['appearance.mode']);
 
   React.useEffect(() => {
     applyTheme(getTheme(themeName));
@@ -94,12 +93,5 @@ function useDesktopNotificationTheme(): void {
 
   React.useEffect(() => {
     applyAppearanceMode(mode);
-
-    if (mode !== 'system') return;
-
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const handler = () => applyAppearanceMode('system');
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
   }, [mode]);
 }

--- a/apps/web/src/components/mail/message-body.tsx
+++ b/apps/web/src/components/mail/message-body.tsx
@@ -274,21 +274,7 @@ function repairLowContrastText(doc: Document) {
 
 function useIsDarkMode(): boolean {
   const { mode } = useTheme();
-  const [systemIsDark, setSystemIsDark] = React.useState(
-    () => window.matchMedia('(prefers-color-scheme: dark)').matches,
-  );
-
-  React.useEffect(() => {
-    if (mode !== 'system') return;
-
-    const media = window.matchMedia('(prefers-color-scheme: dark)');
-    const update = () => setSystemIsDark(media.matches);
-    update();
-    media.addEventListener('change', update);
-    return () => media.removeEventListener('change', update);
-  }, [mode]);
-
-  return mode === 'dark' || (mode === 'system' && systemIsDark);
+  return mode === 'dark';
 }
 
 function getFrameHeight(contentHeight: number): number {

--- a/apps/web/src/components/settings/appearance.tsx
+++ b/apps/web/src/components/settings/appearance.tsx
@@ -8,16 +8,25 @@ import { SettingPage, SettingSection } from '@/components/settings/settings-ui';
 import { Button } from '@/components/ui/button';
 import { useTheme } from '@/hooks/ui/use-theme';
 
-type AppearanceOption = { mode: Exclude<AppearanceMode, 'system'>; label: string };
+type AppearanceOption = { mode: AppearanceMode; label: string };
 
 const APPEARANCE_OPTIONS_BY_THEME = {
   default: [
-    { mode: 'light', label: 'Default Light' },
-    { mode: 'dark', label: 'Default Dark' },
+    { mode: 'light', label: 'Light' },
+    { mode: 'dark', label: 'Dark' },
   ],
-  solarized: [{ mode: 'light', label: 'Solarized Light' }],
-  tokyonight: [{ mode: 'dark', label: 'Tokyo Night' }],
-  dracula: [{ mode: 'dark', label: 'Dracula' }],
+  solarized: [
+    { mode: 'light', label: 'Solarized Light' },
+    { mode: 'dark', label: 'Solarized Dark' },
+  ],
+  tokyonight: [
+    { mode: 'light', label: 'Tokyo Day' },
+    { mode: 'dark', label: 'Tokyo Night' },
+  ],
+  dracula: [
+    { mode: 'light', label: 'Alucard' },
+    { mode: 'dark', label: 'Dracula' },
+  ],
 } satisfies Record<AppearanceTheme, AppearanceOption[]>;
 
 const APPEARANCE_OPTIONS = APPEARANCE_THEMES.flatMap((theme) =>

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -6,7 +6,6 @@ import { Spinner } from '@/components/ui/spinner';
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
-      theme="system"
       className="toaster group"
       closeButton
       icons={{

--- a/apps/web/src/hooks/ui/use-theme.ts
+++ b/apps/web/src/hooks/ui/use-theme.ts
@@ -5,13 +5,13 @@ import { useSuspenseQuery, useQueryClient, useMutation } from '@tanstack/react-q
 import type { AppearanceMode } from '@stitch/shared/appearance/types';
 
 import { settingsQueryOptions, saveSettingMutationOptions } from '@/lib/queries/settings';
-import { getTheme, applyTheme, applyAppearanceMode, DEFAULT_THEME, DEFAULT_MODE } from '@/lib/theme';
+import { getTheme, getAppearanceMode, applyTheme, applyAppearanceMode, DEFAULT_THEME } from '@/lib/theme';
 
 export function useTheme() {
   const queryClient = useQueryClient();
   const { data: settings } = useSuspenseQuery(settingsQueryOptions);
 
-  const mode = (settings['appearance.mode'] as AppearanceMode | undefined) ?? DEFAULT_MODE;
+  const mode = getAppearanceMode(settings['appearance.mode']);
   const themeName = settings['appearance.theme'] ?? DEFAULT_THEME;
 
   React.useEffect(() => {
@@ -20,13 +20,6 @@ export function useTheme() {
 
   React.useEffect(() => {
     applyAppearanceMode(mode);
-
-    if (mode !== 'system') return;
-
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const handler = () => applyAppearanceMode('system');
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
   }, [mode]);
 
   const saveModeMutation = useMutation(saveSettingMutationOptions('appearance.mode', queryClient, { silent: true }));

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,4 +1,4 @@
-import { APPEARANCE_THEMES } from '@stitch/shared/appearance/types';
+import { APPEARANCE_MODES, APPEARANCE_THEMES } from '@stitch/shared/appearance/types';
 import type { AppearanceMode, AppearanceTheme } from '@stitch/shared/appearance/types';
 
 /** Shiki bundled theme ids for each appearance mode. */
@@ -8,17 +8,21 @@ type ThemeDefinition = { name: AppearanceTheme; code: CodeTheme };
 
 const THEME_CODE = {
   default: { light: 'github-light', dark: 'github-dark' },
-  solarized: { light: 'solarized-light', dark: 'solarized-light' },
-  tokyonight: { light: 'tokyo-night', dark: 'tokyo-night' },
-  dracula: { light: 'dracula', dark: 'dracula' },
+  solarized: { light: 'solarized-light', dark: 'solarized-dark' },
+  tokyonight: { light: 'light-plus', dark: 'tokyo-night' },
+  dracula: { light: 'solarized-light', dark: 'dracula' },
 } satisfies Record<AppearanceTheme, CodeTheme>;
 
 export const DEFAULT_THEME: AppearanceTheme = 'default';
-export const DEFAULT_MODE: AppearanceMode = 'system';
+export const DEFAULT_MODE: AppearanceMode = 'light';
 
 export function getTheme(name: string): ThemeDefinition {
   const resolvedName = APPEARANCE_THEMES.find((theme) => theme === name) ?? DEFAULT_THEME;
   return { name: resolvedName, code: THEME_CODE[resolvedName] };
+}
+
+export function getAppearanceMode(mode: string | undefined): AppearanceMode {
+  return APPEARANCE_MODES.find((candidate) => candidate === mode) ?? DEFAULT_MODE;
 }
 
 const SPLASH_MODE_KEY = 'stitch.appearance.mode';
@@ -64,9 +68,7 @@ export function subscribeCodeTheme(listener: () => void): () => void {
 
 export function applyAppearanceMode(mode: AppearanceMode): void {
   const root = document.documentElement;
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const isDark = mode === 'dark' || (mode === 'system' && prefersDark);
-  root.classList.toggle('dark', isDark);
+  root.classList.toggle('dark', mode === 'dark');
   localStorage.setItem(SPLASH_MODE_KEY, mode);
 }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -3,8 +3,6 @@ import * as React from 'react';
 import type { QueryClient } from '@tanstack/react-query';
 import { createRootRouteWithContext, Outlet, useRouter } from '@tanstack/react-router';
 
-import type { AppearanceMode } from '@stitch/shared/appearance/types';
-
 import { TitleBar } from '@/components/layout/title-bar';
 import { ActivityBar } from '@/components/navigation/activity-bar';
 import { AppSidebar } from '@/components/navigation/app-sidebar';
@@ -24,7 +22,7 @@ import { useActions } from '@/hooks/use-actions';
 import { resetServerUrlCache } from '@/lib/api';
 import { settingsQueryOptions } from '@/lib/queries/settings';
 import { shortcutsQueryOptions } from '@/lib/queries/shortcuts';
-import { applyAppearanceMode, applyTheme, DEFAULT_MODE, DEFAULT_THEME, getTheme, removeSplash } from '@/lib/theme';
+import { applyAppearanceMode, applyTheme, DEFAULT_THEME, getAppearanceMode, getTheme, removeSplash } from '@/lib/theme';
 
 interface RouterContext {
   queryClient: QueryClient;
@@ -42,7 +40,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 function RootLayout() {
   const actions = useActions();
   useGlobalHotkeys(actions);
-  useTheme();
+  const { mode } = useTheme();
 
   React.useEffect(() => {
     // Wait two frames so the themed first paint lands before the splash fades,
@@ -84,7 +82,7 @@ function RootLayout() {
       <CommandPalette actions={actions} />
       <OnboardingDialog />
       <RenameSessionDialog />
-      <Toaster position="bottom-right" />
+      <Toaster position="bottom-right" theme={mode} />
     </SidebarProvider>
   );
 }
@@ -100,7 +98,7 @@ function ServerConnectionSync() {
         router.options.context.queryClient.clear();
         const settings = await router.options.context.queryClient.ensureQueryData(settingsQueryOptions);
         applyTheme(getTheme(settings['appearance.theme'] ?? DEFAULT_THEME));
-        applyAppearanceMode((settings['appearance.mode'] as AppearanceMode | undefined) ?? DEFAULT_MODE);
+        applyAppearanceMode(getAppearanceMode(settings['appearance.mode']));
         void router.invalidate();
       });
 

--- a/apps/web/src/styles/themes.css
+++ b/apps/web/src/styles/themes.css
@@ -128,6 +128,49 @@
   --sidebar-ring: oklch(0.619 0.093 264.2);
 }
 
+:root[data-theme='tokyonight'],
+[data-theme='tokyonight'][data-theme-mode='light'] {
+  --background: #e1e2e7;
+  --foreground: #3760bf;
+  --card: #e9e9ed;
+  --card-foreground: #3760bf;
+  --popover: #e9e9ed;
+  --popover-foreground: #3760bf;
+  --primary: #2e7de9;
+  --primary-foreground: #ffffff;
+  --secondary: #d4d6e4;
+  --secondary-foreground: #3760bf;
+  --muted: #d4d6e4;
+  --muted-foreground: #6172b0;
+  --accent: #c4c8da;
+  --accent-foreground: #3760bf;
+  --destructive: #c64343;
+  --destructive-foreground: #ffffff;
+  --success: #587539;
+  --success-foreground: #ffffff;
+  --warning: #8c6c3e;
+  --warning-foreground: #ffffff;
+  --info: #007197;
+  --info-foreground: #ffffff;
+  --border: #b7b9c9;
+  --input: #b7b9c9;
+  --ring: #2e7de9;
+  --chart-1: #2e7de9;
+  --chart-2: #587539;
+  --chart-3: #007197;
+  --chart-4: #8c6c3e;
+  --chart-5: #9854f1;
+  --chart-6: #b15c00;
+  --sidebar: #d4d6e4;
+  --sidebar-foreground: #3760bf;
+  --sidebar-primary: #2e7de9;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #c4c8da;
+  --sidebar-accent-foreground: #3760bf;
+  --sidebar-border: #b7b9c9;
+  --sidebar-ring: #2e7de9;
+}
+
 :root[data-theme='solarized'],
 [data-theme='solarized'][data-theme-mode='light'] {
   --radius: 0.5rem;
@@ -170,6 +213,93 @@
   --sidebar-accent-foreground: oklch(0.474 0.017 219.1);
   --sidebar-border: oklch(0.894 0.039 90.1);
   --sidebar-ring: oklch(0.715 0.098 244.9);
+}
+
+:root.dark[data-theme='solarized'],
+[data-theme='solarized'][data-theme-mode='dark'] {
+  --radius: 0.5rem;
+  --background: #002b36;
+  --foreground: #839496;
+  --card: #073642;
+  --card-foreground: #93a1a1;
+  --popover: #073642;
+  --popover-foreground: #93a1a1;
+  --primary: #268bd2;
+  --primary-foreground: #002b36;
+  --secondary: #073642;
+  --secondary-foreground: #93a1a1;
+  --muted: #073642;
+  --muted-foreground: #657b83;
+  --accent: #0b4654;
+  --accent-foreground: #93a1a1;
+  --destructive: #dc322f;
+  --destructive-foreground: #fdf6e3;
+  --success: #859900;
+  --success-foreground: #002b36;
+  --warning: #b58900;
+  --warning-foreground: #002b36;
+  --info: #2aa198;
+  --info-foreground: #002b36;
+  --border: #174b57;
+  --input: #174b57;
+  --ring: #268bd2;
+  --chart-1: #268bd2;
+  --chart-2: #859900;
+  --chart-3: #2aa198;
+  --chart-4: #b58900;
+  --chart-5: #d33682;
+  --chart-6: #6c71c4;
+  --sidebar: #00252e;
+  --sidebar-foreground: #839496;
+  --sidebar-primary: #268bd2;
+  --sidebar-primary-foreground: #002b36;
+  --sidebar-accent: #073642;
+  --sidebar-accent-foreground: #93a1a1;
+  --sidebar-border: #174b57;
+  --sidebar-ring: #268bd2;
+}
+
+:root[data-theme='dracula'],
+[data-theme='dracula'][data-theme-mode='light'] {
+  --background: #fffbeb;
+  --foreground: #1f1f1f;
+  --card: #ffffff;
+  --card-foreground: #1f1f1f;
+  --popover: #ffffff;
+  --popover-foreground: #1f1f1f;
+  --primary: #644ac9;
+  --primary-foreground: #ffffff;
+  --secondary: #ece9df;
+  --secondary-foreground: #1f1f1f;
+  --muted: #efeddc;
+  --muted-foreground: #6c664b;
+  --accent: #dedccf;
+  --accent-foreground: #1f1f1f;
+  --destructive: #cb3a2a;
+  --destructive-foreground: #ffffff;
+  --success: #14710a;
+  --success-foreground: #ffffff;
+  --warning: #846e15;
+  --warning-foreground: #ffffff;
+  --info: #036a96;
+  --info-foreground: #ffffff;
+  --border: #ceccc0;
+  --input: #ceccc0;
+  --ring: #644ac9;
+  --chart-1: #644ac9;
+  --chart-2: #14710a;
+  --chart-3: #036a96;
+  --chart-4: #846e15;
+  --chart-5: #a3144d;
+  --chart-6: #a34d14;
+  --sidebar: #ece9df;
+  --sidebar-foreground: #1f1f1f;
+  --sidebar-primary: #644ac9;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #dedccf;
+  --sidebar-accent-foreground: #1f1f1f;
+  --sidebar-border: #ceccc0;
+  --sidebar-ring: #644ac9;
 }
 
 :root.dark[data-theme='dracula'],

--- a/packages/shared/src/appearance/types.ts
+++ b/packages/shared/src/appearance/types.ts
@@ -1,4 +1,4 @@
-export const APPEARANCE_MODES = ['light', 'dark', 'system'] as const;
+export const APPEARANCE_MODES = ['light', 'dark'] as const;
 export const APPEARANCE_THEMES = ['default', 'solarized', 'tokyonight', 'dracula'] as const;
 
 export type AppearanceMode = (typeof APPEARANCE_MODES)[number];

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -66,8 +66,8 @@ const SETTINGS_REGISTRY = {
   },
   'appearance.mode': {
     schema: z.enum(APPEARANCE_MODES),
-    default: 'system',
-    description: 'Preferred appearance mode: light, dark, or system.',
+    default: 'light',
+    description: 'Preferred appearance mode: light or dark.',
   },
   'appearance.theme': {
     schema: z.enum(APPEARANCE_THEMES),


### PR DESCRIPTION
## 🚀 Change Summary

Adds complete light and dark variants for every appearance theme and makes explicit theme modes consistent across the app, notifications, email rendering, syntax highlighting, toasts, and the splash screen.

### ✨ New Features
- **Complete Theme Variants**: Adds Solarized Dark, Tokyo Day, and Alucard alongside the existing light and dark themes.

### 🛠 Improvements & Refactors
- **Explicit Light and Dark Modes**: Removes the system mode and consistently resolves persisted appearance values to light or dark.
- **Unified Theme Rendering**: Aligns application chrome, desktop notifications, email content, syntax highlighting, toasts, and splash colors with the selected mode.
