### PR TITLE
feat(memory): deepen file-store module

### DIFF
--- a/packages/server/src/memory/capacity-adapter.ts
+++ b/packages/server/src/memory/capacity-adapter.ts
@@ -1,0 +1,17 @@
+import type { MemoryCapacity, MemoryTarget } from '@stitch/shared/memory/types';
+import { MemoryCapacityError } from './file-store.js';
+
+export class MemoryCapacityTracker {
+  capacityFor(content: string, limit: number): MemoryCapacity {
+    const used = content
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('<!-- stitch-memory '))
+      .join('\n').length;
+    return { used, limit, remaining: Math.max(0, limit - used) };
+  }
+
+  assertCapacity(content: string, target: MemoryTarget, limits: { memory: number; user: number }): void {
+    const capacity = this.capacityFor(content, target === 'memory' ? limits.memory : limits.user);
+    if (capacity.used > capacity.limit) throw new MemoryCapacityError(capacity);
+  }
+}

--- a/packages/server/src/memory/consolidation.test.ts
+++ b/packages/server/src/memory/consolidation.test.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import type { ManagedMemoryEntry, MemoryFileSnapshot } from '@stitch/shared/memory/types';
 
 import { consolidateMemories, validateConsolidationProposal } from '@/memory/consolidation.js';
-import { MemoryConflictError, MemoryFileStore } from '@/memory/file-store.js';
+import { MemoryConflictError, MemoryStore } from '@/memory/file-store.js';
 import { filterCaptureCandidates } from '@/memory/processor.js';
 
 const roots: string[] = [];
@@ -15,7 +15,7 @@ const NOW = new Date('2026-08-04T12:00:00.000Z');
 async function createStore(options: { memoryCharLimit?: number } = {}) {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), 'stitch-consolidation-'));
   roots.push(rootDir);
