### PR TITLE
fix(web): disable view transition on chat switch

### DIFF
--- a/apps/web/src/components/chat/chat-sidebar.tsx
+++ b/apps/web/src/components/chat/chat-sidebar.tsx
@@ -116,7 +116,6 @@ export function ChatSidebarContent() {
                       <Link
                         to="/session/$id"
                         params={{ id: session.id }}
-                        viewTransition
                         className="flex items-center gap-space-m truncate pr-space-3xl"
                       />
                     }>


### PR DESCRIPTION
## 🚀 Change Summary

Disables view transitions when switching between chat sessions in the sidebar to prevent visual artifacts and ensure immediate chat navigation.

### 🐛 Bug Fixes
- **Chat Switching Transitions**: Removed view transition animation when navigating between chat sessions from the sidebar.
