### PR TITLE
fix(desktop): stabilize capture restarter tests

### DIFF
--- a/apps/desktop/src/main/capture-restart.test.ts
+++ b/apps/desktop/src/main/capture-restart.test.ts
@@ -1,14 +1,29 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, jest, test } from 'bun:test';
 
 import { createCaptureRestarter } from './capture-restart.js';
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+async function flushAsyncWork(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
+async function advanceTime(ms: number): Promise<void> {
+  jest.advanceTimersByTime(ms);
+  await flushAsyncWork();
 }
 
 const FAST = { debounceMs: 10, backoffMs: 5 };
 
 describe('createCaptureRestarter', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   test('debounces bursts of triggers into a single restart', async () => {
     let restarts = 0;
     const restarter = createCaptureRestarter({
@@ -22,14 +37,16 @@ describe('createCaptureRestarter', () => {
     restarter.trigger();
     restarter.trigger();
     restarter.trigger();
-    await sleep(30);
+    await advanceTime(FAST.debounceMs - 1);
+    expect(restarts).toBe(0);
 
+    await advanceTime(1);
     expect(restarts).toBe(1);
   });
 
   test('retries with backoff and gives up after maxAttempts', async () => {
     let restarts = 0;
-    const gaveUp: string[] = [];
+    const errors: string[] = [];
     const restarter = createCaptureRestarter({
       ...FAST,
       maxAttempts: 3,
@@ -38,15 +55,17 @@ describe('createCaptureRestarter', () => {
         throw new Error('device busy');
       },
       onGiveUp: (message) => {
-        gaveUp.push(message);
+        errors.push(message);
       },
     });
 
     restarter.trigger();
-    await sleep(100);
+    await advanceTime(FAST.debounceMs);
+    await advanceTime(FAST.backoffMs);
+    await advanceTime(FAST.backoffMs * 2);
 
     expect(restarts).toBe(3);
-    expect(gaveUp).toEqual(['device busy']);
+    expect(errors).toEqual(['device busy']);
   });
 
   test('a successful restart resets the attempt budget', async () => {
@@ -57,7 +76,6 @@ describe('createCaptureRestarter', () => {
       maxAttempts: 2,
       restart: async () => {
         calls += 1;
-        // Fail every first attempt, succeed on the retry.
         if (calls % 2 === 1) {
           throw new Error('transient');
         }
@@ -68,15 +86,19 @@ describe('createCaptureRestarter', () => {
     });
 
     restarter.trigger();
-    await sleep(50);
+    await advanceTime(FAST.debounceMs);
+    await advanceTime(FAST.backoffMs);
+    expect(calls).toBe(2);
+
     restarter.trigger();
-    await sleep(50);
+    await advanceTime(FAST.debounceMs);
+    await advanceTime(FAST.backoffMs);
 
     expect(calls).toBe(4);
     expect(gaveUp).toBe(false);
   });
 
-  test('cancel prevents a scheduled restart', async () => {
+  test('cancel clears scheduled restarts and ignores future triggers', async () => {
     let restarts = 0;
     const restarter = createCaptureRestarter({
       ...FAST,
@@ -88,30 +110,14 @@ describe('createCaptureRestarter', () => {
 
     restarter.trigger();
     restarter.cancel();
-    await sleep(30);
-
-    expect(restarts).toBe(0);
-  });
-
-  test('ignores triggers after cancel', async () => {
-    let restarts = 0;
-    const restarter = createCaptureRestarter({
-      ...FAST,
-      restart: async () => {
-        restarts += 1;
-      },
-      onGiveUp: () => {},
-    });
-
-    restarter.cancel();
     restarter.trigger();
-    await sleep(30);
+    await advanceTime(FAST.debounceMs);
 
     expect(restarts).toBe(0);
   });
 
   test('a trigger during an in-flight restart schedules a follow-up restart', async () => {
-    let restarts = 0;
+    let calls = 0;
     let release: () => void = () => {};
     const firstRestartGate = new Promise<void>((resolve) => {
       release = resolve;
@@ -119,8 +125,8 @@ describe('createCaptureRestarter', () => {
     const restarter = createCaptureRestarter({
       ...FAST,
       restart: async () => {
-        restarts += 1;
-        if (restarts === 1) {
+        calls += 1;
+        if (calls === 1) {
           await firstRestartGate;
         }
       },
@@ -128,13 +134,14 @@ describe('createCaptureRestarter', () => {
     });
 
     restarter.trigger();
-    await sleep(20);
-    expect(restarts).toBe(1);
+    await advanceTime(FAST.debounceMs);
+    expect(calls).toBe(1);
 
     restarter.trigger();
     release();
-    await sleep(30);
+    await flushAsyncWork();
+    await advanceTime(FAST.debounceMs);
 
-    expect(restarts).toBe(2);
+    expect(calls).toBe(2);
   });
 });


### PR DESCRIPTION
## 🚀 Change Summary

Makes the capture restarter tests deterministic across platforms by replacing wall-clock sleeps with Bun fake timers and explicit async work flushing.

### 🐛 Bug Fixes

- Prevents Windows CI failures caused by delayed retry timers.
- Consolidates overlapping cancellation coverage while preserving the restarter state-machine behaviors.
