### PR TITLE
chore(release): revert Intel Mac (x64) from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,11 +178,6 @@ jobs:
             arch: arm64
             rust_target: aarch64-apple-darwin
             package_script: package
-          - runner: macos-15-intel
-            os: macos
-            arch: x64
-            rust_target: x86_64-apple-darwin
-            package_script: package
     steps:
       - name: Checkout release commit
         uses: actions/checkout@v5


### PR DESCRIPTION
Reverts #609 (2800696a).

Removes the `macos-15-intel` (`x86_64-apple-darwin`) matrix entry from `.github/workflows/release.yml:181-185`, restoring pre-Intel release workflow.