### PR TITLE
fix(web): separate main content from chrome

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -67,7 +67,7 @@ function RootLayout() {
           <RightClickMenu>
             <div className="relative flex flex-1 overflow-hidden bg-sidebar">
               <AppSidebar />
-              <SidebarInset className="overflow-hidden border-l border-border-subtle bg-muted shadow-sm peer-data-[state=expanded]:rounded-tl-2xl">
+              <SidebarInset className="overflow-hidden border-t border-border bg-muted shadow-sm peer-data-[state=expanded]:rounded-tl-2xl peer-data-[state=expanded]:border-l">
                 <ServerEventSync />
                 <RecordingEventListener />
                 <UpdaterSync />


### PR DESCRIPTION
## 🚀 Change Summary

Improves visual separation between the main content surface and surrounding application chrome.

### 🐛 Bug Fixes
- **Content Boundary**: Adds a top border in all sidebar states and keeps the left border when the sidebar is expanded.
