### PR TITLE
feat(browser): add optional path parameter to save screenshot to file

### DIFF
--- a/packages/server/src/tools/toolsets/browser/index.ts
+++ b/packages/server/src/tools/toolsets/browser/index.ts
@@ -66,7 +66,7 @@ Use timeoutMs to cap the maximum wait.`;
 
 const SCREENSHOT_DESCRIPTION = `Take a browser screenshot.
 
-Supports viewport, full-page, and element screenshots (via ref). Returns base64 PNG or JPEG image data and format.`;
+Supports viewport, full-page, and element screenshots (via ref). Returns base64 PNG or JPEG image data and format. Optionally save to disk via path - parent directories are created if needed.`;
 
 const DIALOG_DESCRIPTION = `Inspect and control browser dialogs (alert/confirm/prompt).
 

--- a/packages/server/src/tools/toolsets/browser/operations.ts
+++ b/packages/server/src/tools/toolsets/browser/operations.ts
@@ -1,3 +1,6 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
 import { sendBrowserCommand } from '@/lib/browser/browser-manager.js';
 import type { ScrollDirection } from '@/lib/browser/types.js';
 import { BrowserInvalidOpError, BrowserMissingFieldError } from '@/tools/toolsets/browser/errors.js';
@@ -209,6 +212,20 @@ export async function executeOperation(input: OperationInput, signal?: AbortSign
       { action: 'screenshot', format: input.format, quality: input.quality, fullPage: input.fullPage, ref: input.ref },
       signal,
     );
+    if (input.path) {
+      const buffer = Buffer.from(result.data, 'base64');
+      const dir = dirname(input.path);
+      if (dir && dir !== '.') {
+        await mkdir(dir, { recursive: true });
+      }
+      await writeFile(input.path, buffer);
+      return {
+        output: `Screenshot taken (${result.format}) and saved to ${input.path}`,
+        data: result.data,
+        format: result.format,
+        path: input.path,
+      };
+    }
     return { output: `Screenshot taken (${result.format})`, data: result.data, format: result.format };
   }
 

--- a/packages/server/src/tools/toolsets/browser/schemas.ts
+++ b/packages/server/src/tools/toolsets/browser/schemas.ts
@@ -77,6 +77,12 @@ export const browserScreenshotInputSchema = z.object({
   format: z.enum(['png', 'jpeg']).optional().describe('Screenshot format. Default png.'),
   quality: z.number().optional().describe('Screenshot quality 0-100 for jpeg.'),
   fullPage: z.boolean().optional().describe('Capture full page screenshot.'),
+  path: z
+    .string()
+    .optional()
+    .describe(
+      'File path to save the screenshot to. If provided, the screenshot is written to disk at this path. Parent directories are created if needed. Supports absolute or relative paths.',
+    ),
 });
 
 export const browserDialogInputSchema = z.object({


### PR DESCRIPTION
# Add optional `path` parameter to browser screenshot tool

## Summary
Adds the ability to save browser screenshots directly to disk via an optional `path` parameter. Previously `browser_screenshot` only returned base64 data; now users can persist the image to a file in one call.

## Changes
- **Schema** (`packages/server/src/tools/toolsets/browser/schemas.ts`): Added optional `path: string` to `browserScreenshotInputSchema` with description. Automatically inherited by `browser_batch` via `browserBatchActionSchema` extension.
- **Execution** (`packages/server/src/tools/toolsets/browser/operations.ts`): After capturing via `sendBrowserCommand`, if `path` is set, decodes base64, creates parent directories (`mkdir -p`), writes file via `writeFile`, and returns `output: "Screenshot taken (png) and saved to <path>"` plus `path` field.
- **Tool description** (`packages/server/src/tools/toolsets/browser/index.ts`): Updated `SCREENSHOT_DESCRIPTION` to document save-to-disk option.

## Behavior
- Without `path`: unchanged — returns `{output, data, format}`.
- With `path`: saves file, returns `{output, data, format, path}`. Supports absolute or relative paths, `png`/`jpeg` formats, `fullPage` and `ref` modes.
- Batch: `browser_batch` screenshot actions also support `path`.

## Verification
- `bun run check` passes (typecheck, lint, knip, test, format:changed)
- Manual test: base64 decode + mkdir recursive + writeFile verified for viewport/element/fullPage and for relative/absolute paths.