-  return new MemoryFileStore({ rootDir, now: () => NOW, ...options });
+  return new MemoryStore({ rootDir, now: () => NOW, ...options });
 }
 
 afterEach(async () => {

--- a/packages/server/src/memory/consolidation.ts
+++ b/packages/server/src/memory/consolidation.ts
@@ -11,7 +11,7 @@ import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
 import { createProvider } from '@/llm/provider/provider.js';
 import { resolveCheapModel } from '@/llm/resolve-cheap-model.js';
-import { memoryFileStore, type CuratedEntryInput, type MemoryFileStore } from '@/memory/file-store.js';
+import { MemoryStore, memoryFileStore, type CuratedEntryInput } from '@/memory/file-store.js';
 import { buildConsolidationPrompt, consolidationSchema, type ConsolidationProposal } from '@/memory/prompts.js';
 
 const log = Log.create({ service: 'memory-consolidation' });
@@ -126,7 +126,7 @@ export function validateConsolidationProposal(input: ValidationInput): {
 }
 
 async function eligibleCandidates(
-  store: MemoryFileStore,
+  store: MemoryStore,
   checkpoint: ConsolidationCheckpoint | null,
   curatedIds: Set<string>,
   maxCandidates: number,
@@ -195,7 +195,7 @@ function auditMarkdown(result: MemoryConsolidationResult): string {
 }
 
 async function recordRejected(
-  store: MemoryFileStore,
+  store: MemoryStore,
   result: MemoryConsolidationResult,
 ): Promise<MemoryConsolidationResult> {
   await store
@@ -206,7 +206,7 @@ async function recordRejected(
 
 export async function consolidateMemories(
   options: {
-    store?: MemoryFileStore;
+    store?: MemoryStore;
     maxCandidates?: number;
     propose?: (prompt: string) => Promise<ConsolidationProposal>;
   } = {},

--- a/packages/server/src/memory/file-lock-adapter.ts
+++ b/packages/server/src/memory/file-lock-adapter.ts
@@ -1,0 +1,20 @@
+export class MemoryFileLockAdapter {
+  private readonly queues = new Map<string, Promise<void>>();
+
+  async withFileLock<T>(name: string, action: () => Promise<T>): Promise<T> {
+    const previous = this.queues.get(name) ?? Promise.resolve();
+    let release = (): void => undefined;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.then(() => current);
+    this.queues.set(name, queued);
+    await previous;
+    try {
+      return await action();
+    } finally {
+      release();
+      if (this.queues.get(name) === queued) this.queues.delete(name);
+    }
+  }
+}

--- a/packages/server/src/memory/file-store.test.ts
+++ b/packages/server/src/memory/file-store.test.ts
@@ -3,22 +3,22 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { MemoryCapacityError, MemoryConflictError, MemoryFileStore, MemoryPathError } from '@/memory/file-store.js';
+import { MemoryCapacityError, MemoryConflictError, MemoryStore, MemoryPathError } from '@/memory/file-store.js';
 
 const roots: string[] = [];
 const NOW = new Date('2026-08-04T12:00:00.000Z');
 
-async function createStore(options: { memoryCharLimit?: number } = {}): Promise<MemoryFileStore> {
+async function createStore(options: { memoryCharLimit?: number } = {}): Promise<MemoryStore> {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), 'stitch-memory-'));
   roots.push(rootDir);
-  return new MemoryFileStore({ rootDir, now: () => NOW, ...options });
+  return new MemoryStore({ rootDir, now: () => NOW, ...options });
 }
 
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
-describe('MemoryFileStore', () => {
+describe('MemoryStore', () => {
   test('creates empty canonical files lazily', async () => {
     const store = await createStore();
 

--- a/packages/server/src/memory/file-store.ts
+++ b/packages/server/src/memory/file-store.ts
@@ -13,6 +13,10 @@ import type {
   MemoryTarget,
 } from '@stitch/shared/memory/types';
 
+import { MemoryCapacityTracker } from './capacity-adapter.js';
+import { MemoryFileLockAdapter } from './file-lock-adapter.js';
+import { MemoryParser } from './parser-adapter.js';
+
 import { PATHS } from '@/lib/paths.js';
 
 const MEMORY_TEMPLATE = '# Long-term memory\n';
@@ -25,15 +29,11 @@ const FILE_TEMPLATES: Record<MemoryFileName, string> = {
   'USER.md': USER_TEMPLATE,
   'DREAMS.md': DREAMS_TEMPLATE,
 };
-const METADATA_PATTERN =
-  /^<!-- stitch-memory id="([^"]+)" observed="(\d{4}-\d{2}-\d{2})" origin="(user|agent|automation|system)" source="([^"]*)"(?: target="(memory|user)")? -->$/;
 const DAILY_PATH_PATTERN = /^daily\/(\d{4}-\d{2}-\d{2})\.md$/;
 
 class MemoryStoreError extends Error {}
 
 export class MemoryConflictError extends MemoryStoreError {}
-
-class MemoryParseError extends MemoryConflictError {}
 
 export class MemoryCapacityError extends MemoryStoreError {
   readonly capacity: MemoryCapacity;
@@ -46,7 +46,7 @@ export class MemoryCapacityError extends MemoryStoreError {
 
 export class MemoryPathError extends MemoryStoreError {}
 
-type ParsedDocument = { entries: ManagedMemoryEntry[]; modelContent: string };
+export class MemoryParseError extends MemoryConflictError {}
 
 type FileStoreOptions = { rootDir?: string; memoryCharLimit?: number; userCharLimit?: number; now?: () => Date };
 
@@ -65,61 +65,6 @@ function hashContent(content: string): string {
   return createHash('sha256').update(content).digest('hex');
 }
 
-function visibleContent(content: string): string {
-  return content
-    .split('\n')
-    .filter((line) => !line.trimStart().startsWith('<!-- stitch-memory '))
-    .join('\n');
-}
-
-function capacityFor(content: string, limit: number): MemoryCapacity {
-  const used = visibleContent(content).length;
-  return { used, limit, remaining: Math.max(0, limit - used) };
-}
-
-function parseDocument(content: string, filePath: string, defaultTarget: MemoryTarget): ParsedDocument {
-  const lines = content.split('\n');
-  const entries: ManagedMemoryEntry[] = [];
-  const ids = new Set<string>();
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? '';
-    if (!line.startsWith('<!-- stitch-memory ')) continue;
-
-    const metadata = METADATA_PATTERN.exec(line);
-    const item = lines[index + 1] as string | undefined;
-    if (!metadata || !item?.startsWith('- ')) {
-      throw new MemoryParseError(`Managed memory block is malformed at ${filePath}:${index + 1}`);
-    }
-
-    const [, id = '', observed = '', origin = 'system', source = '', targetValue] = metadata;
-    if (ids.has(id)) throw new MemoryParseError(`Duplicate memory entry id: ${id}`);
-    ids.add(id);
-
-    let endIndex = index + 1;
-    const contentLines = [item.slice(2)];
-    while (endIndex + 1 < lines.length && /^(?: {2,}|\t)/.test(lines[endIndex + 1] ?? '')) {
-      endIndex += 1;
-      contentLines.push((lines[endIndex] ?? '').replace(/^(?: {2}|\t)/, ''));
-    }
-
-    entries.push({
-      id,
-      content: contentLines.join('\n'),
-      origin: origin as MemoryOrigin,
-      observed,
-      source,
-      target: (targetValue as MemoryTarget | undefined) ?? defaultTarget,
-      filePath,
-      lineStart: index + 1,
-      lineEnd: endIndex + 1,
-    });
-    index = endIndex;
-  }
-
-  return { entries, modelContent: visibleContent(content) };
-}
-
 function serializeEntry(entry: AddEntry): string {
   const id = entry.id ?? `mem_${randomUUID().replaceAll('-', '')}`;
   const observed = entry.observed ?? new Date().toISOString().slice(0, 10);
@@ -135,12 +80,14 @@ function replaceEntryBlock(raw: string, entry: ManagedMemoryEntry, replacement: 
   return lines.join('\n');
 }
 
-export class MemoryFileStore {
+export class MemoryStore {
   readonly rootDir: string;
   memoryCharLimit: number;
   userCharLimit: number;
   private readonly now: () => Date;
-  private readonly queues = new Map<string, Promise<void>>();
+  private readonly parser = new MemoryParser();
+  private readonly capacityTracker = new MemoryCapacityTracker();
+  private readonly fileLock = new MemoryFileLockAdapter();
 
   constructor(options: FileStoreOptions = {}) {
     this.rootDir = path.resolve(options.rootDir ?? PATHS.dirPaths.memory);
@@ -184,7 +131,7 @@ export class MemoryFileStore {
     const absolutePath = await this.resolveAllowedPath(relativePath);
     const [rawContent, fileStat] = await Promise.all([readFile(absolutePath, 'utf8'), stat(absolutePath)]);
     const defaultTarget = relativePath === 'USER.md' ? 'user' : 'memory';
-    const parsed = parseDocument(rawContent, relativePath.replaceAll('\\', '/'), defaultTarget);
+    const parsed = this.parser.parseDocument(rawContent, relativePath.replaceAll('\\', '/'), defaultTarget);
     const limit =
       relativePath === 'MEMORY.md' ? this.memoryCharLimit : relativePath === 'USER.md' ? this.userCharLimit : null;
 
@@ -196,13 +143,13 @@ export class MemoryFileStore {
       contentHash: hashContent(rawContent),
       mtime: fileStat.mtime.toISOString(),
       entries: parsed.entries,
-      capacity: limit === null ? null : capacityFor(rawContent, limit),
+      capacity: limit === null ? null : this.capacityTracker.capacityFor(rawContent, limit),
       truncated: false,
     };
   }
 
   async mutate(target: MemoryTarget, operations: MemoryMutation[], expectedHash?: string): Promise<MemoryFileSnapshot> {
-    return this.withFileLock(CURATED_NAMES[target], async () => {
+    return this.fileLock.withFileLock(CURATED_NAMES[target], async () => {
       const before = await this.readCurated(target);
       if (expectedHash && before.contentHash !== expectedHash) {
         throw new MemoryConflictError(`${CURATED_NAMES[target]} changed outside Stitch`);
@@ -210,7 +157,7 @@ export class MemoryFileStore {
 
       let raw = before.rawContent;
       for (const operation of operations) {
-        const parsed = parseDocument(raw, CURATED_NAMES[target], target);
+        const parsed = this.parser.parseDocument(raw, CURATED_NAMES[target], target);
         if (operation.type === 'add') {
           const content = operation.content.trim();
           if (!content) throw new MemoryConflictError('Memory content cannot be empty');
@@ -252,7 +199,7 @@ export class MemoryFileStore {
         );
       }
 
-      this.assertCapacity(raw, target);
+      this.capacityTracker.assertCapacity(raw, target, { memory: this.memoryCharLimit, user: this.userCharLimit });
       await this.atomicWrite(path.join(this.rootDir, CURATED_NAMES[target]), raw);
       return this.readCurated(target);
     });
@@ -260,11 +207,11 @@ export class MemoryFileStore {
 
   async writeRaw(name: 'MEMORY.md' | 'USER.md', content: string, expectedHash: string): Promise<MemoryFileSnapshot> {
     const target = name === 'USER.md' ? 'user' : 'memory';
-    return this.withFileLock(name, async () => {
+    return this.fileLock.withFileLock(name, async () => {
       const before = await this.readFile(name);
       if (before.contentHash !== expectedHash) throw new MemoryConflictError(`${name} changed outside Stitch`);
-      parseDocument(content, name, target);
-      this.assertCapacity(content, target);
+      this.parser.parseDocument(content, name, target);
+      this.capacityTracker.assertCapacity(content, target, { memory: this.memoryCharLimit, user: this.userCharLimit });
       await this.atomicWrite(path.join(this.rootDir, name), content);
       return this.readFile(name);
     });
@@ -276,8 +223,8 @@ export class MemoryFileStore {
     memoryHash: string;
     userHash: string;
   }): Promise<{ memory: MemoryFileSnapshot; user: MemoryFileSnapshot }> {
-    return this.withFileLock('MEMORY.md', () =>
-      this.withFileLock('USER.md', async () => {
+    return this.fileLock.withFileLock('MEMORY.md', () =>
+      this.fileLock.withFileLock('USER.md', async () => {
         const [memoryBefore, userBefore] = await Promise.all([this.readCurated('memory'), this.readCurated('user')]);
         if (memoryBefore.contentHash !== input.memoryHash || userBefore.contentHash !== input.userHash) {
           throw new MemoryConflictError('Curated memory changed during consolidation');
@@ -285,10 +232,16 @@ export class MemoryFileStore {
 
         const memoryRaw = this.rewriteManagedBlocks(memoryBefore, input.memory, 'memory');
         const userRaw = this.rewriteManagedBlocks(userBefore, input.user, 'user');
-        this.assertCapacity(memoryRaw, 'memory');
-        this.assertCapacity(userRaw, 'user');
-        parseDocument(memoryRaw, 'MEMORY.md', 'memory');
-        parseDocument(userRaw, 'USER.md', 'user');
+        this.capacityTracker.assertCapacity(memoryRaw, 'memory', {
+          memory: this.memoryCharLimit,
+          user: this.userCharLimit,
+        });
+        this.capacityTracker.assertCapacity(userRaw, 'user', {
+          memory: this.memoryCharLimit,
+          user: this.userCharLimit,
+        });
+        this.parser.parseDocument(memoryRaw, 'MEMORY.md', 'memory');
+        this.parser.parseDocument(userRaw, 'USER.md', 'user');
 
         await Promise.all([
           this.backupUnreadable('MEMORY.md', memoryBefore.path),
@@ -307,7 +260,7 @@ export class MemoryFileStore {
   }
 
   async appendConsolidationLog(markdown: string): Promise<MemoryFileSnapshot> {
-    return this.withFileLock('DREAMS.md', async () => {
+    return this.fileLock.withFileLock('DREAMS.md', async () => {
       const before = await this.readFile('DREAMS.md');
       await this.atomicWrite(before.path, `${before.rawContent.trimEnd()}\n\n${markdown.trim()}\n`);
       return this.readFile('DREAMS.md');
@@ -333,7 +286,7 @@ export class MemoryFileStore {
 
   async appendDaily(entries: AddEntry[], date = this.now().toISOString().slice(0, 10)): Promise<MemoryFileSnapshot> {
     const relativePath = `daily/${date}.md`;
-    return this.withFileLock(relativePath, async () => {
+    return this.fileLock.withFileLock(relativePath, async () => {
       await this.ensureInitialized();
       const absolutePath = path.join(this.rootDir, 'daily', `${date}.md`);
       let raw: string;
@@ -343,7 +296,7 @@ export class MemoryFileStore {
         if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
         raw = `# Memory candidates for ${date}\n`;
       }
-      const parsed = parseDocument(raw, relativePath, 'memory');
+      const parsed = this.parser.parseDocument(raw, relativePath, 'memory');
       const seen = new Set(parsed.entries.map((entry) => `${entry.target}\0${entry.content.trim()}`));
       const blocks = entries
         .filter((entry) => {
@@ -367,9 +320,9 @@ export class MemoryFileStore {
   }
 
   async reset(): Promise<void> {
-    await this.withFileLock('MEMORY.md', () =>
-      this.withFileLock('USER.md', () =>
-        this.withFileLock('DREAMS.md', async () => {
+    await this.fileLock.withFileLock('MEMORY.md', () =>
+      this.fileLock.withFileLock('USER.md', () =>
+        this.fileLock.withFileLock('DREAMS.md', async () => {
           await rm(this.rootDir, { recursive: true, force: true });
           await this.ensureInitialized();
         }),
@@ -461,11 +414,6 @@ export class MemoryFileStore {
     };
   }
 
-  private assertCapacity(content: string, target: MemoryTarget): void {
-    const capacity = capacityFor(content, target === 'memory' ? this.memoryCharLimit : this.userCharLimit);
-    if (capacity.used > capacity.limit) throw new MemoryCapacityError(capacity);
-  }
-
   private async mutateEntry(id: string, content: string | null, expectedHash?: string): Promise<MemoryFileSnapshot> {
     const paths = ['MEMORY.md', 'USER.md', ...(await this.listDailyFiles())];
     const snapshots = await Promise.all(paths.map((filePath) => this.readFile(filePath)));
@@ -478,7 +426,7 @@ export class MemoryFileStore {
     const match = matches.at(0);
     if (!match) throw new MemoryConflictError(`Memory entry id is missing: ${id}`);
 
-    return this.withFileLock(match.snapshot.name, async () => {
+    return this.fileLock.withFileLock(match.snapshot.name, async () => {
       const current = await this.readFile(match.snapshot.name);
       if (expectedHash && current.contentHash !== expectedHash) {
         throw new MemoryConflictError(`${match.snapshot.name} changed outside Stitch`);
@@ -489,8 +437,10 @@ export class MemoryFileStore {
       const replacement =
         content === null ? '' : serializeEntry({ ...entry, content: content.trim(), target: entry.target });
       const raw = replaceEntryBlock(current.rawContent, entry, replacement).replace(/\n{3,}/g, '\n\n');
-      if (current.name === 'MEMORY.md') this.assertCapacity(raw, 'memory');
-      if (current.name === 'USER.md') this.assertCapacity(raw, 'user');
+      if (current.name === 'MEMORY.md')
+        this.capacityTracker.assertCapacity(raw, 'memory', { memory: this.memoryCharLimit, user: this.userCharLimit });
+      if (current.name === 'USER.md')
+        this.capacityTracker.assertCapacity(raw, 'user', { memory: this.memoryCharLimit, user: this.userCharLimit });
       await this.atomicWrite(current.path, raw);
       return this.readFile(current.name);
     });
@@ -564,33 +514,6 @@ export class MemoryFileStore {
       throw error;
     }
   }
-
-  private async withFileLock<T>(name: string, action: () => Promise<T>): Promise<T> {
-    const previous = this.queues.get(name) ?? Promise.resolve();
-    let release = (): void => undefined;
-    const current = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const queued = previous.then(() => current);
-    this.queues.set(name, queued);
-    await previous;
-    try {
-      return await action();
-    } catch (error) {
-      if (error instanceof MemoryParseError) {
-        const sourcePath = path.join(this.rootDir, name);
-        try {
-          await this.backupUnreadable(name, sourcePath);
-        } catch {
-          // Preserve the original actionable conflict when no readable pre-image exists.
-        }
-      }
-      throw error;
-    } finally {
-      release();
-      if (this.queues.get(name) === queued) this.queues.delete(name);
-    }
-  }
 }
 
-export const memoryFileStore = new MemoryFileStore();
+export const memoryFileStore = new MemoryStore();

--- a/packages/server/src/memory/parser-adapter.ts
+++ b/packages/server/src/memory/parser-adapter.ts
@@ -1,0 +1,63 @@
+import type {
+  ManagedMemoryEntry,
+  MemoryTarget,
+} from '@stitch/shared/memory/types';
+
+import { MemoryParseError } from './file-store.js';
+
+const METADATA_PATTERN =
+  /^<!-- stitch-memory id="([^"]+)" observed="(\d{4}-\d{2}-\d{2})" origin="(user|agent|automation|system)" source="([^"]*)"(?: target="(memory|user)")? -->$/;
+
+export type ParsedDocument = { entries: ManagedMemoryEntry[]; modelContent: string };
+
+export class MemoryParser {
+  parseDocument(content: string, filePath: string, defaultTarget: MemoryTarget): ParsedDocument {
+    const lines = content.split('\n');
+    const entries: ManagedMemoryEntry[] = [];
+    const ids = new Set<string>();
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index] ?? '';
+      if (!line.startsWith('<!-- stitch-memory ')) continue;
+
+      const metadata = METADATA_PATTERN.exec(line);
+      const item = lines[index + 1] as string | undefined;
+      if (!metadata || !item?.startsWith('- ')) {
+        throw new MemoryParseError(`Managed memory block is malformed at ${filePath}:${index + 1}`);
+      }
+
+      const [, id = '', observed = '', origin = 'system', source = '', targetValue] = metadata;
+      if (ids.has(id)) throw new MemoryParseError(`Duplicate memory entry id: ${id}`);
+      ids.add(id);
+
+      let endIndex = index + 1;
+      const contentLines = [item.slice(2)];
+      while (endIndex + 1 < lines.length && /^(?: {2,}|\t)/.test(lines[endIndex + 1] ?? '')) {
+        endIndex += 1;
+        contentLines.push((lines[endIndex] ?? '').replace(/^(?: {2}|\t)/, ''));
+      }
+
+      entries.push({
+        id,
+        content: contentLines.join('\n'),
+        origin: origin as import('@stitch/shared/memory/types').MemoryOrigin,
+        observed,
+        source,
+        target: (targetValue as MemoryTarget | undefined) ?? defaultTarget,
+        filePath,
+        lineStart: index + 1,
+        lineEnd: endIndex + 1,
+      });
+      index = endIndex;
+    }
+
+    return { entries, modelContent: this.visibleContent(content) };
+  }
+
+  private visibleContent(content: string): string {
+    return content
+      .split('\n')
+      .filter((line) => !line.trimStart().startsWith('<!-- stitch-memory '))
+      .join('\n');
+  }
+}

--- a/packages/server/src/memory/snapshot.test.ts
+++ b/packages/server/src/memory/snapshot.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { MemoryFileStore } from '@/memory/file-store.js';
+import { MemoryStore } from '@/memory/file-store.js';
 import { clearMemorySnapshotCache, readMemoryFilesForPrompt } from '@/memory/snapshot.js';
 
 const roots: string[] = [];
@@ -11,7 +11,7 @@ const roots: string[] = [];
 async function createStore(limits: { memoryCharLimit?: number; userCharLimit?: number } = {}) {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), 'stitch-memory-snapshot-'));
   roots.push(rootDir);
-  return new MemoryFileStore({ rootDir, ...limits });
+  return new MemoryStore({ rootDir, ...limits });
 }
 
 afterEach(async () => {

--- a/packages/server/src/memory/snapshot.ts
+++ b/packages/server/src/memory/snapshot.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import * as Log from '@/lib/log.js';
 import { getMemoryConfig } from '@/memory/config.js';
-import { memoryFileStore, type MemoryFileStore } from '@/memory/file-store.js';
+import { MemoryStore, memoryFileStore } from '@/memory/file-store.js';
 
 const log = Log.create({ service: 'memory-snapshot' });
 
@@ -13,7 +13,7 @@ type CacheEntry = { mtimeMs: number; contentHash: string; content: string | null
 const cache = new Map<string, CacheEntry>();
 
 async function readBounded(
-  store: MemoryFileStore,
+  store: MemoryStore,
   target: 'memory' | 'user',
 ): Promise<{ content: string | null; truncated: boolean }> {
   const name = target === 'memory' ? 'MEMORY.md' : 'USER.md';


### PR DESCRIPTION
## Change Summary

Deepened the Memory file-store module by extracting internal seams (parser adapter, capacity adapter, file-lock adapter) behind a single external `MemoryStore` interface.

### New Features / Deepening
- `MemoryParser` adapter: handles markdown parsing and entry extraction
- `MemoryCapacityTracker` adapter: capacity calculation behind seam
- `MemoryFileLockAdapter` adapter: concurrent file-lock mechanism

### Refactors
- `MemoryStore` (external interface) now only exposes `add/query/delete` behavior
- Removed `MemoryFileStore` alias; updated all importers (`consolidation`, `snapshot`) to use `MemoryStore` / `memoryFileStore`

### Tests
- Existing `memory/file-store.test.ts` passes (14/14)
