### PR TITLE
feat(stt): add Gemini live transcription

### DIFF
--- a/packages/server/src/stt/adapters/google.test.ts
+++ b/packages/server/src/stt/adapters/google.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createGoogleMessageParser } from '@/stt/adapters/google.js';
+
+describe('createGoogleMessageParser', () => {
+  test('uses one segment id for interim and final transcriptions', () => {
+    const parseMessage = createGoogleMessageParser(Date.now() - 1000);
+
+    const partial = parseMessage(
+      JSON.stringify({ serverContent: { interimInputTranscription: { text: 'Hello wor' } } }),
+    );
+    const final = parseMessage(JSON.stringify({ serverContent: { inputTranscription: { text: 'Hello world.' } } }));
+
+    expect(partial?.transcript).toMatchObject({
+      id: 'google-segment-0',
+      kind: 'partial',
+      text: 'Hello wor',
+    });
+    expect(final?.transcript).toMatchObject({
+      id: 'google-segment-0',
+      kind: 'final',
+      text: 'Hello world.',
+    });
+  });
+
+  test('parses modality token usage', () => {
+    const parseMessage = createGoogleMessageParser(Date.now() - 1000);
+    const result = parseMessage(
+      JSON.stringify({
+        usageMetadata: {
+          promptTokenCount: 20,
+          responseTokenCount: 8,
+          promptTokensDetails: [{ modality: 'AUDIO', tokenCount: 17 }],
+          responseTokensDetails: [{ modality: 'TEXT', tokenCount: 6 }],
+        },
+      }),
+    );
+
+    expect(result?.usage).toMatchObject({ audioInputTokens: 17, textOutputTokens: 6 });
+  });
+});

