### PR TITLE
improvement: enforce PrefixedString branded IDs across shared/server types and routes

### DIFF
--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 import type { ElectronBrowserState } from '@stitch/shared/browser/electron';
 import type { DesktopBridge, ElectronBridge } from '@stitch/shared/desktop/bridge';
+import { PrefixedString } from '@stitch/shared/id';
 import type {
   IpcContract,
   IpcEventContract,
@@ -115,9 +116,9 @@ const api = {
   },
   browser: {
     getState: () => invokeIpc('browser:getState'),
-    registerWebview: (webContentsId: number, sessionId: string) =>
+    registerWebview: (webContentsId: number, sessionId: PrefixedString<'ses'>) =>
       invokeIpc('browser:registerWebview', webContentsId, sessionId),
-    switchSession: (sessionId: string) => invokeIpc('browser:switchSession', sessionId),
+    switchSession: (sessionId: PrefixedString<'ses'>) => invokeIpc('browser:switchSession', sessionId),
     show: () => invokeIpc('browser:show'),
     hide: () => invokeIpc('browser:hide'),
     userNavigate: (url: string): Promise<BrowserNavigateResult> => invokeIpc('browser:userNavigate', url),

--- a/apps/web/src/components/browser/browser-panel.tsx
+++ b/apps/web/src/components/browser/browser-panel.tsx
@@ -3,6 +3,7 @@ import { ArrowLeftIcon, ArrowRightIcon, PlusIcon, RotateCwIcon, XIcon } from 'lu
 import * as React from 'react';
 
 import type { ElectronBrowserDownload, ElectronBrowserState } from '@stitch/shared/browser/electron';
+import type { PrefixedString } from '@stitch/shared/id';
 
 import { Icon } from '@/components/primitives/icon';
 import { Stack } from '@/components/primitives/stack';
@@ -11,7 +12,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 
-type BrowserPanelProps = { sessionId: string; onClose: () => void };
+type BrowserPanelProps = { sessionId: PrefixedString<'ses'>; onClose: () => void };
 
 type WebviewElement = HTMLElement & { getWebContentsId: () => number; getURL: () => string };
 

--- a/apps/web/src/components/session/session-page.tsx
+++ b/apps/web/src/components/session/session-page.tsx
@@ -5,6 +5,7 @@ import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 
 import type { GeneratedAutomationDraft } from '@stitch/shared/automations/types';
+import type { PrefixedString } from '@stitch/shared/id';
 
 import { AutomationDialog } from '@/components/automations/automation-dialog';
 import { BrowserPanel } from '@/components/browser/browser-panel';
@@ -132,7 +133,10 @@ export function SessionPage({ sessionId }: SessionPageProps) {
 
               <ResizablePanel defaultSize="30%" minSize="24%" maxSize="55%">
                 {rightPanel === 'browser' ? (
-                  <BrowserPanel sessionId={sessionId} onClose={() => setRequestedRightPanel('closed')} />
+                  <BrowserPanel
+                    sessionId={sessionId as PrefixedString<'ses'>}
+                    onClose={() => setRequestedRightPanel('closed')}
+                  />
                 ) : (
                   <SessionDetailsSheet {...details} sessionId={sessionId} className="hidden lg:block" />
                 )}

--- a/packages/mail/src/db/schema.ts
+++ b/packages/mail/src/db/schema.ts
@@ -52,7 +52,7 @@ export const mailAccounts = sqliteTable(
   'mail_accounts',
   {
     id: text('id').$type<MailAccountId>().primaryKey().$defaultFn(createMailAccountId),
-    connectorInstanceId: text('connector_instance_id').notNull(),
+    connectorInstanceId: text('connector_instance_id').$type<PrefixedString<'conn'>>().notNull(),
     provider: text('provider').$type<MailProviderId>().notNull(),
     email: text('email').notNull(),
     enabled: integer('enabled', { mode: 'boolean' }).notNull().default(false),

--- a/packages/mail/src/ops/operations.test.ts
+++ b/packages/mail/src/ops/operations.test.ts
@@ -45,7 +45,7 @@ test('hydrateThread refreshes the complete provider thread', async () => {
   const db = getMailDb();
   const [account] = await db
     .insert(mailAccounts)
-    .values({ connectorInstanceId: 'ci_1', provider: 'gmail', email: 'a@example.com' })
+    .values({ connectorInstanceId: 'conn_1', provider: 'gmail', email: 'a@example.com' })
     .returning();
   await persistLabels(account.id, [{ providerLabelId: 'INBOX', name: 'Inbox', kind: 'system', color: null }]);
   const [threadId] = await persistSyncPage(account.id, {

--- a/packages/mail/src/ops/outbox.test.ts
+++ b/packages/mail/src/ops/outbox.test.ts
@@ -23,7 +23,7 @@ test('flushOutbox marks failed sends with exponential retry delay', async () => 
   const db = getMailDb();
   const [account] = await db
     .insert(mailAccounts)
-    .values({ connectorInstanceId: 'ci_1', provider: 'gmail', email: 'a@example.com' })
+    .values({ connectorInstanceId: 'conn_1', provider: 'gmail', email: 'a@example.com' })
     .returning();
   registerMailProvider(failingProvider);
   const outbox = createOutbox({

--- a/packages/mail/src/sync/engine.test.ts
+++ b/packages/mail/src/sync/engine.test.ts
@@ -23,7 +23,7 @@ describe('mail engine enrollment', () => {
     });
 
     const accountId = await engine.accounts.enroll({
-      connectorInstanceId: 'ci_1',
+      connectorInstanceId: 'conn_1',
       provider: 'gmail',
       email: 'a@example.com',
     });

--- a/packages/mail/src/sync/engine.ts
+++ b/packages/mail/src/sync/engine.ts
@@ -2,6 +2,8 @@ import { and, eq, lte, or } from 'drizzle-orm';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+import { PrefixedString } from '@stitch/shared/id';
+
 import { getMailDb } from '../db/client.js';
 import {
   mailAccounts,
@@ -35,14 +37,14 @@ export type MailEngineEvent =
   | { type: 'threads.changed'; accountId: MailAccountId; threadIds: MailThreadId[] };
 
 type MailEngineDeps = {
-  createHttpClient(connectorInstanceId: string): MailHttpClient;
+  createHttpClient(connectorInstanceId: PrefixedString<'conn'>): MailHttpClient;
   logger: MailLogger;
   attachmentsDir: string;
   emit(event: MailEngineEvent): void;
 };
 
 type EnrollInput = {
-  connectorInstanceId: string;
+  connectorInstanceId: PrefixedString<'conn'>;
   provider: MailProviderId;
   email: string;
   backfillDays?: number;

--- a/packages/mail/src/sync/incremental.test.ts
+++ b/packages/mail/src/sync/incremental.test.ts
@@ -45,7 +45,7 @@ test('runIncremental follows cursor-expired recovery ladder', async () => {
   const [account] = await db
     .insert(mailAccounts)
     .values({
-      connectorInstanceId: 'ci_1',
+      connectorInstanceId: 'conn_1',
       provider: 'gmail',
       email: 'a@example.com',
       syncPhase: 'incremental',

--- a/packages/mail/src/sync/persist.test.ts
+++ b/packages/mail/src/sync/persist.test.ts
@@ -43,7 +43,7 @@ test('persistSyncPage recomputes thread denorms and label counts', async () => {
   const db = getMailDb();
   const [account] = await db
     .insert(mailAccounts)
-    .values({ connectorInstanceId: 'ci_1', provider: 'gmail', email: 'a@example.com' })
+    .values({ connectorInstanceId: 'conn_1', provider: 'gmail', email: 'a@example.com' })
     .returning();
   await persistLabels(account.id, [
     { providerLabelId: 'INBOX', name: 'Inbox', kind: 'system', color: null },
@@ -89,7 +89,7 @@ test('persistSyncPage treats fetched thread membership as authoritative', async 
   const db = getMailDb();
   const [account] = await db
     .insert(mailAccounts)
-    .values({ connectorInstanceId: 'ci_1', provider: 'gmail', email: 'a@example.com' })
+    .values({ connectorInstanceId: 'conn_1', provider: 'gmail', email: 'a@example.com' })
     .returning();
   await persistLabels(account.id, [{ providerLabelId: 'INBOX', name: 'Inbox', kind: 'system', color: null }]);
 

--- a/packages/server/src/automations/generation.ts
+++ b/packages/server/src/automations/generation.ts
@@ -145,12 +145,9 @@ function normalizeDraft(
   };
 }
 
-export async function generateAutomationDraft(sessionId: string): Promise<GeneratedAutomationDraft> {
+export async function generateAutomationDraft(sessionId: PrefixedString<'ses'>): Promise<GeneratedAutomationDraft> {
   const db = getDb();
-  const [session] = await db
-    .select()
-    .from(sessions)
-    .where(eq(sessions.id, sessionId as PrefixedString<'ses'>));
+  const [session] = await db.select().from(sessions).where(eq(sessions.id, sessionId));
 
   const messageList = await db
     .select()

--- a/packages/server/src/automations/scheduler.ts
+++ b/packages/server/src/automations/scheduler.ts
@@ -1,5 +1,6 @@
 import type { JobSchedule } from '@stitch/scheduler';
 import type { Automation, AutomationSchedule } from '@stitch/shared/automations/types';
+import type { PrefixedString } from '@stitch/shared/id';
 
 import { listAutomations, runAutomation } from './service.js';
 
@@ -11,7 +12,7 @@ import { getSettings } from '@/settings/service.js';
 const AUTOMATION_JOB_KEY_PREFIX = 'automation:';
 const DEFAULT_TIMEZONE = 'UTC';
 
-function getAutomationJobKey(automationId: string): string {
+function getAutomationJobKey(automationId: PrefixedString<'auto'>): string {
   return `${AUTOMATION_JOB_KEY_PREFIX}${automationId}`;
 }
 
@@ -70,7 +71,7 @@ export async function syncAutomationSchedule(automation: Automation): Promise<vo
   await registerAutomationJob(automation, await resolveUserTimezone());
 }
 
-export async function unregisterAutomationSchedule(automationId: string): Promise<void> {
+export async function unregisterAutomationSchedule(automationId: PrefixedString<'auto'>): Promise<void> {
   await unregisterSchedulerJob(getAutomationJobKey(automationId));
 }
 

--- a/packages/server/src/automations/service.ts
+++ b/packages/server/src/automations/service.ts
@@ -80,14 +80,9 @@ export async function listAutomations(input: { page: number; pageSize: number })
   };
 }
 
-export async function getAutomation(automationId: string): Promise<Automation> {
+export async function getAutomation(automationId: PrefixedString<'auto'>): Promise<Automation> {
   const db = getDb();
-  const automation = (
-    await db
-      .select()
-      .from(automations)
-      .where(eq(automations.id, automationId as PrefixedString<'auto'>))
-  ).at(0);
+  const automation = (await db.select().from(automations).where(eq(automations.id, automationId))).at(0);
 
   if (!automation) {
     throw new HTTPException(404, { message: 'Automation not found' });
@@ -135,14 +130,12 @@ export async function createAutomationAndSync(
   }
 }
 
-async function updateAutomation(automationId: string, input: UpdateAutomationInput): Promise<Automation> {
+async function updateAutomation(
+  automationId: PrefixedString<'auto'>,
+  input: UpdateAutomationInput,
+): Promise<Automation> {
   const db = getDb();
-  const existing = (
-    await db
-      .select()
-      .from(automations)
-      .where(eq(automations.id, automationId as PrefixedString<'auto'>))
-  ).at(0);
+  const existing = (await db.select().from(automations).where(eq(automations.id, automationId))).at(0);
   if (!existing) {
     throw new HTTPException(404, { message: 'Automation not found' });
   }
@@ -173,7 +166,7 @@ async function updateAutomation(automationId: string, input: UpdateAutomationInp
         schedule: serializeAutomationSchedule(schedule),
         updatedAt: Date.now(),
       })
-      .where(eq(automations.id, automationId as PrefixedString<'auto'>))
+      .where(eq(automations.id, automationId))
       .returning()
   ).at(0);
 
@@ -185,7 +178,7 @@ async function updateAutomation(automationId: string, input: UpdateAutomationInp
 }
 
 export async function updateAutomationAndSync(
-  automationId: string,
+  automationId: PrefixedString<'auto'>,
   input: UpdateAutomationInput,
   syncSchedule: SyncAutomationSchedule,
 ): Promise<Automation> {
@@ -206,7 +199,7 @@ export async function updateAutomationAndSync(
         schedule: serializeAutomationSchedule(before.schedule),
         updatedAt: before.updatedAt,
       })
-      .where(eq(automations.id, automationId as PrefixedString<'auto'>));
+      .where(eq(automations.id, automationId));
 
     await syncSchedule(before).catch((syncError) => {
       log.error(
@@ -224,11 +217,11 @@ export async function updateAutomationAndSync(
 }
 
 export async function deleteAutomation(
-  automationId: string,
+  automationId: PrefixedString<'auto'>,
   input: DeleteAutomationInput = { archiveSessions: false },
 ): Promise<void> {
   const db = getDb();
-  const typedId = automationId as PrefixedString<'auto'>;
+  const typedId = automationId;
 
   const deleted = await db.transaction(async (tx) => {
     const now = Date.now();
@@ -249,13 +242,10 @@ export async function deleteAutomation(
   }
 }
 
-export async function listAutomationSessions(automationId: string): Promise<Session[]> {
+export async function listAutomationSessions(automationId: PrefixedString<'auto'>): Promise<Session[]> {
   const db = getDb();
   const existing = (
-    await db
-      .select({ id: automations.id })
-      .from(automations)
-      .where(eq(automations.id, automationId as PrefixedString<'auto'>))
+    await db.select({ id: automations.id }).from(automations).where(eq(automations.id, automationId))
   ).at(0);
   if (!existing) {
     throw new HTTPException(404, { message: 'Automation not found' });
@@ -264,25 +254,14 @@ export async function listAutomationSessions(automationId: string): Promise<Sess
   return db
     .select()
     .from(sessions)
-    .where(
-      and(
-        eq(sessions.type, 'automation'),
-        eq(sessions.automationId, automationId as PrefixedString<'auto'>),
-        isNull(sessions.archivedAt),
-      ),
-    )
+    .where(and(eq(sessions.type, 'automation'), eq(sessions.automationId, automationId), isNull(sessions.archivedAt)))
     .orderBy(desc(sessions.updatedAt));
 }
 
-export async function runAutomation(automationId: string): Promise<RunAutomationResponse> {
+export async function runAutomation(automationId: PrefixedString<'auto'>): Promise<RunAutomationResponse> {
   const db = getDb();
 
-  const automation = (
-    await db
-      .select()
-      .from(automations)
-      .where(eq(automations.id, automationId as PrefixedString<'auto'>))
-  ).at(0);
+  const automation = (await db.select().from(automations).where(eq(automations.id, automationId))).at(0);
   if (!automation) {
     throw new HTTPException(404, { message: 'Automation not found' });
   }
@@ -303,7 +282,7 @@ export async function runAutomation(automationId: string): Promise<RunAutomation
       modelId: automation.modelId,
       assistantMessageId,
     });
-    userMessageId = sendResult.userMessageId as PrefixedString<'msg'>;
+    userMessageId = sendResult.userMessageId;
   } catch (error) {
     const message = Error.isError(error) ? error.message : String(error);
     internalBus.emit('automation.run.failed', { automationId: automation.id, error: message });

--- a/packages/server/src/chat/service.ts
+++ b/packages/server/src/chat/service.ts
@@ -39,7 +39,7 @@ type SendMessageInput = {
   attachments?: Array<{ path: string; mime: string; filename: string }>;
   providerId: string;
   modelId: string;
-  assistantMessageId: string;
+  assistantMessageId: PrefixedString<'msg'>;
 };
 
 type RedoMessageInput = SendMessageInput & { editedMessageId: PrefixedString<'msg'> };
@@ -177,7 +177,7 @@ async function loadTurnContext(
 
 function runTurn(input: {
   sessionId: PrefixedString<'ses'>;
-  assistantMessageId: string;
+  assistantMessageId: PrefixedString<'msg'>;
   session: TurnSession;
   config: LlmTurnConfig;
   modelId: string;
@@ -188,7 +188,7 @@ function runTurn(input: {
     const llmMessages = await buildSessionLlmMessages(input.sessionId, { useBasePrompt: true, systemPrompt: null });
     await runStream({
       sessionId: input.sessionId,
-      assistantMessageId: input.assistantMessageId as PrefixedString<'msg'>,
+      assistantMessageId: input.assistantMessageId,
       modelId: input.modelId,
       llmMessages,
       credentials: input.config.credentials,
@@ -204,7 +204,9 @@ function runTurn(input: {
   });
 }
 
-export async function sendMessage(input: SendMessageInput): Promise<{ messageId: string; userMessageId: string }> {
+export async function sendMessage(
+  input: SendMessageInput,
+): Promise<{ messageId: PrefixedString<'msg'>; userMessageId: PrefixedString<'msg'> }> {
   const db = getDb();
 
   const context = await loadTurnContext(input.sessionId, input.providerId);
@@ -250,7 +252,9 @@ export async function sendMessage(input: SendMessageInput): Promise<{ messageId:
   return { messageId: input.assistantMessageId, userMessageId };
 }
 
-export async function redoMessage(input: RedoMessageInput): Promise<{ messageId: string; userMessageId: string }> {
+export async function redoMessage(
+  input: RedoMessageInput,
+): Promise<{ messageId: PrefixedString<'msg'>; userMessageId: PrefixedString<'msg'> }> {
   const db = getDb();
 
   const context = await loadTurnContext(input.sessionId, input.providerId);

--- a/packages/server/src/chat/session-crud.ts
+++ b/packages/server/src/chat/session-crud.ts
@@ -16,7 +16,7 @@ type CreateSessionInput = {
   title?: string;
   type?: 'chat' | 'automation';
   automationId?: PrefixedString<'auto'>;
-  parentSessionId?: string;
+  parentSessionId?: PrefixedString<'ses'>;
 };
 
 export async function createSession(input: CreateSessionInput): Promise<typeof sessions.$inferSelect> {
@@ -32,7 +32,7 @@ export async function createSession(input: CreateSessionInput): Promise<typeof s
       title,
       type: input.type ?? 'chat',
       automationId: input.automationId ?? null,
-      parentSessionId: (input.parentSessionId ?? null) as PrefixedString<'ses'> | null,
+      parentSessionId: input.parentSessionId ?? null,
       createdAt: now,
       updatedAt: now,
     })

--- a/packages/server/src/connectors/auth/refresh-lock.ts
+++ b/packages/server/src/connectors/auth/refresh-lock.ts
@@ -1,6 +1,8 @@
 const DEFAULT_TIMEOUT_MS = 30_000;
 
-const refreshInFlight = new Map<string, Promise<unknown>>();
+import type { PrefixedString } from '@stitch/shared/id';
+
+const refreshInFlight = new Map<PrefixedString<'conn'>, Promise<unknown>>();
 
 async function withTimeout<T>(promise: Promise<T>): Promise<T> {
   let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -18,7 +20,7 @@ async function withTimeout<T>(promise: Promise<T>): Promise<T> {
   }
 }
 
-export async function withRefreshLock<T>(instanceId: string, refresh: () => Promise<T>): Promise<T> {
+export async function withRefreshLock<T>(instanceId: PrefixedString<'conn'>, refresh: () => Promise<T>): Promise<T> {
   const inFlight = refreshInFlight.get(instanceId) as Promise<T> | undefined;
   if (inFlight) return inFlight;
 

--- a/packages/server/src/connectors/auth/token-vault.ts
+++ b/packages/server/src/connectors/auth/token-vault.ts
@@ -2,6 +2,7 @@ import { and, eq, isNotNull, lt } from 'drizzle-orm';
 import { scheduler } from 'node:timers/promises';
 
 import type { OAuthConfig } from '@stitch/shared/connectors/types';
+import type { PrefixedString } from '@stitch/shared/id';
 
 import { resolveOAuthCredentials } from '@/connectors/auth/oauth-credentials.js';
 import {
@@ -132,7 +133,10 @@ export type TokenRefreshOpts = { forceRefresh?: boolean };
  * no token can be obtained (missing instance, missing refresh token, or a
  * refresh failure — which is thrown).
  */
-export async function ensureFreshAccessToken(instanceId: string, opts: TokenRefreshOpts = {}): Promise<string | null> {
+export async function ensureFreshAccessToken(
+  instanceId: PrefixedString<'conn'>,
+  opts: TokenRefreshOpts = {},
+): Promise<string | null> {
   const db = getDb();
   const [row] = await db
     .select()

--- a/packages/server/src/connectors/service.ts
+++ b/packages/server/src/connectors/service.ts
@@ -140,9 +140,9 @@ export async function createOAuthConnector(input: {
   return toConnectorSafe(toConnector(row));
 }
 
-export async function deleteConnector(connectorRefId: string): Promise<void> {
+export async function deleteConnector(connectorRefId: PrefixedString<'cnr'>): Promise<void> {
   const db = getDb();
-  const typedConnectorRefId = connectorRefId as PrefixedString<'cnr'>;
+  const typedConnectorRefId = connectorRefId;
   const existing = (await db.select().from(connectors).where(eq(connectors.id, typedConnectorRefId))).at(0);
 
   if (!existing) throw new HTTPException(404, { message: 'Connector not found' });
@@ -165,14 +165,9 @@ export async function listConnectorInstances(): Promise<ConnectorInstanceSafe[]>
   });
 }
 
-export async function getConnectorInstance(id: string): Promise<ConnectorInstanceSafe> {
+export async function getConnectorInstance(id: PrefixedString<'conn'>): Promise<ConnectorInstanceSafe> {
   const db = getDb();
-  const row = (
-    await db
-      .select()
-      .from(connectorInstances)
-      .where(eq(connectorInstances.id, id as PrefixedString<'conn'>))
-  ).at(0);
+  const row = (await db.select().from(connectorInstances).where(eq(connectorInstances.id, id))).at(0);
 
   if (!row) throw new HTTPException(404, { message: 'Connector instance not found' });
   const instance = row as ConnectorInstance;
@@ -180,17 +175,12 @@ export async function getConnectorInstance(id: string): Promise<ConnectorInstanc
 }
 
 export async function createOAuthConnectorInstance(input: {
-  connectorRefId: string;
+  connectorRefId: PrefixedString<'cnr'>;
   label: string;
   scopes: string[];
 }): Promise<ConnectorInstanceSafe> {
   const db = getDb();
-  const connector = (
-    await db
-      .select()
-      .from(connectors)
-      .where(eq(connectors.id, input.connectorRefId as PrefixedString<'cnr'>))
-  ).at(0);
+  const connector = (await db.select().from(connectors).where(eq(connectors.id, input.connectorRefId))).at(0);
 
   if (!connector) throw new HTTPException(404, { message: 'Connector not found' });
 
@@ -291,17 +281,12 @@ export async function createApiKeyConnectorInstance(input: {
 }
 
 export async function authorizeOAuthInstance(
-  instanceId: string,
+  instanceId: PrefixedString<'conn'>,
   deps?: { startOAuthFlow?: typeof StartOAuthFlowFn },
   options?: { scopes?: string[]; additionalParams?: Record<string, string> },
 ): Promise<{ authUrl: string; waitForTokens: () => Promise<void> }> {
   const db = getDb();
-  const instance = (
-    await db
-      .select()
-      .from(connectorInstances)
-      .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>))
-  ).at(0);
+  const instance = (await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId))).at(0);
 
   if (!instance) throw new HTTPException(404, { message: 'Connector instance not found' });
 
@@ -358,18 +343,18 @@ export async function authorizeOAuthInstance(
           capabilities: getCapabilitiesForVersion(definition, definition.currentVersion),
           updatedAt: now,
         })
-        .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+        .where(eq(connectorInstances.id, instanceId));
 
       log.info({ event: 'connector.authorized', instanceId, accountEmail }, `Connector authorized: ${instance.label}`);
-      internalBus.emit('connector.authorized', { instanceId, connectorId: instance.connectorId });
+      internalBus.emit('connector.authorized', { instanceId: instanceId, connectorId: instance.connectorId });
     } catch (error) {
       const message = Error.isError(error) ? error.message : String(error);
       await db
         .update(connectorInstances)
         .set({ status: 'error' as ConnectorStatus, authIssue: 'temporary_failure', updatedAt: Date.now() })
-        .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+        .where(eq(connectorInstances.id, instanceId));
       log.warn({ event: 'connector.authorize.failed', instanceId, error: message }, 'connector authorization failed');
-      internalBus.emit('connector.auth.failed', { instanceId });
+      internalBus.emit('connector.auth.failed', { instanceId: instanceId });
       throw error;
     }
   };
@@ -378,16 +363,11 @@ export async function authorizeOAuthInstance(
 }
 
 export async function updateConnectorInstance(
-  instanceId: string,
+  instanceId: PrefixedString<'conn'>,
   updates: { label?: string; scopes?: string[] },
 ): Promise<ConnectorInstanceSafe> {
   const db = getDb();
-  const existing = (
-    await db
-      .select()
-      .from(connectorInstances)
-      .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>))
-  ).at(0);
+  const existing = (await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId))).at(0);
 
   if (!existing) throw new HTTPException(404, { message: 'Connector instance not found' });
 
@@ -395,27 +375,21 @@ export async function updateConnectorInstance(
   if (updates.label !== undefined) setValues['label'] = updates.label;
   if (updates.scopes !== undefined) setValues['scopes'] = updates.scopes;
 
-  await db
-    .update(connectorInstances)
-    .set(setValues)
-    .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+  await db.update(connectorInstances).set(setValues).where(eq(connectorInstances.id, instanceId));
 
-  const [row] = await db
-    .select()
-    .from(connectorInstances)
-    .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+  const [row] = await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId));
 
   const instance = row as ConnectorInstance;
   return toSafe(instance, getConnectorDefinition(instance.connectorId));
 }
 
 export async function upgradeConnectorInstance(
-  instanceId: string,
+  instanceId: PrefixedString<'conn'>,
   input: { apiKey?: string },
   deps?: { startOAuthFlow?: typeof StartOAuthFlowFn },
 ): Promise<{ type: 'reauthorize'; authUrl: string } | { type: 'updated' }> {
   const db = getDb();
-  const typedInstanceId = instanceId as PrefixedString<'conn'>;
+  const typedInstanceId = instanceId;
   const instance = (await db.select().from(connectorInstances).where(eq(connectorInstances.id, typedInstanceId))).at(0);
 
   if (!instance) throw new HTTPException(404, { message: 'Connector instance not found' });
@@ -443,7 +417,7 @@ export async function upgradeConnectorInstance(
         updatedAt: now,
       })
       .where(eq(connectorInstances.id, typedInstanceId));
-    internalBus.emit('connector.authorized', { instanceId, connectorId: instance.connectorId });
+    internalBus.emit('connector.authorized', { instanceId: instanceId, connectorId: instance.connectorId });
     return { type: 'updated' };
   }
 
@@ -471,7 +445,7 @@ export async function upgradeConnectorInstance(
       })
       .where(eq(connectorInstances.id, typedInstanceId));
 
-    internalBus.emit('connector.authorized', { instanceId, connectorId: instance.connectorId });
+    internalBus.emit('connector.authorized', { instanceId: instanceId, connectorId: instance.connectorId });
 
     return { type: 'updated' };
   }
@@ -524,32 +498,22 @@ export async function upgradeConnectorInstance(
   throw new HTTPException(400, { message: 'Unsupported upgrade action for connector' });
 }
 
-export async function deleteConnectorInstance(instanceId: string): Promise<void> {
+export async function deleteConnectorInstance(instanceId: PrefixedString<'conn'>): Promise<void> {
   const db = getDb();
-  const existing = (
-    await db
-      .select()
-      .from(connectorInstances)
-      .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>))
-  ).at(0);
+  const existing = (await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId))).at(0);
 
   if (!existing) throw new HTTPException(404, { message: 'Connector instance not found' });
 
-  await db.delete(connectorInstances).where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
+  await db.delete(connectorInstances).where(eq(connectorInstances.id, instanceId));
 
-  internalBus.emit('connector.removed', { instanceId, connectorId: existing.connectorId });
+  internalBus.emit('connector.removed', { instanceId: instanceId, connectorId: existing.connectorId });
 
   log.info({ event: 'connector.deleted', instanceId }, `Connector instance deleted: ${existing.label}`);
 }
 
-export async function testConnectorInstance(instanceId: string): Promise<boolean> {
+export async function testConnectorInstance(instanceId: PrefixedString<'conn'>): Promise<boolean> {
   const db = getDb();
-  const instance = (
-    await db
-      .select()
-      .from(connectorInstances)
-      .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>))
-  ).at(0);
+  const instance = (await db.select().from(connectorInstances).where(eq(connectorInstances.id, instanceId))).at(0);
 
   if (!instance) throw new HTTPException(404, { message: 'Connector instance not found' });
 
@@ -584,8 +548,8 @@ export async function testConnectorInstance(instanceId: string): Promise<boolean
             authIssue: null,
             updatedAt: now,
           })
-          .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
-        internalBus.emit('connector.token.refreshed', { instanceId });
+          .where(eq(connectorInstances.id, instanceId));
+        internalBus.emit('connector.token.refreshed', { instanceId: instanceId });
         testedInstance = {
           ...instance,
           accessToken: refreshed.accessToken,
@@ -619,8 +583,8 @@ export async function testConnectorInstance(instanceId: string): Promise<boolean
       await db
         .update(connectorInstances)
         .set({ status: 'error' as ConnectorStatus, authIssue: 'reauthorization_required', updatedAt: Date.now() })
-        .where(eq(connectorInstances.id, instanceId as PrefixedString<'conn'>));
-      internalBus.emit('connector.auth.failed', { instanceId });
+        .where(eq(connectorInstances.id, instanceId));
+      internalBus.emit('connector.auth.failed', { instanceId: instanceId });
     }
 
     throw new HTTPException(400, {

--- a/packages/server/src/db/schema/usage.ts
+++ b/packages/server/src/db/schema/usage.ts
@@ -80,8 +80,8 @@ export type ChatTitleGenerationLlmUsageMetadata = {
 export type RecordingTitleGenerationLlmUsageMetadata = {
   source: 'title_generation';
   target: 'recording-analysis';
-  recordingId: string;
-  analysisId: string;
+  recordingId: PrefixedString<'rec'>;
+  analysisId: PrefixedString<'recan'>;
 };
 
 export type TitleGenerationLlmUsageMetadata =
@@ -96,8 +96,8 @@ export type AutomationGenerationLlmUsageMetadata = {
 
 export type RecordingAnalysisLlmUsageMetadata = {
   source: 'recording_analysis';
-  recordingId: string;
-  analysisId: string;
+  recordingId: PrefixedString<'rec'>;
+  analysisId: PrefixedString<'recan'>;
 };
 
 export type MemoryExtractionPhase = 'extraction' | 'deduplication' | 'consolidation';

--- a/packages/server/src/lib/abort-registry.ts
+++ b/packages/server/src/lib/abort-registry.ts
@@ -1,10 +1,12 @@
+import type { PrefixedString } from '@stitch/shared/id';
+
 import * as Log from '@/lib/log.js';
 
 const log = Log.create({ service: 'abort-registry' });
 
-const registry = new Map<string, AbortController>();
+const registry = new Map<PrefixedString<'ses'>, AbortController>();
 
-export function register(sessionId: string): AbortSignal {
+export function register(sessionId: PrefixedString<'ses'>): AbortSignal {
   const existing = registry.get(sessionId);
   if (existing) {
     log.warn(
@@ -19,7 +21,7 @@ export function register(sessionId: string): AbortSignal {
   return controller.signal;
 }
 
-export function abort(sessionId: string): void {
+export function abort(sessionId: PrefixedString<'ses'>): void {
   const controller = registry.get(sessionId);
   if (!controller) return;
   log.info({ event: 'stream.abort.registry_abort', sessionId }, 'aborting session');
@@ -27,6 +29,6 @@ export function abort(sessionId: string): void {
   registry.delete(sessionId);
 }
 
-export function cleanup(sessionId: string): void {
+export function cleanup(sessionId: PrefixedString<'ses'>): void {
   registry.delete(sessionId);
 }

--- a/packages/server/src/lib/browser/browser-manager.ts
+++ b/packages/server/src/lib/browser/browser-manager.ts
@@ -4,6 +4,7 @@ import type {
   ElectronBrowserErrorMessage,
   ElectronBrowserResultMessage,
 } from '@stitch/shared/browser/electron';
+import type { PrefixedString } from '@stitch/shared/id';
 
 import {
   BrowserBridgeNotConfiguredError,
@@ -23,7 +24,7 @@ class DesktopBrowserBridge {
 
   async send<C extends ElectronBrowserCommand>(
     command: C,
-    sessionId: string,
+    sessionId: PrefixedString<'ses'>,
     signal?: AbortSignal,
   ): Promise<ElectronBrowserCommandResult<C['action']>> {
     await this.connect();
@@ -129,13 +130,13 @@ class DesktopBrowserBridge {
 
 class BrowserManager {
   private bridge = new DesktopBrowserBridge();
-  private _sessionId: string | null = null;
+  private _sessionId: PrefixedString<'ses'> | null = null;
 
-  set sessionId(id: string) {
+  set sessionId(id: PrefixedString<'ses'>) {
     this._sessionId = id;
   }
 
-  private getSessionId(): string {
+  private getSessionId(): PrefixedString<'ses'> {
     if (!this._sessionId) throw new BrowserSessionNotSetError();
     return this._sessionId;
   }
@@ -154,7 +155,7 @@ class BrowserManager {
 
 let singleton: BrowserManager | null = null;
 
-export function getBrowserManager(sessionId?: string): BrowserManager {
+export function getBrowserManager(sessionId?: PrefixedString<'ses'>): BrowserManager {
   singleton ??= new BrowserManager();
   if (sessionId) singleton.sessionId = sessionId;
   return singleton;

--- a/packages/server/src/lib/route-schemas.ts
+++ b/packages/server/src/lib/route-schemas.ts
@@ -24,6 +24,7 @@ export const routeSchemas = {
   permissionRuleId: prefixedId(ID_PREFIXES.permissionRule),
   mcpServerId: prefixedId(ID_PREFIXES.mcpServer),
   mcpElicitationId: prefixedId(ID_PREFIXES.mcpElicitation),
+  connectorId: prefixedId(ID_PREFIXES.connector),
   connectorInstanceId: prefixedId(ID_PREFIXES.connectorInstance),
   automationId: prefixedId(ID_PREFIXES.automation),
   scheduledJobId: prefixedId(ID_PREFIXES.scheduledJob),

--- a/packages/server/src/llm/provider-options.ts
+++ b/packages/server/src/llm/provider-options.ts
@@ -1,3 +1,4 @@
+import type { PrefixedString } from '@stitch/shared/id';
 import type { LlmProviderId } from '@stitch/shared/providers/types';
 
 import type { JSONValue } from 'ai';
@@ -5,7 +6,7 @@ import type { JSONValue } from 'ai';
 /** Returns provider-level options for `streamText`. */
 export function getProviderOptions(
   providerId: LlmProviderId,
-  sessionId: string,
+  sessionId: PrefixedString<'ses'>,
 ): Record<string, Record<string, JSONValue>> | undefined {
   switch (providerId) {
     case 'openai':

--- a/packages/server/src/mail/read-model.ts
+++ b/packages/server/src/mail/read-model.ts
@@ -35,33 +35,23 @@ function toDraftView(draft: typeof mailDrafts.$inferSelect): MailDraftView {
   };
 }
 
-export async function getDraftView(draftId: string): Promise<MailDraftView | null> {
+export async function getDraftView(draftId: MailDraftId): Promise<MailDraftView | null> {
   const db = getMailDb();
-  const [draft] = await db
-    .select()
-    .from(mailDrafts)
-    .where(eq(mailDrafts.id, draftId as MailDraftId))
-    .limit(1);
+  const [draft] = await db.select().from(mailDrafts).where(eq(mailDrafts.id, draftId)).limit(1);
   return toDraftView(draft);
 }
 
-export async function getAttachmentRecord(attachmentId: string): Promise<typeof mailAttachments.$inferSelect | null> {
+export async function getAttachmentRecord(
+  attachmentId: MailAttachmentId,
+): Promise<typeof mailAttachments.$inferSelect | null> {
   const db = getMailDb();
-  const [attachment] = await db
-    .select()
-    .from(mailAttachments)
-    .where(eq(mailAttachments.id, attachmentId as MailAttachmentId))
-    .limit(1);
+  const [attachment] = await db.select().from(mailAttachments).where(eq(mailAttachments.id, attachmentId)).limit(1);
   return attachment;
 }
 
-export async function getMessageView(messageId: string): Promise<MailMessageView | null> {
+export async function getMessageView(messageId: MailMessageId): Promise<MailMessageView | null> {
   const db = getMailDb();
-  const [message] = await db
-    .select()
-    .from(mailMessages)
-    .where(eq(mailMessages.id, messageId as MailMessageId))
-    .limit(1);
+  const [message] = await db.select().from(mailMessages).where(eq(mailMessages.id, messageId)).limit(1);
 
   const [labelRows, attachments] = await Promise.all([
     db

--- a/packages/server/src/mail/wiring.ts
+++ b/packages/server/src/mail/wiring.ts
@@ -8,6 +8,7 @@ import type { MailAccountId } from '@stitch/mail/db/schema';
 import { createMailEngine, type MailEngine, type MailEngineEvent } from '@stitch/mail/engine';
 import { gmailOpsProvider, gmailSyncProvider } from '@stitch/mail/providers/gmail';
 import { registerMailProvider } from '@stitch/mail/registry';
+import { PrefixedString } from '@stitch/shared/id';
 
 import { isAppEnabled } from '@/apps/service.js';
 import { ensureFreshAccessToken } from '@/connectors/auth/token-vault.js';
@@ -19,7 +20,7 @@ import { PATHS } from '@/lib/paths.js';
 const log = Log.create({ service: 'mail' });
 
 let mailEngine: MailEngine | null = null;
-const syncProgressByAccount = new Map<string, { processed: number; estimatedTotal: number }>();
+const syncProgressByAccount = new Map<MailAccountId, { processed: number; estimatedTotal: number }>();
 
 function emitMailEvent(event: MailEngineEvent): void {
   if (event.type === 'sync.progress') {
@@ -46,7 +47,7 @@ export function registerMailProviders(): void {
   registerMailProvider({ sync: gmailSyncProvider, ops: gmailOpsProvider });
 }
 
-function createMailHttpClient(connectorInstanceId: string): MailHttpClient {
+function createMailHttpClient(connectorInstanceId: PrefixedString<'conn'>): MailHttpClient {
   const client = new GoogleClient({
     getAccessToken: (options) => getGoogleAccessToken(connectorInstanceId, options?.forceRefresh === true),
     logger: log,
@@ -75,7 +76,9 @@ export async function stopMailEngine(): Promise<void> {
   mailEngine = null;
 }
 
-export function getMailSyncProgress(accountId: string): { processed: number; estimatedTotal: number } | undefined {
+export function getMailSyncProgress(
+  accountId: MailAccountId,
+): { processed: number; estimatedTotal: number } | undefined {
   return syncProgressByAccount.get(accountId);
 }
 
@@ -93,7 +96,10 @@ export async function removeMailAccount(accountId: MailAccountId): Promise<void>
   await fs.promises.rm(attachmentDir, { recursive: true, force: true });
 }
 
-async function getGoogleAccessToken(connectorInstanceId: string, forceRefresh: boolean): Promise<string> {
+async function getGoogleAccessToken(
+  connectorInstanceId: PrefixedString<'conn'>,
+  forceRefresh: boolean,
+): Promise<string> {
   const token = await ensureFreshAccessToken(connectorInstanceId, { forceRefresh });
   if (!token) throw new GoogleAccountNoAccessTokenError('google', connectorInstanceId);
   return token;

--- a/packages/server/src/mcp/client.ts
+++ b/packages/server/src/mcp/client.ts
@@ -34,7 +34,7 @@ const clientCache = new Map<string, Promise<Client>>();
  * in-memory PKCE/code-verifier linkage); a fresh transport would re-trigger
  * discovery and break the exchange.
  */
-const pendingOAuthTransports = new Map<string, StreamableHTTPClientTransport>();
+const pendingOAuthTransports = new Map<PrefixedString<'mcp'>, StreamableHTTPClientTransport>();
 
 export function normalizeMcpToolResult<T>(result: T): T | ToolErrorResult {
   if (
@@ -65,15 +65,18 @@ export function normalizeMcpToolResult<T>(result: T): T | ToolErrorResult {
   return toolError(error || 'MCP tool call failed', result);
 }
 
-export function registerPendingOAuthTransport(serverId: string, transport: StreamableHTTPClientTransport): void {
+export function registerPendingOAuthTransport(
+  serverId: PrefixedString<'mcp'>,
+  transport: StreamableHTTPClientTransport,
+): void {
   pendingOAuthTransports.set(serverId, transport);
 }
 
-export function getPendingOAuthTransport(serverId: string): StreamableHTTPClientTransport | undefined {
+export function getPendingOAuthTransport(serverId: PrefixedString<'mcp'>): StreamableHTTPClientTransport | undefined {
   return pendingOAuthTransports.get(serverId);
 }
 
-export function clearPendingOAuthTransport(serverId: string): void {
+export function clearPendingOAuthTransport(serverId: PrefixedString<'mcp'>): void {
   pendingOAuthTransports.delete(serverId);
 }
 
@@ -119,7 +122,7 @@ export async function listMcpAiTools(
   return Object.fromEntries(result.tools.map((tool) => [tool.name, createAiTool(server, tool, sessionId)]));
 }
 
-function clientCacheKey(serverId: string, sessionId?: string): string {
+function clientCacheKey(serverId: PrefixedString<'mcp'>, sessionId?: PrefixedString<'ses'>): string {
   return sessionId ? `${serverId}:${sessionId}` : serverId;
 }
 
@@ -196,7 +199,7 @@ export function getMcpClient(server: McpServerRef, sessionId?: PrefixedString<'s
 }
 
 /** Evict a cached client, forcing reconnect on next use. */
-export function evictMcpClient(serverId: string): void {
+export function evictMcpClient(serverId: PrefixedString<'mcp'>): void {
   for (const [key, cached] of clientCache) {
     if (key !== serverId && !key.startsWith(`${serverId}:`)) continue;
     clientCache.delete(key);

--- a/packages/server/src/mcp/oauth-callback.ts
+++ b/packages/server/src/mcp/oauth-callback.ts
@@ -9,8 +9,10 @@ const DEFAULT_PORT = 19876;
 const CALLBACK_PATH = '/mcp/oauth/callback';
 const AUTH_TIMEOUT_MS = 5 * 60_000;
 
+import type { PrefixedString } from '@stitch/shared/id';
+
 type PendingAuth = {
-  serverId: string;
+  serverId: PrefixedString<'mcp'>;
   resolve: (code: string) => void;
   reject: (error: Error) => void;
   timeout: ReturnType<typeof setTimeout>;
@@ -94,7 +96,7 @@ export async function ensureRunning(): Promise<void> {
  * Register a pending auth keyed by `state` and return a promise that resolves
  * with the authorization code once the callback fires (or rejects on timeout).
  */
-export function registerPendingAuth(input: { state: string; serverId: string }): Promise<string> {
+export function registerPendingAuth(input: { state: string; serverId: PrefixedString<'mcp'> }): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const timeout = setTimeout(() => {
       pending.delete(input.state);
@@ -107,7 +109,7 @@ export function registerPendingAuth(input: { state: string; serverId: string }):
 }
 
 /** Reject and remove the single pending auth for a server (clears its timer). */
-export function cancelPending(serverId: string): void {
+export function cancelPending(serverId: PrefixedString<'mcp'>): void {
   for (const [state, entry] of pending.entries()) {
     if (entry.serverId !== serverId) continue;
     clearTimeout(entry.timeout);

--- a/packages/server/src/mcp/presentation.ts
+++ b/packages/server/src/mcp/presentation.ts
@@ -1,3 +1,4 @@
+import type { PrefixedString } from '@stitch/shared/id';
 import type { McpIcon, McpRegistryServer } from '@stitch/shared/mcp/types';
 
 import { cacheMcpIcon } from '@/mcp/icons.js';
@@ -14,7 +15,7 @@ export type McpServerLiveInfo = {
 type McpToolPresentation = { title?: string; iconPath?: string };
 
 export type McpServerPresentation = {
-  serverId: string;
+  serverId: PrefixedString<'mcp'>;
   name: string;
   title?: string;
   description?: string;

--- a/packages/server/src/mcp/registry-logos.ts
+++ b/packages/server/src/mcp/registry-logos.ts
@@ -69,12 +69,9 @@ export async function getMcpRegistryLogo(
   return fetchAndCacheLogo(server, filePath, cacheDir, options.fetchImpl ?? fetch);
 }
 
-export async function getMcpInstalledServerRegistryLogo(serverId: string): Promise<string | undefined> {
+export async function getMcpInstalledServerRegistryLogo(serverId: PrefixedString<'mcp'>): Promise<string | undefined> {
   const db = getDb();
-  const serverRows = await db
-    .select()
-    .from(mcpServers)
-    .where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  const serverRows = await db.select().from(mcpServers).where(eq(mcpServers.id, serverId));
   const server = serverRows.at(0);
   if (!server) return undefined;
 

--- a/packages/server/src/mcp/service.ts
+++ b/packages/server/src/mcp/service.ts
@@ -35,7 +35,7 @@ export async function createMcpServer(input: {
   transport: McpTransport;
   url: string;
   authConfig: McpAuthConfig;
-}): Promise<{ id: string }> {
+}): Promise<{ id: PrefixedString<'mcp'> }> {
   const db = getDb();
   const id = createMcpServerId();
   await db
@@ -44,21 +44,18 @@ export async function createMcpServer(input: {
   return { id };
 }
 
-export async function deleteMcpServer(serverId: string): Promise<void> {
+export async function deleteMcpServer(serverId: PrefixedString<'mcp'>): Promise<void> {
   const db = getDb();
   const toolsetId = `mcp:${serverId}`;
   const mcpToolPrefix = `${serverId}_%`;
 
-  const existingRows = await db
-    .select()
-    .from(mcpServers)
-    .where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  const existingRows = await db.select().from(mcpServers).where(eq(mcpServers.id, serverId));
   const existing = existingRows.at(0);
   if (!existing) {
     throw new HTTPException(404, { message: 'MCP server not found' });
   }
 
-  await db.delete(mcpServers).where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  await db.delete(mcpServers).where(eq(mcpServers.id, serverId));
   await db
     .delete(toolEnabled)
     .where(
@@ -70,12 +67,9 @@ export async function deleteMcpServer(serverId: string): Promise<void> {
   await db.delete(toolPermissions).where(like(toolPermissions.toolName, mcpToolPrefix));
 }
 
-export async function fetchMcpTools(serverId: string): Promise<McpTool[]> {
+export async function fetchMcpTools(serverId: PrefixedString<'mcp'>): Promise<McpTool[]> {
   const db = getDb();
-  const serverRows = await db
-    .select()
-    .from(mcpServers)
-    .where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  const serverRows = await db.select().from(mcpServers).where(eq(mcpServers.id, serverId));
   const server = serverRows.at(0);
   if (!server) {
     throw new HTTPException(404, { message: 'MCP server not found' });
@@ -110,10 +104,7 @@ export async function fetchMcpTools(serverId: string): Promise<McpTool[]> {
   });
 
   // Persist tools to cache
-  await db
-    .update(mcpServers)
-    .set({ tools, updatedAt: Date.now() })
-    .where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  await db.update(mcpServers).set({ tools, updatedAt: Date.now() }).where(eq(mcpServers.id, serverId));
 
   return tools;
 }
@@ -148,13 +139,10 @@ function isClientRegistrationError(error: unknown): boolean {
 }
 
 async function loadOAuthServer(
-  serverId: string,
+  serverId: PrefixedString<'mcp'>,
 ): Promise<{ id: PrefixedString<'mcp'>; url: string; authConfig: OAuthAuth }> {
   const db = getDb();
-  const serverRows = await db
-    .select()
-    .from(mcpServers)
-    .where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+  const serverRows = await db.select().from(mcpServers).where(eq(mcpServers.id, serverId));
   const server = serverRows.at(0);
   if (!server) {
     throw new HTTPException(404, { message: 'MCP server not found' });
@@ -170,7 +158,9 @@ async function loadOAuthServer(
  * registers the transport so `finishAuth` can later run on the same instance,
  * then lets the SDK perform discovery + DCR and capture the authorization URL.
  */
-export async function startMcpAuth(serverId: string): Promise<{ authUrl: string; waitForTokens: () => Promise<void> }> {
+export async function startMcpAuth(
+  serverId: PrefixedString<'mcp'>,
+): Promise<{ authUrl: string; waitForTokens: () => Promise<void> }> {
   const server = await loadOAuthServer(serverId);
 
   await OAuthCallback.ensureRunning();
@@ -238,7 +228,7 @@ export async function startMcpAuth(serverId: string): Promise<{ authUrl: string;
 }
 
 /** Clear OAuth credentials and tear down any in-flight auth for a server. */
-export async function logoutMcpAuth(serverId: string): Promise<void> {
+export async function logoutMcpAuth(serverId: PrefixedString<'mcp'>): Promise<void> {
   const server = await loadOAuthServer(serverId);
 
   OAuthCallback.cancelPending(serverId);
@@ -248,12 +238,14 @@ export async function logoutMcpAuth(serverId: string): Promise<void> {
   await setMcpAuthStatus(server.id, 'none');
 }
 
-export async function getMcpAuthStatus(serverId: string): Promise<{ authStatus: McpServerRow['authStatus'] }> {
+export async function getMcpAuthStatus(
+  serverId: PrefixedString<'mcp'>,
+): Promise<{ authStatus: McpServerRow['authStatus'] }> {
   const db = getDb();
   const serverRows = await db
     .select({ authStatus: mcpServers.authStatus })
     .from(mcpServers)
-    .where(eq(mcpServers.id, serverId as PrefixedString<'mcp'>));
+    .where(eq(mcpServers.id, serverId));
   const server = serverRows.at(0);
   if (!server) {
     throw new HTTPException(404, { message: 'MCP server not found' });

--- a/packages/server/src/mcp/tool-executor.ts
+++ b/packages/server/src/mcp/tool-executor.ts
@@ -1,3 +1,4 @@
+import type { PrefixedString } from '@stitch/shared/id';
 import { formatMcpToolName } from '@stitch/shared/mcp/types';
 import type { McpRegistryServer } from '@stitch/shared/mcp/types';
 
@@ -84,7 +85,7 @@ async function fetchServerPrompts(server: McpServerWithTools): Promise<ToolsetPr
   }
 }
 
-function buildMcpToolsetId(serverId: string): string {
+function buildMcpToolsetId(serverId: PrefixedString<'mcp'>): string {
   return `mcp:${serverId}`;
 }
 
@@ -168,7 +169,7 @@ function createMcpToolset(
 }
 
 async function refreshMcpToolsetsInternal(
-  options?: { serverIds?: string[]; refreshTools?: boolean },
+  options?: { serverIds?: PrefixedString<'mcp'>[]; refreshTools?: boolean },
   deps: McpToolExecutorDeps = DEFAULT_DEPS,
 ): Promise<void> {
   const refreshTools = options?.refreshTools ?? true;
@@ -255,7 +256,7 @@ async function refreshMcpToolsetsInternal(
 }
 
 export async function refreshMcpToolsets(
-  options?: { serverIds?: string[]; refreshTools?: boolean },
+  options?: { serverIds?: PrefixedString<'mcp'>[]; refreshTools?: boolean },
   deps?: Partial<McpToolExecutorDeps>,
 ): Promise<void> {
   const resolvedDeps: McpToolExecutorDeps = { ...DEFAULT_DEPS, ...deps };
@@ -276,7 +277,7 @@ export async function refreshMcpToolsets(
   return refreshInFlight;
 }
 
-export function getMcpServerPresentation(serverId: string): McpServerPresentation | undefined {
+export function getMcpServerPresentation(serverId: PrefixedString<'mcp'>): McpServerPresentation | undefined {
   return getToolset(buildMcpToolsetId(serverId))?.presentation;
 }
 

--- a/packages/server/src/memory/processor.ts
+++ b/packages/server/src/memory/processor.ts
@@ -20,7 +20,7 @@ const TASK_PATTERN = /\b(?:remind me|todo|to-do|deadline|due (?:today|tomorrow|o
 
 type Candidate = { content: string; target: MemoryTarget; durability: 'ephemeral' | 'session' | 'long_term' };
 type SessionWriteState = { factsWritten: number; lastWriteTurn: number; turnCount: number };
-const sessionWriteState = new Map<string, SessionWriteState>();
+const sessionWriteState = new Map<PrefixedString<'ses'>, SessionWriteState>();
 
 export function filterCaptureCandidates(candidates: Candidate[], existing: Set<string>, limit: number): Candidate[] {
   const accepted: Candidate[] = [];
@@ -55,7 +55,7 @@ async function existingCandidateKeys(): Promise<Set<string>> {
   );
 }
 
-function incrementTurn(sessionId: string): SessionWriteState {
+function incrementTurn(sessionId: PrefixedString<'ses'>): SessionWriteState {
   const state = sessionWriteState.get(sessionId) ?? { factsWritten: 0, lastWriteTurn: -1, turnCount: 0 };
   state.turnCount += 1;
   sessionWriteState.set(sessionId, state);
@@ -63,7 +63,7 @@ function incrementTurn(sessionId: string): SessionWriteState {
 }
 
 export async function processMemories(input: {
-  sessionId: string;
+  sessionId: PrefixedString<'ses'>;
   userMessage: string;
   assistantMessage: string;
   providerId: string;
@@ -130,14 +130,13 @@ export async function processMemories(input: {
   }
 }
 
-async function resolveMemorySource(sessionId: string, override: MemorySource | undefined): Promise<MemorySource> {
+async function resolveMemorySource(
+  sessionId: PrefixedString<'ses'>,
+  override: MemorySource | undefined,
+): Promise<MemorySource> {
   if (override) return override;
   const session = (
-    await getDb()
-      .select({ type: sessions.type })
-      .from(sessions)
-      .where(eq(sessions.id, sessionId as PrefixedString<'ses'>))
-      .limit(1)
+    await getDb().select({ type: sessions.type }).from(sessions).where(eq(sessions.id, sessionId)).limit(1)
   ).at(0);
   return session?.type === 'automation' ? 'automation' : 'chat';
 }

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -32,7 +32,7 @@ const splitParamSchema = z.object({ id: routeSchemas.sessionId, msgId: routeSche
 
 const createSessionSchema = z.object({
   title: z.string().trim().min(1).optional(),
-  parentSessionId: z.string().optional(),
+  parentSessionId: routeSchemas.sessionId.optional(),
 });
 
 const listSessionsQuerySchema = z.object({

--- a/packages/server/src/routes/config.ts
+++ b/packages/server/src/routes/config.ts
@@ -2,11 +2,11 @@ import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
 import { z } from 'zod';
 
-import type { PrefixedString } from '@stitch/shared/id';
 import { formatMcpToolName } from '@stitch/shared/mcp/types';
 import { TOOL_ENABLED_SCOPES } from '@stitch/shared/tools/types';
 
 import { getAppEnabledStates } from '@/apps/service.js';
+import { routeSchemas } from '@/lib/route-schemas.js';
 import { getMcpServersWithCachedTools } from '@/mcp/service.js';
 import { getMcpServerPresentation } from '@/mcp/tool-executor.js';
 import { deletePerm, getPerms, upsertPerm } from '@/permission/service.js';
@@ -103,8 +103,12 @@ configRouter.put('/permissions', zValidator('json', upsertPermissionSchema), asy
   return c.body(null, 204);
 });
 
-configRouter.delete('/permissions/:permissionId', async (c) => {
-  const permissionId = c.req.param('permissionId') as PrefixedString<'perm'>;
-  await deletePerm(permissionId);
-  return c.body(null, 204);
-});
+configRouter.delete(
+  '/permissions/:permissionId',
+  zValidator('param', z.object({ permissionId: routeSchemas.permissionRuleId })),
+  async (c) => {
+    const permissionId = c.req.valid('param').permissionId;
+    await deletePerm(permissionId);
+    return c.body(null, 204);
+  },
+);

--- a/packages/server/src/routes/connectors.ts
+++ b/packages/server/src/routes/connectors.ts
@@ -18,6 +18,7 @@ import {
   upgradeConnectorInstance,
 } from '@/connectors/service.js';
 import * as Log from '@/lib/log.js';
+import { routeSchemas } from '@/lib/route-schemas.js';
 
 export const connectorsRouter = new Hono();
 const log = Log.create({ service: 'connectors-route' });
@@ -55,15 +56,18 @@ connectorsRouter.get('/instances', async (c) => {
 });
 
 // Get a specific connector instance
-connectorsRouter.get('/instances/:id', async (c) => {
-  const id = c.req.param('id');
+const connectorInstanceIdParamSchema = z.object({ id: routeSchemas.connectorInstanceId });
+const connectorIdParamSchema = z.object({ id: routeSchemas.connectorId });
+
+connectorsRouter.get('/instances/:id', zValidator('param', connectorInstanceIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   const result = await getConnectorInstance(id);
   return c.json(result);
 });
 
 // Create an OAuth connector instance
 const createOAuthSchema = z.object({
-  connectorRefId: z.string().min(1),
+  connectorRefId: routeSchemas.connectorId,
   label: z.string().min(1),
   scopes: z.array(z.string()).min(1),
 });
@@ -88,8 +92,8 @@ connectorsRouter.post('/instances/api-key', zValidator('json', createApiKeySchem
 });
 
 // Start OAuth authorization flow for an instance
-connectorsRouter.post('/instances/:id/authorize', async (c) => {
-  const id = c.req.param('id');
+connectorsRouter.post('/instances/:id/authorize', zValidator('param', connectorInstanceIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   const result = await authorizeOAuthInstance(id);
 
   const { waitForTokens } = result;
@@ -109,38 +113,48 @@ const updateSchema = z.object({ label: z.string().min(1).optional(), scopes: z.a
 
 const upgradeSchema = z.object({ apiKey: z.string().min(1).optional() });
 
-connectorsRouter.patch('/instances/:id', zValidator('json', updateSchema), async (c) => {
-  const id = c.req.param('id');
-  const body = c.req.valid('json');
-  const result = await updateConnectorInstance(id, body);
-  return c.json(result);
-});
+connectorsRouter.patch(
+  '/instances/:id',
+  zValidator('param', connectorInstanceIdParamSchema),
+  zValidator('json', updateSchema),
+  async (c) => {
+    const id = c.req.valid('param').id;
+    const body = c.req.valid('json');
+    const result = await updateConnectorInstance(id, body);
+    return c.json(result);
+  },
+);
 
 // Delete a connector instance
-connectorsRouter.delete('/instances/:id', async (c) => {
-  const id = c.req.param('id');
+connectorsRouter.delete('/instances/:id', zValidator('param', connectorInstanceIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   await deleteConnectorInstance(id);
   return c.body(null, 204);
 });
 
 // Delete connector credentials and all linked accounts
-connectorsRouter.delete('/:id', async (c) => {
-  const id = c.req.param('id');
+connectorsRouter.delete('/:id', zValidator('param', connectorIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   await deleteConnector(id);
   return c.body(null, 204);
 });
 
 // Test a connector instance connection
-connectorsRouter.post('/instances/:id/test', async (c) => {
-  const id = c.req.param('id');
+connectorsRouter.post('/instances/:id/test', zValidator('param', connectorInstanceIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   await testConnectorInstance(id);
   return c.json({ success: true });
 });
 
 // Upgrade a connector instance to the latest connector version
-connectorsRouter.post('/instances/:id/upgrade', zValidator('json', upgradeSchema), async (c) => {
-  const id = c.req.param('id');
-  const body = c.req.valid('json');
-  const result = await upgradeConnectorInstance(id, body);
-  return c.json(result);
-});
+connectorsRouter.post(
+  '/instances/:id/upgrade',
+  zValidator('param', connectorInstanceIdParamSchema),
+  zValidator('json', upgradeSchema),
+  async (c) => {
+    const id = c.req.valid('param').id;
+    const body = c.req.valid('json');
+    const result = await upgradeConnectorInstance(id, body);
+    return c.json(result);
+  },
+);

--- a/packages/server/src/routes/mail.ts
+++ b/packages/server/src/routes/mail.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { getMailDb } from '@stitch/mail/db/client';
 import { getAccount, getThread, listAccounts, listDrafts, listLabels, listThreads } from '@stitch/mail/db/queries';
 import { mailAccounts } from '@stitch/mail/db/schema';
+import type { PrefixedString } from '@stitch/shared/id';
 
 import { getDb } from '@/db/client.js';
 import { connectorInstances } from '@/db/schema/connectors.js';
@@ -28,7 +29,7 @@ const accountPatchSchema = z.object({
 });
 
 const enrollSchema = z.object({
-  connectorInstanceId: z.string().min(1),
+  connectorInstanceId: routeSchemas.connectorInstanceId,
   backfillDays: z.number().int().positive().optional(),
   syncFrequencySeconds: z.number().int().min(30).optional(),
 });
@@ -63,7 +64,6 @@ const draftSchema = z.object({
 const draftPatchSchema = draftSchema.partial().omit({ accountId: true });
 
 export const mailRouter = new Hono();
-type ConnectorInstanceId = (typeof connectorInstances.$inferSelect)['id'];
 
 function errorResponse(c: Context, error: unknown, status: 400 | 404 | 500 = 500): Response {
   return c.json({ error: Error.isError(error) ? error.message : String(error) }, status);
@@ -82,8 +82,8 @@ function getConnectorInstances(where: SQL | undefined) {
     .where(where);
 }
 
-async function connectorInstanceById(connectorInstanceId: string) {
-  const [instance] = await getConnectorInstances(eq(connectorInstances.id, connectorInstanceId as ConnectorInstanceId));
+async function connectorInstanceById(connectorInstanceId: PrefixedString<'conn'>) {
+  const [instance] = await getConnectorInstances(eq(connectorInstances.id, connectorInstanceId));
   return instance;
 }
 

--- a/packages/server/src/routes/mcp.ts
+++ b/packages/server/src/routes/mcp.ts
@@ -6,6 +6,7 @@ import { MCP_TRANSPORT_TYPES } from '@stitch/shared/mcp/types';
 
 import { ICON_CACHE_CONTROL, SVG_CONTENT_TYPE } from '@/lib/icon-cache.js';
 import * as Log from '@/lib/log.js';
+import { routeSchemas } from '@/lib/route-schemas.js';
 import { evictMcpClient } from '@/mcp/client.js';
 import * as OAuthCallback from '@/mcp/oauth-callback.js';
 import { getMcpInstalledServerRegistryLogo, getMcpRegistryLogo } from '@/mcp/registry-logos.js';
@@ -45,6 +46,8 @@ const createMcpServerSchema = z.object({
   url: z.url(),
   authConfig: authConfigSchema,
 });
+
+const mcpServerIdParamSchema = z.object({ id: routeSchemas.mcpServerId });
 
 export const mcpRouter = new Hono();
 
@@ -87,15 +90,15 @@ mcpRouter.get('/registry/:registryId/logo', async (c) => {
   return c.body(logo, 200);
 });
 
-mcpRouter.get('/:id/tools', async (c) => {
-  const id = c.req.param('id');
+mcpRouter.get('/:id/tools', zValidator('param', mcpServerIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   const result = await fetchMcpTools(id);
   await refreshMcpToolsets({ serverIds: [id], refreshTools: false });
   return c.json(result);
 });
 
-mcpRouter.get('/:id/logo', async (c) => {
-  const id = c.req.param('id');
+mcpRouter.get('/:id/logo', zValidator('param', mcpServerIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   const logo = await getMcpInstalledServerRegistryLogo(id);
   if (!logo) {
     return c.json({ error: 'MCP server logo not found' }, 404);
@@ -111,14 +114,14 @@ mcpRouter.post('/refresh', async (c) => {
   return c.body(null, 204);
 });
 
-mcpRouter.post('/:id/refresh', async (c) => {
-  const id = c.req.param('id');
+mcpRouter.post('/:id/refresh', zValidator('param', mcpServerIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   await refreshMcpToolsets({ serverIds: [id], refreshTools: true });
   return c.body(null, 204);
 });
 
-mcpRouter.delete('/:id', async (c) => {
-  const id = c.req.param('id');
+mcpRouter.delete('/:id', zValidator('param', mcpServerIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   await deleteMcpServer(id);
   OAuthCallback.cancelPending(id);
   evictMcpClient(id);
@@ -126,8 +129,8 @@ mcpRouter.delete('/:id', async (c) => {
   return c.body(null, 204);
 });
 
-mcpRouter.post('/:id/auth', async (c) => {
-  const id = c.req.param('id');
+mcpRouter.post('/:id/auth', zValidator('param', mcpServerIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   const result = await startMcpAuth(id);
 
   const { waitForTokens } = result;
@@ -139,14 +142,14 @@ mcpRouter.post('/:id/auth', async (c) => {
   return c.json({ authUrl: result.authUrl });
 });
 
-mcpRouter.get('/:id/auth/status', async (c) => {
-  const id = c.req.param('id');
+mcpRouter.get('/:id/auth/status', zValidator('param', mcpServerIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   const result = await getMcpAuthStatus(id);
   return c.json(result);
 });
 
-mcpRouter.post('/:id/auth/logout', async (c) => {
-  const id = c.req.param('id');
+mcpRouter.post('/:id/auth/logout', zValidator('param', mcpServerIdParamSchema), async (c) => {
+  const id = c.req.valid('param').id;
   await logoutMcpAuth(id);
   evictMcpClient(id);
   await refreshMcpToolsets({ serverIds: [id], refreshTools: false });

--- a/packages/server/src/stt/route.ts
+++ b/packages/server/src/stt/route.ts
@@ -6,6 +6,7 @@ import type { SttOutboundMessage } from '@stitch/shared/stt/types';
 
 import { internalBus } from '@/lib/internal-bus.js';
 import * as Log from '@/lib/log.js';
+import { routeSchemas } from '@/lib/route-schemas.js';
 import { pushTranscriptEvent, startTranscriptCollection } from '@/recordings/transcript-store.js';
 import { createSTTSession, STTSessionError, type STTSession } from '@/stt/session.js';
 import type { createNodeWebSocket } from '@hono/node-ws';
@@ -20,7 +21,7 @@ const startMessageSchema = z.object({
   providerId: z.string().min(1),
   modelId: z.string().min(1),
   service: z.enum(['chat-input', 'meeting-recording']),
-  recordingId: z.string().min(1),
+  recordingId: routeSchemas.recordingId.optional(),
   capabilityRequest: z
     .record(z.string(), z.enum(['required', 'preferred']))
     .optional()
@@ -105,7 +106,11 @@ function send(ws: WsSender, msg: SttOutboundMessage): void {
   ws.send(JSON.stringify(msg));
 }
 
-type SessionState = { session: STTSession | null; inputEncoding: 'f32le' | 'pcm_s16le'; recordingId: string | null };
+type SessionState = {
+  session: STTSession | null;
+  inputEncoding: 'f32le' | 'pcm_s16le';
+  recordingId: PrefixedString<'rec'> | null;
+};
 
 async function handleStart(
   message: z.infer<typeof startMessageSchema>,
@@ -123,7 +128,7 @@ async function handleStart(
   }
 
   state.inputEncoding = message.audioChunkConfig.encoding;
-  state.recordingId = message.recordingId;
+  state.recordingId = message.recordingId ?? null;
 
   try {
     const session = await createSTTSession({
@@ -142,7 +147,7 @@ async function handleStart(
 
     // Start in-memory transcript collection for meeting recordings
     if (message.service === 'meeting-recording' && state.recordingId) {
-      startTranscriptCollection(state.recordingId as PrefixedString<'rec'>);
+      startTranscriptCollection(state.recordingId);
     }
 
     session.onTranscript((evt) => {
@@ -172,7 +177,7 @@ async function handleStart(
         });
 
         // Accumulate all transcript events (partial + final) in the store for DB persistence
-        pushTranscriptEvent(state.recordingId as PrefixedString<'rec'>, {
+        pushTranscriptEvent(state.recordingId, {
           kind: evt.kind,
           source,
           speaker: typeof evt.speaker === 'string' ? evt.speaker : 'Unknown',
@@ -192,10 +197,7 @@ async function handleStart(
       send(ws, { type: 'unrecoverable', sttSessionId: message.sttSessionId, reason });
 
       if (message.service === 'meeting-recording' && state.recordingId) {
-        internalBus.emit('recording.unrecoverable', {
-          recordingId: state.recordingId as PrefixedString<'rec'>,
-          reason,
-        });
+        internalBus.emit('recording.unrecoverable', { recordingId: state.recordingId, reason });
       }
     });
 

--- a/packages/server/src/tools/toolsets/browser/queue.ts
+++ b/packages/server/src/tools/toolsets/browser/queue.ts
@@ -1,3 +1,5 @@
+import { PrefixedString } from '@stitch/shared/id';
+
 import { getBrowserManager } from '@/lib/browser/browser-manager.js';
 import { ToolError } from '@/tools/errors.js';
 
@@ -11,7 +13,7 @@ function runSerialized<T>(fn: () => Promise<T>): Promise<T> {
 
 export async function runBrowserTool(
   abortSignal: AbortSignal | undefined,
-  sessionId: string,
+  sessionId: PrefixedString<'ses'>,
   execute: (signal?: AbortSignal) => Promise<unknown>,
 ): Promise<unknown> {
   return runSerialized(async () => {

--- a/packages/shared/src/browser/electron.ts
+++ b/packages/shared/src/browser/electron.ts
@@ -163,10 +163,12 @@ type _ActionsCoveredByResultMap = AssertExtends<
   keyof ElectronBrowserCommandResultMap
 >;
 
+import type { PrefixedString } from '../id/index.js';
+
 export type ElectronBrowserCommandMessage = {
   id: string;
   type: 'browser:command';
-  sessionId: string;
+  sessionId: PrefixedString<'ses'>;
   command: ElectronBrowserCommand;
 };
 

--- a/packages/shared/src/connectors/events.ts
+++ b/packages/shared/src/connectors/events.ts
@@ -1,3 +1,5 @@
+import type { PrefixedString } from '../id/index.js';
+
 export const CONNECTOR_EVENT_NAMES = [
   'connector.token.refreshed',
   'connector.auth.failed',
@@ -6,8 +8,8 @@ export const CONNECTOR_EVENT_NAMES = [
 ] as const;
 
 export type ConnectorEvents = {
-  'connector.token.refreshed': { instanceId: string };
-  'connector.auth.failed': { instanceId: string };
-  'connector.authorized': { instanceId: string; connectorId: string };
-  'connector.removed': { instanceId: string | null; connectorId: string };
+  'connector.token.refreshed': { instanceId: PrefixedString<'conn'> };
+  'connector.auth.failed': { instanceId: PrefixedString<'conn'> };
+  'connector.authorized': { instanceId: PrefixedString<'conn'>; connectorId: string };
+  'connector.removed': { instanceId: PrefixedString<'conn'> | null; connectorId: string };
 };

--- a/packages/shared/src/desktop/bridge.ts
+++ b/packages/shared/src/desktop/bridge.ts
@@ -1,4 +1,5 @@
 import type { ElectronBrowserState } from '../browser/electron.js';
+import type { PrefixedString } from '../id/index.js';
 import type {
   BrowserNavigateResult,
   DesktopNotificationEvent,
@@ -73,8 +74,8 @@ export type DesktopBridge = {
   };
   browser: {
     getState: () => Promise<ElectronBrowserState>;
-    registerWebview: (webContentsId: number, sessionId: string) => Promise<ElectronBrowserState>;
-    switchSession: (sessionId: string) => Promise<ElectronBrowserState>;
+    registerWebview: (webContentsId: number, sessionId: PrefixedString<'ses'>) => Promise<ElectronBrowserState>;
+    switchSession: (sessionId: PrefixedString<'ses'>) => Promise<ElectronBrowserState>;
     show: () => Promise<ElectronBrowserState>;
     hide: () => Promise<ElectronBrowserState>;
     userNavigate: (url: string) => Promise<BrowserNavigateResult>;

--- a/packages/shared/src/ipc/types.ts
+++ b/packages/shared/src/ipc/types.ts
@@ -1,4 +1,5 @@
 import type { ElectronBrowserState } from '../browser/electron.js';
+import type { PrefixedString } from '../id/index.js';
 import type { RecordingDeviceChangedPayload, RecordingWarningPayload } from '../recordings/events.js';
 import type { MeetingCallDetectedPayload, MeetingCallEndedPayload } from '../recordings/meeting-ipc.js';
 import type { StartRecordingInput, StartRecordingResponse, StopRecordingResponse } from '../recordings/types.js';
@@ -83,8 +84,11 @@ export interface IpcContract {
   'notifications:dismiss': { args: [id: string]; return: void };
   'notifications:set-height': { args: [height: number]; return: void };
   'browser:getState': { args: []; return: ElectronBrowserState };
-  'browser:registerWebview': { args: [webContentsId: number, sessionId: string]; return: ElectronBrowserState };
-  'browser:switchSession': { args: [sessionId: string]; return: ElectronBrowserState };
+  'browser:registerWebview': {
+    args: [webContentsId: number, sessionId: PrefixedString<'ses'>];
+    return: ElectronBrowserState;
+  };
+  'browser:switchSession': { args: [sessionId: PrefixedString<'ses'>]; return: ElectronBrowserState };
   'browser:show': { args: []; return: ElectronBrowserState };
   'browser:hide': { args: []; return: ElectronBrowserState };
   'browser:userNavigate': { args: [url: string]; return: BrowserNavigateResult };

--- a/packages/shared/src/mail/types.ts
+++ b/packages/shared/src/mail/types.ts
@@ -14,7 +14,7 @@ export type MailAddressView = { name: string | null; email: string };
 
 export type MailAccountView = {
   id: MailAccountId;
-  connectorInstanceId: string;
+  connectorInstanceId: PrefixedString<'conn'>;
   provider: 'gmail';
   email: string;
   enabled: boolean;

--- a/packages/shared/src/mcp/events.ts
+++ b/packages/shared/src/mcp/events.ts
@@ -9,8 +9,8 @@ export const MCP_EVENT_NAMES = [
 ] as const;
 
 export type McpEvents = {
-  'mcp.tools.changed': { serverId: string; serverName: string; toolCount: number | null };
-  'mcp.auth.status_changed': { serverId: string; authStatus: McpAuthStatus };
+  'mcp.tools.changed': { serverId: PrefixedString<'mcp'>; serverName: string; toolCount: number | null };
+  'mcp.auth.status_changed': { serverId: PrefixedString<'mcp'>; authStatus: McpAuthStatus };
   'mcp.elicitation.requested': { elicitation: McpElicitationRequest };
   'mcp.elicitation.resolved': {
     elicitationId: PrefixedString<'mcpel'>;

--- a/packages/shared/src/mcp/types.ts
+++ b/packages/shared/src/mcp/types.ts
@@ -156,15 +156,15 @@ export type McpElicitationRequest = {
 const MCP_SERVER_ID_LENGTH = 30; // "mcp_" (4) + 26 body chars
 
 /** Formats a tool name for the AI SDK tools map by combining the server ID and tool name. */
-export function formatMcpToolName(serverId: string, toolName: string): string {
+export function formatMcpToolName(serverId: PrefixedString<'mcp'>, toolName: string): string {
   return `${serverId}_${toolName}`;
 }
 
 /** Parses a tool name back into its components. Returns null if not an MCP tool name. */
-export function parseMcpToolName(prefixedName: string): { serverId: string; toolName: string } | null {
+export function parseMcpToolName(prefixedName: string): { serverId: PrefixedString<'mcp'>; toolName: string } | null {
   if (!prefixedName.startsWith('mcp_')) return null;
   if (prefixedName.length <= MCP_SERVER_ID_LENGTH + 1) return null;
-  const serverId = prefixedName.slice(0, MCP_SERVER_ID_LENGTH);
+  const serverId = prefixedName.slice(0, MCP_SERVER_ID_LENGTH) as PrefixedString<'mcp'>;
   const sep = prefixedName[MCP_SERVER_ID_LENGTH];
   if (sep !== '_') return null;
   const toolName = prefixedName.slice(MCP_SERVER_ID_LENGTH + 1);

--- a/packages/shared/src/recordings/events.ts
+++ b/packages/shared/src/recordings/events.ts
@@ -22,7 +22,7 @@ type RecordingStoppedPayload = { recordingId: PrefixedString<'rec'> };
 type RecordingUnrecoverablePayload = { recordingId: PrefixedString<'rec'>; reason: string };
 
 type RecordingTranscriptEntryPayload = {
-  recordingId: string;
+  recordingId: PrefixedString<'rec'>;
   kind: 'partial' | 'final';
   source: 'mic' | 'speaker';
   speaker: string;

--- a/packages/shared/src/telemetry/types.ts
+++ b/packages/shared/src/telemetry/types.ts
@@ -1,8 +1,10 @@
+import type { PrefixedString } from '../id/index.js';
+
 /**
  * Client telemetry state persisted locally (Electron userData or localStorage).
  */
 export type TelemetryState = {
-  clientInstallationId: string;
+  clientInstallationId: PrefixedString<'tcli'>;
   enabled: boolean;
   lastActiveDate: string | null;
   lastMessageDate: string | null;


### PR DESCRIPTION
## Summary
Enforces branded `PrefixedString<P>` IDs everywhere types define domain IDs and tightens Hono route validation to use `routeSchemas`. This closes the gap where shared/server types used plain `string` for session/message/connector/mcp/mail/recording/telemetry IDs.

## Shared package (`packages/shared/src`)
- `connectors/events.ts` – `instanceId: PrefixedString<'conn'>`
- `mcp/events.ts` / `mcp/types.ts` – `serverId: PrefixedString<'mcp'>` (incl. `formatMcpToolName`/`parseMcpToolName`)
- `recordings/events.ts` – `recordingId: PrefixedString<'rec'>`
- `mail/types.ts` – `MailAccountView.connectorInstanceId: PrefixedString<'conn'>`
- `telemetry/types.ts` – `clientInstallationId: PrefixedString<'tcli'>`
- `browser/electron.ts` – `ElectronBrowserCommandMessage.sessionId: PrefixedString<'ses'>`
- `desktop/bridge.ts` / `ipc/types.ts` – `registerWebview`/`switchSession` `sessionId: PrefixedString<'ses'>`

## Server route schemas (`packages/server/src/lib/route-schemas.ts`)
- Added missing `connectorId: prefixedId(ID_PREFIXES.connector)` (`cnr`).

## Server routes (`packages/server/src/routes`)
- `chat.ts` – `parentSessionId: routeSchemas.sessionId`
- `connectors.ts` – added `connectorInstanceIdParamSchema`/`connectorIdParamSchema`, `connectorRefId: routeSchemas.connectorId`, validated all `/:id` instance/connector endpoints via `zValidator`
- `mcp.ts` – added `mcpServerIdParamSchema` to all `/:id` endpoints
- `config.ts` – `DELETE /permissions/:permissionId` via `routeSchemas.permissionRuleId`
- `mail.ts` – `enrollSchema.connectorInstanceId: routeSchemas.connectorInstanceId`, `connectorInstanceById: PrefixedString<'conn'>`
- `stt/route.ts` – `recordingId: routeSchemas.recordingId.optional()` + `SessionState.recordingId: PrefixedString<'rec'> | null`

## Server type definitions (`packages/server/src`)
- `db/schema/usage.ts` – `recordingId: PrefixedString<'rec'>`, `analysisId: PrefixedString<'recan'>`
- `automations/*`, `chat/*` – `automationId: PrefixedString<'auto'>`, `sessionId: PrefixedString<'ses'>`, `assistantMessageId/messageId: PrefixedString<'msg'>`, `parentSessionId: PrefixedString<'ses'>`
- `lib/abort-registry.ts`, `lib/browser/browser-manager.ts` – `sessionId: PrefixedString<'ses'>`
- `connectors/*` – `instanceId: PrefixedString<'conn'>`, `connectorRefId: PrefixedString<'cnr'>`, `deleteConnector: PrefixedString<'cnr'>`
- `mcp/*` – `serverId: PrefixedString<'mcp'>` across `client`, `oauth-callback`, `presentation`, `registry-logos`, `service`, `tool-executor`
- `mail/*` – `read-model`, `wiring` `accountId/draftId/messageId: Mail*Id`, `connectorInstanceId: PrefixedString<'conn'>`
- `memory/processor.ts` – `sessionId: PrefixedString<'ses'>`
- `llm/provider-options.ts`, `tools/toolsets/browser/queue.ts` – `sessionId: PrefixedString<'ses'>`

## Downstream fixes
- `packages/mail/src/db/schema.ts` – `connectorInstanceId: $type<PrefixedString<'conn'>>`
- `apps/desktop/src/preload/index.ts`, `apps/web/src/components/*` – uses `PrefixedString<'ses'>` / `PrefixedString<'mcp'>`

## Verification
- `bunx turbo typecheck --force` – 15 packages pass
