### PR TITLE
chore(release): add Intel Mac (x64) to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,11 @@ jobs:
             arch: arm64
             rust_target: aarch64-apple-darwin
             package_script: package
+          - runner: macos-15-intel
+            os: macos
+            arch: x64
+            rust_target: x86_64-apple-darwin
+            package_script: package
     steps:
       - name: Checkout release commit
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
Adds Intel Mac (x64) target to the release workflow `build` matrix.

- Adds `macos-15-intel` runner (x64, `x86_64-apple-darwin`) alongside existing `macos-14` arm64 and `windows-2022` builds
- Produces dedicated artifact `desktop-macos-x64` (via existing `desktop-${{ matrix.os }}-${{ matrix.arch }}` naming) with dmg/zip/blockmap for Intel Macs
- Retains existing signing/notarization logic (`if: matrix.os == 'macos'`) - Intel builds benefit from same CSC/APPLE_API_KEY flow as ARM
- Native addons (`@stitch/audio-capture`, `@stitch/meeting-detection` via `napi build --platform`) and Bun sidecar (`stitch-server`/`stitch-sandbox`) compile natively on the Intel host

### Runner note
`macos-15-intel` is the current GA Intel label per `actions/runner-images` (x64). `macos-14`/ `macos-14-large` are deprecated July-Nov 2026; migration path is `macos-15` (ARM) / `macos-15-intel` (Intel). If org is on free tier without Intel large runners, fallback label is `macos-13` (deprecated but still queued).

Fixes Intel distribution gap - release now ships:
- `Stitch-macos-arm64.*` (Apple Silicon)
- `Stitch-macos-x64.*` (Intel) 
- `Stitch-windows-setup.exe`
- `stitch-server-linux-x64-*`

### Testing
- `bun run format:changed:check` passes
- Workflow YAML validated