--- a/packages/server/src/stt/adapters/google.ts
+++ b/packages/server/src/stt/adapters/google.ts
@@ -1,0 +1,170 @@
+import type { TranscriptEvent, STTUsage } from '@stitch/shared/stt/types';
+
+import * as Log from '@/lib/log.js';
+import { getModelDescriptor } from '@/models/stt/service.js';
+import type { STTAdapter, STTConnection } from '@/stt/adapter-iface.js';
+import { createManagedConnection, type STTErrorClassification } from '@/stt/base-adapter.js';
+import type { ModelDescriptor, STTConnectionConfig } from '@/stt/types.js';
+import { createWsTransport, type WsMessageResult } from '@/stt/ws-transport.js';
+
+const log = Log.create({ service: 'stt.google' });
+
+const GEMINI_LIVE_URL =
+  'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent';
+const CREDENTIALS_ERROR_REASON = 'Invalid transcription API credentials. Please check your settings.';
+const QUOTA_ERROR_REASON = 'Transcription quota exceeded. Please check your billing.';
+const MODEL_ERROR_REASON = 'Selected transcription model is unavailable. Please check your settings.';
+
+type ModalityTokenCount = { modality: string; tokenCount: number };
+
+type GeminiLiveMessage = {
+  setupComplete?: Record<string, never>;
+  serverContent?: {
+    interimInputTranscription?: { text: string };
+    inputTranscription?: { text: string };
+  };
+  usageMetadata?: {
+    promptTokenCount?: number;
+    responseTokenCount?: number;
+    promptTokensDetails?: ModalityTokenCount[];
+    responseTokensDetails?: ModalityTokenCount[];
+  };
+  error?: { code?: number; message: string; status?: string };
+};
+
+function tokensForModality(details: ModalityTokenCount[] | undefined, modality: string): number | undefined {
+  const matching = details?.filter((detail) => detail.modality === modality);
+  if (!matching || matching.length === 0) return undefined;
+  return matching.reduce((total, detail) => total + detail.tokenCount, 0);
+}
+
+function parseUsage(message: GeminiLiveMessage, durationMs: number): STTUsage | undefined {
+  const metadata = message.usageMetadata;
+  if (!metadata) return undefined;
+
+  return {
+    durationMs,
+    audioInputTokens: tokensForModality(metadata.promptTokensDetails, 'AUDIO') ?? metadata.promptTokenCount,
+    textOutputTokens: tokensForModality(metadata.responseTokensDetails, 'TEXT') ?? metadata.responseTokenCount,
+  };
+}
+
+export function createGoogleMessageParser(sessionStartMs: number) {
+  let segmentId = 0;
+
+  return function parseMessage(data: string): WsMessageResult | null {
+    const message = JSON.parse(data) as GeminiLiveMessage;
+    const durationMs = Date.now() - sessionStartMs;
+    const usage = parseUsage(message, durationMs);
+
+    if (message.error) {
+      log.error({ error: message.error }, 'Google Gemini STT error message');
+      const error = new Error(`Google Gemini STT: ${message.error.message}`);
+      (error as Error & { code?: string }).code = message.error.status ?? String(message.error.code ?? '');
+      return { error, usage };
+    }
+
+    const content = message.serverContent;
+    if (content?.interimInputTranscription?.text) {
+      const transcript: TranscriptEvent = {
+        id: `google-segment-${segmentId}`,
+        kind: 'partial',
+        text: content.interimInputTranscription.text,
+        offsetMs: durationMs,
+      };
+      return { transcript, usage };
+    }
+
+    if (content?.inputTranscription) {
+      const transcript: TranscriptEvent = {
+        id: `google-segment-${segmentId++}`,
+        kind: 'final',
+        text: content.inputTranscription.text,
+        offsetMs: durationMs,
+      };
+      return { transcript, usage };
+    }
+
+    return usage ? { usage } : null;
+  };
+}
+
+function buildSetupMessage(config: STTConnectionConfig): string {
+  const inputAudioTranscription: { languageCodes: string[]; customVocabulary?: string[] } = {
+    languageCodes: config.language ? [config.language] : [],
+  };
+  if (config.keyterms && config.keyterms.length > 0) {
+    inputAudioTranscription.customVocabulary = config.keyterms;
+  }
+
+  return JSON.stringify({
+    setup: {
+      model: `models/${config.modelId}`,
+      generationConfig: { responseModalities: ['TEXT'] },
+      inputAudioTranscription,
+    },
+  });
+}
+
+function isSetupComplete(data: string): boolean {
+  return 'setupComplete' in (JSON.parse(data) as GeminiLiveMessage);
+}
+
+function classifyGoogleError(err: Error): STTErrorClassification {
+  const message = err.message.toLowerCase();
+  const code = (err as Error & { code?: string }).code ?? '';
+
+  if (code === 'UNAUTHENTICATED' || code === 'PERMISSION_DENIED' || message.includes('401') || message.includes('403')) {
+    return { fatal: true, reason: CREDENTIALS_ERROR_REASON };
+  }
+  if (code === 'RESOURCE_EXHAUSTED' || message.includes('429') || message.includes('quota')) {
+    return { fatal: true, reason: QUOTA_ERROR_REASON };
+  }
+  if (code === 'NOT_FOUND' || message.includes('404') || message.includes('model not found')) {
+    return { fatal: true, reason: MODEL_ERROR_REASON };
+  }
+  return { fatal: false };
+}
+
+function createGoogleTransport(config: STTConnectionConfig) {
+  const apiKey = config.auth.kind === 'apiKey' ? config.auth.key : '';
+  return createWsTransport(
+    {
+      url: `${GEMINI_LIVE_URL}?key=${encodeURIComponent(apiKey)}`,
+      headers: {},
+      onReady: () => [buildSetupMessage(config)],
+      parseMessage: createGoogleMessageParser(config.captureStartMs),
+      isReadyMessage: isSetupComplete,
+      label: 'Google Gemini',
+      pingIntervalMs: config.reconnect.pingIntervalMs,
+      pongTimeoutMs: config.reconnect.pongTimeoutMs,
+      keepAliveMessage: config.reconnect.keepAliveMessage,
+    },
+    (chunk) =>
+      JSON.stringify({
+        realtimeInput: {
+          audio: { data: chunk.samplesB64, mimeType: `audio/pcm;rate=${chunk.sampleRateHz}` },
+        },
+      }),
+    () => JSON.stringify({ realtimeInput: { audioStreamEnd: true } }),
+  );
+}
+
+export const googleAdapter: STTAdapter = {
+  providerId: 'google',
+
+  async models(): Promise<ModelDescriptor[]> {
+    const descriptor = await getModelDescriptor('google', 'gemini-3.5-transcribe-live');
+    return descriptor ? [descriptor] : [];
+  },
+
+  async connect(config: STTConnectionConfig): Promise<STTConnection> {
+    return createManagedConnection({
+      buffer: config.buffer,
+      reconnect: config.reconnect,
+      partialStrategy: config.partialStrategy,
+      classifyError: classifyGoogleError,
+      openConnection: () => createGoogleTransport(config),
+    });
+  },
+};

