### PR TITLE
improvement(code-mode): limit sandbox resources

### DIFF
--- a/packages/sandbox/src/process-driver.ts
+++ b/packages/sandbox/src/process-driver.ts
@@ -123,13 +123,13 @@ async function dispatchToolCall(
  */
 export function createProcessSandbox(driverOptions: SandboxProcessDriverOptions): IsolateDriver {
   const execPath = driverOptions.execPath;
-  const memoryLimitMB = driverOptions.memoryLimit ?? DEFAULT_MEMORY_LIMIT_MB;
-  const memoryLimitBytes = memoryLimitMB * 1024 * 1024;
   const isScript = /\.[mc]?[jt]sx?$/.test(execPath);
   const cmd = isScript ? [process.execPath, '--smol', execPath] : [execPath];
 
   return {
     async createContext(bindings: Record<string, ToolBinding>, options: IsolateOptions = {}): Promise<IsolateContext> {
+      const memoryLimitMB = options.memoryLimit ?? driverOptions.memoryLimit ?? DEFAULT_MEMORY_LIMIT_MB;
+      const memoryLimitBytes = memoryLimitMB * 1024 * 1024;
       const timeoutMs = options.timeout ?? DEFAULT_TIMEOUT_MS;
       const maxToolCalls = options.maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS;
       const maxMessageBytes = options.maxMessageBytes ?? DEFAULT_MAX_MESSAGE_BYTES;

--- a/packages/sandbox/src/sandbox.test.ts
+++ b/packages/sandbox/src/sandbox.test.ts
@@ -120,8 +120,8 @@ describe('process sandbox', () => {
   });
 
   test('kills process when memory limit is exceeded', async () => {
-    const driver = createProcessSandbox({ execPath: PROCESS_ENTRY, memoryLimit: 64 });
-    const context = await driver.createContext({}, { timeout: 15_000 });
+    const driver = createProcessSandbox({ execPath: PROCESS_ENTRY });
+    const context = await driver.createContext({}, { memoryLimit: 64, timeout: 15_000 });
     try {
       const result = await context.execute(`
         const arrays = [];

--- a/packages/sandbox/src/types.ts
+++ b/packages/sandbox/src/types.ts
@@ -22,6 +22,8 @@ export type SandboxProcessDriverOptions = {
 };
 
 export type IsolateOptions = {
+  /** Memory limit in MB (default: driver limit or 512) */
+  memoryLimit?: number;
   /** Execution timeout in ms, excluding time spent waiting for tool calls (default: 30_000) */
   timeout?: number;
   /** AbortSignal to cancel execution and all in-flight tool calls */

--- a/packages/server/src/code-mode/tool.test.ts
+++ b/packages/server/src/code-mode/tool.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import type { IsolateDriver } from '@stitch/sandbox';
+import type { IsolateDriver, IsolateOptions } from '@stitch/sandbox';
 
 import { createCodeModeTool, serializeIsolateOutput } from '@/code-mode/tool.js';
 
@@ -57,6 +57,36 @@ describe('serializeIsolateOutput', () => {
 });
 
 describe('createCodeModeTool', () => {
+  test('applies resource limits while preserving isolate option overrides', async () => {
+    const createdOptions: IsolateOptions[] = [];
+    const driver: IsolateDriver = {
+      createContext: async (_bindings, options) => {
+        createdOptions.push(options ?? {});
+        return { execute: async () => ({ ok: true, result: true, logs: [] }), dispose: () => {} };
+      },
+    };
+    const { tool: defaultTool } = createCodeModeTool({ getTools: () => ({}), driver });
+    const { tool: overriddenTool } = createCodeModeTool({
+      getTools: () => ({}),
+      driver,
+      isolateOptions: { memoryLimit: 256, timeout: 45_000 },
+    });
+
+    await defaultTool.execute?.(
+      { code: 'return true;', description: 'run with default limits' },
+      { toolCallId: 'call-default-limits', messages: [] },
+    );
+    await overriddenTool.execute?.(
+      { code: 'return true;', description: 'run with custom limits' },
+      { toolCallId: 'call-custom-limits', messages: [] },
+    );
+
+    expect(createdOptions).toEqual([
+      expect.objectContaining({ memoryLimit: 128, timeout: 30_000 }),
+      expect.objectContaining({ memoryLimit: 256, timeout: 45_000 }),
+    ]);
+  });
+
   test('throws on invalid syntax without creating a sandbox context', () => {
     const driver: IsolateDriver = {
       createContext: () => {

--- a/packages/server/src/code-mode/tool.ts
+++ b/packages/server/src/code-mode/tool.ts
@@ -16,6 +16,7 @@ import { truncateOutput } from '@/tools/runtime/truncation.js';
 import type { Tool } from 'ai';
 
 const log = Log.create({ service: 'code-mode' });
+const DEFAULT_CODE_MODE_ISOLATE_OPTIONS: IsolateOptions = { memoryLimit: 128, timeout: 30_000 };
 
 function getDefaultDriver(): IsolateDriver {
   const sandboxExecPath = process.env['SANDBOX_EXEC_PATH'];
@@ -40,7 +41,7 @@ type CodeModeToolResult = { tool: Tool; getSystemPrompt: () => string };
 
 export function createCodeModeTool(options: CodeModeOptions): CodeModeToolResult {
   const driver = options.driver ?? getDefaultDriver();
-  const isolateOptions = options.isolateOptions ?? {}; // TODO: Bun1.4 Upgrade allows these now, use sensible defaults
+  const isolateOptions = { ...DEFAULT_CODE_MODE_ISOLATE_OPTIONS, ...options.isolateOptions };
 
   const getFilteredTools = () => applyToolFilter(options.getTools());
 


### PR DESCRIPTION
## Change Summary

Constrains code-mode execution with explicit memory and CPU-time defaults now that the stack runs on Bun 1.4.

### Improvements & Refactors

- Limits each code-mode isolate to 128 MB and 30 seconds of active execution by default.
- Supports per-isolate memory overrides while retaining the sandbox driver's fallback limit.
- Verifies default and overridden limits, including termination of runaway allocations.
