### PR TITLE
fix(web): preload session route from home

### DIFF
--- a/apps/web/src/components/home/new-session-page.tsx
+++ b/apps/web/src/components/home/new-session-page.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 import type { InfiniteData } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useRouter } from '@tanstack/react-router';
 
 import type { MessagesPage, Session } from '@stitch/shared/chat/messages';
 import { createMessageId } from '@stitch/shared/id';
@@ -19,6 +19,7 @@ import { useStreamStore } from '@/stores/stream-store';
 
 export function NewSessionPage() {
   const navigate = useNavigate();
+  const router = useRouter();
   const queryClient = useQueryClient();
   const createSession = useCreateSession();
   const sendMessage = useSendMessage();
@@ -27,6 +28,10 @@ export function NewSessionPage() {
   const [value, setValue] = React.useState('');
 
   const { selectedModel, handleModelChange } = useChatModel();
+
+  React.useEffect(() => {
+    void router.loadRouteChunk(router.routesByPath['/session/$id']);
+  }, [router]);
 
   const isSubmitting = createSession.isPending || sendMessage.isPending;
 


### PR DESCRIPTION
## Change Summary

Preloads the code-split session route while the home page is open, removing the extra route-chunk fetch from the first chat navigation without starting session data requests early.

### Bug Fixes

- Reduce the delay when opening the first chat after app startup by loading the session page code before submission.