--- a/packages/server/src/stt/init.ts
+++ b/packages/server/src/stt/init.ts
@@ -1,5 +1,6 @@
 import { assemblyaiAdapter } from '@/stt/adapters/assemblyai.js';
 import { elevenlabsAdapter } from '@/stt/adapters/elevenlabs.js';
+import { googleAdapter } from '@/stt/adapters/google.js';
 import { openaiAdapter } from '@/stt/adapters/openai.js';
 import { registerAdapter } from '@/stt/registry.js';
 
@@ -7,4 +8,5 @@ export function initSttAdapters(): void {
   registerAdapter(openaiAdapter);
   registerAdapter(elevenlabsAdapter);
   registerAdapter(assemblyaiAdapter);
+  registerAdapter(googleAdapter);
 }

--- a/packages/server/src/stt/ws-transport.test.ts
+++ b/packages/server/src/stt/ws-transport.test.ts
@@ -83,6 +83,36 @@ afterEach(() => {
 });
 
 describe('createWsTransport', () => {
+  test('waits for an optional server readiness message', async () => {
+    globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+    let resolved = false;
+
+    const transportPromise = createWsTransport(
+      {
+        url: 'wss://example.test/stt',
+        headers: {},
+        onReady: () => ['setup'],
+        parseMessage: () => null,
+        isReadyMessage: (data) => data === 'ready',
+        label: 'Test',
+      },
+      () => 'audio',
+      () => 'commit',
+    ).then((transport) => {
+      resolved = true;
+      return transport;
+    });
+    FakeWebSocket.last?.open();
+    await Promise.resolve();
+
+    expect(FakeWebSocket.last?.sent).toEqual(['setup']);
+    expect(resolved).toBe(false);
+
+    FakeWebSocket.last?.message('ready');
+    await transportPromise;
+    expect(resolved).toBe(true);
+  });
+
   test('emits a typed error and closes when a pong is missing', async () => {
     globalThis.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
 

--- a/packages/server/src/stt/ws-transport.ts
+++ b/packages/server/src/stt/ws-transport.ts
@@ -12,6 +12,8 @@ type WsTransportConfig = {
   onReady?: () => string[];
   /** Parse an incoming message. Return events to dispatch, or null to skip. */
   parseMessage: (data: string) => WsMessageResult | null;
+  /** If provided, wait for a matching server message before resolving the transport. */
+  isReadyMessage?: (data: string) => boolean;
   /** Log label for diagnostics. */
   label: string;
   pingIntervalMs?: number;
@@ -41,7 +43,7 @@ export function createWsTransport(
 
     const ws = new WebSocket(config.url, { headers: config.headers });
 
-    let opened = false;
+    let ready = false;
     let closed = false;
     let pingTimer: ReturnType<typeof setInterval> | null = null;
     let pongTimer: ReturnType<typeof setTimeout> | null = null;
@@ -123,7 +125,6 @@ export function createWsTransport(
     }
 
     function handleOpen(): void {
-      opened = true;
       log.debug({ label: config.label }, 'WebSocket opened');
 
       if (config.onReady) {
@@ -131,6 +132,13 @@ export function createWsTransport(
           ws.send(msg);
         }
       }
+
+      if (!config.isReadyMessage) resolveTransport();
+    }
+
+    function resolveTransport(): void {
+      if (ready) return;
+      ready = true;
 
       const transport: STTTransport = {
         sendAudio(chunk) {
@@ -178,7 +186,10 @@ export function createWsTransport(
     function handleMessage(event: MessageEvent): void {
       markAlive();
       try {
-        const result = config.parseMessage(String(event.data));
+        const data = String(event.data);
+        if (config.isReadyMessage?.(data)) resolveTransport();
+
+        const result = config.parseMessage(data);
         if (!result) return;
 
         if (result.transcript) {
@@ -203,7 +214,7 @@ export function createWsTransport(
       const err = new Error(`${config.label} WebSocket closed: ${event.code} ${event.reason}`);
       (err as Error & { code?: string }).code = String(event.code);
 
-      if (!opened) {
+      if (!ready) {
         reject(err);
         return;
       }
@@ -218,7 +229,7 @@ export function createWsTransport(
     function handleError(event: Event): void {
       const message = (event as { message?: string }).message ?? 'unknown';
       const err = new Error(`${config.label} WebSocket error: ${message}`);
-      if (!opened) {
+      if (!ready) {
         reject(err);
         return;
       }

--- a/packages/shared/src/providers/catalog.ts
+++ b/packages/shared/src/providers/catalog.ts
@@ -78,7 +78,7 @@ export const PROVIDER_META: Record<ProviderId, ProviderMeta> = {
     displayName: 'Google AI',
     description: 'Access to Gemini and other Google AI models',
     api: 'https://generativelanguage.googleapis.com',
-    capabilities: ['llm', 'embedding'],
+    capabilities: ['llm', 'stt', 'embedding'],
     extraFields: [],
     authMethods: [
       {

--- a/packages/shared/src/providers/types.ts
+++ b/packages/shared/src/providers/types.ts
@@ -49,7 +49,7 @@ const PROVIDER_CAPABILITIES = {
   anthropic: ['llm'],
   assemblyai: ['stt'],
   elevenlabs: ['stt'],
-  google: ['llm', 'embedding'],
+  google: ['llm', 'stt', 'embedding'],
   'google-vertex': ['llm'],
   lmstudio_local: ['llm'],
   nvidia: ['llm', 'embedding'],

--- a/registries/stt/models/google.json
+++ b/registries/stt/models/google.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://usestitch.ai/schemas/stt-provider.schema.json",
+  "providerId": "google",
+  "providerName": "Google Gemini",
+  "models": [
+    {
+      "modelId": "gemini-3.5-transcribe-live",
+      "displayName": "Gemini 3.5 Transcribe Live",
+      "deprecated": false,
+      "capabilities": {
+        "partials": true,
+        "word_timestamps": false,
+        "utterance_timestamps": false,
+        "diarization": false,
+        "native_vad": true,
+        "language_detection": true,
+        "keyterm_biasing": true
+      },
+      "inputFormat": { "encoding": "pcm_s16le", "sampleRateHz": 16000, "channels": 1 },
+      "partialStrategy": "cumulative",
+      "buffer": { "maxChunkBytes": 32768, "flushIntervalMs": 100, "maxBufferedMs": 30000, "paceRealtime": false },
+      "reconnect": { "enabled": true, "maxRetries": 5, "backoffMs": 500 },
+      "pricing": { "type": "token", "perMillionTokens": { "audioInput": 3.5, "textOutput": 21 } }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add Google Gemini `gemini-3.5-transcribe-live` as a first-class live STT provider
- support interim and final transcripts, token usage, native VAD, language hints, and custom vocabulary
- register the model with its published capabilities and token pricing
- gate WebSocket readiness on Gemini's `setupComplete` handshake before streaming audio

## Testing

- `bun run check`
